### PR TITLE
[FIX] replace Locale::getDefault() with getRoot() in all case conversion functions

### DIFF
--- a/bolt/functions/lib/string/StringCore.h
+++ b/bolt/functions/lib/string/StringCore.h
@@ -979,11 +979,16 @@ FOLLY_ALWAYS_INLINE static bool isDecimal(const StringView& str) {
   return isDecimal(str.data(), str.size());
 }
 
+FOLLY_ALWAYS_INLINE static const icu::Locale& getDefaultLocale() {
+  static const icu::Locale locale = icu::Locale::getRoot();
+  return locale;
+}
+
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const char* str,
     size_t length,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   if (str == nullptr || length == 0) {
     return "";
   }
@@ -1014,21 +1019,21 @@ FOLLY_ALWAYS_INLINE static std::string toLower(
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const std::string& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toLower<isAscii>(str.data(), str.size(), locale);
 }
 
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const std::string_view& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toLower<isAscii>(str.data(), str.size(), locale);
 }
 
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const StringView& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toLower<isAscii>(str.data(), str.size(), locale);
 }
 
@@ -1036,7 +1041,7 @@ template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const char* str,
     size_t length,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   if (str == nullptr || length == 0) {
     return "";
   }
@@ -1067,28 +1072,28 @@ FOLLY_ALWAYS_INLINE static std::string toUpper(
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const std::string& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toUpper<isAscii>(str.data(), str.size(), locale);
 }
 
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const std::string_view& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toUpper<isAscii>(str.data(), str.size(), locale);
 }
 
 template <bool isAscii = true>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const StringView& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toUpper<isAscii>(str.data(), str.size(), locale);
 }
 
 FOLLY_ALWAYS_INLINE static std::string toTitle(
     const char* str,
     size_t length,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   if (str == nullptr || length == 0) {
     return "";
   }
@@ -1112,19 +1117,19 @@ FOLLY_ALWAYS_INLINE static std::string toTitle(
 
 FOLLY_ALWAYS_INLINE static std::string toTitle(
     const std::string& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toTitle(str.data(), str.size(), locale);
 }
 
 FOLLY_ALWAYS_INLINE static std::string toTitle(
     const std::string_view& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toTitle(str.data(), str.size(), locale);
 }
 
 FOLLY_ALWAYS_INLINE static std::string toTitle(
     const StringView& str,
-    const icu::Locale& locale = icu::Locale::getDefault()) {
+    const icu::Locale& locale = getDefaultLocale()) {
   return toTitle(str.data(), str.size(), locale);
 }
 

--- a/bolt/functions/lib/string/tests/StringImplTest.cpp
+++ b/bolt/functions/lib/string/tests/StringImplTest.cpp
@@ -1280,7 +1280,7 @@ TEST_F(StringImplTest, toLower) {
   EXPECT_EQ(toLower<true>(std::string_view("𝔸")), "𝔸");
 }
 
-TEST_F(StringImplTest, DISABLED_toTitle) {
+TEST_F(StringImplTest, toTitle) {
   EXPECT_EQ(toTitle(std::string_view("ʻcAt! ʻeTc.")), "ʻCat! ʻEtc.");
   EXPECT_EQ(toTitle(std::string_view("aBc ABc")), "Abc Abc");
   EXPECT_EQ(toTitle(std::string_view("a")), "A");

--- a/bolt/functions/sparksql/tests/StringTest.cpp
+++ b/bolt/functions/sparksql/tests/StringTest.cpp
@@ -1493,7 +1493,7 @@ TEST_F(StringTest, uuidWithSeed) {
       uuidManyWithSeed(321, 1233, 33), uuidManyWithSeed(321, 1233, 33));
 }
 
-TEST_F(StringTest, DISABLED_initCap) {
+TEST_F(StringTest, initCap) {
   EXPECT_EQ(initCap("ʻcAt! ʻeTc."), "ʻCat! ʻEtc.");
   EXPECT_EQ(initCap("aBc ABc"), "Abc Abc");
   EXPECT_EQ(initCap("a"), "A");


### PR DESCRIPTION
### Problem:
The toTitle(), toLower(), and toUpper() functions were using icu::Locale::getDefault(), which reads system environment variables (LC_ALL, LC_CTYPE, LANG). This caused inconsistent outputs across different environments.

### Examples:
- toTitle(a.b,c): A.b,C (en_US) vs A.B,C (C/POSIX)
- toLower(TITLE): locale-specific lowercasing rules
- toUpper(title): locale-specific uppercasing rules

### Special cases affected:
- Turkish: 'I' ↔ 'ı' vs 'İ' ↔ 'i' (different from English)
- German: 'ß' → 'SS' vs 'ß' → 'ss' (locale-dependent)

### Solution:
Use icu::Locale::getRoot() to enforce consistent, language-neutral behavior that matches Spark SQL's string functions (initcap, lower, upper). (close #5 )

### Benefits:
- Guarantees deterministic output regardless of system locale
- Aligns with Spark's behavior (uses Locale.ROOT in Java)
- Eliminates performance overhead from locale detection and locking

### Affected functions:
- toTitle()
- toLower()
- toUpper()