### PR TITLE
ci(workflows): optimize CI by running jobs conditionally

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,4 @@
 name: Build and Test
-
 on:
   push:
     branches: [ main ]
@@ -13,7 +12,25 @@ env:
   CI_NUM_THREADS: "16"
 
 jobs:
+  changes:
+    runs-on:  [ self-hosted, small ]
+    outputs:
+      source_code: ${{ steps.filter.outputs.source_code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source_code:
+              - 'bolt/**'
+              - '!bolt/**/*.md'
+              - 'Makefile'
+              - 'conanfile.py'
+              - 'CMakeLists.txt'
+              - 'scripts/**'
   build-test:
+    needs: changes
+    if: ${{ needs.changes.outputs.source_code == 'true' }}
     runs-on: [ self-hosted, medium ]
     container: 
       image: bolt-registry:5000/bolt-ci:latest

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,7 +7,21 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on:  [ self-hosted, small ]
+    outputs:
+      source_code: ${{ steps.filter.outputs.source_code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source_code:
+              - 'bolt/**'
+              - '!bolt/**/*.md'
   format-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.source_code == 'true' }}
     runs-on: [ self-hosted, small ]
     container: bolt-registry:5000/bolt-ci:latest
     steps:


### PR DESCRIPTION
Introduces path filtering to the `build-test` and `clang-format` workflows to avoid running unnecessary jobs.

- The `build-test` workflow will now only run build and test jobs if there are changes to source code, build scripts, or dependencies.
- The `clang-format` workflow will only run the formatting check if there are changes to the source code in the `bolt/` directory.