### PR TITLE
[Optimization] Recluster RowContainer in HashJoin Array Mode to impro…

### DIFF
--- a/bolt/common/base/tests/GTestUtils.h
+++ b/bolt/common/base/tests/GTestUtils.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include <cstdlib>
 
 // gtest v1.10 deprecated *_TEST_CASE in favor of *_TEST_SUITE. These
 // macros are provided for portability between different gtest versions.
@@ -112,3 +113,11 @@
 #define DEBUG_ONLY_TEST_P(test_fixture, test_name) \
   TEST_P(test_fixture, DISABLED_##test_name)
 #endif
+
+namespace bytedance::bolt::test {
+inline struct GTestEnvSetter {
+  GTestEnvSetter() {
+    ::setenv("BOLT_IN_GTEST", "1", 1);
+  }
+} g_gtest_env_setter;
+} // namespace bytedance::bolt::test

--- a/bolt/common/caching/AsyncDataCache.cpp
+++ b/bolt/common/caching/AsyncDataCache.cpp
@@ -300,9 +300,7 @@ bool CoalescedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
     setEndState(State::kLoading, State::kLoaded, State::kCancelled);
   } catch (std::exception& e) {
     // preload can fail in async thread, then retry in sync load
-    if (isAsyncPreloadThread() &&
-        std::string(e.what()).find(kAsyncPreloadThreadName) !=
-            std::string::npos) {
+    if (isAsyncPreloadThread()) {
       LOG(WARNING) << "thread " << folly::getCurrentThreadName().value()
                    << " CoalescedLoad " << (uint64_t)this << " state "
                    << (state_ == State::kLoading         ? "kLoading"

--- a/bolt/connectors/hive/HiveDataSource.h
+++ b/bolt/connectors/hive/HiveDataSource.h
@@ -38,9 +38,6 @@
 #include "bolt/connectors/hive/PaimonConnectorSplit.h"
 #include "bolt/connectors/hive/SplitReader.h"
 #include "bolt/connectors/hive/TableHandle.h"
-#ifdef BOLT_ENABLE_HDFS
-#include "bolt/connectors/hive/storage_adapters/hdfs/StorageException.h"
-#endif
 #include "bolt/core/QueryConfig.h"
 #include "bolt/dwio/common/BufferedInput.h"
 #include "bolt/dwio/common/Reader.h"
@@ -226,19 +223,8 @@ class HiveDataSource : public DataSource {
 
   std::unique_ptr<dwio::common::RuntimeStatistics> runtimeStats_;
 
-  // ignore corrupt file
   int64_t ignoredFileSizes_{0};
-  bool ignoreCorruptFiles_{false};
-#ifdef BOLT_ENABLE_HDFS
-  int64_t taskMaxFailures_{0};
-  inline static std::mutex canIgnoredExceptionsMutex_;
-  inline static std::vector<std::string> canIgnoredExceptions_{};
-  inline const static std::set<filesystems::StorageException::StorageErrorType>
-      kMustIgnoredExceptions{
-          filesystems::StorageException::StorageErrorType::HdfsIOException,
-          filesystems::StorageException::StorageErrorType::
-              MissingBlockException};
-#endif
+
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
   int32_t decodeRepDefPageCount_{10};
 };

--- a/bolt/connectors/hive/IgnoreCorruptFile.h
+++ b/bolt/connectors/hive/IgnoreCorruptFile.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fmt/core.h>
+#include <folly/Format.h>
+#include <glog/logging.h>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/connectors/hive/storage_adapters/hdfs/StorageException.h"
+
+class IgnoreCorruptFileHelper {
+ public:
+  static void globalInitialize(
+      int64_t taskMaxFailures,
+      bool enableIgnoreCorruptFiles,
+      const std::string& userDefineIgnoreExceptions) {
+    bool inTestEnv = isInTestEnv();
+    if (hasInitialized_ && !inTestEnv) {
+      return;
+    }
+    taskMaxFailures_ = taskMaxFailures;
+    enableIgnoreCorruptFiles_ = enableIgnoreCorruptFiles;
+    {
+      std::unique_lock guard(mutex_);
+      enrichExceptionSetFromConf(
+          userDefineIgnoreExceptions, userDefinedSet_, inTestEnv);
+    }
+    hasInitialized_ = true;
+  }
+  static bool isIgnoreCorruptFilesEnabled() {
+    BOLT_CHECK(
+        hasInitialized_,
+        "IgnoreCorruptFileHelper is not initialized, please call initialize() first");
+    return enableIgnoreCorruptFiles_;
+  }
+  static bool isLastRetry(const std::string& taskId) {
+    BOLT_CHECK(
+        hasInitialized_,
+        "IgnoreCorruptFileHelper is not initialized, please call initialize() first");
+    // ignoreCorruptFiles_ only set in gluten/spark env, so it's safe to
+    // extract attempt number from task id
+    const auto attemptNumber = extractAttemptNumber(taskId);
+    BOLT_CHECK(
+        attemptNumber != -1,
+        "Failed to extract attempt number from task ID: {}",
+        taskId);
+    return attemptNumber >= taskMaxFailures_ - 1;
+  }
+  static bool canBeIgnoredInMustIgnoreSet(
+      ::bytedance::bolt::filesystems::StorageException::StorageErrorType
+          errorType) {
+    BOLT_CHECK(
+        hasInitialized_,
+        "IgnoreCorruptFileHelper is not initialized, please call initialize() first");
+    return IgnoreCorruptFileHelper::kMustIgnoredExceptions.find(errorType) !=
+        IgnoreCorruptFileHelper::kMustIgnoredExceptions.end();
+  }
+  static bool canBeIgnoredInUserDefineSet(const std::string& msg) {
+    BOLT_CHECK(
+        hasInitialized_,
+        "IgnoreCorruptFileHelper is not initialized, please call initialize() first");
+    for (const std::string& expected : userDefinedSet_) {
+      if (msg.find(expected) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  static bool isInTestEnv() {
+    return std::getenv("BOLT_IN_GTEST") != nullptr;
+  }
+
+  static void enrichExceptionSetFromConf(
+      std::string exceptionStr,
+      std::vector<std::string>& exceptionKeyWords,
+      bool overrideSet) {
+    // only init exceptionSet exactly once
+    if (exceptionStr.empty()) {
+      return;
+    }
+    if (!exceptionKeyWords.empty() && !overrideSet) {
+      return;
+    }
+    exceptionKeyWords.clear();
+    const char delimeter = exceptionStr.back();
+    exceptionStr.pop_back();
+    folly::split(delimeter, exceptionStr, exceptionKeyWords);
+    LOG(INFO) << "Split exception str by " << (char)delimeter
+              << ", and split result is: "
+              << fmt::format("{}", fmt::join(exceptionKeyWords, ", "));
+  }
+  static int64_t extractAttemptNumber(const std::string& taskId) {
+    const std::string prefix = "ATTEMPT_";
+    size_t prefix_pos = taskId.find(prefix);
+    if (prefix_pos == std::string::npos) {
+      return -1;
+    }
+    size_t num_start = prefix_pos + prefix.length();
+    size_t num_end = num_start;
+    while (num_end < taskId.length() && std::isdigit(taskId[num_end])) {
+      num_end++;
+    }
+    if (num_end == num_start) {
+      return -1;
+    }
+    try {
+      return std::stoi(taskId.substr(num_start, num_end - num_start));
+    } catch (...) {
+      return -1;
+    }
+    return -1;
+  }
+  inline static bool hasInitialized_{false};
+  inline static int64_t taskMaxFailures_{0};
+  inline static bool enableIgnoreCorruptFiles_{false};
+  inline static std::mutex mutex_;
+  inline static std::vector<std::string> userDefinedSet_{};
+  inline const static std::set<
+      ::bytedance::bolt::filesystems::StorageException::StorageErrorType>
+      kMustIgnoredExceptions{
+          ::bytedance::bolt::filesystems::StorageException::StorageErrorType::
+              HdfsIOException,
+          ::bytedance::bolt::filesystems::StorageException::StorageErrorType::
+              MissingBlockException};
+};
+
+#ifndef TRY_WITH_IGNORE
+#define TRY_WITH_IGNORE(taskId, operation, onIgnoreOperation)                  \
+  do {                                                                         \
+    if (!IgnoreCorruptFileHelper::isIgnoreCorruptFilesEnabled()) {             \
+      operation;                                                               \
+    } else {                                                                   \
+      try {                                                                    \
+        operation;                                                             \
+      } catch (const ::bytedance::bolt::filesystems::StorageException& e) {    \
+        bool canbeIgnored = (IgnoreCorruptFileHelper::isLastRetry(taskId)) &&  \
+            IgnoreCorruptFileHelper::canBeIgnoredInMustIgnoreSet(              \
+                                e.getStorageErrorType());                      \
+        LOG(ERROR) << "Catch StorageException, exception_type="                \
+                   << e.getStorageErrorType()                                  \
+                   << (canbeIgnored ? "Can" : "Can't")                         \
+                   << " be ignored, exception_msg="                            \
+                   << e.getStorageErrorMessage();                              \
+        if (canbeIgnored) {                                                    \
+          onIgnoreOperation;                                                   \
+        } else {                                                               \
+          std::rethrow_exception(std::current_exception());                    \
+        }                                                                      \
+      } catch (                                                                \
+          const dwio::common::exception::DecompressionLoggedException& e) {    \
+        bool canbeIgnored = (IgnoreCorruptFileHelper::isLastRetry(taskId));    \
+        LOG(ERROR) << "Catch DecompressionLoggedException. "                   \
+                   << (canbeIgnored ? "Can" : "Can't")                         \
+                   << " be ignored, exception_msg=" << e.what();               \
+        if (canbeIgnored) {                                                    \
+          onIgnoreOperation;                                                   \
+        } else {                                                               \
+          std::rethrow_exception(std::current_exception());                    \
+        }                                                                      \
+      } catch (const std::exception& e) {                                      \
+        std::string errorReason = e.what();                                    \
+        bool isLastRetry = IgnoreCorruptFileHelper::isLastRetry(taskId);       \
+        bool inIgnoreSet =                                                     \
+            IgnoreCorruptFileHelper::canBeIgnoredInUserDefineSet(errorReason); \
+        bool canbeIgnored = isLastRetry && inIgnoreSet;                        \
+        LOG(ERROR) << "Catch std::exception. "                                 \
+                   << (canbeIgnored ? "Can" : "Can't")                         \
+                   << " be ignored, isLastRetry is "                           \
+                   << (isLastRetry ? "true" : "false") << ", inIgnoreSet is "  \
+                   << (inIgnoreSet ? "true" : "false")                         \
+                   << " exception_msg=" << e.what();                           \
+        if (canbeIgnored) {                                                    \
+          onIgnoreOperation;                                                   \
+        } else {                                                               \
+          std::rethrow_exception(std::current_exception());                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  } while (false);
+#endif

--- a/bolt/connectors/hive/SplitReader.cpp
+++ b/bolt/connectors/hive/SplitReader.cpp
@@ -289,6 +289,13 @@ void SplitReader::prepareSplit(
   baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.getFileFormat())
                     ->createReader(std::move(baseFileInput), baseReaderOpts_);
 
+  // only for testing
+  if (UNLIKELY(
+          !FLAGS_testing_only_set_scan_exception_mesg_for_prepare.empty())) {
+    throw std::runtime_error(
+        FLAGS_testing_only_set_scan_exception_mesg_for_prepare);
+  }
+
   // Note that this doesn't apply to Hudi tables.
   emptySplit_ = false;
   if (baseReader_->numberOfRows() == 0) {
@@ -531,6 +538,13 @@ uint64_t SplitReader::next(int64_t size, VectorPtr& output) {
     rows = baseRowReader_->next(size, output);
   }
   populatePaimonMetadataColumns(output);
+
+  // only for testing
+  if (UNLIKELY(!FLAGS_testing_only_set_scan_exception_mesg_for_next.empty())) {
+    throw std::runtime_error(
+        FLAGS_testing_only_set_scan_exception_mesg_for_next);
+  }
+
   return rows;
 }
 

--- a/bolt/connectors/hive/SplitReader.h
+++ b/bolt/connectors/hive/SplitReader.h
@@ -35,6 +35,10 @@
 #include "bolt/connectors/hive/HiveSplitReaderBase.h"
 #include "bolt/connectors/hive/PaimonMetadataColumn.h"
 #include "bolt/dwio/common/Options.h"
+
+DECLARE_string(testing_only_set_scan_exception_mesg_for_prepare);
+DECLARE_string(testing_only_set_scan_exception_mesg_for_next);
+
 namespace bytedance::bolt {
 class BaseVector;
 class variant;

--- a/bolt/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/bolt/exec/tests/utils/AssertQueryBuilder.cpp
@@ -87,6 +87,11 @@ AssertQueryBuilder& AssertQueryBuilder::serialExecution(bool serial) {
   return *this;
 }
 
+AssertQueryBuilder& AssertQueryBuilder::taskId(const std::string& taskId) {
+  params_.taskId = taskId;
+  return *this;
+}
+
 AssertQueryBuilder& AssertQueryBuilder::config(
     const std::string& key,
     const std::string& value) {

--- a/bolt/exec/tests/utils/AssertQueryBuilder.h
+++ b/bolt/exec/tests/utils/AssertQueryBuilder.h
@@ -57,6 +57,9 @@ class AssertQueryBuilder {
   /// Default is false.
   AssertQueryBuilder& serialExecution(bool serial);
 
+  /// Set task id if need
+  AssertQueryBuilder& taskId(const std::string& taskId);
+
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);

--- a/bolt/exec/tests/utils/Cursor.cpp
+++ b/bolt/exec/tests/utils/Cursor.cpp
@@ -155,7 +155,11 @@ class TaskCursorBase : public TaskCursor {
       const CursorParameters& params,
       const std::shared_ptr<folly::Executor>& executor) {
     static std::atomic<int32_t> cursorId;
-    taskId_ = fmt::format("test_cursor_{}", ++cursorId);
+    if (params.taskId.has_value()) {
+      taskId_ = *params.taskId;
+    } else {
+      taskId_ = fmt::format("test_cursor_{}", ++cursorId);
+    }
 
     if (params.queryCtx) {
       queryCtx_ = params.queryCtx;

--- a/bolt/exec/tests/utils/Cursor.h
+++ b/bolt/exec/tests/utils/Cursor.h
@@ -33,6 +33,9 @@
 #include "bolt/core/PlanNode.h"
 #include "bolt/exec/Driver.h"
 #include "bolt/exec/Task.h"
+
+#include <optional>
+
 namespace bytedance::bolt::exec::test {
 
 /// Wait up to maxWaitMicros for all the task drivers to finish. The function
@@ -102,6 +105,8 @@ struct CursorParameters {
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations
   /// in 'queryCtx' will be overridden by 'queryConfig'.
   std::unordered_map<std::string, std::string> queryConfigs;
+
+  std::optional<std::string> taskId;
 };
 
 class TaskQueue {

--- a/bolt/flag_definitions/flags.cpp
+++ b/bolt/flag_definitions/flags.cpp
@@ -121,3 +121,12 @@ DEFINE_int32(
     "shuffle_zstd_compression_level");
 
 DEFINE_bool(bolt_ssd_odirect, true, "Use O_DIRECT for SSD cache IO");
+
+DEFINE_string(
+    testing_only_set_scan_exception_mesg_for_prepare,
+    "",
+    "Only used in testing env. Throwing std::exception when call SplitReader::prepareSplit");
+DEFINE_string(
+    testing_only_set_scan_exception_mesg_for_next,
+    "",
+    "Only used in testing env. Throwing std::exception when call SplitReader::next");


### PR DESCRIPTION
<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #51 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

#### Summary:

This PR introduces an optimization for Hash Join in Array mode. When the build side has low cardinality but a high number of rows (high duplication factor), the linked lists in the hash table often point to scattered memory locations in the RowContainer. This causes severe cache thrashing during the probe phase.

This change adds a tryRecluster step in HashTable::prepareJoinTable. If the duplication ratio exceeds a threshold, it creates a new, sorted RowContainer where rows with the same key are stored contiguously.

#### Implementation Details:

Added QueryConfig for enable_hash_join_array_recluster.
Implemented reclusterDataByKey in HashTable or by sort.
Implemented RowContainer::cloneByOrder to deep copy rows into a new container based on the sorted order.
Added logic to estimate Probe side row count to decide if optimization costs are justified.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
<details>
    <summary>Click to view Benchmark Results</summary>

**Performance Results (TPC-DS 100G):**

Environment:
```
spark.master                     local[32]
spark.executor.memoryOverhead    5g
spark.driver.maxResultSize       2g
spark.driver.memory              40g
spark.executor.memory            40g
spark.memory.offHeap.enabled     true
spark.memory.offHeap.size        30g
spark.gluten.memory.task.offHeap.size.in.bytes 102400
spark.gluten.memory.offHeap.size.in.bytes 1024000
spark.executor.instances         1
spark.executor.cores             1
```
BF config:
```
spark.sql.optimizer.runtime.bloomFilter.enabled true
spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold 0
```

Pre-sorted: Sort inventory by inv_item_sk
Target Query: Q72 (High duplication, low cardinality join).

| Scenario         | Optimization        | Time (s)   | Improvement |
| :--------------- | :------------------ | :--------- | :---------- |
| **BF Disabled**  | Baseline            | 2112.70    | -           |
| **BF Disabled**  | **New (Recluster)** | **620.66** | **3.4x**    |
| BF Enabled       | Baseline            | 20.18      | -           |
| BF Enabled       | New (Recluster)     | 20.30      | Neutral     |
| Pre-sorted Input | Baseline            | 630.44     | -           |
| Pre-sorted Input | New (Recluster)     | 496.33     | ~1.27x      |

For simple query on tpcds 100G
```
SELECT count(*) total_cnt
FROM   catalog_sales
       JOIN inventory
         ON cs_item_sk = inv_item_sk; 
```
Baseline: 1711.516s
 **New: 178.003s** 

**Analysis:**

- **Significant Gain:** When Bloom Filter is disabled (or theoretically when filter selectivity is low), the optimization reduces execution time by 3.4x. This confirms the bottleneck was indeed random memory access.
- **Neutral with BF:** With aggressive Runtime Bloom Filters, the probe phase is skipped for most rows, hiding the hash table lookup latency. However, this optimization makes the operator much more robust.
- **With Pre Sort:** Even when inputs are pre-sorted (Pre-sorted Input case), strictly reclustering in the `RowContainer` yields an additional ~27% speedup (630s -> 496s) because it guarantees physical compactness better than the upstream iterator order (which might be chunked).

</details>

- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
Introduces an optimization for Hash Join in Array mode. When the build side has low cardinality but a high number of rows (high duplication factor), the linked lists in the hash table often point to scattered memory locations in the RowContainer. This causes severe cache thrashing during the probe phase.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
<details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
</details>  
