### PR TITLE
feat: support constant value for lead/lag

### DIFF
--- a/bolt/exec/Window.cpp
+++ b/bolt/exec/Window.cpp
@@ -1066,7 +1066,8 @@ bool Window::isSpillableWindowBuild() {
     } else if (
         supportedNonAggFunc.find(sanitizedName) != supportedNonAggFunc.end()) {
       // lead/lag, but offset not 1
-      if (!supportedNonAggWindowFuncOffsetBySpill(windowNodeFunction)) {
+      if (!supportedNonAggWindowFuncOffsetBySpill(windowNodeFunction) ||
+          (windowNodeFunction.ignoreNulls)) {
         // for offset >= 2 in lead/lag, spillableWindow does not support
         // supportedNonAggWindowFuncOffsetBySpill() returns
         // - false if offset >=2

--- a/bolt/exec/WindowBuild.h
+++ b/bolt/exec/WindowBuild.h
@@ -88,7 +88,7 @@ class WindowBuild {
   /// Returns the spiller stats including total bytes and rows spilled so far.
   std::optional<common::SpillStats> spilledStats() const {
     return sortSpiller_ ? std::make_optional(sortSpiller_->stats())
-                        : std::nullopt;
+                        : windowSpilledStats();
   }
 
   /// Returns the spiller stats including total bytes and rows spilled so far.


### PR DESCRIPTION
<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #66 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail. 
For complex logic, explain the "Why" and "How". 

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
