### PR TITLE
[fix][shuffle] Ensure a minimum memory limit for the shuffle writer to avoid performance fallback

### DIFF
--- a/bolt/shuffle/sparksql/ShuffleWriterNode.h
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.h
@@ -131,6 +131,7 @@ class SparkShuffleWriter : public bytedance::bolt::exec::Operator {
  private:
   std::once_flag initOnceFlag_;
   ShuffleWriterOptions shuffleWriterOptions_;
+  uint64_t minMemLimit_;
   std::unique_ptr<BoltArrowMemoryPool> arrowPool_;
   std::shared_ptr<BoltShuffleWriter> shuffleWriter_;
   bool finished_ = false;


### PR DESCRIPTION
…ance fallback

<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #68 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
BoltShuffleWriter currently has no minimum memory limit. When memory is very constrained, it may trigger spills very frequently, resulting in excessively small compression batches and a significantly larger shuffle output size.

This patch enforces a minimum memory threshold for the shuffle writer using spark.gluten.sql.columnar.maxShuffleBatchByteSize, with a default value of 40 MB.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**:

before fix duration: 15h+, Stage 1 shuffle writer size: 18.5TB
<img width="2550" height="228" alt="截屏2026-01-04 10 50 08" src="https://github.com/user-attachments/assets/f4506b3b-b379-47f0-8de8-d8359bc1a726" />

after fix duration: 1.4h, Stage 1 shuffle write size: 5.0TB

<img width="2530" height="244" alt="image" src="https://github.com/user-attachments/assets/ac1c206e-ab45-42b3-bc5c-a692677bcd25" />


- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).



### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
