### PR TITLE
[fix][shuffle] Try reserve memory with precise memory compute by compact row in row based shuffle

### DIFF
--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -97,14 +97,6 @@ arrow::Status BoltRowBasedSortShuffleWriter::split(
       isInitialized_ = true;
     }
 
-    // calc rv memory size and try reserve, reserve failed
-    auto incrementSize = std::max(
-        rv->estimateFlatSize(), rv->size() * rowConverter_->averageRowSize());
-    if (!boltPool_->maybeReserve(incrementSize)) {
-      RETURN_NOT_OK(tryEvict());
-      requestSpill_ = false;
-    }
-
     // estimate batchSize based on UnsafeRowSize
     slicedBatchSize = rowConverter_->averageRowSize()
         ? (options_.recommendedColumn2RowSize / rowConverter_->averageRowSize())
@@ -140,13 +132,18 @@ arrow::Status BoltRowBasedSortShuffleWriter::split(
       RETURN_NOT_OK(partitioner_->compute(
           pidArr, rv->size(), row2Partition_, partition2RowCount_));
       strippedRv = getStrippedRowVectorWrapper(*rv);
-      setSplitState(SplitState::kSplit);
+    }
+    auto rowVectorWithStats = rowConverter_->getWithStats(strippedRv);
+    if (!boltPool_->maybeReserve(rowVectorWithStats.getTotalMemorySize())) {
+      RETURN_NOT_OK(tryEvict());
+      requestSpill_ = false;
     }
     // RowVector->UnsafeRow
     {
+      setSplitState(SplitState::kSplit);
       bytedance::bolt::NanosecondTimer timer(&convertTime_);
       rowConverter_->convert(
-          strippedRv, row2Partition_, sortedRows_, partitionBytes_);
+          rowVectorWithStats, row2Partition_, sortedRows_, partitionBytes_);
     }
   }
 

--- a/bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.cpp
+++ b/bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.cpp
@@ -46,40 +46,42 @@ void ShuffleColumnarToRowConverter::init(
   }
 }
 
-void ShuffleColumnarToRowConverter::refreshStates(
+ShuffleColumnarToRowConverter::RowVectorWithStats
+ShuffleColumnarToRowConverter::getWithStats(
     const bytedance::bolt::RowVectorPtr& rowVector) {
-  compactRow_ = std::make_unique<bolt::row::CompactRow>(rowVector);
-
-  size_t totalMemorySize = 0;
+  RowVectorWithStats stats;
+  stats.compactRow = std::make_shared<bolt::row::CompactRow>(rowVector);
+  stats.numRows = rowVector->size();
+  stats.totalMemorySize = 0;
   auto numRows = rowVector->size();
   if (fixedRowSize_) {
-    totalMemorySize = fixedRowSize_ * numRows;
+    stats.totalMemorySize = fixedRowSize_ * numRows;
   } else {
     for (auto i = 0; i < numRows; ++i) {
-      totalMemorySize += compactRow_->rowSize(i);
+      stats.totalMemorySize += stats.compactRow->rowSize(i);
     }
   }
   // layout : rowSize | unsafeRow
-  totalMemorySize += numRows * kSizeOfRowHeader;
-  totalBufferSize_ += totalMemorySize;
-
-  boltBuffers_.emplace_back(
-      RowInternalBuffer::allocate(totalMemorySize, boltPool_));
-  bufferAddress_ = boltBuffers_.back()->mutable_data();
-  memset(bufferAddress_, 0, sizeof(int8_t) * totalMemorySize);
-  averageRowSize_ = numRows ? (totalMemorySize / numRows) : 0;
+  stats.totalMemorySize += numRows * kSizeOfRowHeader;
+  return stats;
 }
 
 void ShuffleColumnarToRowConverter::convert(
-    const bytedance::bolt::RowVectorPtr& rowVector,
+    const RowVectorWithStats& rowVector,
     const std::vector<uint32_t>& indexes,
     std::vector<std::vector<uint8_t*>>& sortedRows,
     std::vector<int64_t>& partitionBytes) {
-  refreshStates(rowVector);
-
+  auto numRows = rowVector.numRows;
+  totalBufferSize_ += rowVector.totalMemorySize;
+  boltBuffers_.emplace_back(
+      RowInternalBuffer::allocate(rowVector.totalMemorySize, boltPool_));
+  bufferAddress_ = boltBuffers_.back()->mutable_data();
+  memset(bufferAddress_, 0, sizeof(int8_t) * rowVector.totalMemorySize);
+  averageRowSize_ = numRows ? (rowVector.totalMemorySize / numRows) : 0;
   size_t offset = kSizeOfRowHeader;
-  for (auto i = 0; i < rowVector->size(); ++i) {
-    auto rowSize = compactRow_->serialize(i, (char*)(bufferAddress_ + offset));
+  for (auto i = 0; i < numRows; ++i) {
+    auto rowSize =
+        rowVector.compactRow->serialize(i, (char*)(bufferAddress_ + offset));
     // set rowSize
     *(int32_t*)(bufferAddress_ + offset - kSizeOfRowHeader) = rowSize;
     sortedRows[indexes[i]].push_back(

--- a/bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.h
+++ b/bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.h
@@ -88,8 +88,25 @@ class ShuffleColumnarToRowConverter {
     init(rowType);
   }
 
+  class RowVectorWithStats {
+    friend class ShuffleColumnarToRowConverter;
+
+   public:
+    int64_t getTotalMemorySize() {
+      return totalMemorySize;
+    }
+
+   private:
+    std::shared_ptr<bytedance::bolt::row::CompactRow> compactRow;
+    int64_t numRows;
+    int64_t totalMemorySize;
+  };
+
+  RowVectorWithStats getWithStats(
+      const bytedance::bolt::RowVectorPtr& rowVector);
+
   void convert(
-      const bytedance::bolt::RowVectorPtr& rowVector,
+      const RowVectorWithStats& rowVector,
       const std::vector<uint32_t>& indexes,
       std::vector<std::vector<uint8_t*>>& sortedRows,
       std::vector<int64_t>& partitionBytes);
@@ -109,14 +126,12 @@ class ShuffleColumnarToRowConverter {
 
  private:
   void init(const bytedance::bolt::RowTypePtr& rowType);
-  void refreshStates(const bytedance::bolt::RowVectorPtr& rowVector);
 
   int32_t fixedRowSize_ = 0;
   uint8_t* bufferAddress_;
   int64_t totalBufferSize_{0};
   size_t averageRowSize_{0};
   bytedance::bolt::memory::MemoryPool* boltPool_;
-  std::shared_ptr<bytedance::bolt::row::CompactRow> compactRow_;
   std::vector<RowInternalBufferPtr> boltBuffers_;
 };
 


### PR DESCRIPTION
<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #69 

Row-based shuffle reserves memory based on the estimated flattened size of the row vector. However, this estimate often deviates from the actual memory usage during the split phase. To bridge the gap between reserved and actual memory consumption, we should calculate the precise size of the CompactRow and reserve the exact amount required before the split occurs.


### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail. 
For complex logic, explain the "Why" and "How". 

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**:

Test with a internal workload

| Scenario       | Failed Tasks | OOM Tasks | RuntimeException |
|-------------|--------------|----------------------|------------------|
| Before fix   | 605          | ~480                 | 60               |
| After fix    | 327          | ~100                 | 2 (OOM-related)  |




- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).


### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
