### PR TITLE
enable error=return-type and fix compiling errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,7 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-type-limits \
          -Wno-stringop-overflow \
          -Wno-stringop-overread \
-         -Wno-return-type")
+        ")
   endif()
 
   set(KNOWN_WARNINGS

--- a/bolt/connectors/hive/PaimonSplitReader.cpp
+++ b/bolt/connectors/hive/PaimonSplitReader.cpp
@@ -274,6 +274,7 @@ std::shared_ptr<PaimonEngine> PaimonSplitReader::getMergeEngine() {
       return std::make_shared<PartialUpdateEngine>(
           ignoreDelete_, aggregations_, sequenceGroups_);
     case PaimonMergeEngineType::FirstRow:
+    default:
       throw std::runtime_error("FirstRow engine is shouldn't come here.");
   }
 }

--- a/bolt/connectors/hive/paimon_merge_engines/PaimonRowKind.cpp
+++ b/bolt/connectors/hive/paimon_merge_engines/PaimonRowKind.cpp
@@ -27,6 +27,8 @@ const char* toString(PaimonRowKind rowKind) {
       return "+U";
     case PaimonRowKind::DELETE:
       return "-D";
+    default:
+      return "UNKNOWN_ROW_KIND";
   }
 }
 

--- a/bolt/exec/fuzzer/AggregationFuzzer.cpp
+++ b/bolt/exec/fuzzer/AggregationFuzzer.cpp
@@ -713,6 +713,7 @@ bool AggregationFuzzer::verifyWindow(
     if (!reproPersistPath_.empty()) {
       persistReproInfo({{plan, {}}}, reproPersistPath_);
     }
+    return true;
   }
 }
 
@@ -1110,6 +1111,7 @@ bool AggregationFuzzer::compareEquivalentPlanResults(
     if (!reproPersistPath_.empty()) {
       persistReproInfo(plans, reproPersistPath_);
     }
+    return true;
   }
 }
 

--- a/bolt/exec/tests/TableWriteTest.cpp
+++ b/bolt/exec/tests/TableWriteTest.cpp
@@ -80,6 +80,8 @@ std::string testModeString(TestMode mode) {
       return "BUCKETED";
     case TestMode::kOnlyBucketed:
       return "BUCKETED (NOT PARTITIONED)";
+    default:
+      return "UNKNOWN";
   }
 }
 

--- a/bolt/functions/lib/DateTimeFormatter.cpp
+++ b/bolt/functions/lib/DateTimeFormatter.cpp
@@ -594,6 +594,8 @@ std::string getSpecifierName(DateTimeFormatSpecifier s) {
       return "WEEK_OF_MONTH";
     case DateTimeFormatSpecifier::DAY_OF_WEEK_IN_MONTH:
       return "DAY_OF_WEEK_IN_MONTH";
+    default:
+      return "UNKNOWN_SPECIFIER";
   }
 }
 


### PR DESCRIPTION
forgotten return will cause coredump which is hard to debug.
enable error=return-type by default

<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail. 
For complex logic, explain the "Why" and "How". 

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
