### PR TITLE
[expr][ut] Add Unit Test about constant compare with column

### DIFF
--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -4475,3 +4475,90 @@ TEST_F(TableScanTest, orcDecimalFilter) {
   auto amount = rows->childAt(1)->asFlatVector<int64_t>();
   ASSERT_TRUE(amount);
 }
+
+TEST_F(TableScanTest, constantCompareWithCol) {
+  {
+    auto filePaths = makeFilePaths(1);
+    auto size = 300;
+    auto rowVector = makeRowVector(
+        {makeFlatVector<int32_t>(size, [](auto row) { return 100; }),
+         makeFlatVector<int32_t>(size, [](auto row) { return 300; })});
+
+    writeToFile(filePaths[0]->path, rowVector);
+    createDuckDbTable({rowVector});
+
+    std::string filter = "100 >= c0";
+
+    auto task = TableScanTest::assertQuery(
+        PlanBuilder(pool_.get())
+            .tableScan(ROW({"c0", "c1"}, {INTEGER(), INTEGER()}), {filter})
+            .planNode(),
+        filePaths,
+        "SELECT c0,c1 FROM tmp WHERE " + filter);
+
+    EXPECT_EQ(size, getTableScanStats(task).outputRows);
+  }
+  {
+    auto filePaths = makeFilePaths(1);
+    auto size = 300;
+    auto rowVector = makeRowVector(
+        {makeFlatVector<int32_t>(size, [](auto row) { return 100; }),
+         makeFlatVector<int32_t>(size, [](auto row) { return 300; })});
+
+    writeToFile(filePaths[0]->path, rowVector);
+    createDuckDbTable({rowVector});
+
+    std::string filter = "100 > c0";
+
+    auto task = TableScanTest::assertQuery(
+        PlanBuilder(pool_.get())
+            .tableScan(ROW({"c0", "c1"}, {INTEGER(), INTEGER()}), {filter})
+            .planNode(),
+        filePaths,
+        "SELECT c0,c1 FROM tmp WHERE " + filter);
+
+    EXPECT_EQ(0, getTableScanStats(task).outputRows);
+  }
+  {
+    auto filePaths = makeFilePaths(1);
+    auto size = 300;
+    auto rowVector = makeRowVector(
+        {makeFlatVector<int32_t>(size, [](auto row) { return 100; }),
+         makeFlatVector<int32_t>(size, [](auto row) { return 300; })});
+
+    writeToFile(filePaths[0]->path, rowVector);
+    createDuckDbTable({rowVector});
+
+    std::string filter = "100 <= c0";
+
+    auto task = TableScanTest::assertQuery(
+        PlanBuilder(pool_.get())
+            .tableScan(ROW({"c0", "c1"}, {INTEGER(), INTEGER()}), {filter})
+            .planNode(),
+        filePaths,
+        "SELECT c0,c1 FROM tmp WHERE " + filter);
+
+    EXPECT_EQ(size, getTableScanStats(task).outputRows);
+  }
+  {
+    auto filePaths = makeFilePaths(1);
+    auto size = 300;
+    auto rowVector = makeRowVector(
+        {makeFlatVector<int32_t>(size, [](auto row) { return 100; }),
+         makeFlatVector<int32_t>(size, [](auto row) { return 300; })});
+
+    writeToFile(filePaths[0]->path, rowVector);
+    createDuckDbTable({rowVector});
+
+    std::string filter = "100 < c0";
+
+    auto task = TableScanTest::assertQuery(
+        PlanBuilder(pool_.get())
+            .tableScan(ROW({"c0", "c1"}, {INTEGER(), INTEGER()}), {filter})
+            .planNode(),
+        filePaths,
+        "SELECT c0,c1 FROM tmp WHERE " + filter);
+
+    EXPECT_EQ(0, getTableScanStats(task).outputRows);
+  }
+}


### PR DESCRIPTION
<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close https://github.com/bytedance/bolt/issues/82

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

As described in issue https://github.com/bytedance/bolt/issues/82, there was a bug with subfeit pushdown. However, I eventually discovered that this code only existed in the internal Bytedance repository and not in the GitHub repository (it was removed by commit https://github.com/bytedance/bolt/commit/2d88e8a61218505c7124633736512599aaa68073). Therefore, I only added the unit test without applying the fix.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Add Unit Test about filter pushdown in TableScan.

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
