### PR TITLE
Refactor the cmake target names from the adopted Arrow

### DIFF
--- a/bolt/dwio/parquet/arrow/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/CMakeLists.txt
@@ -34,7 +34,7 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 add_library(
-  bolt_dwio_arrow_parquet_writer_lib
+  bolt_dwio_parquet_arrow_lib
   ArrowSchema.cpp
   ArrowSchemaInternal.cpp
   ColumnWriter.cpp
@@ -59,9 +59,9 @@ add_library(
   Writer.cpp)
 
 target_link_libraries(
-  bolt_dwio_arrow_parquet_writer_lib
-  bolt_dwio_arrow_parquet_writer_util_lib
-  bolt_dwio_arrow_parquet_writer_thrift_lib
+  bolt_dwio_parquet_arrow_lib
+  bolt_dwio_parquet_arrow_util_lib
+  bolt_dwio_parquet_arrow_thrift_lib
   bolt_dwio_common
   bolt_arrow_bridge
   bolt_process

--- a/bolt/dwio/parquet/arrow/generated/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/generated/CMakeLists.txt
@@ -26,7 +26,7 @@
 # --------------------------------------------------------------------------
 
 
-add_library(bolt_dwio_arrow_parquet_writer_thrift_lib parquet_types.cpp)
+add_library(bolt_dwio_parquet_arrow_thrift_lib parquet_types.cpp)
 
-target_link_libraries(bolt_dwio_arrow_parquet_writer_thrift_lib arrow::arrow
+target_link_libraries(bolt_dwio_parquet_arrow_thrift_lib arrow::arrow
                       Boost::headers)

--- a/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
@@ -27,7 +27,7 @@
 
 
 add_executable(
-  bolt_dwio_arrow_parquet_writer_test
+  bolt_dwio_parquet_arrow_test
   BloomFilterTest.cpp
   ColumnReaderTest.cpp
   ColumnWriterTest.cpp
@@ -43,12 +43,12 @@ add_executable(
   TypesTest.cpp
   LZ4HadoopCodecTest.cpp)
 
-add_test(bolt_dwio_arrow_parquet_writer_test
-         bolt_dwio_arrow_parquet_writer_test)
+add_test(bolt_dwio_parquet_arrow_test
+         bolt_dwio_parquet_arrow_test)
 target_link_libraries(
-  bolt_dwio_arrow_parquet_writer_test
-  bolt_dwio_arrow_parquet_writer_lib
-  bolt_dwio_arrow_parquet_writer_test_lib
+  bolt_dwio_parquet_arrow_test
+  bolt_dwio_parquet_arrow_lib
+  bolt_dwio_parquet_arrow_test_lib
   GTest::gmock
   arrow::arrow
   arrow::libarrow_testing
@@ -58,7 +58,7 @@ target_link_libraries(
   GTest::gtest_main)
 
 add_library(
-  bolt_dwio_arrow_parquet_writer_test_lib
+  bolt_dwio_parquet_arrow_test_lib
   BloomFilter.cpp
   BloomFilterReader.cpp
   ColumnReader.cpp
@@ -67,5 +67,5 @@ add_library(
   TestUtil.cpp
   XxHasher.cpp)
 
-target_link_libraries(bolt_dwio_arrow_parquet_writer_test_lib
-                      bolt_dwio_arrow_parquet_writer_lib arrow::arrow GTest::gtest GTest::gtest_main)
+target_link_libraries(bolt_dwio_parquet_arrow_test_lib
+                      bolt_dwio_parquet_arrow_lib arrow::arrow GTest::gtest GTest::gtest_main)

--- a/bolt/dwio/parquet/arrow/util/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/util/CMakeLists.txt
@@ -27,7 +27,7 @@
 
 
 add_library(
-  bolt_dwio_arrow_parquet_writer_util_lib
+  bolt_dwio_parquet_arrow_util_lib
   Compression.cpp
   CompressionSnappy.cpp
   CompressionZstd.cpp
@@ -39,7 +39,7 @@ add_library(
 find_package(xxHash CONFIG REQUIRED)
 
 target_link_libraries(
-  bolt_dwio_arrow_parquet_writer_util_lib
+  bolt_dwio_parquet_arrow_util_lib
   arrow::arrow
   Snappy::snappy
   zstd::libzstd_static

--- a/bolt/dwio/parquet/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/reader/CMakeLists.txt
@@ -67,7 +67,7 @@ add_library(bolt_dwio_native_parquet_reader_cli STATIC ParquetReaderCli.cpp)
 
 target_link_libraries(bolt_dwio_native_parquet_reader_cli
         bolt_dwio_parquet_reader
-        bolt_dwio_arrow_parquet_writer_lib
+        bolt_dwio_parquet_arrow_lib
         bolt_dwio_native_parquet_reader
         bolt_dwio_common
         bolt_hdfs)

--- a/bolt/dwio/parquet/writer/CMakeLists.txt
+++ b/bolt/dwio/parquet/writer/CMakeLists.txt
@@ -31,8 +31,8 @@ find_package(Snappy CONFIG REQUIRED)
 
 target_link_libraries(
   bolt_dwio_arrow_parquet_writer
-  bolt_dwio_arrow_parquet_writer_lib
-  bolt_dwio_arrow_parquet_writer_util_lib
+  bolt_dwio_parquet_arrow_lib
+  bolt_dwio_parquet_arrow_util_lib
   bolt_dwio_common
   bolt_arrow_bridge
   arrow::arrow


### PR DESCRIPTION

<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
This commit refactors the cmake target names under dwio/parquet/arrow to make sure these names are consistent with their path.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
