### PR TITLE
Support value type varchar in aggregate_map_sum to be consistent with Spark

### DIFF
--- a/bolt/functions/prestosql/aggregates/MapSumAggregate.cpp
+++ b/bolt/functions/prestosql/aggregates/MapSumAggregate.cpp
@@ -338,6 +338,9 @@ std::unique_ptr<exec::Aggregate> constructImpl(
       case TypeKind::DOUBLE:
         return std::make_unique<MapSumAggregate<false, TypeKind::DOUBLE>>(
             resultType, valueType);
+      case TypeKind::VARCHAR:
+        return std::make_unique<MapSumAggregate<false, TypeKind::VARCHAR>>(
+            resultType, valueType);
       default:
         BOLT_FAIL(fmt::format(
             "aggregate_map_sum: invalid value type: {}",
@@ -368,7 +371,7 @@ exec::AggregateRegistrationResult registerMapSum(
         BOLT_USER_CHECK_EQ(argTypes.size(), 1);
         auto type = argTypes[0];
         auto errorMsg = fmt::format(
-            "the argument of {} must be map(varchar, integer type/float type/decimal)",
+            "the argument of {} must be map(varchar, integer type/float type/decimal/varchar)",
             name);
         BOLT_USER_CHECK(type->isMap(), errorMsg);
         auto keyType = type->childAt(0);
@@ -378,7 +381,7 @@ exec::AggregateRegistrationResult registerMapSum(
             valueType->isTinyint() || valueType->isSmallint() ||
                 valueType->isInteger() || valueType->isBigint() ||
                 valueType->isDouble() || valueType->isReal() ||
-                valueType->isDecimal(),
+                valueType->isDecimal() || valueType->isVarchar(),
             errorMsg);
         return constructImpl(resultType, valueType);
       },

--- a/bolt/functions/prestosql/aggregates/tests/MapSumAggregateTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/MapSumAggregateTest.cpp
@@ -521,5 +521,31 @@ TEST_F(MapSumAggTest, castTruncate) {
       {makeRowVector({expectedVec})});
 }
 
+TEST_F(MapSumAggTest, simpleStringValue) {
+  auto data = std::vector<
+      std::vector<std::pair<StringView, std::optional<StringView>>>>{
+      {{"0", "1"}}, {{"0", "2"}}};
+  auto expected = getExpectedResult(
+      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
+          {{"0", 1}}, {{"0", 2}}});
+  testGlobal<false, StringView>(data, expected);
+}
+
+TEST_F(MapSumAggTest, stringCastTruncate) {
+  auto data = std::vector<
+      std::vector<std::pair<StringView, std::optional<StringView>>>>{
+      {{"0", "1.9"}}};
+  auto expected =
+      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
+          {{"0", 1}}};
+  auto inputVec = makeMapVector(data);
+  auto expectedVec = makeMapVector(expected);
+  testAggregations(
+      {makeRowVector({inputVec})},
+      {},
+      {"aggregate_map_sum(c0)"},
+      {makeRowVector({expectedVec})});
+}
+
 }; // namespace
 }; // namespace bytedance::bolt::aggregate::test


### PR DESCRIPTION
… Spark

<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
Issue Number: close #92

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
- Support Varchar value type in aggregate_map_sum to be consistent with Spark.
- Varchar string will automatically be cast to int64_t during execution.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

- Support Varchar value type in aggregate_map_sum to be consistent with Spark.
- Varchar string will automatically be cast to int64_t during execution.

Release Note:

```text
Release Note:
- Support Varchar value type in aggregate_map_sum to be consistent with Spark.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
