### PR TITLE
Add workflow to upload build dependencies to CI conan server

### DIFF
--- a/.github/runners/Dockerfile.conanserver
+++ b/.github/runners/Dockerfile.conanserver
@@ -41,4 +41,4 @@ RUN chmod +x /usr/local/bin/start-conan-server.sh
 EXPOSE 9300
 
 # Start Conan server using the custom script
-CMD ["/usr/local/bin/start-conan-server.sh", "--no-admin"]
+CMD ["/usr/local/bin/start-conan-server.sh"]

--- a/.github/runners/conanserver/start-conan-server.sh
+++ b/.github/runners/conanserver/start-conan-server.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# check if $1 exists, and is "--no-admin"
-ARG=${1:-""}
-if [[ "${ARG}" == "--no-admin" ]]; then
+if [[ -n ${CONAN_ADMIN_USER+x} ]] || [[ -n ${CONAN_ADMIN_PASSWORD+x} ]]; then
+    echo "Starting conan server with admin credentials"
+    NEEDS_ADMIN=1
+else
     echo "Starting read-only conan server"
     NEEDS_ADMIN=0
-    shift
-else
-    NEEDS_ADMIN=1
-fi  
+fi
+
 
 
 if [[ "$NEEDS_ADMIN" == "1" ]]; then

--- a/.github/workflows/conan-upload.yml
+++ b/.github/workflows/conan-upload.yml
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Conan CI Dependency Upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: Build type to use for Conan install/export
+        required: true
+        type: choice
+        options: [Release, Debug]
+        default: Release
+
+env:
+  CCACHE_DIR: /data/ccache-data
+  CCACHE_MAX_SIZE: '100G'
+  CI_NUM_THREADS: "16"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upload:
+    runs-on: [ self-hosted, medium ]
+    container:
+      image: bolt-registry:5000/bolt-ci:20251217
+      options: --user root
+      volumes:
+        - /data/ccache-data:/data/ccache-data
+    services:
+      conanserver:
+        image: bolt-registry:5000/conan-server:latest
+        env:
+          CONAN_ADMIN_USER: ${{ secrets.CONAN_ADMIN_USERNAME }}
+          CONAN_ADMIN_PASSWORD: ${{ secrets.CONAN_ADMIN_PASSWORD }}
+        volumes:
+          - /data/conan-server-data:/var/conan/data
+    strategy:
+      matrix:
+        build_options:
+          - ""
+          - "-o '*:spark_compatible=True'"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - id: env-setup
+        uses: ./.github/actions/bolt-build-base
+
+      - name: Conan install
+        run: |
+          conan install ${{ matrix.build_options }} -s llvm-core/*:build_type=Release -s build_type=${{ inputs.build_type }} --build=missing
+
+      - name: Upload packages to conan remote
+        env:
+          CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_ADMIN_USERNAME }}
+          CONAN_PASSWORD: ${{ secrets.CONAN_ADMIN_PASSWORD }}
+        run: |
+          conan remote auth ci
+          conan upload -r ci --confirm "*"


### PR DESCRIPTION
### What problem does this PR solve?

Improve CI build times and maintenance by creating a workflow which automatically publishes the conan dependencies which are required by the build in the `main` branch

Issue Number: close #55 

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Adds the `conan-upload` workflow to our github actions. It will not run on PRs. Only when directly triggered.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

N/A

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)