### PR TITLE
[bugfix] fix build failure 'undefined reference to bytedance::bolt::common::testutil::TestValue::adjust' in TimeZoneMap.cpp

### DIFF
--- a/bolt/type/tz/CMakeLists.txt
+++ b/bolt/type/tz/CMakeLists.txt
@@ -31,4 +31,5 @@ endif()
 add_library(bolt_type_tz TimeZoneMap.h TimeZoneDatabase.cpp TimeZoneMap.cpp TimeZoneNames.cpp)
 
 target_link_libraries(bolt_type_tz ${Boost_REGEX_LIBRARIES} ${FMT}
-                      ${FOLLY_WITH_DEPENDENCIES} date::date)
+                      ${FOLLY_WITH_DEPENDENCIES} date::date
+                      bolt_test_util)


### PR DESCRIPTION
<!-- 
Copyright (c) 2025 ByteDance Ltd. and/or its affiliates.

Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #97

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Link `bolt_type_tz` with `bolt_test_util` to resolve the build failure 'undefined reference to bytedance::bolt::common::testutil::TestValue::adjust' in TimeZoneMap.cpp occurred during `make debug_with_test`.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Link `bolt_type_tz` with `bolt_test_util` to resolve the build failure 'undefined reference to bytedance::bolt::common::testutil::TestValue::adjust' in TimeZoneMap.cpp occurred during `make debug_with_test`.

Release Note:

```text
Release Note:
- Fixed build failure 'undefined reference to bytedance::bolt::common::testutil::TestValue::adjust' in TimeZoneMap.cpp in make debug_with_test
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
