### PR TITLE
[feature] Add Spark checked arithmetic operations functions [Source: Velox (commit 372abeb) Original-Author: zhli1142015]

### DIFF
--- a/bolt/functions/sparksql/registration/RegisterMathArithmetic.cpp
+++ b/bolt/functions/sparksql/registration/RegisterMathArithmetic.cpp
@@ -54,5 +54,11 @@ void registerMathArithmeticFunctions(const std::string& prefix) {
 
   // Power function
   registerFunction<PowerFunction, double, double, double>({prefix + "power"});
+
+  // Checked arithmetic functions
+  registerBinaryNumeric<CheckedAddFunction>({prefix + "checked_add"});
+  registerBinaryNumeric<CheckedSubtractFunction>({prefix + "checked_subtract"});
+  registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "checked_multiply"});
+  registerBinaryNumeric<CheckedDivideFunction>({prefix + "checked_divide"});
 }
 } // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/bolt/functions/sparksql/tests/ArithmeticTest.cpp
@@ -203,6 +203,83 @@ class ArithmeticTest : public SparkFunctionBaseTest {
     return evaluateOnce<double>("divide(c0, c1)", numerator, denominator);
   }
 
+  template <typename T>
+  std::optional<T> checkedAdd(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return evaluateOnce<T>("checked_add(c0, c1)", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> checkedDivide(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return evaluateOnce<T>("checked_divide(c0, c1)", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> checkedMultiply(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return evaluateOnce<T>("checked_multiply(c0, c1)", a, b);
+  }
+
+  template <typename T>
+  std::optional<T> checkedSubtract(
+      const std::optional<T> a,
+      const std::optional<T> b) {
+    return evaluateOnce<T>("checked_subtract(c0, c1)", a, b);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedArithmetic(
+      const std::string& func,
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    auto res = evaluateOnce<T>(fmt::format("try({}(c0, c1))", func), a, b);
+    ASSERT_TRUE(!res.has_value());
+    try {
+      evaluateOnce<T>(fmt::format("{}(c0, c1)", func), a, b);
+      FAIL() << "Expected an error";
+    } catch (const std::exception& e) {
+      ASSERT_TRUE(
+          std::string(e.what()).find(errorMessage) != std::string::npos);
+    }
+  }
+
+  template <typename T>
+  void assertErrorForCheckedAdd(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_add", a, b, errorMessage);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedDivide(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_divide", a, b, errorMessage);
+  }
+
+  template <typename T>
+  void assertErrorForCheckedMultiply(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_multiply", a, b, errorMessage);
+  }
+
+  template <typename T>
+  void assertErrorForcheckedSubtract(
+      const std::optional<T> a,
+      const std::optional<T> b,
+      const std::string& errorMessage) {
+    assertErrorForCheckedArithmetic("checked_subtract", a, b, errorMessage);
+  }
+
   static constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
   static constexpr double kNanDouble = std::numeric_limits<double>::quiet_NaN();
   static constexpr float kInf = std::numeric_limits<float>::infinity();
@@ -667,6 +744,58 @@ TEST_F(ArithmeticTest, expm1) {
   // may be 1.000009e-12, while the true value should be
   // below 1.000000000000005e-12.
   EXPECT_LT(expm1(1e-12), 1.00009e-12);
+}
+
+TEST_F(ArithmeticTest, checkedAdd) {
+  assertErrorForCheckedAdd<int8_t>(INT8_MAX, 1, "Arithmetic overflow: 127 + 1");
+  assertErrorForCheckedAdd<int16_t>(
+      INT16_MAX, 1, "Arithmetic overflow: 32767 + 1");
+  assertErrorForCheckedAdd<int32_t>(
+      INT32_MAX, 1, "Arithmetic overflow: 2147483647 + 1");
+  assertErrorForCheckedAdd<int64_t>(
+      INT64_MAX, 1, "Arithmetic overflow: 9223372036854775807 + 1");
+  EXPECT_EQ(checkedAdd<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedAdd<double>(kInfDouble, 1), kInfDouble);
+}
+
+TEST_F(ArithmeticTest, checkedSubtract) {
+  assertErrorForcheckedSubtract<int8_t>(
+      INT8_MIN, 1, "Arithmetic overflow: -128 - 1");
+  assertErrorForcheckedSubtract<int16_t>(
+      INT16_MIN, 1, "Arithmetic overflow: -32768 - 1");
+  assertErrorForcheckedSubtract<int32_t>(
+      INT32_MIN, 1, "Arithmetic overflow: -2147483648 - 1");
+  assertErrorForcheckedSubtract<int64_t>(
+      INT64_MIN, 1, "Arithmetic overflow: -9223372036854775808 - 1");
+  EXPECT_EQ(checkedSubtract<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedSubtract<double>(kInfDouble, 1), kInfDouble);
+}
+
+TEST_F(ArithmeticTest, checkedMultiply) {
+  assertErrorForCheckedMultiply<int8_t>(
+      INT8_MAX, 2, "Arithmetic overflow: 127 * 2");
+  assertErrorForCheckedMultiply<int16_t>(
+      INT16_MAX, 2, "Arithmetic overflow: 32767 * 2");
+  assertErrorForCheckedMultiply<int32_t>(
+      INT32_MAX, 2, "Arithmetic overflow: 2147483647 * 2");
+  assertErrorForCheckedMultiply<int64_t>(
+      INT64_MAX, 2, "Arithmetic overflow: 9223372036854775807 * 2");
+  EXPECT_EQ(checkedMultiply<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedMultiply<double>(kInfDouble, 1), kInfDouble);
+}
+
+TEST_F(ArithmeticTest, checkedDivide) {
+  assertErrorForCheckedDivide<int32_t>(1, 0, "division by zero");
+  assertErrorForCheckedDivide<int8_t>(
+      INT8_MIN, -1, "Arithmetic overflow: -128 / -1");
+  assertErrorForCheckedDivide<int16_t>(
+      INT16_MIN, -1, "Arithmetic overflow: -32768 / -1");
+  assertErrorForCheckedDivide<int32_t>(
+      INT32_MIN, -1, "Arithmetic overflow: -2147483648 / -1");
+  assertErrorForCheckedDivide<int64_t>(
+      INT64_MIN, -1, "Arithmetic overflow: -9223372036854775808 / -1");
+  EXPECT_EQ(checkedDivide<float>(kInf, 1), kInf);
+  EXPECT_EQ(checkedDivide<double>(kInfDouble, 1), kInfDouble);
 }
 
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?
Cherrypick functions `checked_add`, `checked_subtract`, `checked_multiply`, `checked_divide` from Velox.
### Type of Change
<!-- Please check the one that applies to this PR -->
- [] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Cherrypick spark functions `checked_add`, `checked_subtract`, `checked_multiply`, `checked_divide`  from https://github.com/facebookincubator/velox/commit/372abebc3ded838f2f06544b7c4416db0ec4dab1

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Add Spark checked arithmetic operations functions checked_add, checked_subtract, checked_multiply, checked_divide

Release Note:

```text
Release Note:
- Add Spark checked arithmetic operations functions checked_add, checked_subtract, checked_multiply, checked_divide
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>  
