### PR TITLE
chore: Fix devcontainer and improve pre-commit hooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,13 +20,16 @@
     // Use 'portsAttributes' to set default properties for specific forwarded ports.
     "portsAttributes": {},
     // Use 'remoteEnv' to set environment variables that are only available inside the container.
-    "remoteEnv": {
-    },
+    "remoteEnv": {},
     // Use 'mounts' to make files or directories from your local machine available inside the container.
     "mounts": [
         "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
         "source=conan-cache,target=/home/code/.conan2/p",
         "source=ccache-cache,target=/home/code/.ccache"
+    ],
+    "runArgs": [
+        "--security-opt",
+        "label=disable"
     ],
     // Configure tool-specific properties.
     "features": {}

--- a/.github/runners/Dockerfile.ci
+++ b/.github/runners/Dockerfile.ci
@@ -55,6 +55,8 @@ RUN apt-get update && apt-get install -y \
     less \
     nodejs \
     npm \
+    bsdextrautils \
+    locales \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -73,6 +75,14 @@ RUN https_proxy=${https_proxy} curl -L -# -o /tmp/skywalking-eyes-bin.tgz https:
     sudo tar -C /opt/skywalking-license-eye --strip-components=1 -xzf /tmp/skywalking-eyes-bin.tgz
 
 ENV PATH="/opt/skywalking-license-eye/bin/linux:${PATH}"
+
+RUN export arch=$(arch | sed 's/^aarch64$/arm64/; s/^x86_64$/amd64/') && \
+    export https_proxy=${https_proxy} && \
+    export filename=go1.25.5.linux-${arch}.tar.gz && \
+    curl -L -O --output-dir /tmp https://go.dev/dl/${filename} && \
+    sudo rm -rf /usr/local/bin/go && tar -C /usr/local -xzf /tmp/${filename} && \
+    rm /tmp/${filename}
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Set up default python virtualenv, and make it the default on PATH
 RUN virtualenv -p python3 /opt/venv
@@ -116,6 +126,14 @@ os=Linux
 [conf]
 tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}
 EOF
+
+# Generate Locales
+RUN sudo sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && \
+    sudo locale-gen && \
+    echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc && \
+    echo "export LANG=en_US.UTF-8" >> ~/.bashrc && \
+    echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
+
 
 ENV SHELL=/bin/bash
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         types_or: [c++, c]
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
+    rev: v8.30.0
     hooks:
       - id: gitleaks
 
@@ -29,9 +29,8 @@ repos:
     rev: 0.25.1
     hooks:
     - id: gersemi
+      name: Check CMake files
       args: ["--no-warn-about-unknown-commands"]
-
-
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -46,3 +45,12 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: check-xml
+
+  - repo: local
+    hooks:
+      -   id: license-header-check
+          name: Check for license headers
+          entry: license-eye header check
+          pass_filenames: false
+          language: golang
+          additional_dependencies: ['github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0']


### PR DESCRIPTION
### What problem does this PR solve?

Fixes a small number of outstanding issues in the devcontainer and improves our pre-commit configurations

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Install go 1.25 inside of the devcontainer. I found in `pre-commit run` that gitleaks is not compatible with the default go version of 1.18 in the container
- Update gitleaks to latest v8.30.0
- Add pre-commit hook for license header check
- Add security-opt to devcontainer run args to prevent permission denied (even with sudo) due to SELinux volume labels with podman on MacOS
- Install and configure locales by default

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

N/A

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)