### PR TITLE
fix JIT ut failure

### DIFF
--- a/bolt/jit/LRUCache.h
+++ b/bolt/jit/LRUCache.h
@@ -33,8 +33,8 @@
 #pragma once
 
 #include <list>
-#include <map>
 #include <optional>
+#include <unordered_map>
 
 namespace bytedance::bolt::jit {
 
@@ -45,8 +45,9 @@ class LRUCache {
   using key_type = Key;
   using value_type = Value;
   using list_type = std::list<key_type>;
-  using map_type =
-      std::map<key_type, std::pair<value_type, typename list_type::iterator>>;
+  using map_type = std::unordered_map<
+      key_type,
+      std::pair<value_type, typename list_type::iterator>>;
 
   LRUCache() = default;
   ~LRUCache() = default;
@@ -68,7 +69,7 @@ class LRUCache {
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full
 
-      if (evictPolicy_()) {
+      while (evictPolicy_()) {
         // cache is full, evict the least recently used item
         evict();
       }
@@ -102,11 +103,11 @@ class LRUCache {
 
       // return the value
       return value;
-    } else {
-      // the item is already at the front of the most recently
-      // used list so just return it
-      return i->second.first;
     }
+
+    // the item is already at the front of the most recently
+    // used list so just return it
+    return i->second.first;
   }
 
   void clear() {
@@ -122,7 +123,6 @@ class LRUCache {
     list_.erase(i);
   }
 
- private:
   map_type map_;
   list_type list_;
   EvictPolicy evictPolicy_;

--- a/bolt/jit/ThrustJIT.h
+++ b/bolt/jit/ThrustJIT.h
@@ -218,6 +218,11 @@ class ThrustJIT {
     return jit_memory_usage_limit_;
   }
 
+  // for ut
+  LRUCache<std::string, CompiledModuleSP, CacheEvictPred>& GetCache() {
+    return lruCache_;
+  }
+
  private:
   llvm::Expected<llvm::orc::ThreadSafeModule> optimizeModule(
       llvm::orc::ThreadSafeModule TSM,

--- a/bolt/jit/tests/CMakeLists.txt
+++ b/bolt/jit/tests/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 if(${ENABLE_BOLT_JIT})
 
-  add_executable(bolt_thrustjit_test ThrustJitEngineTest.cpp RowContainerIRTest.cpp)
+  add_executable(bolt_thrustjit_test RowContainerIRTest.cpp ThrustJitEngineTest.cpp )
   target_compile_features(bolt_thrustjit_test PUBLIC cxx_std_20)
   target_link_libraries(
     bolt_thrustjit_test bolt_process bolt_thrustjit bolt_exception GTest::gtest GTest::gtest_main

--- a/bolt/jit/tests/ThrustJitEngineTest.cpp
+++ b/bolt/jit/tests/ThrustJitEngineTest.cpp
@@ -180,6 +180,7 @@ TEST_F(JitEngineTest, cacheLimit) {
     )IR";
 
   constexpr size_t LIMIT = 1024;
+  jit->GetCache().clear();
   jit->SetMemoryLimit(LIMIT);
 
   for (auto i = 0; i < 16; ++i) {
@@ -193,6 +194,7 @@ TEST_F(JitEngineTest, cacheLimit) {
       ASSERT_TRUE(!err);
     });
 
+    // 768 bytes
     CompiledModuleSP mod = jit->CompileModule(std::move(tsm));
 
     typedef int64_t (*FuncProto)(int64_t, int64_t);


### PR DESCRIPTION
* fix UT failure
* fix style

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
