### PR TITLE
fix: try catch execptions in folly::guard

### DIFF
--- a/bolt/common/caching/AsyncDataCache.cpp
+++ b/bolt/common/caching/AsyncDataCache.cpp
@@ -303,9 +303,9 @@ bool CoalescedLoad::loadOrFuture(folly::SemiFuture<bool>* wait) {
     if (isAsyncPreloadThread()) {
       LOG(WARNING) << "thread " << folly::getCurrentThreadName().value()
                    << " CoalescedLoad " << (uint64_t)this << " state "
-                   << (state_ == State::kLoading         ? "kLoading"
-                           : state_ == State::kCancelled ? "kCancelled"
-                                                         : "unExpected")
+                   << (state_ == State::kLoading           ? "kLoading"
+                           : (state_ == State::kCancelled) ? "kCancelled"
+                                                           : "unExpected")
                    << " preload failed: " << e.what();
       setEndState(State::kLoading, State::kPlanned, State::kCancelled);
       return false;
@@ -738,8 +738,8 @@ bool AsyncDataCache::makeSpace(
   auto guard = folly::makeGuard([&]() {
     try {
       allocator_->freeNonContiguous(acquired);
-    } catch (...) {
-      LOG(WARNING) << "Exception from freeNonContiguous()";
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Exception from freeNonContiguous(): " << e.what();
     }
     if (isCounted) {
       --numThreadsInAllocate_;

--- a/bolt/dwio/common/DirectBufferedInput.cpp
+++ b/bolt/dwio/common/DirectBufferedInput.cpp
@@ -250,8 +250,9 @@ void DirectBufferedInput::readRegions(
           auto guard = folly::makeGuard([&]() {
             try {
               asyncLoad.asyncThreadCtx->out();
-            } catch (...) {
-              LOG(WARNING) << "Exception from asyncThreadCtx->out()";
+            } catch (std::exception& e) {
+              LOG(ERROR) << "Exception from asyncThreadCtx->out(): "
+                         << e.what();
             }
           });
           asyncLoad.asyncThreadCtx->in(); // trace in-flight loading

--- a/bolt/exec/TableScan.cpp
+++ b/bolt/exec/TableScan.cpp
@@ -476,10 +476,11 @@ void TableScan::preload(std::shared_ptr<connector::ConnectorSplit> split) {
         // let TableScan::close() wait for this AsyncSource to finish
         auto guard = folly::makeGuard([&] {
           try {
-            if (ctx->asyncThreadCtx())
+            if (ctx->asyncThreadCtx()) {
               ctx->asyncThreadCtx()->out();
-          } catch (...) {
-            LOG(ERROR) << "Exception in TableScan::preload guard";
+            }
+          } catch (std::exception& e) {
+            LOG(ERROR) << "Exception in TableScan::preload guard: " << e.what();
           }
         });
         if (ctx->asyncThreadCtx()) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #141 , #147 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".
Why: 
1. 
```
This program will now terminate because a folly::ScopeGuard callback threw an 

exception.

terminate called after throwing an instance of 'std::system_error'

  what():  Invalid argument

```

2. report asan use-after-free

How: 
1. try cache possible exceptions for folly gurad
2. fix use-after-free in tableScan::preload()

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a core from folly::guard
- Fixed a use-after-free in tableScan::preload()
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
