### PR TITLE
[feat] Enable the hash join to accept a pre-built hash table for joining

### DIFF
--- a/bolt/core/PlanNode.cpp
+++ b/bolt/core/PlanNode.cpp
@@ -1115,6 +1115,10 @@ void HashJoinNode::addDetails(std::stringstream& stream) const {
 }
 
 folly::dynamic HashJoinNode::serialize() const {
+  BOLT_CHECK(
+      reusedHashTableAddress_ == nullptr,
+      "HashJoinNode with reusedHashTableAddress_ cannot be serialized "
+      "across processes or machines");
   auto obj = serializeBase();
   obj["nullAware"] = nullAware_;
   return obj;

--- a/bolt/core/PlanNode.h
+++ b/bolt/core/PlanNode.h
@@ -1783,6 +1783,8 @@ class HashJoinNode : public AbstractJoinNode {
 
   const bool nullAware_;
 
+  // Process-local pointer used only for hash table reuse. It must not be
+  // serialized or used across processes or machines.
   void* reusedHashTableAddress_;
 };
 

--- a/bolt/core/PlanNode.h
+++ b/bolt/core/PlanNode.h
@@ -1699,7 +1699,8 @@ class HashJoinNode : public AbstractJoinNode {
       TypedExprPtr filter,
       PlanNodePtr left,
       PlanNodePtr right,
-      RowTypePtr outputType)
+      RowTypePtr outputType,
+      void* reusedHashTableAddress = nullptr)
       : AbstractJoinNode(
             id,
             joinType,
@@ -1709,7 +1710,8 @@ class HashJoinNode : public AbstractJoinNode {
             std::move(left),
             std::move(right),
             std::move(outputType)),
-        nullAware_{nullAware} {
+        nullAware_{nullAware},
+        reusedHashTableAddress_(reusedHashTableAddress) {
     if (nullAware) {
       BOLT_USER_CHECK(
           isNullAwareSupported(joinType),
@@ -1768,6 +1770,10 @@ class HashJoinNode : public AbstractJoinNode {
     return nullAware_;
   }
 
+  void* reusedHashTableAddress() const {
+    return reusedHashTableAddress_;
+  }
+
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
@@ -1776,6 +1782,8 @@ class HashJoinNode : public AbstractJoinNode {
   void addDetails(std::stringstream& stream) const override;
 
   const bool nullAware_;
+
+  void* reusedHashTableAddress_;
 };
 
 /// Represents inner/outer/semi/anti merge joins. Translates to an

--- a/bolt/exec/HashBuild.cpp
+++ b/bolt/exec/HashBuild.cpp
@@ -104,7 +104,8 @@ HashBuild::HashBuild(
           driverCtx->queryConfig().skewRowCountRatioThreshold()),
       isDREnabled_(operatorCtx_->driverCtx()
                        ->queryConfig()
-                       .isDataRetentionUpdateEnabled()) {
+                       .isDataRetentionUpdateEnabled()),
+      reusedHashTableAddress_(joinNode_->reusedHashTableAddress()) {
   BOLT_CHECK(pool()->trackUsage());
   BOLT_CHECK_NOT_NULL(joinBridge_);
 
@@ -118,6 +119,40 @@ HashBuild::HashBuild(
   }
   joinBridge_->addBuilder();
 
+  if (reusedHashTableAddress_ != nullptr) {
+    auto baseHashTable =
+        reinterpret_cast<exec::BaseHashTable*>(reusedHashTableAddress_);
+
+    BOLT_CHECK_NOT_NULL(joinBridge_);
+    joinBridge_->start();
+
+    if (baseHashTable->joinHasNullKeys() && isAntiJoin(joinType_) &&
+        nullAware_ && !joinNode_->filter()) {
+      joinBridge_->setAntiJoinHasNullKeys();
+    } else {
+      baseHashTable->prepareJoinTable({});
+
+      BOLT_CHECK_NOT_NULL(joinBridge_);
+      std::unique_ptr<
+          exec::BaseHashTable,
+          std::function<void(exec::BaseHashTable*)>>
+          hashTable(nullptr, [](exec::BaseHashTable* ptr) { /* Do nothing */ });
+
+      if (auto hasheTableWithNullKeys =
+              dynamic_cast<exec::HashTable<true>*>(baseHashTable)) {
+        hashTable.reset(hasheTableWithNullKeys);
+      } else if (
+          auto hasheTableWithoutNullKeys =
+              dynamic_cast<exec::HashTable<false>*>(baseHashTable)) {
+        hashTable.reset(hasheTableWithoutNullKeys);
+      } else {
+        BOLT_UNREACHABLE("Unexpected HashTable {}", baseHashTable->toString());
+      }
+
+      auto joinHashNullKeys = hashTable->joinHasNullKeys();
+      joinBridge_->setHashTable(std::move(hashTable), joinHashNullKeys);
+    }
+  } else {
   auto inputType = joinNode_->sources()[1]->outputType();
 
   const auto numKeys = joinNode_->rightKeys().size();
@@ -1012,6 +1047,10 @@ void HashBuild::addAndClearSpillTarget(uint64_t& numRows, uint64_t& numBytes) {
 }
 
 void HashBuild::noMoreInput() {
+  if (reusedHashTableAddress_ != nullptr) {
+    return;
+  }
+
   checkRunning();
 
   if (noMoreInput_) {
@@ -1552,6 +1591,9 @@ BlockingReason HashBuild::isBlocked(ContinueFuture* future) {
 }
 
 bool HashBuild::isFinished() {
+  if (reusedHashTableAddress_ != nullptr) {
+    return true;
+  }
   return state_ == State::kFinish;
 }
 

--- a/bolt/exec/HashBuild.cpp
+++ b/bolt/exec/HashBuild.cpp
@@ -120,121 +120,114 @@ HashBuild::HashBuild(
   joinBridge_->addBuilder();
 
   if (reusedHashTableAddress_ != nullptr) {
-    auto baseHashTable =
+    auto* baseHashTable =
         reinterpret_cast<exec::BaseHashTable*>(reusedHashTableAddress_);
 
     BOLT_CHECK_NOT_NULL(joinBridge_);
     joinBridge_->start();
 
-    if (baseHashTable->joinHasNullKeys() && isAntiJoin(joinType_) &&
-        nullAware_ && !joinNode_->filter()) {
+    baseHashTable->prepareJoinTable({});
+
+    const bool hasNullKeys = baseHashTable->joinHasNullKeys();
+
+    if (hasNullKeys && isAntiJoin(joinType_) && nullAware_ &&
+        !joinNode_->filter()) {
       joinBridge_->setAntiJoinHasNullKeys();
     } else {
-      baseHashTable->prepareJoinTable({});
-
-      BOLT_CHECK_NOT_NULL(joinBridge_);
-      std::unique_ptr<
-          exec::BaseHashTable,
-          std::function<void(exec::BaseHashTable*)>>
-          hashTable(nullptr, [](exec::BaseHashTable* ptr) { /* Do nothing */ });
-
-      if (auto hasheTableWithNullKeys =
-              dynamic_cast<exec::HashTable<true>*>(baseHashTable)) {
-        hashTable.reset(hasheTableWithNullKeys);
-      } else if (
-          auto hasheTableWithoutNullKeys =
-              dynamic_cast<exec::HashTable<false>*>(baseHashTable)) {
-        hashTable.reset(hasheTableWithoutNullKeys);
-      } else {
-        BOLT_UNREACHABLE("Unexpected HashTable {}", baseHashTable->toString());
-      }
-
-      auto joinHashNullKeys = hashTable->joinHasNullKeys();
-      joinBridge_->setHashTable(std::move(hashTable), joinHashNullKeys);
+      joinBridge_->setHashTable(
+          std::shared_ptr<exec::BaseHashTable>(
+              baseHashTable, [](exec::BaseHashTable*) {}),
+          hasNullKeys);
     }
   } else {
-  auto inputType = joinNode_->sources()[1]->outputType();
+    auto inputType = joinNode_->sources()[1]->outputType();
 
-  const auto numKeys = joinNode_->rightKeys().size();
-  keyChannels_.reserve(numKeys);
-  std::vector<std::string> names;
-  names.reserve(inputType->size());
-  std::vector<TypePtr> types;
-  types.reserve(inputType->size());
+    const auto numKeys = joinNode_->rightKeys().size();
+    keyChannels_.reserve(numKeys);
+    std::vector<std::string> names;
+    names.reserve(inputType->size());
+    std::vector<TypePtr> types;
+    types.reserve(inputType->size());
 
-  for (int i = 0; i < numKeys; ++i) {
-    auto& key = joinNode_->rightKeys()[i];
-    auto channel = exprToChannel(key.get(), inputType);
-    keyChannelMap_[channel] = i;
-    keyChannels_.emplace_back(channel);
-    names.emplace_back(inputType->nameOf(channel));
-    types.emplace_back(inputType->childAt(channel));
-  }
+    for (int i = 0; i < numKeys; ++i) {
+      auto& key = joinNode_->rightKeys()[i];
+      auto channel = exprToChannel(key.get(), inputType);
+      keyChannelMap_[channel] = i;
+      keyChannels_.emplace_back(channel);
+      names.emplace_back(inputType->nameOf(channel));
+      types.emplace_back(inputType->childAt(channel));
+    }
 
-  maxHashTableBucketCount_ =
-      operatorCtx_->driverCtx()->queryConfig().maxHashTableSize();
-  BOLT_CHECK(maxHashTableBucketCount_ > 1);
+    maxHashTableBucketCount_ =
+        operatorCtx_->driverCtx()->queryConfig().maxHashTableSize();
+    BOLT_CHECK(maxHashTableBucketCount_ > 1);
 
-  dropDuplicates_ = canDropDuplicates(joinNode_);
-  addRuntimeStat(
-      "triggerDeduplicateInHashBuild", RuntimeCounter(dropDuplicates_ ? 1 : 0));
+    dropDuplicates_ = canDropDuplicates(joinNode_);
+    addRuntimeStat(
+        "triggerDeduplicateInHashBuild",
+        RuntimeCounter(dropDuplicates_ ? 1 : 0));
 
-  // Identify the non-key build side columns and make a decoder for each.
-  const int32_t numDependents = inputType->size() - numKeys;
-  std::vector<std::string> dependentNames;
-  std::vector<TypePtr> dependentTypes;
+    // Identify the non-key build side columns and make a decoder for each.
+    const int32_t numDependents = inputType->size() - numKeys;
+    std::vector<std::string> dependentNames;
+    std::vector<TypePtr> dependentTypes;
 
-  hybridJoin_ = operatorCtx_->driverCtx()->queryConfig().hybridJoinEnabled() &&
-      numDependents > 0 && !joinNode_->isLeftSemiFilterJoin() &&
-      !joinNode_->isLeftSemiProjectJoin() && !joinNode_->isAntiJoin();
-  scatteredMode_ = hybridJoin_ &&
-      operatorCtx_->driverCtx()->queryConfig().hybridJoinScatteredModeEnabled();
+    hybridJoin_ =
+        operatorCtx_->driverCtx()->queryConfig().hybridJoinEnabled() &&
+        numDependents > 0 && !joinNode_->isLeftSemiFilterJoin() &&
+        !joinNode_->isLeftSemiProjectJoin() && !joinNode_->isAntiJoin();
+    scatteredMode_ = hybridJoin_ &&
+        operatorCtx_->driverCtx()
+            ->queryConfig()
+            .hybridJoinScatteredModeEnabled();
 
-  if (!dropDuplicates_ && numDependents > 0) {
-    // Number of join keys (numKeys) may be less then number of input columns
-    // (inputType->size()). In this case numDependents is negative and cannot be
-    // used to call 'reserve'. This happens when we join different probe side
-    // keys with the same build side key: SELECT * FROM t LEFT JOIN u ON t.k1 =
-    // u.k AND t.k2 = u.k.
-    dependentChannels_.reserve(numDependents);
-    decoders_.reserve(numDependents);
-    dependentNames.reserve(numDependents);
-    dependentTypes.reserve(numDependents);
-  }
-  if (!dropDuplicates_) {
-    // For left semi and anti join with no extra filter, hash table does not
-    // store dependent columns.
-    for (auto i = 0; i < inputType->size(); ++i) {
-      if (keyChannelMap_.find(i) == keyChannelMap_.end()) {
-        dependentChannels_.emplace_back(i);
-        decoders_.emplace_back(std::make_unique<DecodedVector>());
-        names.emplace_back(inputType->nameOf(i));
-        types.emplace_back(inputType->childAt(i));
-        dependentNames.emplace_back(inputType->nameOf(i));
-        dependentTypes.emplace_back(inputType->childAt(i));
+    if (!dropDuplicates_ && numDependents > 0) {
+      // Number of join keys (numKeys) may be less then number of input columns
+      // (inputType->size()). In this case numDependents is negative and cannot
+      // be used to call 'reserve'. This happens when we join different probe
+      // side keys with the same build side key: SELECT * FROM t LEFT JOIN u ON
+      // t.k1 = u.k AND t.k2 = u.k.
+      dependentChannels_.reserve(numDependents);
+      decoders_.reserve(numDependents);
+      dependentNames.reserve(numDependents);
+      dependentTypes.reserve(numDependents);
+    }
+    if (!dropDuplicates_) {
+      // For left semi and anti join with no extra filter, hash table does not
+      // store dependent columns.
+      for (auto i = 0; i < inputType->size(); ++i) {
+        if (keyChannelMap_.find(i) == keyChannelMap_.end()) {
+          dependentChannels_.emplace_back(i);
+          decoders_.emplace_back(std::make_unique<DecodedVector>());
+          names.emplace_back(inputType->nameOf(i));
+          types.emplace_back(inputType->childAt(i));
+          dependentNames.emplace_back(inputType->nameOf(i));
+          dependentTypes.emplace_back(inputType->childAt(i));
+        }
       }
     }
-  }
 
-  tableType_ = ROW(std::move(names), std::move(types));
-  dependentTypes_ = ROW(std::move(dependentNames), std::move(dependentTypes));
-  driverId_ = driverCtx->driverId;
-  if (hybridJoin_) {
-    BOLT_CHECK_LE(
-        driverId_,
-        255,
-        "driverId {} exceeds maximum 255 for hybrid join mode",
-        driverId_);
-  }
-  setupTable();
-  setupSpiller();
-  intermediateStateCleared_ = false;
+    tableType_ = ROW(std::move(names), std::move(types));
+    dependentTypes_ = ROW(std::move(dependentNames), std::move(dependentTypes));
+    driverId_ = driverCtx->driverId;
+    if (hybridJoin_) {
+      BOLT_CHECK_LE(
+          driverId_,
+          255,
+          "driverId {} exceeds maximum 255 for hybrid join mode",
+          driverId_);
+    }
+    setupTable();
+    setupSpiller();
+    intermediateStateCleared_ = false;
 
-  LOG(INFO) << name() << " HashBuild created for " << operatorCtx_->toString()
-            << ", spill enabled: " << spillEnabled()
-            << ", maxHashTableSize = " << maxHashTableBucketCount_
-            << ", hybrid mode " << (hybridJoin_ ? "enabled" : "disabled")
-            << ", scattered mode " << (scatteredMode_ ? "enabled" : "disabled");
+    LOG(INFO) << name() << " HashBuild created for " << operatorCtx_->toString()
+              << ", spill enabled: " << spillEnabled()
+              << ", maxHashTableSize = " << maxHashTableBucketCount_
+              << ", hybrid mode " << (hybridJoin_ ? "enabled" : "disabled")
+              << ", scattered mode "
+              << (scatteredMode_ ? "enabled" : "disabled");
+  }
 }
 
 void HashBuild::initialize() {

--- a/bolt/exec/HashBuild.h
+++ b/bolt/exec/HashBuild.h
@@ -97,6 +97,9 @@ class HashBuild final : public Operator {
   }
 
   bool needsInput() const override {
+    if (reusedHashTableAddress_ != nullptr) {
+      return false;
+    }
     return !noMoreInput_;
   }
 
@@ -465,6 +468,8 @@ class HashBuild final : public Operator {
   bool scatteredMode_{false}; // Use scattered (non-coalesced) mode
   int driverId_;
   std::unique_ptr<HybridContainer> hybridData_;
+
+  void* reusedHashTableAddress_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {

--- a/bolt/exec/HashJoinBridge.h
+++ b/bolt/exec/HashJoinBridge.h
@@ -60,6 +60,8 @@ class HashJoinBridge : public JoinBridge {
       bool hasNullKeys,
       SpillOffsetToBitsSet offsetToJoinBits = nullptr);
 
+  void setHashTable(std::shared_ptr<BaseHashTable> table, bool hasNullKeys);
+
   void setAntiJoinHasNullKeys();
 
   /// Represents the result of HashBuild operators: a hash table, an optional
@@ -82,6 +84,9 @@ class HashJoinBridge : public JoinBridge {
           offsetToJoinBits(_offsetToJoinBits) {}
 
     HashBuildResult() : hasNullKeys(true) {}
+
+    HashBuildResult(std::shared_ptr<BaseHashTable> _table, bool _hasNullKeys)
+        : hasNullKeys(_hasNullKeys), table(std::move(_table)) {}
 
     bool hasNullKeys;
     std::shared_ptr<BaseHashTable> table;

--- a/bolt/exec/HashProbe.cpp
+++ b/bolt/exec/HashProbe.cpp
@@ -502,6 +502,8 @@ void HashProbe::prepareForSpillRestore() {
 
   // Reset the internal states which are relevant to the previous probe run.
   noMoreSpillInput_ = false;
+  // bolt current doesn't have HashProbe Spill function
+  // https://github.com/facebookincubator/velox/commit/2ea66c6204d8f1b27f7682111b335bd4de8ef6fc#diff-9a2573a9b3648b92c3e9342bfcb69ab4748e85e1bb18eea7cd08513e9911b532
   table_.reset();
   spiller_.reset();
   if (!reuseSpillReader_) {

--- a/bolt/exec/HashTable.cpp
+++ b/bolt/exec/HashTable.cpp
@@ -28,13 +28,15 @@
  * --------------------------------------------------------------------------
  */
 
+#include <boost/sort/pdqsort/pdqsort.hpp>
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <sstream>
+#include <thread>
 #include <vector>
 
-#include <boost/sort/pdqsort/pdqsort.hpp>
 #include "bolt/common/base/AsyncSource.h"
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/common/base/Portability.h"
@@ -77,13 +79,15 @@ HashTable<ignoreNullKeys>::HashTable(
     memory::MemoryPool* pool,
     const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
     bool enableJit,
-    bool hybridMode)
+    bool hybridMode,
+    bool reused)
     : BaseHashTable(std::move(hashers)),
       minTableSizeForParallelJoinBuild_(minTableSizeForParallelJoinBuild),
       isJoinBuild_(isJoinBuild),
       joinBuildNoDuplicates_(!allowDuplicates),
       hashMode_(mode),
-      enableJit_(enableJit) {
+      enableJit_(enableJit),
+      reused_(reused) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
     keys.push_back(hasher->type());
@@ -148,7 +152,8 @@ HashTable<ignoreNullKeys>::HashTable(
     memory::MemoryPool* pool,
     const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
     bool enableJitRowEqVectors,
-    bool hybridMode)
+    bool hybridMode,
+    bool reused)
     : HashTable<ignoreNullKeys>(
           std::move(hashers),
           accumulators,
@@ -161,7 +166,8 @@ HashTable<ignoreNullKeys>::HashTable(
           pool,
           stringArena,
           enableJitRowEqVectors,
-          hybridMode) {}
+          hybridMode,
+          reused) {}
 
 int32_t ProbeState::row() const {
   return row_;
@@ -1820,87 +1826,92 @@ void HashTable<ignoreNullKeys>::prepareJoinTable(
     folly::Executor* executor,
     bool dropDuplicates,
     int8_t spillInputStartPartitionBit) {
-  buildExecutor_ = executor;
-  if (dropDuplicates) {
-    if (table_ != nullptr) {
-      // Set table_ to nullptr to trigger rehash.
-      rows_->pool()->freeContiguous(tableAllocation_);
-      table_ = nullptr;
-      capacity_ = 0;
-      numDistinct_ = rows()->numRows();
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!prepared_) {
+    buildExecutor_ = executor;
+    if (dropDuplicates) {
+      if (table_ != nullptr) {
+        // Set table_ to nullptr to trigger rehash.
+        rows_->pool()->freeContiguous(tableAllocation_);
+        table_ = nullptr;
+        capacity_ = 0;
+        numDistinct_ = rows()->numRows();
+      }
+      // Call analyze to insert all unique values in row container to the
+      // table hashers' uniqueValues_;
+      bool analyzeValue = !analyze();
+      if (analyzeValue) {
+        if (hashMode_ != HashMode::kHash) {
+          setHashMode(HashMode::kHash, 0);
+        } else {
+          checkSize(0, true);
+        }
+      }
     }
-    // Call analyze to insert all unique values in row container to the
-    // table hashers' uniqueValues_;
-    bool analyzeValue = !analyze();
-    if (analyzeValue) {
+
+    otherTables_.reserve(tables.size());
+    for (auto& table : tables) {
+      otherTables_.emplace_back(std::unique_ptr<HashTable<ignoreNullKeys>>(
+          dynamic_cast<HashTable<ignoreNullKeys>*>(table.release())));
+    }
+
+    // For hybrid mode
+    if (hybridData_) {
+      std::unordered_map<uint8_t, HybridContainer*> hybridDataChannel;
+      hybridDataChannel[hybridData_->getId()] = hybridData_.get();
+      for (auto& table : otherTables_)
+        hybridDataChannel[table->hybridData()->getId()] = table->hybridData();
+      hybridData_->setAllContainers(hybridDataChannel);
+    }
+
+    bool useValueIds = mayUseValueIds(*this);
+    if (useValueIds) {
+      for (auto& other : otherTables_) {
+        if (!mayUseValueIds(*other)) {
+          useValueIds = false;
+          break;
+        }
+      }
+      if (useValueIds) {
+        for (auto& other : otherTables_) {
+          if (dropDuplicates) {
+            // Before merging with the current hashers, all values in the row
+            // containers of other table need to be inserted into uniqueValues_.
+            if (!other->analyze()) {
+              other->setHashMode(HashMode::kHash, 0);
+              useValueIds = false;
+              break;
+            }
+          }
+          for (auto i = 0; i < hashers_.size(); ++i) {
+            hashers_[i]->merge(*other->hashers_[i]);
+            if (!hashers_[i]->mayUseValueIds()) {
+              useValueIds = false;
+              break;
+            }
+          }
+          if (!useValueIds) {
+            break;
+          }
+        }
+      }
+    }
+    numDistinct_ = rows()->numRows();
+
+    for (const auto& other : otherTables_) {
+      numDistinct_ += other->rows()->numRows();
+    }
+    if (!useValueIds) {
       if (hashMode_ != HashMode::kHash) {
         setHashMode(HashMode::kHash, 0);
       } else {
         checkSize(0, true);
       }
-    }
-  }
-
-  otherTables_.reserve(tables.size());
-  for (auto& table : tables) {
-    otherTables_.emplace_back(std::unique_ptr<HashTable<ignoreNullKeys>>(
-        dynamic_cast<HashTable<ignoreNullKeys>*>(table.release())));
-  }
-
-  // For hybrid mode
-  if (hybridData_) {
-    std::unordered_map<uint8_t, HybridContainer*> hybridDataChannel;
-    hybridDataChannel[hybridData_->getId()] = hybridData_.get();
-    for (auto& table : otherTables_)
-      hybridDataChannel[table->hybridData()->getId()] = table->hybridData();
-    hybridData_->setAllContainers(hybridDataChannel);
-  }
-
-  bool useValueIds = mayUseValueIds(*this);
-  if (useValueIds) {
-    for (auto& other : otherTables_) {
-      if (!mayUseValueIds(*other)) {
-        useValueIds = false;
-        break;
-      }
-    }
-    if (useValueIds) {
-      for (auto& other : otherTables_) {
-        if (dropDuplicates) {
-          // Before merging with the current hashers, all values in the row
-          // containers of other table need to be inserted into uniqueValues_.
-          if (!other->analyze()) {
-            other->setHashMode(HashMode::kHash, 0);
-            useValueIds = false;
-            break;
-          }
-        }
-        for (auto i = 0; i < hashers_.size(); ++i) {
-          hashers_[i]->merge(*other->hashers_[i]);
-          if (!hashers_[i]->mayUseValueIds()) {
-            useValueIds = false;
-            break;
-          }
-        }
-        if (!useValueIds) {
-          break;
-        }
-      }
-    }
-  }
-  numDistinct_ = rows()->numRows();
-
-  for (const auto& other : otherTables_) {
-    numDistinct_ += other->rows()->numRows();
-  }
-  if (!useValueIds) {
-    if (hashMode_ != HashMode::kHash) {
-      setHashMode(HashMode::kHash, 0);
     } else {
-      checkSize(0, true);
+      decideHashMode(0);
     }
-  } else {
-    decideHashMode(0);
+
+    prepared_ = true;
   }
   checkHashBitsOverlap(spillInputStartPartitionBit);
   LOG(INFO) << __FUNCTION__ << ": capacity_ = " << capacity_

--- a/bolt/exec/HashTable.h
+++ b/bolt/exec/HashTable.h
@@ -1205,7 +1205,7 @@ class HashTable : public BaseHashTable {
 
   // True if this is a build side of an anti or left semi project join and has
   // at least one entry with null join keys.
-  bool joinHasNullKeys_{false};
+  std::atomic<bool> joinHasNullKeys_{false};
 };
 
 } // namespace exec

--- a/bolt/exec/HashTable.h
+++ b/bolt/exec/HashTable.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include <vector/TypeAliases.h>
+#include <thread>
+
 #include "bolt/common/base/Portability.h"
 #include "bolt/exec/OneWayStatusFlag.h"
 #include "bolt/exec/RowContainer.h"
@@ -329,6 +331,12 @@ class BaseHashTable {
   /// side. This is used for sizing the internal hash table.
   virtual uint64_t numDistinct() const = 0;
 
+  virtual bool reused() const = 0;
+
+  virtual bool joinHasNullKeys() const = 0;
+
+  virtual void setJoinHasNullKeys() = 0;
+
   virtual float getDistinctRatio() const = 0;
 
   /// Return a number of current stats that can help with debugging and
@@ -551,7 +559,8 @@ class HashTable : public BaseHashTable {
       memory::MemoryPool* pool,
       const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
       bool enableJitRowEqVectors,
-      bool hybridMode = false);
+      bool hybridMode = false,
+      bool reused = false);
 
   HashTable(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
@@ -565,7 +574,8 @@ class HashTable : public BaseHashTable {
       memory::MemoryPool* pool,
       const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
       bool enableJitRowEqVectors,
-      bool hybridMode = false);
+      bool hybridMode = false,
+      bool reused = false);
 
   ~HashTable() override = default;
 
@@ -597,7 +607,8 @@ class HashTable : public BaseHashTable {
       uint32_t minTableSizeForParallelJoinBuild,
       memory::MemoryPool* pool,
       bool jitRowEqVectors,
-      bool hybridMode = false) {
+      bool hybridMode = false,
+      bool reused = false) {
     return std::make_unique<HashTable>(
         std::move(hashers),
         std::vector<Accumulator>{},
@@ -610,7 +621,8 @@ class HashTable : public BaseHashTable {
         pool,
         nullptr,
         jitRowEqVectors,
-        hybridMode);
+        hybridMode,
+        reused);
   }
 
   void groupProbe(HashLookup& lookup) override;
@@ -679,6 +691,18 @@ class HashTable : public BaseHashTable {
 
   uint64_t numDistinct() const override {
     return numDistinct_;
+  }
+
+  bool reused() const override {
+    return reused_;
+  }
+
+  bool joinHasNullKeys() const override {
+    return joinHasNullKeys_;
+  }
+
+  void setJoinHasNullKeys() override {
+    joinHasNullKeys_ = true;
   }
 
   float getDistinctRatio() const override {
@@ -1171,8 +1195,17 @@ class HashTable : public BaseHashTable {
 #ifdef ENABLE_BOLT_JIT
   bolt::jit::CompiledModuleSP jitModule_;
   bolt::jit::CompiledModuleSP jitModuleRow_;
-
 #endif
+
+  std::mutex mutex_;
+
+  bool prepared_{false};
+
+  bool reused_{false};
+
+  // True if this is a build side of an anti or left semi project join and has
+  // at least one entry with null join keys.
+  bool joinHasNullKeys_{false};
 };
 
 } // namespace exec

--- a/bolt/exec/tests/HashJoinTest.cpp
+++ b/bolt/exec/tests/HashJoinTest.cpp
@@ -8396,6 +8396,100 @@ TEST_F(HashJoinTest, duplicateLazyNotLoadedProbeVector) {
       .run();
 }
 
+TEST_F(HashJoinTest, reuseHashTable) {
+  auto probe = makeRowVector(
+      {"t0"},
+      {
+          makeNullableFlatVector<int64_t>({1, std::nullopt, 2}),
+      });
+  auto build = makeRowVector(
+      {"u0"},
+      {
+          makeNullableFlatVector<int64_t>({1, 2, 3, std::nullopt}),
+      });
+  std::shared_ptr<TempFilePath> probeFile = TempFilePath::create();
+  writeToFile(probeFile->getPath(), {probe});
+
+  std::shared_ptr<TempFilePath> buildFile = TempFilePath::create();
+  writeToFile(buildFile->getPath(), {build});
+
+  createDuckDbTable("t", {probe});
+  createDuckDbTable("u", {build});
+
+  // Build the HashTable for build side data
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.push_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+
+  auto table = HashTable<false>::createForJoin(
+      std::move(hashers),
+      {}, /*dependentTypes*/
+      true /*allowDuplicates*/,
+      true /*hasProbedFlag*/,
+      BaseHashTable::HashMode::kArray,
+      1 /*minTableSizeForParallelJoinBuild*/,
+      pool(),
+      false /*jitRowEqVectors*/);
+
+  auto rowContainer = table->rows();
+  std::vector<DecodedVector> decodedVectors;
+  for (auto& vector : build->children()) {
+    decodedVectors.emplace_back(*vector);
+  }
+
+  for (auto i = 0; i < build->size(); ++i) {
+    auto* row = rowContainer->newRow();
+
+    for (auto j = 0; j < decodedVectors.size(); ++j) {
+      rowContainer->store(decodedVectors[j], i, row, j);
+    }
+  }
+
+  table->prepareJoinTable(
+      {}, nullptr, false, BaseHashTable::kNoSpillInputStartPartitionBit);
+  if (build->childAt(0)->mayHaveNulls()) {
+    for (auto i = 0; i < build->size(); ++i) {
+      if (build->childAt(0)->isNullAt(i)) {
+        table->setJoinHasNullKeys();
+        break;
+      }
+    }
+  }
+
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId buildScanId;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .tableScan(asRowType(probe->type()))
+                  .capturePlanNodeId(probeScanId)
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .tableScan(asRowType(build->type()))
+                          .capturePlanNodeId(buildScanId)
+                          .planNode(),
+                      "",
+                      {"u0", "match"},
+                      core::JoinType::kRightSemiProject,
+                      true /*nullAware*/,
+                      table.get())
+                  .planNode();
+
+  SplitInput splitInput = {
+      {probeScanId,
+       {exec::Split(makeHiveConnectorSplit(probeFile->getPath()))}},
+      {buildScanId,
+       {exec::Split(makeHiveConnectorSplit(buildFile->getPath()))}},
+  };
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(plan)
+      .inputSplits(splitInput)
+      .checkSpillStats(false)
+      .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
+      .run();
+}
+
 /// a lazy vector can't be wrapped twice, such as when filtering and get output
 TEST_F(HashJoinTest, wrapLazyVectorInFilterAndOutput) {
   // VectorMaker vectorMaker{pool_};

--- a/bolt/exec/tests/utils/PlanBuilder.cpp
+++ b/bolt/exec/tests/utils/PlanBuilder.cpp
@@ -1449,7 +1449,8 @@ PlanBuilder& PlanBuilder::hashJoin(
     const std::string& filter,
     const std::vector<std::string>& outputLayout,
     core::JoinType joinType,
-    bool nullAware) {
+    bool nullAware,
+    void* reusedHashTableAddress) {
   BOLT_CHECK_NOT_NULL(planNode_, "HashJoin cannot be the source node");
   BOLT_CHECK_EQ(leftKeys.size(), rightKeys.size());
 
@@ -1490,7 +1491,8 @@ PlanBuilder& PlanBuilder::hashJoin(
       std::move(filterExpr),
       std::move(planNode_),
       build,
-      outputType);
+      outputType,
+      reusedHashTableAddress);
   return *this;
 }
 

--- a/bolt/exec/tests/utils/PlanBuilder.h
+++ b/bolt/exec/tests/utils/PlanBuilder.h
@@ -939,7 +939,8 @@ class PlanBuilder {
       const std::string& filter,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner,
-      bool nullAware = false);
+      bool nullAware = false,
+      void* reusedHashTableAddress = nullptr);
 
   /// Add a MergeJoinNode to join two inputs using one or more join keys and an
   /// optional filter. The caller is responsible to ensure that inputs are


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #149

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

In Spark, the hash table is constructed only once in the driver and then broadcasted to each executor. In Gluten, we replace the broadcast hash join with a hash join, which leads to performance issues when the broadcast threshold increases. This is because each task must build its own hash table when using hash join.

This PR enables HashBuild to accept pre-built HashTable, thereby bypassing the hash table construction process. Additionally, it modifies HashProbe  to avoid clearing the shared hash table after use.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
