### PR TITLE
refactor: Introduce ConnectorNames.h in connectors

### DIFF
--- a/bolt/benchmarks/QueryBenchmarkBase.cpp
+++ b/bolt/benchmarks/QueryBenchmarkBase.cpp
@@ -197,15 +197,13 @@ void QueryBenchmarkBase::initialize() {
       std::move(configurationValues));
 
   // Create hive connector with config...
-  if (!connector::hasConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)) {
+  if (!connector::hasConnectorFactory(connector::kHiveConnectorName)) {
     connector::registerConnectorFactory(
         std::make_shared<connector::hive::HiveConnectorFactory>());
   }
   if (!connector::isConnectorRegistered(kHiveConnectorId)) {
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
     connector::registerConnector(hiveConnector);
   }

--- a/bolt/connectors/ConnectorNames.h
+++ b/bolt/connectors/ConnectorNames.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+namespace bytedance::bolt::connector {
+
+constexpr const char* kArrowMemoryConnectorName = "arrow-memory";
+constexpr const char* kFuzzerConnectorName = "fuzzer";
+constexpr const char* kHiveConnectorName = "hive";
+constexpr const char* kHiveHadoop2ConnectorName = "hive-hadoop2";
+constexpr const char* kTosConnectorName = "tos";
+constexpr const char* kTpchConnectorName = "tpch";
+
+} // namespace bytedance::bolt::connector

--- a/bolt/connectors/arrow/ArrowMemoryConnector.h
+++ b/bolt/connectors/arrow/ArrowMemoryConnector.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "bolt/connectors/Connector.h"
+#include "bolt/connectors/ConnectorNames.h"
 #include "bolt/connectors/arrow/ArrowMemoryConnectorSplit.h"
 #include "bolt/vector/arrow/Abi.h"
 #include "bolt/vector/arrow/Bridge.h"
@@ -140,8 +141,6 @@ class ArrowMemoryConnector : public Connector {
 
 class ArrowMemoryConnectorFactory : public ConnectorFactory {
  public:
-  static constexpr const char* FOLLY_NONNULL kArrowMemoryConnectorName =
-      "arrow-memory";
   ArrowMemoryConnectorFactory() : ConnectorFactory(kArrowMemoryConnectorName) {}
 
   explicit ArrowMemoryConnectorFactory(const char* FOLLY_NONNULL connectorName)

--- a/bolt/connectors/arrow/tests/ArrowMemoryConnectorTest.cpp
+++ b/bolt/connectors/arrow/tests/ArrowMemoryConnectorTest.cpp
@@ -58,10 +58,9 @@ class ArrowConnectorTest : public exec::test::OperatorTestBase {
     bytedance::bolt::connector::arrow::CheckArrowMemoryConnectorFactoryInit<
         bytedance::bolt::connector::arrow::ArrowMemoryConnectorFactory>();
     std::shared_ptr<const config::ConfigBase> config;
-    auto arrowConnector = connector::getConnectorFactory(
-                              connector::arrow::ArrowMemoryConnectorFactory::
-                                  kArrowMemoryConnectorName)
-                              ->newConnector(kArrowConnectorId, config);
+    auto arrowConnector =
+        connector::getConnectorFactory(connector::kArrowMemoryConnectorName)
+            ->newConnector(kArrowConnectorId, config);
     connector::registerConnector(arrowConnector);
 
     sampleBigIntVector_ = createSampleVectorColumn<int64_t>(bigIntVec_);

--- a/bolt/connectors/fuzzer/FuzzerConnector.h
+++ b/bolt/connectors/fuzzer/FuzzerConnector.h
@@ -32,9 +32,11 @@
 
 #include "bolt/common/config/Config.h"
 #include "bolt/connectors/Connector.h"
+#include "bolt/connectors/ConnectorNames.h"
 #include "bolt/connectors/fuzzer/FuzzerConnectorSplit.h"
 #include "bolt/core/Config.h"
 #include "bolt/vector/fuzzer/VectorFuzzer.h"
+
 namespace bytedance::bolt::connector::fuzzer {
 
 /// `FuzzerConnector` is a connector that generates data on-the-fly using
@@ -148,8 +150,6 @@ class FuzzerConnector final : public Connector {
 
 class FuzzerConnectorFactory : public ConnectorFactory {
  public:
-  static constexpr const char* FOLLY_NONNULL kFuzzerConnectorName{"fuzzer"};
-
   FuzzerConnectorFactory() : ConnectorFactory(kFuzzerConnectorName) {}
 
   explicit FuzzerConnectorFactory(const char* FOLLY_NONNULL connectorName)

--- a/bolt/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
+++ b/bolt/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
@@ -31,6 +31,7 @@
 #include "bolt/connectors/fuzzer/FuzzerConnector.h"
 #include "bolt/exec/tests/utils/OperatorTestBase.h"
 #include "bolt/vector/fuzzer/VectorFuzzer.h"
+
 namespace bytedance::bolt::connector::fuzzer::test {
 
 class FuzzerConnectorTestBase : public exec::test::OperatorTestBase {
@@ -41,8 +42,7 @@ class FuzzerConnectorTestBase : public exec::test::OperatorTestBase {
     OperatorTestBase::SetUp();
     std::shared_ptr<const config::ConfigBase> config;
     auto fuzzerConnector =
-        connector::getConnectorFactory(
-            connector::fuzzer::FuzzerConnectorFactory::kFuzzerConnectorName)
+        connector::getConnectorFactory(connector::kFuzzerConnectorName)
             ->newConnector(kFuzzerConnectorId, config);
     connector::registerConnector(fuzzerConnector);
   }

--- a/bolt/connectors/hive/HiveConnector.h
+++ b/bolt/connectors/hive/HiveConnector.h
@@ -32,9 +32,11 @@
 
 #include "bolt/common/file/FileSystems.h"
 #include "bolt/connectors/Connector.h"
+#include "bolt/connectors/ConnectorNames.h"
 #include "bolt/connectors/hive/FileHandle.h"
 #include "bolt/connectors/hive/HiveConfig.h"
 #include "bolt/core/PlanNode.h"
+
 namespace bytedance::bolt::dwio::common {
 class DataSink;
 class DataSource;
@@ -99,11 +101,6 @@ class HiveConnector : public Connector {
 
 class HiveConnectorFactory : public ConnectorFactory {
  public:
-  static constexpr const char* FOLLY_NONNULL kHiveConnectorName = "hive";
-  static constexpr const char* FOLLY_NONNULL kHiveHadoop2ConnectorName =
-      "hive-hadoop2";
-  static constexpr const char* FOLLY_NONNULL kTosConnectorName = "tos";
-
   HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {}
 
   explicit HiveConnectorFactory(const char* FOLLY_NONNULL connectorName)

--- a/bolt/connectors/tpch/TpchConnector.h
+++ b/bolt/connectors/tpch/TpchConnector.h
@@ -32,6 +32,7 @@
 
 #include "bolt/common/config/Config.h"
 #include "bolt/connectors/Connector.h"
+#include "bolt/connectors/ConnectorNames.h"
 #include "bolt/connectors/tpch/TpchConnectorSplit.h"
 #include "bolt/tpch/gen/TpchGen.h"
 namespace bytedance::bolt::connector::tpch {

--- a/bolt/connectors/tpch/tests/SpeedTest.cpp
+++ b/bolt/connectors/tpch/tests/SpeedTest.cpp
@@ -70,8 +70,7 @@ class TpchSpeedTest {
  public:
   TpchSpeedTest() {
     auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+        connector::getConnectorFactory(connector::kTpchConnectorName)
             ->newConnector(
                 kTpchConnectorId_,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/bolt/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -50,8 +50,7 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
   void SetUp() override {
     OperatorTestBase::SetUp();
     auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+        connector::getConnectorFactory(connector::kTpchConnectorName)
             ->newConnector(
                 kTpchConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/orc/test/OrcTpchTest.cpp
+++ b/bolt/dwio/orc/test/OrcTpchTest.cpp
@@ -30,6 +30,7 @@
 #include "bolt/functions/prestosql/registration/RegistrationFunctions.h"
 #include "bolt/functions/sparksql/Register.h"
 #include "bolt/parse/TypeResolver.h"
+
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec;
 using namespace bytedance::bolt::exec::test;
@@ -58,15 +59,13 @@ class OrcTpchTest : public testing::Test {
     bytedance::bolt::orc::registerOrcWriterFactory();
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId, std::make_shared<core::MemConfig>());
     connector::registerConnector(hiveConnector);
 
     auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+        connector::getConnectorFactory(connector::kTpchConnectorName)
             ->newConnector(
                 kBoltTpchConnectorId, std::make_shared<core::MemConfig>());
     connector::registerConnector(tpchConnector);

--- a/bolt/dwio/paimon/deletionvectors/tests/DeletionFileReaderTest.cpp
+++ b/bolt/dwio/paimon/deletionvectors/tests/DeletionFileReaderTest.cpp
@@ -23,6 +23,7 @@
 #include "bolt/dwio/paimon/deletionvectors/DeletionFileReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 #include "bolt/vector/BaseVector.h"
+
 namespace bytedance::bolt::paimon {
 class DeleteionFileReaderTest : public parquet::ParquetTestBase {
  protected:
@@ -32,8 +33,7 @@ class DeleteionFileReaderTest : public parquet::ParquetTestBase {
     bytedance::bolt::connector::hive::CheckHiveConnectorFactoryInit<
         bytedance::bolt::connector::hive::HiveConnectorFactory>();
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/paimon/reader/tests/PaimonReaderAggregateTest.cpp
+++ b/bolt/dwio/paimon/reader/tests/PaimonReaderAggregateTest.cpp
@@ -47,6 +47,7 @@
 
 #include <folly/init/Init.h>
 #include <algorithm>
+
 using namespace bytedance::bolt;
 // using exec::test::HiveConnectorTestBase;
 using namespace bytedance::bolt;
@@ -69,8 +70,7 @@ class PaimonReaderAggregateTest : public testing::Test,
     leafPool_ = rootPool_->addLeafChild("ParquetTests");
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/paimon/reader/tests/PaimonReaderDeduplicateTest.cpp
+++ b/bolt/dwio/paimon/reader/tests/PaimonReaderDeduplicateTest.cpp
@@ -70,8 +70,7 @@ class PaimonReaderDeduplicateTest
     leafPool_ = rootPool_->addLeafChild("ParquetTests");
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/paimon/reader/tests/PaimonReaderMetadataFieldTest.cpp
+++ b/bolt/dwio/paimon/reader/tests/PaimonReaderMetadataFieldTest.cpp
@@ -72,8 +72,7 @@ class PaimonReaderMetadataFieldTest
     leafPool_ = rootPool_->addLeafChild("PaimonTests");
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/paimon/reader/tests/PaimonReaderPartialUpdateTest.cpp
+++ b/bolt/dwio/paimon/reader/tests/PaimonReaderPartialUpdateTest.cpp
@@ -69,8 +69,7 @@ class PaimonReaderPartialUpdateTest
     leafPool_ = rootPool_->addLeafChild("ParquetTests");
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/bolt/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -72,8 +72,7 @@ class ParquetTpchTest : public testing::Test {
     bytedance::bolt::parquet::registerParquetWriterFactory();
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(
@@ -81,8 +80,7 @@ class ParquetTpchTest : public testing::Test {
     connector::registerConnector(hiveConnector);
 
     auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+        connector::getConnectorFactory(connector::kTpchConnectorName)
             ->newConnector(
                 kBoltTpchConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -55,8 +55,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     registerParquetReaderFactory();
 
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -58,8 +58,7 @@ class ParquetWriterTest : public ParquetTestBase {
     bytedance::bolt::connector::hive::CheckHiveConnectorFactoryInit<
         bytedance::bolt::connector::hive::HiveConnectorFactory>();
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/examples/ScanAndSort.cpp
+++ b/bolt/examples/ScanAndSort.cpp
@@ -101,8 +101,7 @@ int main(int argc, char** argv) {
   // Create a new connector instance from the connector factory and register
   // it:
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+      connector::getConnectorFactory(connector::kHiveConnectorName)
           ->newConnector(
               kHiveConnectorId,
               std::make_shared<config::ConfigBase>(

--- a/bolt/exec/fuzzer/AggregationFuzzerBase.h
+++ b/bolt/exec/fuzzer/AggregationFuzzerBase.h
@@ -96,8 +96,7 @@ class AggregationFuzzerBase {
         vectorFuzzer_{getFuzzerOptions(timestampPrecision), pool_.get()} {
     filesystems::registerLocalFileSystem();
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+        connector::getConnectorFactory(connector::kHiveConnectorName)
             ->newConnector(
                 kHiveConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/exec/tests/BoltIn10MinDemo.cpp
+++ b/bolt/exec/tests/BoltIn10MinDemo.cpp
@@ -63,8 +63,7 @@ class BoltIn10MinDemo : public VectorTestBase {
 
     // Register TPC-H connector.
     auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+        connector::getConnectorFactory(connector::kTpchConnectorName)
             ->newConnector(
                 kTpchConnectorId,
                 std::make_shared<config::ConfigBase>(

--- a/bolt/exec/tests/JoinFuzzer.cpp
+++ b/bolt/exec/tests/JoinFuzzer.cpp
@@ -204,8 +204,7 @@ JoinFuzzer::JoinFuzzer(size_t initialSeed)
       enableDuckdbVerification_{FLAGS_enable_duckdb_verification} {
   filesystems::registerLocalFileSystem();
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+      connector::getConnectorFactory(connector::kHiveConnectorName)
           ->newConnector(kHiveConnectorId, std::make_shared<core::MemConfig>());
   connector::registerConnector(hiveConnector);
 

--- a/bolt/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/bolt/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -46,8 +46,7 @@ void HiveConnectorTestBase::SetUp() {
   bytedance::bolt::connector::hive::CheckHiveConnectorFactoryInit<
       bytedance::bolt::connector::hive::HiveConnectorFactory>();
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+      connector::getConnectorFactory(connector::kHiveConnectorName)
           ->newConnector(
               kHiveConnectorId,
               std::make_shared<config::ConfigBase>(
@@ -68,8 +67,7 @@ void HiveConnectorTestBase::resetHiveConnector(
     const std::shared_ptr<const config::ConfigBase>& config) {
   connector::unregisterConnector(kHiveConnectorId);
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+      connector::getConnectorFactory(connector::kHiveConnectorName)
           ->newConnector(kHiveConnectorId, config, ioExecutor_.get());
   connector::registerConnector(hiveConnector);
 }

--- a/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -91,8 +91,7 @@ void AggregationTestBase::SetUp() {
   OperatorTestBase::SetUp();
   filesystems::registerLocalFileSystem();
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+      connector::getConnectorFactory(connector::kHiveConnectorName)
           ->newConnector(
               kHiveConnectorId,
               std::make_shared<config::ConfigBase>(


### PR DESCRIPTION
### What problem does this PR solve?

Today, the Hive connector’s internal structures are widely referenced across unrelated modules (e.g., exec/tests, dwio, and others). This creates an undesirable coupling and violates the design principle of modular connector boundaries. Before introducing the new Iceberg connector, we should refactor the connector layer to establish a clean, common connector interface that external components depend on, rather than exposing or leaking implementation details of a specific connector.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
In order to decouple Hive and other specific connectors from exec and core modules, we need to put the connector names in a central location at connectors/ConnectorNames.h. The idea is similar to dwio::common:: FileFormat where all file formats are specified. Modules outside of the connectors module can just reference this central and connector- agnostic header instead of connector specific headers like HiveConnector.h.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
N/A

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

