### PR TITLE
[ci]: optimize license check performance and fix ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.github export-ignore
+.licenserc.yaml export-ignore
+.pre-commit-config.yaml export-ignore

--- a/.github/license_check/check_license.go
+++ b/.github/license_check/check_license.go
@@ -1,0 +1,131 @@
+// Copyright (c) ByteDance Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Header struct {
+		PathsIgnore []string `yaml:"paths-ignore"`
+	} `yaml:"header"`
+}
+
+func main() {
+	files := os.Args[1:]
+	if len(files) == 0 {
+		fmt.Printf("[INFO] No files to check.\n")
+		return
+	}
+	cwd, err := os.Getwd()
+
+	if err != nil {
+		panic(err)
+	}
+
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "../../"))
+	if err != nil {
+		panic(err)
+	}
+	configFile := filepath.Join(projectRoot, ".licenserc.yaml")
+
+	fmt.Printf("[INFO] Project Root: %s\n", projectRoot)
+	fmt.Printf("[INFO] Config Path:  %s\n", configFile)
+
+	// 1. print files to check
+	fmt.Printf("[INFO] Files to check: %v\n", files)
+
+	// 2. read and parse config file
+	ignores, err := loadIgnorePatterns(configFile)
+	if err != nil {
+		fmt.Printf("[WARNING] Failed to load config: %v\n", err)
+	}
+
+	// 3. filter files
+	validFiles := filterFiles(files, ignores)
+	if len(validFiles) == 0 {
+		fmt.Printf("[INFO] All files are ignored.\n")
+		os.Exit(0)
+	}
+	fmt.Printf("[INFO] Valid files to check: %v\n", validFiles)
+	// 4.1 print license-eye command
+	fmt.Printf("[INFO] license-eye command: license-eye header check %v -c %s\n", validFiles, configFile)
+
+	args := append([]string{"header", "check"}, validFiles...)
+	args = append(args, "-c", configFile)
+
+	cmd := exec.Command("license-eye", args...)
+	cmd.Dir = projectRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitError.ExitCode())
+		}
+		fmt.Printf("[ERROR] Failed to run license-eye: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func loadIgnorePatterns(configFile string) ([]string, error) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.Header.PathsIgnore, nil
+}
+
+func filterFiles(files []string, patterns []string) []string {
+	if len(patterns) == 0 {
+		return files
+	}
+
+	var valid []string
+	for _, file := range files {
+		if _, err := os.Stat(file); os.IsNotExist(err) {
+			continue
+		}
+		ignored := false
+		for _, pattern := range patterns {
+			// use doublestar to support **/ pattern
+			matched, _ := doublestar.Match(pattern, file)
+			if matched {
+				ignored = true
+				break
+			}
+		}
+		if !ignored {
+			valid = append(valid, file)
+		}
+	}
+	return valid
+}

--- a/.github/license_check/go.mod
+++ b/.github/license_check/go.mod
@@ -1,0 +1,23 @@
+// Copyright (c) ByteDance Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+module license_check
+
+go 1.20
+
+require (
+	github.com/bmatcuk/doublestar/v4 v4.9.2
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/.github/license_check/go.sum
+++ b/.github/license_check/go.sum
@@ -1,0 +1,6 @@
+github.com/bmatcuk/doublestar/v4 v4.9.2 h1:b0mc6WyRSYLjzofB2v/0cuDUZ+MqoGyH3r0dVij35GI=
+github.com/bmatcuk/doublestar/v4 v4.9.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -103,6 +103,8 @@ header:
     - '**/.gitignore'
     - '**/*.json'
     - '**/*.md'
+    - "**/go.mod"
+    - "**/go.sum"
     - '**/*.patch'
     - '**/*.txt'
     - '.git/**'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,10 +63,19 @@ repos:
 
   - repo: local
     hooks:
-      -   id: license-header-check
-          name: Check for license headers
+      -   id: license-header-check-commit
+          name: Check for license headers (Changed files only)
+          entry: go run -C .github/license_check check_license.go
+          language: golang
+          pass_filenames: true
+          additional_dependencies: ['github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0']
+          exclude: '^\.github/'
+      -   id: license-header-check-all
+          name: Check for license headers (All files)
           entry: license-eye header check
           language: golang
           pass_filenames: false
           additional_dependencies: ['github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0']
           args: ["-c", ".licenserc.yaml"]
+          exclude: '^\.github/'
+          stages: [manual]


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #152

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

1. Performance: The previous full scan (`pass_filenames: false`) was too slow for every commit.
2. Bug Fix: When `pass_filenames: true` is enabled, `license-eye` ignores the exclusion rules in `.licenserc.yaml` when file paths are passed explicitly as arguments.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
1. Introduce a wrapper script `.github/license_check/check_license.go`:
   - Loads ignore patterns from `.licenserc.yaml`.
   - Filters the file list provided by pre-commit using `doublestar`.
   - Passes only valid files to `license-eye`.
2. Update `.pre-commit-config.yaml`:
   - `license-header-check-commit`: Uses the new wrapper for incremental checks on changed files.
   - `license-header-check-all`: Moves the full scan to manual stage.
3. Initialize Go module in `.github/license_check`.
4. Add `.gitattributes` to exclude config files from export.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
