### PR TITLE
Improve contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Bolt uses Conan for dependency management and a Makefile to drive its build and 
 - **Dependency Manager**: Conan 2.
 
 
-### One-Click Script (Recommended)
+### Setup Development Environment On Linux
 
 Run the following script to check your compiler, install Conan, configure its profile, and import dependency recipes into your local cache:
 
@@ -71,6 +71,42 @@ This script will:
 
 
 **Note**: The first-time build will compile dependencies from source and cache them, which can be time-consuming. You can set up your own Conan remote to speed up builds.
+
+
+### Setup Development Environment on MacOS
+
+This guide outlines the steps to compile and build Bolt directly on macOS.
+You can follow the following steps
+1. Install Xcode Command Line Tools
+
+```Bash
+xcode-select --install
+```
+2. Install Conan and Pydot
+
+```Bash
+pip install conan
+pip install pydot
+```
+
+3. Run the provided script to install Bolt's specific dependencies.
+
+```Bash
+scripts/install-bolt-deps.sh
+```
+
+4. Install CMake
+   We recommend using CMake version 3.25 or higher. Not using CMake 4.0 or higher may cause some third-party dependencies build failure.
+   Download the macOS installer (.dmg) directly from the official website and install it.
+* Download Link: https://cmake.org/download/
+  Note: After installation, ensure the cmake command is available in your terminal path. You may need to follow the instructions in the installer to add it to your system PATH.
+
+5. Configure Conan Profile
+   Detect and generate the default Conan profile for your machine.
+
+```bash
+conan profile detect
+```
 
 ## Fork and PR Workflow
 
@@ -121,48 +157,6 @@ make release_spark
 
 ```Bash
 make release_spark BUILD_VERSION=main
-```
-
-### Building Bolt on macOS
-
-This guide outlines the steps to compile and build Bolt directly on macOS.
-You can follow the following steps
-1. Install Xcode Command Line Tools
-
-```Bash
-xcode-select --install
-```
-2. Install Conan and Pydot
-
-```Bash
-pip install conan
-pip install pydot
-```
-
-3. Run the provided script to install Bolt's specific dependencies.
-
-```Bash
-scripts/install-bolt-deps.sh
-```
-
-4. Install CMake
-We recommend using CMake version 3.25 or higher. Not using CMake 4.0 or higher may cause some third-party dependencies build failure.
-Download the macOS installer (.dmg) directly from the official website and install it.
-* Download Link: https://cmake.org/download/
-Note: After installation, ensure the cmake command is available in your terminal path. You may need to follow the instructions in the installer to add it to your system PATH.
-
-5. Configure Conan Profile
-Detect and generate the default Conan profile for your machine.
-
-```bash
-conan profile detect
-```
-
-6. Build the Project
-Finally, compile the project. You can use `make release` for a release build or substitute it with other make targets as needed.
-
-```bash
-make release
 ```
 
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close [#159](https://github.com/bytedance/bolt/issues/159)

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [x] 📝 Documentation only

### Description

Existing contributing.md put MacOS setup section at a very bottom
    position. This makes people think scripts/setup-dev-env.sh itself is
    enough for MacOS because it was named as "One-click Script
    (Recommended)". In fact, this script does NOT install conan and pydot
    on MacOS and the new users would encounter a series of issues. This
    commit re-positions the MacOS setup to appear earlier, and updates
    the "One-click Script (Recommended)" title to "Setup Development
    Environment On Linux". This helps new developers to get onboard
    more easily.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

No Release Note

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
