### PR TITLE
[fix][shuffle] make shuffle ut ends with _test to avoid install as library

### DIFF
--- a/bolt/shuffle/sparksql/tests/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/tests/CMakeLists.txt
@@ -28,13 +28,13 @@ target_link_libraries(
 )
 
 add_executable(
-    bolt_shuffle_spark_matrix_tests
+    bolt_shuffle_spark_matrix_test
     ShuffleTestBase.cpp
     ShuffleMatrixTest.cpp
 )
 
 target_link_libraries(
-    bolt_shuffle_spark_matrix_tests
+    bolt_shuffle_spark_matrix_test
     PRIVATE
         bolt_shuffle_spark_impl
         bolt_exec_test_lib
@@ -47,18 +47,18 @@ target_link_libraries(
 
 # Add test
 add_test(
-    NAME bolt_shuffle_spark_matrix_tests
-    COMMAND bolt_shuffle_spark_matrix_tests
+    NAME bolt_shuffle_spark_matrix_test
+    COMMAND bolt_shuffle_spark_matrix_test
 )
 
 add_executable(
-    bolt_shuffle_spark_large_partition_tests
+    bolt_shuffle_spark_large_partition_test
     ShuffleTestBase.cpp
     ShuffleLargePartitionTest.cpp
 )
 
 target_link_libraries(
-    bolt_shuffle_spark_large_partition_tests
+    bolt_shuffle_spark_large_partition_test
     PRIVATE
         bolt_shuffle_spark_impl
         bolt_exec_test_lib
@@ -71,18 +71,18 @@ target_link_libraries(
 
 # Add test
 add_test(
-    NAME bolt_shuffle_spark_large_partition_tests
-    COMMAND bolt_shuffle_spark_large_partition_tests
+    NAME bolt_shuffle_spark_large_partition_test
+    COMMAND bolt_shuffle_spark_large_partition_test
 )
 
 add_executable(
-    bolt_shuffle_spark_memory_tests
+    bolt_shuffle_spark_memory_test
     ShuffleTestBase.cpp
     ShuffleMemoryTest.cpp
 )
 
 target_link_libraries(
-    bolt_shuffle_spark_memory_tests
+    bolt_shuffle_spark_memory_test
     PRIVATE
         bolt_shuffle_spark_impl
         bolt_exec_test_lib
@@ -94,6 +94,6 @@ target_link_libraries(
 
 # Add test
 add_test(
-    NAME bolt_shuffle_spark_memory_tests
-    COMMAND bolt_shuffle_spark_memory_tests
+    NAME bolt_shuffle_spark_memory_test
+    COMMAND bolt_shuffle_spark_memory_test
 )


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close  #172 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
in #106, we add some shuffle ut, which ends with _tests, and currently, only ut ends with _test will ignored during export as library, so `bolt_shuffle_spark_memory_tests` would be exported as library and ends up with error when build gluten with tests.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
