### PR TITLE
chore: make error message 'hasBeenProcessedRowCountStr can't be empty…

### DIFF
--- a/bolt/core/PlanNode.h
+++ b/bolt/core/PlanNode.h
@@ -538,13 +538,8 @@ class TableScanNode : public PlanNode {
     rowCount_ = rowCount;
   }
 
-  // Make sure call existRowCount before call getRowCount
-  uint64_t getRowCount() const {
-    return rowCount_.value();
-  }
-
-  bool existRowCount() const {
-    return rowCount_.has_value();
+  int64_t getRowCount() const {
+    return rowCount_;
   }
 
   folly::dynamic serialize() const override;
@@ -559,7 +554,7 @@ class TableScanNode : public PlanNode {
   const std::
       unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
           assignments_;
-  std::optional<uint64_t> rowCount_;
+  int64_t rowCount_ = 0;
 };
 
 using TableScanNodePtr = std::shared_ptr<const TableScanNode>;

--- a/bolt/exec/Operator.cpp
+++ b/bolt/exec/Operator.cpp
@@ -331,7 +331,8 @@ void OperatorCtx::traverseOpToGetRowCount(
         BOLT_CHECK_NE(
             hasBeenProcessedRowCountStr,
             "",
-            "hasBeenProcessedRowCountStr can't be empty");
+            "hasBeenProcessedRowCountStr can't be empty, operator {}",
+            operators[i]->toString());
 
         totalRowCount = folly::to<uint64_t>(totalRowCountStr);
         processedRowCount = folly::to<uint64_t>(hasBeenProcessedRowCountStr);

--- a/bolt/exec/TableScan.cpp
+++ b/bolt/exec/TableScan.cpp
@@ -94,15 +94,11 @@ TableScan::TableScan(
   this->setRuntimeMetric(kCanUsedToEstimateHashBuildPartitionNum, "true");
   this->setRuntimeMetric(
       OperatorMetricKey::kHasBeenProcessedRowCount, folly::to<std::string>(0));
-  if (tableScanNode->existRowCount()) {
-    VLOG(1) << "TableScan RowCount=" << tableScanNode->getRowCount();
-    this->setRuntimeMetric(
-        OperatorMetricKey::kTotalRowCount,
-        std::to_string(tableScanNode->getRowCount()));
-  } else {
-    this->setRuntimeMetric(
-        OperatorMetricKey::kTotalRowCount, folly::to<std::string>(0));
-  }
+
+  VLOG(1) << "TableScan RowCount=" << tableScanNode->getRowCount();
+  this->setRuntimeMetric(
+      OperatorMetricKey::kTotalRowCount,
+      std::to_string(tableScanNode->getRowCount()));
 }
 
 folly::dynamic TableScan::toJson() const {


### PR DESCRIPTION
…' more informative and simplify impl

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #174 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

1. raise hasBeenProcessedRowCountStr can't be empty error together with empty string operator details
2. std::optional<uint64_t> rowCount_ is not necessary, use rowCount_ = 0 by default

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- chore: make error message 'hasBeenProcessedRowCountStr can't be empty' more informative and simplify impl
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
