### PR TITLE
fix(shuffle): avoid shuffle writer OOM caused by minMemLimit_ preventing spill

### DIFF
--- a/bolt/common/memory/sparksql/tests/MemoryTestUtils.h
+++ b/bolt/common/memory/sparksql/tests/MemoryTestUtils.h
@@ -89,6 +89,10 @@ class TestMemoryManagerHolder {
     return ptr->shared_from_this();
   }
 
+  int64_t taskAttemptId() {
+    return tmm_->getTaskAttemptId();
+  }
+
   ~TestMemoryManagerHolder() {
     delete memoryManagerHolder_;
     MemoryTargetBuilder::invalidate(tmm_, kIsolateMemory, memoryLimit_);

--- a/bolt/shuffle/sparksql/tests/ShuffleTestBase.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleTestBase.cpp
@@ -469,8 +469,9 @@ ShuffleRunResult ShuffleTestBase::runShuffle(
     writerOptions.partitionWriterOptions.numPartitions = param.numPartitions;
     writerOptions.forceShuffleWriterType = param.shuffleMode;
     writerOptions.partitionWriterOptions.partitionWriterType = param.writerType;
-    writerOptions.taskAttemptId = 0;
-    writerOptions.partitionWriterOptions.shuffleBufferSize = 1024 * 1024; // 1MB
+    writerOptions.taskAttemptId = memoryManagerHolder->taskAttemptId();
+    writerOptions.partitionWriterOptions.shuffleBufferSize =
+        param.shuffleBufferSize;
 
     if (param.writerType == PartitionWriterType::kCeleborn) {
       writerOptions.partitionWriterOptions.rssClient = mockRssClient;

--- a/bolt/shuffle/sparksql/tests/ShuffleTestBase.h
+++ b/bolt/shuffle/sparksql/tests/ShuffleTestBase.h
@@ -64,6 +64,7 @@ struct ShuffleTestParam {
   int64_t memoryLimit = 1024 * 1024 * 1024; // 1GB
   int32_t batchSize = 32;
   int32_t numBatches = 4;
+  int32_t shuffleBufferSize = kDefaultShuffleWriterBufferSize;
 
   std::string toString() const;
 


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #183 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

BoltShuffleWriter uses minMemLimit_ to guarantee a minimum memory budget for the shuffle writer. However, minMemLimit_ is currently used to forcibly update memLimit_, which can cause memLimit_ to remain too large even when system memory is exhausted.

The correct approach is to subtract the memory already consumed by the shuffle writer from minMemLimit_ and use the remaining value to update memLimit_.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).


### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
