### PR TITLE
[ci]: Generate compile db   before run pre-commit clang-tidy hook

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,13 +77,9 @@ jobs:
     - id: env-setup
       uses: ./.github/actions/bolt-build-base
 
-    - name: Bolt build
+    - name: Build and Run Tests
       run: |
-        make ${{ matrix.build_type }}_with_test
-
-    - name: Run tests
-      run: |
-        make unittest_${{ matrix.build_type }}
+         make unittest_${{ matrix.build_type }}
 
   build-only:
       needs: changes
@@ -101,7 +97,7 @@ jobs:
             - /data/conan-server-data:/var/conan/data
       strategy:
         matrix:
-          build_target: [ benchmarks-build, debug_with_test ]
+          build_target: [ benchmarks-build, debug_spark_with_test ]
       steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -26,6 +26,10 @@ concurrency:
 
 env:
   PRE_COMMIT_HOME: /data/pre-commit-cache
+  CCACHE_DIR: /data/ccache-data
+  CCACHE_MAX_SIZE: '100G'
+  CI_NUM_THREADS: "16"
+  IN_CI: '1'
   GOMAXPROCS: 8
 
 jobs:
@@ -36,12 +40,31 @@ jobs:
       options: --user root
       volumes:
         - pre-commit-cache:/data/pre-commit-cache
+        - /data/ccache-data:/data/ccache-data
+    services:
+      conanserver:
+        image: bolt-registry:5000/conan-server:latest
+        volumes:
+          - /data/conan-server-data:/var/conan/data
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: env-setup
+        uses: ./.github/actions/bolt-build-base
       - name: Install pre-commit
         run: |
           pip install -r requirements.txt
+      - name: Generate Compile Database
+        run: |
+          make compile_db_all
       - name: Run pre-commit hooks
         run: |
-          pre-commit run --all-files
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "Detected Pull Request: Checking modified files only."
+            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
+          else
+            echo "Detected Push/Merge: Checking all files."
+            pre-commit run --all-files
+          fi

--- a/bolt/serializers/tests/ArrowSerializerTest.cpp
+++ b/bolt/serializers/tests/ArrowSerializerTest.cpp
@@ -282,8 +282,10 @@ class ArrowSerializerTest
     for (const auto& child : rowVector->children()) {
       paramOptions.encodings.push_back(child->encoding());
     }
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     serde_->deprecatedSerializeEncoded(rowVector, &arena, &paramOptions, &out);
+#pragma GCC diagnostic pop
   }
 
   void assertEqualEncoding(

--- a/bolt/serializers/tests/PrestoSerializerTest.cpp
+++ b/bolt/serializers/tests/PrestoSerializerTest.cpp
@@ -301,8 +301,10 @@ class PrestoSerializerTest
     for (const auto& child : rowVector->children()) {
       paramOptions.encodings.push_back(child->encoding());
     }
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     serde_->deprecatedSerializeEncoded(rowVector, &arena, &paramOptions, &out);
+#pragma GCC diagnostic pop
   }
 
   void assertEqualEncoding(

--- a/conanfile.py
+++ b/conanfile.py
@@ -534,7 +534,12 @@ class BoltConan(ConanFile):
 
         cmake = CMake(self)
         cmake.configure()
-        cmake.build()
+        if os.getenv("BOLT_CONAN_CONFIGURE_ONLY") == "1":
+            self.output.info(
+                f"✓ compile_commands.json at {self.build_folder}/compile_commands.json"
+            )
+        else:
+            cmake.build()
 
     def package(self):
         files.copy(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #204

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Currently, our workflow (or CI pipeline) runs pre-commit run --all-files before the project is compiled.

However, the clang-tidy hook requires a compilation database (compile_commands.json) to function correctly and analyze the code context. Since the build hasn't happened yet at this stage, the compile_commands.json file is either missing or outdated.

This causes clang-tidy to fail or produce incorrect errors during the pre-build check on a fresh environment.

We should modify the pre-build workflow to explicitly skip the clang-tidy hook. We should strictly run clang-tidy only after the build system has generated the compilation database.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Skip clang-tidy hook during pre-build pre-commit
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
