### PR TITLE
Add a `Flush` API to the Parquet writer to flush the buffered row group.

### DIFF
--- a/bolt/dwio/parquet/arrow/Writer.h
+++ b/bolt/dwio/parquet/arrow/Writer.h
@@ -146,6 +146,8 @@ class PARQUET_EXPORT FileWriter {
   /// Returns an error if not all columns have been written.
   virtual ::arrow::Status NewBufferedRowGroup() = 0;
 
+  virtual ::arrow::Status Flush() = 0;
+
   /// \brief Write a RecordBatch into the buffered row group.
   ///
   /// Multiple RecordBatches can be written into the same row group

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -506,6 +506,10 @@ void Writer::flush() {
 }
 
 void Writer::flush(int64_t rowsInCurrentRowGroup) {
+  if (enableFlushBasedOnBlockSize_ && arrowContext_->writer) {
+    PARQUET_THROW_NOT_OK(arrowContext_->writer->Flush());
+    return;
+  }
   if (arrowContext_->stagingRows > 0) {
     createFileWriterIfNotExist();
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #212

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add a Flush API to the Parquet writer to flush the buffered row group.

In scenarios where `BufferedRowGroup` is used, the current `NewBufferedRowGroup` API flushes the current row group and also creates a new `BufferedRowGroup`. In some cases, we only want to flush the current row group without creating a new `BufferedRowGroup`, to avoid writing an empty row group.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Add a `Flush` API to the Parquet writer to flush the buffered row group.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
