### PR TITLE
feat: Add months_between(timestamp, timestamp, boolean)

### DIFF
--- a/bolt/functions/prestosql/DateTimeFunctions.h
+++ b/bolt/functions/prestosql/DateTimeFunctions.h
@@ -1941,6 +1941,15 @@ struct MonthsBetweenFunction {
       const core::QueryConfig& config,
       const arg_type<Timestamp>* /*toTimestamp*/,
       const arg_type<Timestamp>* /*fromTimestamp*/,
+      const arg_type<bool>* /*roundOff*/) {
+    sessionTimeZone_ = getTimeZoneFromConfig(config);
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Timestamp>* /*toTimestamp*/,
+      const arg_type<Timestamp>* /*fromTimestamp*/,
       const arg_type<bool>* /*roundOff*/,
       const arg_type<Varchar>* timeZone) {
     if (timeZone == nullptr || timeZone->empty()) {
@@ -2021,6 +2030,15 @@ struct MonthsBetweenFunction {
       const arg_type<Timestamp>& fromTimestamp) {
     calcMonthsBetween(
         toTimestamp, fromTimestamp, false, sessionTimeZone_, tzID_, result);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<double>& result,
+      const arg_type<Timestamp>& toTimestamp,
+      const arg_type<Timestamp>& fromTimestamp,
+      const arg_type<bool>& roundOff) {
+    calcMonthsBetween(
+        toTimestamp, fromTimestamp, roundOff, sessionTimeZone_, tzID_, result);
   }
 
   FOLLY_ALWAYS_INLINE void call(

--- a/bolt/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/bolt/functions/sparksql/registration/RegisterDatetime.cpp
@@ -151,6 +151,8 @@ void registerDatetimeFunctions(const std::string& prefix) {
       Timestamp,
       bool,
       Varchar>({prefix + "months_between"});
+  registerFunction<MonthsBetweenFunction, double, Timestamp, Timestamp, bool>(
+      {prefix + "months_between"});
 
   registerFunction<DayOfWeekFunction, int32_t, Timestamp>(
       {prefix + "dow", prefix + "dayofweek"});


### PR DESCRIPTION
### What problem does this PR solve?

SparkSQL has a `months_between` function signature which contains 3 arguments. The third parameter is the `roundOff` parameter[^1]. We currently only support a 4-argument version with the `roundOff` and Time Zone parameter.

[^1]: https://spark.apache.org/docs/latest/api/sql/index.html#months_between

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Adds the implementation and registration for the 3-argument version of the `months_between` function.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Adds the (TIMESTAMP, TIMESTAMP, BOOLEAN) signature for `months_between` function 
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)