### PR TITLE
ci: Add cron schedule for conan upload

### DIFF
--- a/.github/workflows/conan-upload.yml
+++ b/.github/workflows/conan-upload.yml
@@ -21,13 +21,8 @@ name: Conan CI Dependency Upload
 
 on:
   workflow_dispatch:
-    inputs:
-      build_type:
-        description: Build type to use for Conan install/export
-        required: true
-        type: choice
-        options: [Release, Debug]
-        default: Release
+  schedule:
+    - cron: '0 14 * * *'
 
 env:
   CCACHE_DIR: /data/ccache-data
@@ -69,7 +64,7 @@ jobs:
 
       - name: Conan install
         run: |
-          conan install ${{ matrix.build_options }} -s llvm-core/*:build_type=Release -s build_type=${{ inputs.build_type }} --build=missing
+          conan install ${{ matrix.build_options }} -s llvm-core/*:build_type=Release -s build_type=Release --build=missing
 
       - name: Upload packages to conan remote
         env:


### PR DESCRIPTION
### What problem does this PR solve?

We run a conan server in CI to cache pre-built dependencies. There is a github action job to run it, but it is a manual process and not everyone may have access to it. This change automates the population of the cache via a scheduled cron job on a daily basis.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Adds a cron schedule to run every day to upload new dependencies to the CI cache. When new dependencies don't need to be built, this is effectively a no-op

### Performance Impact

N/A

### Release Note

N/A

### Checklist (For Author)


- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
