### PR TITLE
fix: init rows with nulls in Paimon PartialUpdate

### DIFF
--- a/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.cpp
+++ b/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.cpp
@@ -46,6 +46,10 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
       }
     }
     result->resize(result->size() + 1);
+    const auto newRowIdx = result->size() - 1;
+    for (int i = 0; i < result->childrenSize(); i++) {
+      result->childAt(i)->setNull(newRowIdx, true);
+    }
     lastSequenceGroupKeyValues =
         std::vector<RowVectorPtr>(sequenceGroups_.size(), nullptr);
   }


### PR DESCRIPTION
### What problem does this PR solve?

In paimon tables, if a particular field is not initialized in any of the files in the split, it should be returned as null. In the previous implementation, fields were not set to null properly, so it cause reads of uninitialized memory which led to wrong query results and crashes.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

As each new row is initialized, all fields must be assumed to be null. This change explicitly sets each field to null every time a row is added

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fix possible reads of uninitialized memory in Paimon PartialUpdate engine
```

### Checklist (For Author)


- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
