### PR TITLE
fix: define missing variable on ARM

### DIFF
--- a/bolt/functions/lib/string/StringCore.h
+++ b/bolt/functions/lib/string/StringCore.h
@@ -88,14 +88,15 @@ static utf8proc_int32_t utf8proc_codepoint_length(utf8proc_int32_t uc);
 FOLLY_ALWAYS_INLINE bool isAscii(const char* str, size_t length) {
 #if defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
   size_t i = 0;
-  const size_t sve_vector_size = svcntb();
+  const size_t sveVectorSize = svcntb();
+  const svuint8_t v80 = svdup_u8(0x80);
   while (i < length) {
     svbool_t pgTail = svwhilelt_b8(i, length);
     svuint8_t v = svld1_u8(pgTail, reinterpret_cast<const uint8_t*>(str) + i);
     if (svptest_any(pgTail, svcmpge(pgTail, v, v80))) {
       return false;
     }
-    i += sve_vector_size;
+    i += sveVectorSize;
   }
   return true;
 #else


### PR DESCRIPTION
### What problem does this PR solve?

Fixes compilation issue on ARM arch

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The code would not compile without this. The constant value 0x80 is used to check whether a character code is Ascii or not, since all ascii code are < 0x80

### Performance Impact
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

N/A

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
