### PR TITLE
[fix][cp] Drop support for TIMESTAMP input from dayofweek Spark function

### DIFF
--- a/bolt/functions/prestosql/registration/DateTimeFunctionsDateComponentExtractionRegistration.cpp
+++ b/bolt/functions/prestosql/registration/DateTimeFunctionsDateComponentExtractionRegistration.cpp
@@ -33,14 +33,6 @@ void registerDateTimeDateComponentExtractionFunctionsInternal(
       {prefix + "week", prefix + "week_of_year"});
   registerFunction<WeekFunction, int64_t, Date>(
       {prefix + "week", prefix + "week_of_year"});
-  registerFunction<
-      bytedance::bolt::functions::sparksql::DayOfWeekFunction,
-      int64_t,
-      Date>({prefix + "dayofweek"});
-  registerFunction<
-      bytedance::bolt::functions::sparksql::DayOfWeekFunction,
-      int64_t,
-      Timestamp>({prefix + "dayofweek"});
   registerFunction<HourFunction, int64_t, Timestamp>({prefix + "hour"});
   registerFunction<MinuteFunction, int64_t, Timestamp>({prefix + "minute"});
   registerFunction<SecondFunction, int64_t, Timestamp>({prefix + "second"});

--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -955,7 +955,7 @@ struct DateSubFunction {
 };
 
 template <typename T>
-struct DayOfWeekFunction : public InitSessionTimezone<T> {
+struct DayOfWeekFunction {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 
   // 1 = Sunday, 2 = Monday, ..., 7 = Saturday
@@ -963,23 +963,7 @@ struct DayOfWeekFunction : public InitSessionTimezone<T> {
     return time.tm_wday + 1;
   }
 
-  FOLLY_ALWAYS_INLINE void call(
-      int32_t& result,
-      const arg_type<Timestamp>& timestamp) {
-    result = getDayOfWeek(getDateTime(timestamp, this->timeZone_));
-  }
-
   FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
-    result = getDayOfWeek(getDateTime(date));
-  }
-
-  FOLLY_ALWAYS_INLINE void call(
-      int64_t& result,
-      const arg_type<Timestamp>& timestamp) {
-    result = getDayOfWeek(getDateTime(timestamp, this->timeZone_));
-  }
-
-  FOLLY_ALWAYS_INLINE void call(int64_t& result, const arg_type<Date>& date) {
     result = getDayOfWeek(getDateTime(date));
   }
 };

--- a/bolt/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/bolt/functions/sparksql/registration/RegisterDatetime.cpp
@@ -154,10 +154,7 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<MonthsBetweenFunction, double, Timestamp, Timestamp, bool>(
       {prefix + "months_between"});
 
-  registerFunction<DayOfWeekFunction, int32_t, Timestamp>(
-      {prefix + "dow", prefix + "dayofweek"});
-  registerFunction<DayOfWeekFunction, int32_t, Date>(
-      {prefix + "dow", prefix + "dayofweek"});
+  registerFunction<DayOfWeekFunction, int32_t, Date>({prefix + "dayofweek"});
 
   registerTimestampWithTimeZoneType();
   registerFunction<QuarterFunction, int32_t, Date>({prefix + "quarter"});

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -765,95 +765,30 @@ TEST_F(SparkSqlDateTimeFunctionsTest, dayOfMonth) {
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, dayOfWeekDate) {
-  const auto dayOfWeek = [&](std::optional<int32_t> date,
-                             const std::string& func) {
-    return evaluateOnce<int32_t, int32_t>(
-        fmt::format("{}(c0)", func), {date}, {DATE()});
+  const auto dayOfWeek = [&](std::optional<int32_t> date) {
+    return evaluateOnce<int32_t, int32_t>("dayofweek(c0)", {date}, {DATE()});
   };
 
-  for (const auto& func : {"dayofweek", "dow"}) {
-    EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt, func));
-    EXPECT_EQ(5, dayOfWeek(0, func));
-    EXPECT_EQ(4, dayOfWeek(-1, func));
-    EXPECT_EQ(7, dayOfWeek(-40, func));
-    EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30"), func));
-    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20"), func));
-    EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21"), func));
-    EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22"), func));
-    EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23"), func));
-    EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24"), func));
-    EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25"), func));
-    EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26"), func));
-    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27"), func));
+  EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt));
+  EXPECT_EQ(5, dayOfWeek(0));
+  EXPECT_EQ(4, dayOfWeek(-1));
+  EXPECT_EQ(7, dayOfWeek(-40));
+  EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30")));
+  EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20")));
+  EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21")));
+  EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22")));
+  EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23")));
+  EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24")));
+  EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25")));
+  EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26")));
+  EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27")));
+  EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06", nullptr)));
+  EXPECT_EQ(4, dayOfWeek(util::fromDateString("2015-04-08", nullptr)));
+  EXPECT_EQ(7, dayOfWeek(util::fromDateString("2017-05-27", nullptr)));
+  EXPECT_EQ(6, dayOfWeek(util::fromDateString("1582-10-15", nullptr)));
 
-    // test cases from spark's DateExpressionSuite.
-    EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06", nullptr), func));
-  }
-}
-
-TEST_F(SparkSqlDateTimeFunctionsTest, dayofWeekTs) {
-  const auto dayOfWeek = [&](std::optional<Timestamp> date,
-                             const std::string& func) {
-    return evaluateOnce<int32_t>(fmt::format("{}(c0)", func), date);
-  };
-
-  for (const auto& func : {"dayofweek", "dow"}) {
-    EXPECT_EQ(5, dayOfWeek(Timestamp(0, 0), func));
-    EXPECT_EQ(4, dayOfWeek(Timestamp(-1, 0), func));
-    EXPECT_EQ(
-        1,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-20 20:23:00.001", nullptr),
-            func));
-    EXPECT_EQ(
-        2,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-21 21:23:00.030", nullptr),
-            func));
-    EXPECT_EQ(
-        3,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-22 11:23:00.100", nullptr),
-            func));
-    EXPECT_EQ(
-        4,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-23 22:23:00.030", nullptr),
-            func));
-    EXPECT_EQ(
-        5,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-24 15:23:00.000", nullptr),
-            func));
-    EXPECT_EQ(
-        6,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-25 03:23:04.000", nullptr),
-            func));
-    EXPECT_EQ(
-        7,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-26 01:03:00.300", nullptr),
-            func));
-    EXPECT_EQ(
-        1,
-        dayOfWeek(
-            util::fromTimestampString("2023-08-27 01:13:00.000", nullptr),
-            func));
-    // test cases from spark's DateExpressionSuite.
-    EXPECT_EQ(
-        4,
-        dayOfWeek(
-            util::fromTimestampString("2015-04-08 13:10:15", nullptr), func));
-    EXPECT_EQ(
-        7,
-        dayOfWeek(
-            util::fromTimestampString("2017-05-27 13:10:15", nullptr), func));
-    EXPECT_EQ(
-        6,
-        dayOfWeek(
-            util::fromTimestampString("1582-10-15 13:10:15", nullptr), func));
-  }
+  // test cases from spark's DateExpressionSuite.
+  EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06", nullptr)));
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, dateDiffDate) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number:  discussion #191 
see https://github.com/facebookincubator/velox/pull/8746

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

n Spark dayofweek doesn't directly accept TIMESTAMP input. For TIMESTAMP input, Spark will add a cast expression to convert it to date type, so only DATE type can be considered in Velox.

Also removing alias dow.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
