### PR TITLE
[fix][cp] Add support for lambda functions to StreamingAggregation

### DIFF
--- a/bolt/exec/AggregateInfo.cpp
+++ b/bolt/exec/AggregateInfo.cpp
@@ -86,9 +86,6 @@ std::vector<AggregateInfo> toAggregateInfo(
         constants.push_back(constant->toConstantVector(operatorCtx.pool()));
       } else if (
           auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(arg.get())) {
-        BOLT_USER_CHECK(
-            !isStreaming,
-            "StreamingAggregation doesn't support lambda functions yet.");
         for (const auto& name : lambda->signature()->names()) {
           if (auto captureIndex = inputType->getChildIdxIfExists(name)) {
             channels.push_back(captureIndex.value());
@@ -97,8 +94,7 @@ std::vector<AggregateInfo> toAggregateInfo(
         }
       } else {
         BOLT_FAIL(
-            "Expression must be field access, constant, or "
-            "lambda (HashAggregation): {}",
+            "Expression must be field access, constant, or lambda: {}",
             arg->toString());
       }
     }
@@ -139,15 +135,13 @@ std::vector<AggregateInfo> toAggregateInfo(
         aggResultType,
         operatorCtx.driverCtx()->queryConfig());
 
-    if (!isStreaming) {
-      auto lambdas = extractLambdaInputs(aggregate);
-      if (!lambdas.empty()) {
-        if (expressionEvaluator == nullptr) {
-          expressionEvaluator = std::make_shared<SimpleExpressionEvaluator>(
-              operatorCtx.execCtx()->queryCtx(), operatorCtx.execCtx()->pool());
-        }
-        info.function->setLambdaExpressions(lambdas, expressionEvaluator);
+    auto lambdas = extractLambdaInputs(aggregate);
+    if (!lambdas.empty()) {
+      if (expressionEvaluator == nullptr) {
+        expressionEvaluator = std::make_shared<SimpleExpressionEvaluator>(
+            operatorCtx.execCtx()->queryCtx(), operatorCtx.execCtx()->pool());
       }
+      info.function->setLambdaExpressions(lambdas, expressionEvaluator);
     }
 
     // Sorting keys and orders.

--- a/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1072,6 +1072,70 @@ void AggregationTestBase::testAggregationsImpl(
   }
 }
 
+void AggregationTestBase::testStreamingAggregationsImpl(
+    std::function<void(PlanBuilder&)> makeSource,
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& postAggregationProjections,
+    std::function<std::shared_ptr<exec::Task>(AssertQueryBuilder&)>
+        assertResults,
+    const std::unordered_map<std::string, std::string>& config) {
+  {
+    SCOPED_TRACE("Test StreamingAggregation: run single");
+    PlanBuilder builder(pool());
+    makeSource(builder);
+    builder.orderBy(groupingKeys, false)
+        .streamingAggregation(
+            groupingKeys,
+            aggregates,
+            {},
+            core::AggregationNode::Step::kSingle,
+            false);
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
+    assertResults(queryBuilder);
+  }
+
+  {
+    SCOPED_TRACE(
+        "Test StreamingAggregation: run partial + final StreamingAggregation");
+    PlanBuilder builder(pool());
+    makeSource(builder);
+    builder.orderBy(groupingKeys, false)
+        .partialStreamingAggregation(groupingKeys, aggregates)
+        .finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
+    assertResults(queryBuilder);
+  }
+
+  {
+    SCOPED_TRACE(
+        "Test StreamingAggregation: run partial + intermediate + final");
+    PlanBuilder builder(pool());
+    makeSource(builder);
+    builder.orderBy(groupingKeys, false)
+        .partialStreamingAggregation(groupingKeys, aggregates)
+        .intermediateAggregation()
+        .finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
+    assertResults(queryBuilder);
+  }
+}
+
 void AggregationTestBase::testAggregations(
     std::function<void(PlanBuilder&)> makeSource,
     const std::vector<std::string>& groupingKeys,
@@ -1092,6 +1156,16 @@ void AggregationTestBase::testAggregations(
   if (testIncremental_) {
     SCOPED_TRACE("testIncrementalAggregation");
     testIncrementalAggregation(makeSource, aggregates, config);
+  }
+
+  if (allowInputShuffle_ && !groupingKeys.empty()) {
+    testStreamingAggregationsImpl(
+        makeSource,
+        groupingKeys,
+        aggregates,
+        postAggregationProjections,
+        assertResults,
+        config);
   }
 
   if (testWithTableScan) {

--- a/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h
+++ b/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h
@@ -309,6 +309,15 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
           exec::test::AssertQueryBuilder&)> assertResults,
       const std::unordered_map<std::string, std::string>& config);
 
+  void testStreamingAggregationsImpl(
+      std::function<void(exec::test::PlanBuilder&)> makeSource,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& postAggregationProjections,
+      std::function<std::shared_ptr<exec::Task>(
+          exec::test::AssertQueryBuilder&)> assertResults,
+      const std::unordered_map<std::string, std::string>& config);
+
   bool allowInputShuffle_{false};
 };
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number:  discussion #191 
see https://github.com/facebookincubator/velox/pull/8890

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR removes the constraint of lambda functions to StreamingAggregation
and extracts lambda inputs in AggregationInfo::toAggregateInfo.
Add StreamingAggregation plans in AggregationTestBase::testAggregations
if there are grouping keys. So that the UTs in ReduceAggTest would cover
both the HashAggregation and StreamingAggregation scenarios.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
