### PR TITLE
[fix][cp] Fix unhex Spark function with inputs of odd length

### DIFF
--- a/bolt/functions/sparksql/Arithmetic.h
+++ b/bolt/functions/sparksql/Arithmetic.h
@@ -531,9 +531,6 @@ struct UnHexFunction {
       if (v == -1) {
         return false;
       }
-      // out_type<Varbinary> resize does not guarantee all chars initialized
-      // with 0, filling last char with 0 to align with Spark.
-      resultBuffer[resultSize - 1] = 0;
       resultBuffer[0] = v;
       i += 1;
     }
@@ -544,7 +541,7 @@ struct UnHexFunction {
       if (first == -1 || second == -1) {
         return false;
       }
-      resultBuffer[i / 2] = (first << 4) | second;
+      resultBuffer[(i + 1) / 2] = (first << 4) | second;
       i += 2;
     }
     return true;

--- a/bolt/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/bolt/functions/sparksql/tests/ArithmeticTest.cpp
@@ -434,11 +434,9 @@ TEST_F(ArithmeticTest, unhex) {
   EXPECT_EQ(unhex("737472696E67"), "string");
   EXPECT_EQ(unhex(""), "");
   EXPECT_EQ(unhex("23"), "#");
-  std::string b("#\0", 2);
-  EXPECT_EQ(unhex("123"), b);
-  EXPECT_EQ(unhex("b23"), b);
-  b = std::string("##\0", 3);
-  EXPECT_EQ(unhex("b2323"), b);
+  EXPECT_EQ(unhex("123"), "\x01#");
+  EXPECT_EQ(unhex("b23"), "\x0B#");
+  EXPECT_EQ(unhex("b2323"), "\x0B##");
   EXPECT_EQ(unhex("F"), "\x0F");
   EXPECT_EQ(unhex("ff"), "\xFF");
   EXPECT_EQ(unhex("G"), std::nullopt);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number:  discussion #191 
see https://github.com/facebookincubator/velox/pull/8993/changes

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

fixed unhex function when input string has an odd number of characters.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
