### PR TITLE
fix(shuffle): Reset outputPos after flushing output buffer in CompressInternal

### DIFF
--- a/bolt/shuffle/sparksql/CompressionStream.h
+++ b/bolt/shuffle/sparksql/CompressionStream.h
@@ -317,6 +317,7 @@ class AdaptiveParallelZstdCodec {
           // stream
           bytedance::bolt::NanosecondTimer timer1(&writeTime);
           RETURN_NOT_OK(outputStream->Write(output, outputPos));
+          outputPos = 0;
         }
       } while (inputLen > 0);
     }

--- a/bolt/shuffle/sparksql/tests/AdaptiveParallelZstdCodecTest.cpp
+++ b/bolt/shuffle/sparksql/tests/AdaptiveParallelZstdCodecTest.cpp
@@ -115,6 +115,31 @@ void runRoundTrip(
   EXPECT_EQ(0, std::memcmp(output.data(), expected.data(), expected.size()));
 }
 
+std::vector<uint8_t> buildIncompressibleData(size_t size) {
+  std::vector<uint8_t> data(size);
+  uint32_t state = 0x12345678u;
+  for (size_t i = 0; i < size; ++i) {
+    state = state * 1664525u + 1013904223u;
+    data[i] = static_cast<uint8_t>(state >> 24);
+  }
+  return data;
+}
+
+std::vector<uint8_t> buildIncompressibleRow(size_t payloadSize, uint32_t seed) {
+  std::vector<uint8_t> row(sizeof(int32_t) + payloadSize);
+  auto payloadSize32 = static_cast<int32_t>(payloadSize);
+  std::memcpy(row.data(), &payloadSize32, sizeof(int32_t));
+
+  auto payload = buildIncompressibleData(payloadSize);
+  uint32_t state = seed;
+  for (size_t i = 0; i < payloadSize; ++i) {
+    state = state * 1103515245u + 12345u;
+    payload[i] ^= static_cast<uint8_t>(state >> 24);
+  }
+  std::memcpy(row.data() + sizeof(int32_t), payload.data(), payload.size());
+  return row;
+}
+
 } // namespace
 
 TEST(AdaptiveParallelZstdCodecTest, RoundTripSmallPayloads) {
@@ -142,6 +167,29 @@ TEST(AdaptiveParallelZstdCodecTest, RoundTripLargePayload) {
   }
 
   runRoundTrip(rows, rawSize, RowVectorLayout::kComposite);
+}
+
+TEST(
+    AdaptiveParallelZstdCodecTest,
+    CompressAndFlushStressRoundTripWithoutCorruption) {
+  constexpr int32_t kRounds = 6;
+  constexpr int32_t kRowsPerRound = 256;
+  const auto payloadSize =
+      static_cast<size_t>(ZSTD_CStreamInSize() - sizeof(int32_t) - 1);
+
+  for (int32_t round = 0; round < kRounds; ++round) {
+    std::vector<std::vector<uint8_t>> rows;
+    rows.reserve(kRowsPerRound);
+
+    int64_t rawSize = 0;
+    for (int32_t i = 0; i < kRowsPerRound; ++i) {
+      rows.emplace_back(buildIncompressibleRow(
+          payloadSize, static_cast<uint32_t>(round * kRowsPerRound + i + 1)));
+      rawSize += static_cast<int64_t>(rows.back().size());
+    }
+
+    runRoundTrip(rows, rawSize, RowVectorLayout::kComposite);
+  }
 }
 
 } // namespace bytedance::bolt::shuffle::sparksql::test


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #270 

`AdaptiveParallelZstdCodec::CompressInternal` had a stream-state bug: after writing compressed bytes to `outputStream`, `outputPos` was not reset to `0`. This could make the next compression iteration run with an effectively exhausted output window (`outputLen - outputPos == 0`) while keeping stale cursor state, which may produce malformed compressed stream output. On read path, this surfaced as `ZSTD_decompressStream` failures (`Destination buffer is too small` / `Data corruption detected`) and then `INVALID_STATE`. This PR also adds a regression test that reproduces the bug path.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Code changes:
- `bolt/shuffle/sparksql/CompressionStream.h`
  - In `CompressInternal`, reset `outputPos = 0` immediately after `outputStream->Write(output, outputPos)`.
Test changes:
- `bolt/shuffle/sparksql/tests/AdaptiveParallelZstdCodecTest.cpp`
  - Added incompressible payload builders.
  - Added `CompressAndFlushStressRoundTripWithoutCorruption` to stress near `ZSTD_CStreamInSize()` boundaries across multiple rounds/rows.
  - Test validates full public round-trip (`CompressAndFlush` + `Decompress`) and guards against stream corruption regressions.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).


### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
