### PR TITLE
[perf][cp] Collect and use columns' HasNulls info for RowContainer

### DIFF
--- a/bolt/exec/HashProbe.cpp
+++ b/bolt/exec/HashProbe.cpp
@@ -98,8 +98,7 @@ void extractColumns(
       child = BaseVector::create(resultTypes[resultChannel], rows.size(), pool);
     }
     child->resize(rows.size());
-    table->rows()->extractColumn(
-        rows.data(), rows.size(), projection.inputChannel, child);
+    table->extractColumn(rows, projection.inputChannel, child);
   }
 }
 
@@ -1334,16 +1333,14 @@ void HashProbe::applyFilterOnTableRowsForNullAwareJoin(
   if (!rows.hasSelections()) {
     return;
   }
-  auto* tableRows = table_->rows();
-  BOLT_CHECK(tableRows, "Should not move rows in hash joins");
+  BOLT_CHECK(table_->rows(), "Should not move rows in hash joins");
   char* data[kBatchSize];
   while (auto numRows = iterator(data, kBatchSize)) {
     filterTableInput_->resize(numRows);
     filterTableInputRows_.resizeFill(numRows, true);
     for (auto& projection : filterTableProjections_) {
-      tableRows->extractColumn(
-          data,
-          numRows,
+      table_->extractColumn(
+          folly::Range<char* const*>(data, numRows),
           projection.inputChannel,
           filterTableInput_->childAt(projection.outputChannel));
     }

--- a/bolt/exec/HashTable.cpp
+++ b/bolt/exec/HashTable.cpp
@@ -1807,6 +1807,20 @@ void HashTable<ignoreNullKeys>::prepareJoinTable(
     otherTables_.emplace_back(std::unique_ptr<HashTable<ignoreNullKeys>>(
         dynamic_cast<HashTable<ignoreNullKeys>*>(table.release())));
   }
+
+  // If there are multiple tables, we need to merge the 'columnHasNulls' flags
+  // from the containers of each table and store them in the main table. This
+  // is necessary because, when extracting results, 'rows' may contain row
+  // pointers from multiple containers. We need to ensure the correctness of
+  // the 'columnHasNulls' flags.
+  for (int i = 0; i < rows_->columnTypes().size(); ++i) {
+    columnHasNulls_.emplace_back(rows_->columnHasNulls(i));
+    for (auto& other : otherTables_) {
+      columnHasNulls_[i] =
+          columnHasNulls_[i] || other->rows()->columnHasNulls(i);
+    }
+  }
+
   bool useValueIds = mayUseValueIds(*this);
   if (useValueIds) {
     for (auto& other : otherTables_) {

--- a/bolt/exec/HashTable.h
+++ b/bolt/exec/HashTable.h
@@ -431,6 +431,14 @@ class BaseHashTable {
     return offThreadBuildTiming_;
   }
 
+  /// Copies the values at 'columnIndex' into 'result' for the 'rows.size' rows
+  /// pointed to by 'rows'. If an entry in 'rows' is null, sets corresponding
+  /// row in 'result' to null.
+  virtual void extractColumn(
+      folly::Range<char* const*> rows,
+      int32_t columnIndex,
+      const VectorPtr& result) = 0;
+
  protected:
   static FOLLY_ALWAYS_INLINE size_t tableSlotSize() {
     // Each slot is 8 bytes.
@@ -757,6 +765,18 @@ class HashTable : public BaseHashTable {
 
   auto& testingOtherTables() const {
     return otherTables_;
+  }
+
+  void extractColumn(
+      folly::Range<char* const*> rows,
+      int32_t columnIndex,
+      const VectorPtr& result) override {
+    RowContainer::extractColumn(
+        rows.data(),
+        rows.size(),
+        rows_->columnAt(columnIndex),
+        columnHasNulls_[columnIndex],
+        result);
   }
 
  private:
@@ -1116,6 +1136,10 @@ class HashTable : public BaseHashTable {
   // combined into a single probe hash table.
   std::vector<std::unique_ptr<HashTable<ignoreNullKeys>>> otherTables_;
   // Statistics maintained if kTrackLoads is set.
+
+  // Flags indicate whether the same column in all build-side join hash tables
+  // contains null values.
+  std::vector<bool> columnHasNulls_;
 
   // Number of times a row is looked up or inserted.
   mutable tsan_atomic<int64_t> numProbes_{0};

--- a/bolt/exec/RowContainer.cpp
+++ b/bolt/exec/RowContainer.cpp
@@ -256,6 +256,7 @@ RowContainer::RowContainer(
       ++nullOffset;
     }
     keyIndices_.emplace_back(keyIdx++);
+    columnHasNulls_.push_back(false);
   }
   // Make offset at least sizeof pointer so that there is space for a
   // free list next pointer below the bit at 'freeFlagOffset_'.
@@ -275,6 +276,7 @@ RowContainer::RowContainer(
     nullOffsets_.push_back(nullOffset);
     ++nullOffset;
     isVariableWidth |= !type->isFixedWidth();
+    columnHasNulls_.push_back(false);
   }
   if (hasProbedFlag) {
     nullOffsets_.push_back(nullOffset);
@@ -550,7 +552,8 @@ void RowContainer::store(
         row,
         rowColumn.offset(),
         rowColumn.nullByte(),
-        rowColumn.nullMask());
+        rowColumn.nullMask(),
+        column);
   }
 }
 
@@ -833,11 +836,13 @@ void RowContainer::storeComplexType(
     char* row,
     int32_t offset,
     int32_t nullByte,
-    uint8_t nullMask) {
+    uint8_t nullMask,
+    int32_t column) {
   if (decoded.isNullAt(index)) {
     BOLT_DCHECK(nullMask);
     row[nullByte] |= nullMask;
     valueAt<std::string_view>(row, offset) = std::string_view();
+    updateColumnHasNulls(column, true);
     return;
   }
   // RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);

--- a/bolt/exec/RowContainer.h
+++ b/bolt/exec/RowContainer.h
@@ -354,7 +354,7 @@ class RowContainer {
       auto mask = rowColumn.nullMask();
 
       for (auto r = 0; r < size; ++r) {
-        storeWithNulls<Kind>(decoded, r, rows[r], off, nullByte, mask);
+        storeWithNulls<Kind>(decoded, r, rows[r], off, nullByte, mask, column);
       }
     }
   }
@@ -397,10 +397,15 @@ class RowContainer {
   /// Copies the values at 'col' into 'result' (starting at 'resultOffset')
   /// for the 'numRows' rows pointed to by 'rows'. If a 'row' is null, sets
   /// corresponding row in 'result' to null.
+  /// @param hasNulls indicates whether the 'col' column contains null
+  /// values. If 'hasNulls' is false, a null-free optimization will be
+  /// applied. It is the caller's responsibility to ensure this flag is set
+  /// correctly.
   static void extractColumn(
       const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
       int32_t numRows,
       RowColumn col,
+      bool hasNulls,
       vector_size_t resultOffset,
       const VectorPtr& result,
       bool exactSize = false);
@@ -408,13 +413,18 @@ class RowContainer {
   /// Copies the values at 'col' into 'result' for the 'numRows' rows pointed to
   /// by 'rows'. If an entry in 'rows' is null, sets corresponding row in
   /// 'result' to null.
+  /// @param hasNulls indicates whether the 'col' column contains null
+  /// values. If 'hasNulls' is false, a null-free optimization will be
+  /// applied. It is the caller's responsibility to ensure this flag is set
+  /// correctly.
   static void extractColumn(
       const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
       int32_t numRows,
       RowColumn col,
+      bool hasNulls,
       const VectorPtr& result,
       bool exactSize = false) {
-    extractColumn(rows, numRows, col, 0, result, exactSize);
+    extractColumn(rows, numRows, col, hasNulls, 0, result, exactSize);
   }
 
   /// Copies the values from the array pointed to by 'rows' at 'col' into
@@ -423,10 +433,15 @@ class RowContainer {
   /// 'result' to null. The positions in 'rowNumbers' array can repeat and also
   /// appear out of order. If rowNumbers has a negative value, then the
   /// corresponding row in 'result' is set to null.
+  /// @param hasNulls indicates whether the 'col' column contains null
+  /// values. If 'hasNulls' is false, a null-free optimization will be
+  /// applied. It is the caller's responsibility to ensure this flag is set
+  /// correctly.
   static void extractColumn(
       const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
       folly::Range<const vector_size_t*> rowNumbers,
       RowColumn col,
+      bool hasNulls,
       vector_size_t resultOffset,
       const VectorPtr& result,
       bool exactSize = false);
@@ -448,7 +463,13 @@ class RowContainer {
       int32_t columnIndex,
       const VectorPtr& result,
       bool exactSize = false) {
-    extractColumn(rows, numRows, columnAt(columnIndex), result, exactSize);
+    extractColumn(
+        rows,
+        numRows,
+        columnAt(columnIndex),
+        columnHasNulls(columnIndex),
+        result,
+        exactSize);
   }
 
   /// Copies the values at 'columnIndex' into 'result' (starting at
@@ -462,7 +483,13 @@ class RowContainer {
       const VectorPtr& result,
       bool exactSize = false) {
     extractColumn(
-        rows, numRows, columnAt(columnIndex), resultOffset, result, exactSize);
+        rows,
+        numRows,
+        columnAt(columnIndex),
+        columnHasNulls(columnIndex),
+        resultOffset,
+        result,
+        exactSize);
   }
 
   /// Copies the values at 'columnIndex' at positions in the 'rowNumbers' array
@@ -483,6 +510,7 @@ class RowContainer {
         rows,
         rowNumbers,
         columnAt(columnIndex),
+        columnHasNulls(columnIndex),
         resultOffset,
         result,
         exactSize);
@@ -792,6 +820,11 @@ class RowContainer {
     return keyIndices_;
   }
 
+  /// Returns true if specified column may have nulls, false otherwise.
+  inline bool columnHasNulls(int32_t columnIndex) const {
+    return columnHasNulls_[columnIndex];
+  }
+
   const std::vector<Accumulator>& accumulators() const {
     return accumulators_;
   }
@@ -907,6 +940,7 @@ class RowContainer {
       folly::Range<const vector_size_t*> rowNumbers,
       int32_t numRows,
       RowColumn column,
+      bool hasNulls,
       int32_t resultOffset,
       const VectorPtr& result,
       bool exactSize) {
@@ -916,12 +950,20 @@ class RowContainer {
           rowNumbers,
           rowNumbers.size(),
           column,
+          hasNulls,
           resultOffset,
           result,
           exactSize);
     } else {
       extractColumnTypedInternal<false, Kind>(
-          rows, rowNumbers, numRows, column, resultOffset, result, exactSize);
+          rows,
+          rowNumbers,
+          numRows,
+          column,
+          hasNulls,
+          resultOffset,
+          result,
+          exactSize);
     }
   }
 
@@ -931,6 +973,7 @@ class RowContainer {
       folly::Range<const vector_size_t*> rowNumbers,
       int32_t numRows,
       RowColumn column,
+      bool hasNulls,
       int32_t resultOffset,
       const VectorPtr& result,
       bool exactSize) {
@@ -948,7 +991,7 @@ class RowContainer {
     auto* flatResult = result->as<FlatVector<T>>();
     auto nullMask = column.nullMask();
     auto offset = column.offset();
-    if (!nullMask) {
+    if (!nullMask || !hasNulls) {
       extractValuesNoNulls<useRowNumbers, T>(
           rows,
           rowNumbers,
@@ -987,7 +1030,8 @@ class RowContainer {
       char* FOLLY_NONNULL row,
       int32_t offset,
       int32_t nullByte,
-      uint8_t nullMask) {
+      uint8_t nullMask,
+      int32_t column) {
     using T = typename TypeTraits<Kind>::NativeType;
     if (decoded.isNullAt(index)) {
       row[nullByte] |= nullMask;
@@ -1007,6 +1051,7 @@ class RowContainer {
         // null. This is an error with valgrind/asan.
         *reinterpret_cast<T*>(row + offset) = T();
       }
+      updateColumnHasNulls(column, true);
       return;
     }
     if constexpr (std::is_same_v<T, StringView>) {
@@ -1274,7 +1319,8 @@ class RowContainer {
       char* FOLLY_NONNULL row,
       int32_t offset,
       int32_t nullByte = 0,
-      uint8_t nullMask = 0);
+      uint8_t nullMask = 0,
+      int32_t column = 0);
 
   template <bool useRowNumbers>
   static void extractComplexType(
@@ -1383,12 +1429,20 @@ class RowContainer {
   // Free any aggregates associated with the 'rows'.
   void freeAggregates(folly::Range<char**> rows);
 
+  // Updates the specific column's columnHasNulls_ flag if 'hasNulls' is true.
+  // 'columnHasNulls_' is false by default.
+  inline void updateColumnHasNulls(int32_t columnIndex, bool hasNulls) {
+    columnHasNulls_[columnIndex] = columnHasNulls_[columnIndex] || hasNulls;
+  }
+
   const bool checkFree_ = false;
 
   const std::vector<TypePtr> keyTypes_;
   std::vector<column_index_t> keyIndices_;
   const bool nullableKeys_;
   const bool isJoinBuild_;
+
+  std::vector<bool> columnHasNulls_;
 
   // Indicates if we can add new row to this row container. It is set to false
   // after user calls 'getRowPartitions()' to create 'rowPartitions' object for
@@ -1461,8 +1515,9 @@ inline void RowContainer::storeWithNulls<TypeKind::ROW>(
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
-    uint8_t nullMask) {
-  storeComplexType(decoded, index, row, offset, nullByte, nullMask);
+    uint8_t nullMask,
+    int32_t column) {
+  storeComplexType(decoded, index, row, offset, nullByte, nullMask, column);
 }
 
 template <>
@@ -1481,8 +1536,9 @@ inline void RowContainer::storeWithNulls<TypeKind::ARRAY>(
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
-    uint8_t nullMask) {
-  storeComplexType(decoded, index, row, offset, nullByte, nullMask);
+    uint8_t nullMask,
+    int32_t column) {
+  storeComplexType(decoded, index, row, offset, nullByte, nullMask, column);
 }
 
 template <>
@@ -1501,8 +1557,9 @@ inline void RowContainer::storeWithNulls<TypeKind::MAP>(
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
-    uint8_t nullMask) {
-  storeComplexType(decoded, index, row, offset, nullByte, nullMask);
+    uint8_t nullMask,
+    int32_t column) {
+  storeComplexType(decoded, index, row, offset, nullByte, nullMask, column);
 }
 
 template <>
@@ -1521,12 +1578,14 @@ inline void RowContainer::storeWithNulls<TypeKind::HUGEINT>(
     char* FOLLY_NONNULL row,
     int32_t offset,
     int32_t nullByte,
-    uint8_t nullMask) {
+    uint8_t nullMask,
+    int32_t column) {
   if (decoded.isNullAt(index)) {
     row[nullByte] |= nullMask;
     // Do not leave an uninitialized value in the case of a
     // null. This is an error with valgrind/asan.
     memset(row + offset, 0, sizeof(int128_t));
+    updateColumnHasNulls(column, true);
     return;
   }
   HugeInt::serialize(decoded.valueAt<int128_t>(index), row + offset);
@@ -1547,6 +1606,7 @@ inline void RowContainer::extractColumnTyped<TypeKind::OPAQUE>(
     folly::Range<const vector_size_t*> /*rowNumbers*/,
     int32_t /*numRows*/,
     RowColumn /*column*/,
+    bool /*hasNulls*/,
     int32_t /*resultOffset*/,
     const VectorPtr& /*result*/,
     bool exactSize /*exactSize*/) {
@@ -1557,6 +1617,7 @@ inline void RowContainer::extractColumn(
     const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
     int32_t numRows,
     RowColumn column,
+    bool hasNulls,
     int32_t resultOffset,
     const VectorPtr& result,
     bool exactSize) {
@@ -1567,6 +1628,7 @@ inline void RowContainer::extractColumn(
       {},
       numRows,
       column,
+      hasNulls,
       resultOffset,
       result,
       exactSize);
@@ -1576,6 +1638,7 @@ inline void RowContainer::extractColumn(
     const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
     folly::Range<const vector_size_t*> rowNumbers,
     RowColumn column,
+    bool hasNulls,
     int32_t resultOffset,
     const VectorPtr& result,
     bool exactSize) {
@@ -1586,6 +1649,7 @@ inline void RowContainer::extractColumn(
       rowNumbers,
       rowNumbers.size(),
       column,
+      hasNulls,
       resultOffset,
       result,
       exactSize);

--- a/bolt/exec/WindowPartition.cpp
+++ b/bolt/exec/WindowPartition.cpp
@@ -56,6 +56,7 @@ void WindowPartition::extractColumn(
       partition_.data(),
       rowNumbers,
       columns_[columnIndex],
+      data_->columnHasNulls(inputMapping_[columnIndex]),
       resultOffset,
       result,
       exactSize);
@@ -72,6 +73,7 @@ void WindowPartition::extractColumn(
       partition_.data() + partitionOffset - offsetInPartition(),
       numRows,
       columns_[columnIndex],
+      data_->columnHasNulls(inputMapping_[columnIndex]),
       resultOffset,
       result,
       exactSize);
@@ -371,6 +373,7 @@ void WindowPartitionImpl<T>::extractColumn(
         partition_.data(),
         rowNumbers,
         columns_[columnIndex],
+        data_->columnHasNulls(inputMapping_[columnIndex]),
         resultOffset,
         result,
         exactSize);
@@ -400,6 +403,7 @@ void WindowPartitionImpl<T>::extractColumn(
         partition_.data() + partitionOffset - offsetInPartition(),
         numRows,
         columns_[columnIndex],
+        data_->columnHasNulls(inputMapping_[columnIndex]),
         resultOffset,
         result,
         exactSize);

--- a/bolt/exec/tests/RowContainerTest.cpp
+++ b/bolt/exec/tests/RowContainerTest.cpp
@@ -1788,3 +1788,56 @@ TEST_F(RowContainerTest, DISABLED_ConvertBenchmark) {
     benchmark("string_array_10K", lambda, 1000, data);
   }
 }
+
+TEST_F(RowContainerTest, columnHasNulls) {
+  auto rowContainer =
+      makeRowContainer({BIGINT(), BIGINT()}, {BIGINT(), BIGINT()}, false);
+  for (int i = 0; i < rowContainer->columnTypes().size(); ++i) {
+    ASSERT_TRUE(!rowContainer->columnHasNulls(i));
+  }
+
+  const uint64_t kNumRows = 1000;
+  auto rowVector = makeRowVector(
+      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row % 5; }),
+       makeFlatVector<int64_t>(
+           kNumRows, [](auto row) { return row % 5; }, nullEvery(3)),
+       makeFlatVector<int64_t>(kNumRows, [](auto row) { return row % 7; }),
+       makeFlatVector<int64_t>(
+           kNumRows, [](auto row) { return row % 7; }, nullEvery(999))});
+
+  std::vector<char*> rows;
+  rows.reserve(kNumRows);
+
+  ASSERT_EQ(rowContainer->numRows(), 0);
+  SelectivityVector allRows(kNumRows);
+  for (size_t i = 0; i < kNumRows; i++) {
+    auto row = rowContainer->newRow();
+    rows.push_back(row);
+  }
+  for (int i = 0; i < rowContainer->columnTypes().size(); ++i) {
+    DecodedVector decoded(*rowVector->childAt(i), allRows);
+    for (int j = 0; j < kNumRows; ++j) {
+      char* row = rows[i];
+      rowContainer->store(decoded, j, row, i);
+    }
+  }
+  for (int i = 0; i < rowContainer->columnTypes().size(); ++i) {
+    if (i % 2 == 0) {
+      ASSERT_TRUE(!rowContainer->columnHasNulls(i));
+    } else {
+      ASSERT_TRUE(rowContainer->columnHasNulls(i));
+    }
+  }
+  // If the column's mayHaveNulls is false, the extracted vector's mayHaveNulls
+  // should be false.
+  for (int i = 0; i < rowContainer->columnTypes().size(); ++i) {
+    auto vector =
+        BaseVector::create(rowVector->childAt(i)->type(), kNumRows, pool());
+    rowContainer->extractColumn(rows.data(), kNumRows, i, vector);
+    if (i % 2 == 0) {
+      ASSERT_TRUE(!vector->mayHaveNulls());
+    } else {
+      ASSERT_TRUE(vector->mayHaveNulls());
+    }
+  }
+}


### PR DESCRIPTION
Summary:
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: discussion #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Collect and use columns' HasNulls info for RowContainer.
1. Collect information on whether each column contains null values.
2. If there is no null values in the column, `extractValuesNoNulls` instead of `extractValuesWithNulls` is used to extract results from the row container. This would help reduce the unnecessary cost: [nulls buffer memory allocation](https://github.com/facebookincubator/velox/blob/main/velox/exec/RowContainer.h#L929C37-L929C49), [null bits checking](https://github.com/facebookincubator/velox/blob/main/velox/exec/RowContainer.h#L942C29-L942C62).

We observed perf gains for several queries from our TPCDS runs (1TB, 8*8 cores, ABFS) with this change. Listing some of them as below, for more details please see: https://github.com/facebookincubator/velox/issues/10776. (As the perf gains are from replacing `extractValuesWithNulls` with `extractValuesNoNulls`, some queries' latency change is not so noticeable, they are not listed here.)

  | Before | After | PerfGain
-- | -- | -- | --
query14b | 30968 | 29481 | 5%
query47 | 19324 | 18364 | 5%
query65 | 21569 | 20384 | 5%
query72 | 23209 | 22209 | 4%
query95 | 40723 | 39439 | 3%

Corresponding PR: https://github.com/facebookincubator/velox/pull/10775

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
