### PR TITLE
[perf][cp] Avoid extra overhead call sanitizeName and find

### DIFF
--- a/bolt/expression/SimpleFunctionRegistry.cpp
+++ b/bolt/expression/SimpleFunctionRegistry.cpp
@@ -70,6 +70,31 @@ const SignatureMap* getSignatureMap(
 }
 } // namespace
 
+std::unordered_map<
+    std::string,
+    std::vector<std::shared_ptr<const FunctionSignature>>>
+SimpleFunctionRegistry::getFunctionSignatureMap() const {
+  std::unordered_map<
+      std::string,
+      std::vector<std::shared_ptr<const FunctionSignature>>>
+      result;
+  registeredFunctions_.withRLock([&](const auto& map) {
+    result.reserve(map.size());
+
+    for (const auto& entry : map) {
+      std::vector<std::shared_ptr<const FunctionSignature>> signatures;
+      const auto signatureMap = &entry.second;
+      signatures.reserve(signatureMap->size());
+      for (const auto& pair : *signatureMap) {
+        signatures.emplace_back(
+            std::make_shared<const FunctionSignature>(pair.first));
+      }
+      result[entry.first] = signatures;
+    }
+  });
+  return result;
+}
+
 std::vector<std::shared_ptr<const FunctionSignature>>
 SimpleFunctionRegistry::getFunctionSignatures(const std::string& name) const {
   std::vector<std::shared_ptr<const FunctionSignature>> signatures;

--- a/bolt/expression/SimpleFunctionRegistry.h
+++ b/bolt/expression/SimpleFunctionRegistry.h
@@ -104,6 +104,11 @@ class SimpleFunctionRegistry {
   std::vector<std::shared_ptr<const FunctionSignature>> getFunctionSignatures(
       const std::string& name) const;
 
+  std::unordered_map<
+      std::string,
+      std::vector<std::shared_ptr<const exec::FunctionSignature>>>
+  getFunctionSignatureMap() const;
+
   class ResolvedSimpleFunction {
    public:
     ResolvedSimpleFunction(

--- a/bolt/functions/FunctionRegistry.cpp
+++ b/bolt/functions/FunctionRegistry.cpp
@@ -46,13 +46,6 @@
 namespace bytedance::bolt {
 namespace {
 
-void populateSimpleFunctionSignatures(FunctionSignatureMap& map) {
-  const auto& simpleFunctions = exec::simpleFunctions();
-  for (const auto& functionName : simpleFunctions.getFunctionNames()) {
-    map[functionName] = simpleFunctions.getFunctionSignatures(functionName);
-  }
-}
-
 void populateVectorFunctionSignatures(FunctionSignatureMap& map) {
   auto vectorFunctions = exec::vectorFunctionFactories();
   vectorFunctions.withRLock([&map](const auto& locked) {
@@ -68,8 +61,8 @@ void populateVectorFunctionSignatures(FunctionSignatureMap& map) {
 } // namespace
 
 FunctionSignatureMap getFunctionSignatures() {
-  FunctionSignatureMap result;
-  populateSimpleFunctionSignatures(result);
+  const auto& simpleFunctions = exec::simpleFunctions();
+  FunctionSignatureMap result = simpleFunctions.getFunctionSignatureMap();
   populateVectorFunctionSignatures(result);
   return result;
 }

--- a/bolt/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/bolt/functions/sparksql/benchmarks/CMakeLists.txt
@@ -78,3 +78,10 @@ target_link_libraries(
   bolt_benchmark_builder
   ${BOLT_BENCHMARK_DEPS}
 )
+
+add_executable(bolt_sparksql_benchmarks_get_funcs FunctionBenchmark.cpp)
+target_link_libraries(
+  bolt_sparksql_benchmarks_get_funcs PRIVATE
+  bolt_benchmark_builder
+  ${BOLT_BENCHMARK_DEPS}
+)

--- a/bolt/functions/sparksql/benchmarks/FunctionBenchmark.cpp
+++ b/bolt/functions/sparksql/benchmarks/FunctionBenchmark.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <functions/FunctionRegistry.h>
+
+#include "bolt/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "bolt/functions/sparksql/registration/Register.h"
+
+using namespace bytedance::bolt;
+class FunctionBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  FunctionBenchmark() : FunctionBenchmarkBase() {
+    functions::sparksql::registerFunctions("");
+  }
+
+  void run() {
+    volatile int total = 0;
+    for (auto i = 0; i < 1000; i++) {
+      auto functions = getFunctionSignatures();
+      auto size = functions.size();
+      total += size;
+    }
+    std::cout << total << std::endl;
+  }
+};
+
+BENCHMARK(get_function_signatures_1000) {
+  FunctionBenchmark benchmark;
+  benchmark.run();
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number:  discussion #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
This PR proposes to add `getFunctionSignatureMap`. So we can avoid the overhead of extra loop (`for (const auto& functionName : simpleFunctions.getFunctionNames())`) and the overhead of calling `getSignatureMap`.

This PR also adds a benchmark named `velox_sparksql_benchmarks_get_funcs`. Before this PR, the output of benchmark show below.

```
cmake-build-debug/velox/functions/sparksql/benchmarks/velox_sparksql_benchmarks_get_funcs
WARNING: Benchmark running in DEBUG mode
225000
225000
225000
225000
============================================================================
[...]ksql/benchmarks/FunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
get_function_signatures_1000                              256.17ms      3.90
WARNING: Benchmark running in DEBUG mode
```

After this PR, the output of benchmark show below.

```
cmake-build-debug/velox/functions/sparksql/benchmarks/velox_sparksql_benchmarks_get_funcs
WARNING: Benchmark running in DEBUG mode
225000
225000
225000
225000
225000
============================================================================
[...]ksql/benchmarks/FunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
get_function_signatures_1000                              209.14ms      4.78
WARNING: Benchmark running in DEBUG mode
```

Corresponding PR: https://github.com/facebookincubator/velox/pull/14378

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
