### PR TITLE
[cp] Add slice Spark function

### DIFF
--- a/bolt/functions/lib/CMakeLists.txt
+++ b/bolt/functions/lib/CMakeLists.txt
@@ -66,6 +66,7 @@ bolt_add_library(
   MapUpdate.cpp
   Re2Functions.cpp
   Repeat.cpp
+  Slice.cpp
   SimpleComparisonMatcher.cpp
   Size.cpp
   StringEncodingUtils.cpp

--- a/bolt/functions/lib/Slice.cpp
+++ b/bolt/functions/lib/Slice.cpp
@@ -28,9 +28,14 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/functions/lib/Slice.h"
+
 #include "bolt/expression/Expr.h"
 #include "bolt/expression/VectorFunction.h"
 #include "bolt/type/Type.h"
+
+#include <algorithm>
+
 namespace bytedance::bolt::functions {
 namespace {
 
@@ -63,6 +68,13 @@ namespace {
 /// rawSizes vector   [2, 2, 2]
 class SliceFunction : public exec::VectorFunction {
  public:
+  SliceFunction(TypeKind kind) : kind_(kind) {
+    BOLT_CHECK(
+        kind == TypeKind::BIGINT || kind == TypeKind::INTEGER,
+        "Unsupported parameter type {} to register slice function",
+        mapTypeKindToName(kind));
+  }
+
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -73,11 +85,11 @@ class SliceFunction : public exec::VectorFunction {
         args[0]->typeKind(),
         TypeKind::ARRAY,
         "Function slice() requires first argument of type ARRAY");
-    if (args[1]->typeKind() != TypeKind::BIGINT &&
-        args[1]->typeKind() != TypeKind::INTEGER) {
-      BOLT_USER_FAIL(
-          "Function slice() requires second argument of type BIGINT or INTEGER");
-    }
+    BOLT_USER_CHECK_EQ(
+        args[1]->typeKind(),
+        kind_,
+        "Function slice() requires second argument of type {}",
+        mapTypeKindToName(kind_));
     BOLT_USER_CHECK_EQ(
         args[1]->typeKind(),
         args[2]->typeKind(),
@@ -90,16 +102,16 @@ class SliceFunction : public exec::VectorFunction {
     if (!args[1]->isConstantEncoding() || !args[2]->isConstantEncoding()) {
       BaseVector::flattenVector(args[0]);
     }
-    VectorPtr localResult = nullptr;
-    if (args[1]->typeKind() == TypeKind::BIGINT) {
-      localResult = applyArray<int64_t>(rows, args, context, outputType);
-    } else {
-      localResult = applyArray<int32_t>(rows, args, context, outputType);
-    }
+
+    VectorPtr localResult = kind_ == TypeKind::INTEGER
+        ? applyArray<int32_t>(rows, args, context, outputType)
+        : applyArray<int64_t>(rows, args, context, outputType);
     context.moveOrCopyResult(localResult, rows, result);
   }
 
  private:
+  // The type kind of start and length.
+  TypeKind kind_;
   // Use template parameter rather than hard-coded TypeKind to specify array
   // data type.
   template <typename T>
@@ -218,28 +230,29 @@ class SliceFunction : public exec::VectorFunction {
   }
 };
 
-static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-  return {// array(T, bigint, bigint) -> array(T)
-          exec::FunctionSignatureBuilder()
-              .typeVariable("T")
-              .returnType("array(T)")
-              .argumentType("array(T)")
-              .argumentType("bigint")
-              .argumentType("bigint")
-              .build(),
-          exec::FunctionSignatureBuilder()
-              .typeVariable("T")
-              .returnType("array(T)")
-              .argumentType("array(T)")
-              .argumentType("integer")
-              .argumentType("integer")
-              .build()};
-}
+// @param kind The type kind of start and length.
+void registerSliceFunction(const std::string& prefix, TypeKind kind) {
+  auto kindName = exec::sanitizeName(mapTypeKindToName(kind));
 
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures = {
+      exec::FunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("array(T)")
+          .argumentType("array(T)")
+          .argumentType(kindName)
+          .argumentType(kindName)
+          .build()};
+  exec::registerVectorFunction(
+      prefix + "slice", signatures, std::make_unique<SliceFunction>(kind));
+}
 } // namespace
 
-BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_slice,
-    signatures(),
-    std::make_unique<SliceFunction>());
+void registerBigintSliceFunction(const std::string& prefix) {
+  registerSliceFunction(prefix, TypeKind::BIGINT);
+}
+
+void registerIntegerSliceFunction(const std::string& prefix) {
+  registerSliceFunction(prefix, TypeKind::INTEGER);
+}
+
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/Slice.h
+++ b/bolt/functions/lib/Slice.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <string>
+
+namespace bytedance::bolt::functions {
+
+// BIGINT type for start and length (Presto's behavior).
+void registerBigintSliceFunction(const std::string& prefix);
+
+// INTEGER type for start and length (Spark's behavior).
+void registerIntegerSliceFunction(const std::string& prefix);
+} // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/tests/SliceTestBase.h
+++ b/bolt/functions/lib/tests/SliceTestBase.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "bolt/parse/TypeResolver.h"
+
+namespace bytedance::bolt::functions::test {
+
+class SliceTestBase : public FunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    parse::registerTypeResolver();
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  virtual void testSlice(
+      const std::string& expression,
+      const std::vector<VectorPtr>& parameters,
+      const ArrayVectorPtr& expectedArrayVector) {
+    auto result = evaluate<ArrayVector>(expression, makeRowVector(parameters));
+    ::bytedance::bolt::test::assertEqualVectors(expectedArrayVector, result);
+    EXPECT_NO_THROW(expectedArrayVector->checkRanges());
+  }
+
+  void basicTestCases() {
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      testSlice("slice(C0, 1, 4)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{1, 2}});
+      testSlice("slice(C0, 1, 4)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{3, 4}});
+      testSlice("slice(C0, 3, 2)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{3, 4}});
+      testSlice("slice(C0, 3, 3)", {arrayVector}, expectedArrayVector);
+    }
+    // Negative start index.
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{2, 3, 4}});
+      testSlice("slice(C0, -3, 3)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{2, 3, 4}});
+      testSlice("slice(C0, -3, 5)", {arrayVector}, expectedArrayVector);
+    }
+    // Negative length.
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      BOLT_ASSERT_THROW(
+          testSlice(
+              "slice(C0, 1, -1)",
+              {arrayVector, arrayVector, expectedArrayVector},
+              expectedArrayVector),
+          "The value of length argument of slice() function should not be negative");
+    }
+    // 0 start index.
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      BOLT_ASSERT_THROW(
+          testSlice(
+              "slice(C0, 0, 1)",
+              {arrayVector, arrayVector, expectedArrayVector},
+              expectedArrayVector),
+          "SQL array indices start at 1");
+    }
+    // 0 length.
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      testSlice("slice(C0, 1, 0)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      testSlice("slice(C0, -2, 0)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      testSlice("slice(C0, -2, 0)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      testSlice("slice(C0, -5, 5)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      testSlice("slice(C0, -6, 5)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
+      auto expectedArrayVector = makeArrayVector<int64_t>({{}});
+      testSlice("slice(C0, -6, 5)", {arrayVector}, expectedArrayVector);
+    }
+    {
+      // The implementation is zero-copy, so floating point number comparison
+      // won't have issue here since numerical representation remains the same.
+      auto arrayVector = makeArrayVector<double>({{2.3, 2.3, 2.2}});
+      auto expectedArrayVector = makeArrayVector<double>({{2.3, 2.2}});
+      testSlice("slice(C0, 2, 3)", {arrayVector}, expectedArrayVector);
+    }
+    // String array.
+    {
+      auto arrayVector = makeArrayVector<StringView>({{"a", "b", "c", "d"}});
+      auto expectedArrayVector = makeArrayVector<StringView>({{"b", "c"}});
+      testSlice("slice(C0, 2, 2)", {arrayVector}, expectedArrayVector);
+    }
+    // Out of bound start index.
+    {
+      auto arrayVector = makeArrayVector<StringView>({{"a", "b", "c", "d"}});
+      auto expectedArrayVector = makeArrayVector<StringView>({{}});
+      testSlice("slice(C0, 5, 2)", {arrayVector}, expectedArrayVector);
+    }
+    // Out of bound length.
+    {
+      auto arrayVector = makeArrayVector<StringView>({{"a", "b", "c", "d"}});
+      auto expectedArrayVector = makeArrayVector<StringView>({{"b", "c", "d"}});
+      testSlice("slice(C0, 2, 5)", {arrayVector}, expectedArrayVector);
+    }
+  }
+};
+
+} // namespace bytedance::bolt::functions::test

--- a/bolt/functions/prestosql/CMakeLists.txt
+++ b/bolt/functions/prestosql/CMakeLists.txt
@@ -60,7 +60,6 @@ bolt_add_library(
   Reverse.cpp
   RowFunction.cpp
   Sequence.cpp
-  Slice.cpp
   Split.cpp
   StringFunctions.cpp
   StringToMap.cpp

--- a/bolt/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/bolt/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -34,12 +34,14 @@
 #include "bolt/functions/lib/ArrayRemoveNullFunction.h"
 #include "bolt/functions/lib/ArrayShuffle.h"
 #include "bolt/functions/lib/Repeat.h"
+#include "bolt/functions/lib/Slice.h"
 #include "bolt/functions/prestosql/ArrayConstructor.h"
 #include "bolt/functions/prestosql/ArrayContains.h"
 #include "bolt/functions/prestosql/ArrayFunctions.h"
 #include "bolt/functions/prestosql/ArraySort.h"
 #include "bolt/functions/prestosql/WidthBucketArray.h"
 #include "bolt/functions/sparksql/ArraySort.h"
+
 namespace bytedance::bolt::functions {
 extern void registerArrayConcatFunctions(const std::string& prefix);
 extern void registerArrayNGramsFunctions(const std::string& prefix);
@@ -149,13 +151,12 @@ void registerArrayFunctions(const std::string& prefix) {
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_contains, prefix + "array_contains");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_except, prefix + "array_except");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, prefix + "arrays_overlap");
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_slice, prefix + "slice");
+  registerBigintSliceFunction(prefix);
   BOLT_REGISTER_VECTOR_FUNCTION(udf_zip, prefix + "zip");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_zip_with, prefix + "zip_with");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_position, prefix + "array_position");
 
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_element, prefix + "element");
-
   exec::registerStatefulVectorFunction(
       prefix + "shuffle", arrayShuffleSignatures(), makeArrayShuffle);
 

--- a/bolt/functions/prestosql/tests/SliceTest.cpp
+++ b/bolt/functions/prestosql/tests/SliceTest.cpp
@@ -28,116 +28,23 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/common/base/tests/GTestUtils.h"
-#include "bolt/functions/prestosql/tests/utils/FunctionBaseTest.h"
-using namespace bytedance::bolt;
-using namespace bytedance::bolt::test;
-using namespace bytedance::bolt::functions::test;
+#include "bolt/functions/lib/tests/SliceTestBase.h"
+#include "bolt/functions/prestosql/registration/RegistrationFunctions.h"
 
+namespace bytedance::bolt::functions::prestosql {
 namespace {
 
-class SliceTest : public FunctionBaseTest {
+class SliceTest : public test::SliceTestBase {
  protected:
   static const vector_size_t kVectorSize{1000};
-
-  void testSlice(
-      const std::string& expression,
-      const std::vector<VectorPtr>& parameters,
-      const ArrayVectorPtr& expectedArrayVector) {
-    auto result = evaluate<ArrayVector>(expression, makeRowVector(parameters));
-    assertEqualVectors(expectedArrayVector, result);
-    EXPECT_NO_THROW(expectedArrayVector->checkRanges());
+  static void SetUpTestCase() {
+    SliceTestBase::SetUpTestCase();
+    registerAllScalarFunctions();
   }
 };
 
-TEST_F(SliceTest, prestoTestCases) {
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    testSlice("slice(C0, 1, 4)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{1, 2}});
-    testSlice("slice(C0, 1, 4)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{3, 4}});
-    testSlice("slice(C0, 3, 2)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{3, 4}});
-    testSlice("slice(C0, 3, 3)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{2, 3, 4}});
-    testSlice("slice(C0, -3, 3)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{2, 3, 4}});
-    testSlice("slice(C0, -3, 5)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    testSlice("slice(C0, 1, 0)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    testSlice("slice(C0, -2, 0)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    testSlice("slice(C0, -2, 0)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    testSlice("slice(C0, -5, 5)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    testSlice("slice(C0, -6, 5)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    testSlice("slice(C0, -6, 5)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    // The implementation is zero-copy, so floating point number comparison
-    // won't have issue here since numerical representation remains the same.
-    auto arrayVector = makeArrayVector<double>({{2.3, 2.3, 2.2}});
-    auto expectedArrayVector = makeArrayVector<double>({{2.3, 2.2}});
-    testSlice("slice(C0, 2, 3)", {arrayVector}, expectedArrayVector);
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    BOLT_ASSERT_THROW(
-        testSlice(
-            "slice(C0, 1, -1)",
-            {arrayVector, arrayVector, expectedArrayVector},
-            expectedArrayVector),
-        "The value of length argument of slice() function should not be negative");
-  }
-  {
-    auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3, 4}});
-    auto expectedArrayVector = makeArrayVector<int64_t>({{}});
-    BOLT_ASSERT_THROW(
-        testSlice(
-            "slice(C0, 0, 1)",
-            {arrayVector, arrayVector, expectedArrayVector},
-            expectedArrayVector),
-        "SQL array indices start at 1");
-  }
+TEST_F(SliceTest, basic) {
+  basicTestCases();
 }
 
 TEST_F(SliceTest, constantInputArray) {
@@ -239,78 +146,6 @@ TEST_F(SliceTest, variableInputArray) {
     auto startsVector = makeFlatVector<int64_t>(
         kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
     auto lengthsVector = makeFlatVector<int64_t>(
-        kVectorSize, [](vector_size_t /*row*/) { return 7; });
-    auto sizeAt = [](vector_size_t /*row*/) { return 7; };
-    auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
-      return 1 + idx;
-    };
-    auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
-
-    auto expectedSizeAt = [](vector_size_t row) { return 7 - row % 7; };
-    auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
-      return 1 + row % 7 + idx;
-    };
-    auto expectedArrayVector =
-        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
-    testSlice(
-        "slice(C0, C1, C2)",
-        {arrayVector, startsVector, lengthsVector},
-        expectedArrayVector);
-  }
-}
-
-TEST_F(SliceTest, variableInputIntegerArray) {
-  {
-    auto startsVector = makeFlatVector<int32_t>(
-        kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
-    auto lengthsVector = makeFlatVector<int32_t>(
-        kVectorSize, [](vector_size_t /*row*/) { return 1; });
-    auto sizeAt = [](vector_size_t /*row*/) { return 7; };
-    auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
-      return 1 + idx;
-    };
-    auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
-
-    auto expectedSizeAt = [](vector_size_t /*row*/) { return 1; };
-    auto expectedValueAt = [](vector_size_t row, vector_size_t /*idx*/) {
-      return 1 + row % 7;
-    };
-    auto expectedArrayVector =
-        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
-    testSlice(
-        "slice(C0, C1, C2)",
-        {arrayVector, startsVector, lengthsVector},
-        expectedArrayVector);
-  }
-  {
-    auto startsVector = makeFlatVector<int32_t>(
-        kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
-    auto lengthsVector = makeFlatVector<int32_t>(
-        kVectorSize, [](vector_size_t /*row*/) { return 2; });
-    auto sizeAt = [](vector_size_t /*row*/) { return 7; };
-    auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
-      return 1 + idx;
-    };
-    auto arrayVector = makeArrayVector<int64_t>(kVectorSize, sizeAt, valueAt);
-
-    auto expectedSizeAt = [](vector_size_t row) {
-      return (row + 1) % 7 == 0 ? 1 : 2;
-    };
-    auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
-      return 1 + row % 7 + idx;
-    };
-    auto expectedArrayVector =
-        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
-    testSlice(
-        "slice(C0, C1, C2)",
-        {arrayVector, startsVector, lengthsVector},
-        expectedArrayVector);
-  }
-
-  {
-    auto startsVector = makeFlatVector<int32_t>(
-        kVectorSize, [](vector_size_t row) { return 1 + row % 7; });
-    auto lengthsVector = makeFlatVector<int32_t>(
         kVectorSize, [](vector_size_t /*row*/) { return 7; });
     auto sizeAt = [](vector_size_t /*row*/) { return 7; };
     auto valueAt = [](vector_size_t /*row*/, vector_size_t idx) {
@@ -484,3 +319,4 @@ TEST_F(SliceTest, constantArrayNonConstantLength) {
 }
 
 } // namespace
+} // namespace bytedance::bolt::functions::prestosql

--- a/bolt/functions/sparksql/registration/RegisterArray.cpp
+++ b/bolt/functions/sparksql/registration/RegisterArray.cpp
@@ -32,6 +32,7 @@
 #include "bolt/functions/lib/ArrayShuffle.h"
 #include "bolt/functions/lib/RegistrationHelpers.h"
 #include "bolt/functions/lib/Repeat.h"
+#include "bolt/functions/lib/Slice.h"
 #include "bolt/functions/prestosql/ArrayFunctions.h"
 #include "bolt/functions/sparksql/ArrayAppend.h"
 #include "bolt/functions/sparksql/ArrayFlattenFunction.h"
@@ -204,6 +205,8 @@ void registerArrayFunctions(const std::string& prefix) {
       prefix + "array_repeat",
       repeatSignatures(),
       makeRepeatAllowNegativeCount);
+
+  registerIntegerSliceFunction(prefix);
 
   // for now, register ArrayRemoveFunctionString that takes String input and
   // output is enough for our use cases. In future, if need to support more

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(
   RaiseErrorTest.cpp
   RandTest.cpp
   RegexFunctionsTest.cpp
+  SliceTest.cpp
   SizeTest.cpp
   SortArrayTest.cpp
   SparkArraySortTest.cpp

--- a/bolt/functions/sparksql/tests/SliceTest.cpp
+++ b/bolt/functions/sparksql/tests/SliceTest.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/functions/lib/tests/SliceTestBase.h"
+#include "bolt/functions/sparksql/registration/Register.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+
+namespace {
+class SliceTest : public ::bytedance::bolt::functions::test::SliceTestBase {
+ protected:
+  static void SetUpTestCase() {
+    SliceTestBase::SetUpTestCase();
+    sparksql::registerFunctions("");
+  }
+
+  void SetUp() override {
+    // Parses integer literals as INTEGER, not BIGINT.
+    options_.parseIntegerAsBigint = false;
+  }
+};
+
+TEST_F(SliceTest, basic) {
+  basicTestCases();
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

In Spark,  the type of 'start' and 'length' is INTEGER, while in Presto it is BIGINT.

Spark's documentation: https://spark.apache.org/docs/latest/api/sql/#slice

Spark's implementation:
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L1864-L1978

Corresponding PR: https://github.com/facebookincubator/velox/pull/9620


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Add slice Spark function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
