### PR TITLE
[cp]Reject duplicate sorting keys

### DIFF
--- a/bolt/core/PlanNode.h
+++ b/bolt/core/PlanNode.h
@@ -1998,6 +1998,15 @@ class OrderByNode : public PlanNode {
         sortingKeys.size(),
         sortingOrders.size(),
         "Number of sorting keys and sorting orders in OrderBy must be the same");
+    // Reject duplicate sorting keys.
+    std::unordered_set<std::string> uniqueKeys;
+    for (const auto& sortKey : sortingKeys) {
+      BOLT_USER_CHECK_NOT_NULL(sortKey, "Sorting key cannot be null");
+      BOLT_USER_CHECK(
+          uniqueKeys.insert(sortKey->name()).second,
+          "Duplicate sorting keys are not allowed: {}",
+          sortKey->name());
+    }
   }
 
   const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {

--- a/bolt/core/tests/PlanFragmentTest.cpp
+++ b/bolt/core/tests/PlanFragmentTest.cpp
@@ -120,7 +120,8 @@ TEST_F(PlanFragmentTest, orderByCanSpill) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
 
-    const std::vector<FieldAccessTypedExprPtr> sortingKeys{nullptr};
+    const std::vector<FieldAccessTypedExprPtr> sortingKeys{
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0")};
     const std::vector<SortOrder> sortingOrders{{true, true}};
     auto orderBy = std::make_shared<OrderByNode>(
         "orderBy", sortingKeys, sortingOrders, false, valueNode_);

--- a/bolt/core/tests/PlanNodeTest.cpp
+++ b/bolt/core/tests/PlanNodeTest.cpp
@@ -30,6 +30,7 @@
 
 #include <gtest/gtest.h>
 
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/PlanNode.h"
 
 using namespace ::bytedance::bolt;
@@ -119,5 +120,19 @@ TEST_F(PlanNodeTest, sortOrder) {
       ASSERT_NE(testData.order1, testData.order2);
     }
   }
+}
+
+TEST_F(PlanNodeTest, duplicateSortKeys) {
+  auto sortingKeys = std::vector<FieldAccessTypedExprPtr>{
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0"),
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c1"),
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0"),
+  };
+  auto sortingOrders =
+      std::vector<SortOrder>{{true, true}, {false, false}, {true, true}};
+  BOLT_ASSERT_USER_THROW(
+      std::make_shared<OrderByNode>(
+          "orderBy", sortingKeys, sortingOrders, false, nullptr),
+      "Duplicate sorting keys are not allowed: c0");
 }
 } // namespace


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

A SQL query may specify duplicate sorting keys:

``` sql
SELECT c1 FROM t ORDER BY c1, c1
```

Such query fails in Gluten:
```
Caused by: java.lang.RuntimeException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (1 vs. 2)
Retriable: False
Expression: input_->size() >= sortCompareFlags_.size()
Function: SortBuffer
File: /opt/gluten/gluten/ep/build-velox/build/velox_ep/velox/exec/SortBuffer.cpp
Line: 36
```

Harden OrderByNode to reject duplicate sorting keys. The query planner should ensure the sorting keys are unique.

Corresponding PR: https://github.com/facebookincubator/velox/pull/10040

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Reject duplicate sorting keys
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>



