### PR TITLE
[cp]Fix NaN handling in Spark In function

### DIFF
--- a/bolt/functions/sparksql/In.cpp
+++ b/bolt/functions/sparksql/In.cpp
@@ -37,11 +37,24 @@
 #include "bolt/functions/sparksql/Arena.h"
 #include "bolt/functions/sparksql/Comparisons.h"
 #include "bolt/type/Filter.h"
+#include "bolt/type/FloatingPointUtil.h"
 namespace bytedance::bolt::functions::sparksql {
 namespace {
 
 template <typename T>
 class Set : public folly::F14FastSet<T, folly::hasher<T>, Equal<T>> {};
+
+template <>
+class Set<float> : public folly::F14FastSet<
+                       float,
+                       util::floating_point::NaNAwareHash<float>,
+                       util::floating_point::NaNAwareEquals<float>> {};
+
+template <>
+class Set<double> : public folly::F14FastSet<
+                        double,
+                        util::floating_point::NaNAwareHash<double>,
+                        util::floating_point::NaNAwareEquals<double>> {};
 
 template <>
 class Set<StringView> {

--- a/bolt/functions/sparksql/tests/InTest.cpp
+++ b/bolt/functions/sparksql/tests/InTest.cpp
@@ -157,6 +157,7 @@ TEST_F(InTest, Float) {
   EXPECT_EQ(in<float>(-0.0, {-1.0, 0.0, 1.0}), true);
   EXPECT_EQ(in<float>(kNan, {-1.0, 0.0, 1.0}), false);
   EXPECT_EQ(in<float>(kNan, {kNan, -1.0, 0.0, 1.0}), true);
+  EXPECT_EQ(in<float>(std::nanf("1"), {kNan, -1.0, 0.0, 1.0}), true);
 }
 
 TEST_F(InTest, Double) {
@@ -165,6 +166,7 @@ TEST_F(InTest, Double) {
   EXPECT_EQ(in<double>(-0.0, {-1.0, 0.0, 1.0}), true);
   EXPECT_EQ(in<double>(kNan, {-1.0, 0.0, 1.0}), false);
   EXPECT_EQ(in<double>(kNan, {kNan, -1.0, 0.0, 1.0}), true);
+  EXPECT_EQ(in<double>(std::nan("1"), {kNan, -1.0, 0.0, 1.0}), true);
   EXPECT_EQ(in<double>(kInf, {kNan, -1.0, 0.0, 1.0}), false);
   EXPECT_EQ(in<double>(kInf, {kNan, -1.0, 0.0, 1.0, kInf}), true);
   EXPECT_EQ(in<double>(-kInf, {kNan, -1.0, 0.0, 1.0}), false);


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Different NaNs are handled as same in Spark.
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/SQLOrderingUtil.scala#L28

```
spark.sql("select cast('inf' as double)/cast('inf' as double)  in (1, 2, 3, cast('nan' as double))").collect
res11: Array[org.apache.spark.sql.Row] = Array([true])
spark.sql("select 0 * cast('inf' as double)  in (1, cast('nan' as double))").collect
res12: Array[org.apache.spark.sql.Row] = Array([true])
```

Corresponding PR: https://github.com/facebookincubator/velox/pull/10259

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fix NaN handling in Spark In function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>







