### PR TITLE
[cp]Support complex types for Spark EqualTo and EqualNullSafe functions

### DIFF
--- a/bolt/functions/sparksql/Comparisons.h
+++ b/bolt/functions/sparksql/Comparisons.h
@@ -30,7 +30,10 @@
 
 #pragma once
 
+#include "bolt/common/base/CompareFlags.h"
 #include "bolt/expression/VectorFunction.h"
+#include "bolt/functions/Macros.h"
+
 namespace bytedance::bolt::functions::sparksql {
 
 // Comparison functions that implement SparkSQL semantics.
@@ -242,5 +245,44 @@ std::shared_ptr<exec::VectorFunction> makeEqualToNullSafe(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
+
+template <typename T>
+struct EqualToFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+  // For arbitrary nested complex types.
+  FOLLY_ALWAYS_INLINE bool call(
+      bool& out,
+      const arg_type<Generic<T1>>& lhs,
+      const arg_type<Generic<T1>>& rhs) {
+    static constexpr CompareFlags kFlags =
+        CompareFlags::equality(CompareFlags::NullHandlingMode::kNullAsValue);
+
+    auto result = lhs.compare(rhs, kFlags);
+    out = (result.value() == 0);
+    return true;
+  }
+};
+
+template <typename T>
+struct EqualNullSafeFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+  // For arbitrary nested complex types.
+  FOLLY_ALWAYS_INLINE bool callNullable(
+      bool& out,
+      const arg_type<Generic<T1>>* lhs,
+      const arg_type<Generic<T1>>* rhs) {
+    static constexpr CompareFlags kFlags =
+        CompareFlags::equality(CompareFlags::NullHandlingMode::kNullAsValue);
+    if (!lhs && !rhs) {
+      out = true;
+    } else if (!lhs || !rhs) {
+      out = false;
+    } else {
+      auto result = lhs->compare(*rhs, kFlags);
+      out = (result.value() == 0);
+    }
+    return true;
+  }
+};
 
 } // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/registration/RegisterComparison.cpp
+++ b/bolt/functions/sparksql/registration/RegisterComparison.cpp
@@ -44,6 +44,8 @@ void registerCompareFunctions(const std::string& prefix) {
   registerSparkCompareFunctions(prefix);
   exec::registerStatefulVectorFunction(
       prefix + "equalto", comparisonSignatures(), makeEqualTo);
+  registerFunction<EqualToFunction, bool, Generic<T1>, Generic<T1>>(
+      {prefix + "equalto"});
   exec::registerStatefulVectorFunction(
       prefix + "lessthan", comparisonSignatures(), makeLessThan);
   exec::registerStatefulVectorFunction(
@@ -57,12 +59,13 @@ void registerCompareFunctions(const std::string& prefix) {
   // Compare nullsafe functions.
   exec::registerStatefulVectorFunction(
       prefix + "equalnullsafe", equalSignatures(), makeEqualToNullSafe);
+  registerFunction<EqualNullSafeFunction, bool, Generic<T1>, Generic<T1>>(
+      {prefix + "equalnullsafe"});
 
   exec::registerStatefulVectorFunction(
       prefix + "least", leastSignatures(), makeLeast);
   exec::registerStatefulVectorFunction(
       prefix + "greatest", greatestSignatures(), makeGreatest);
-
   registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>(
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, int16_t, int16_t, int16_t>(

--- a/bolt/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/bolt/functions/sparksql/tests/ComparisonsTest.cpp
@@ -176,10 +176,58 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     auto actual = evaluate<SimpleVector<bool>>(
         fmt::format("{}(c0, c1)", functionName), makeRowVector(input));
     bytedance::bolt::test::assertEqualVectors(expectedResult, actual);
-  };
+  }
+
+  RowVectorPtr constructRowVector(
+      const std::optional<int64_t>& value,
+      const bool rowIsNull = false) {
+    auto child = makeNullableFlatVector<int64_t>({value});
+    if (rowIsNull) {
+      return makeRowVector({child}, nullEvery(1));
+    }
+    return makeRowVector({child});
+  }
+
+  void runAndCompareForArrayInput(
+      const std::string& functionName,
+      const std::string& array1,
+      const std::string& array2,
+      std::optional<bool> expectedResult) {
+    auto vector1 = makeArrayVectorFromJson<double>({array1});
+    auto vector2 = makeArrayVectorFromJson<double>({array2});
+    runAndCompare(
+        functionName,
+        {vector1, vector2},
+        makeNullableFlatVector<bool>({expectedResult}));
+  }
+
+  void runAndCompareForRowInput(
+      const std::string& functionName,
+      const RowVectorPtr& vector1,
+      const RowVectorPtr& vector2,
+      const VectorPtr& expectedResult) {
+    runAndCompare(functionName, {vector1, vector2}, expectedResult);
+  }
 };
 
 TEST_F(ComparisonsTest, equaltonullsafe) {
+  const auto funcName = "equalnullsafe";
+  auto testArrayInput = [&](const std::string& array1,
+                            const std::string& array2,
+                            std::optional<bool> expectedResult) {
+    runAndCompareForArrayInput(funcName, array1, array2, expectedResult);
+  };
+
+  auto testRowInput = [&](const std::optional<int64_t>& value1,
+                          const std::optional<int64_t>& value2,
+                          std::optional<bool> expectedResult) {
+    runAndCompareForRowInput(
+        funcName,
+        constructRowVector(value1),
+        constructRowVector(value2),
+        makeNullableFlatVector<bool>({expectedResult}));
+  };
+
   EXPECT_EQ(equaltonullsafe<int64_t>(1, 1), true);
   EXPECT_EQ(equaltonullsafe<int32_t>(1, 2), false);
   EXPECT_EQ(equaltonullsafe<float>(std::nullopt, std::nullopt), true);
@@ -189,9 +237,67 @@ TEST_F(ComparisonsTest, equaltonullsafe) {
   EXPECT_EQ(equaltonullsafe<double>(kNaN, std::nullopt), false);
   EXPECT_EQ(equaltonullsafe<double>(kNaN, 1), false);
   EXPECT_EQ(equaltonullsafe<double>(kNaN, kNaN), true);
+
+  testArrayInput("null", "null", true);
+  testArrayInput("null", "[1.0]", false);
+  testArrayInput("[1.0]", "null", false);
+
+  testArrayInput("[]", "[]", true);
+
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 3.0]", true);
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 4.0]", false);
+
+  testArrayInput("[1.0, null]", "[6.0, 2.0]", false);
+  testArrayInput("[1.0, null]", "[1.0, 2.0]", false);
+  testArrayInput("[1.0, NaN]", "[1.0, NaN]", true);
+
+  testArrayInput("[]", "[null, null]", false);
+  testArrayInput("[1.0, 2.0]", "[1.0, 2.0, null]", false);
+  testArrayInput("[null, null]", "[null, null, null]", false);
+
+  testArrayInput("[null, null]", "[null, null]", true);
+
+  testRowInput(std::nullopt, std::nullopt, true);
+  testRowInput(std::nullopt, 1, false);
+  testRowInput(1, std::nullopt, false);
+
+  testRowInput(1, 2, false);
+  testRowInput(1, 1, true);
+
+  runAndCompareForRowInput(
+      funcName,
+      constructRowVector(std::nullopt, true),
+      constructRowVector(std::nullopt, true),
+      makeNullableFlatVector<bool>({true}));
+  runAndCompareForRowInput(
+      funcName,
+      constructRowVector(std::nullopt, true),
+      constructRowVector(1, false),
+      makeNullableFlatVector<bool>({false}));
+  runAndCompareForRowInput(
+      funcName,
+      constructRowVector(1, false),
+      constructRowVector(std::nullopt, true),
+      makeNullableFlatVector<bool>({false}));
 }
 
 TEST_F(ComparisonsTest, equalto) {
+  const auto funcName = "equalto";
+  auto testArrayInput = [&](const std::string& array1,
+                            const std::string& array2,
+                            std::optional<bool> expectedResult) {
+    runAndCompareForArrayInput(funcName, array1, array2, expectedResult);
+  };
+
+  auto testRowInput = [&](const std::optional<int64_t>& value1,
+                          const std::optional<int64_t>& value2,
+                          std::optional<bool> expectedResult) {
+    runAndCompareForRowInput(
+        funcName,
+        constructRowVector(value1),
+        constructRowVector(value2),
+        makeNullableFlatVector<bool>({expectedResult}));
+  };
   EXPECT_EQ(equalto<Timestamp>(Timestamp(2, 2), Timestamp(2, 2)), true);
   EXPECT_EQ(equalto<StringView>("test"_sv, "test"_sv), true);
   EXPECT_EQ(equalto<StringView>("test"_sv, std::nullopt), std::nullopt);
@@ -213,6 +319,48 @@ TEST_F(ComparisonsTest, equalto) {
   EXPECT_EQ(equalto<float>(-kInfF, 1.0), false);
   EXPECT_EQ(equalto<float>(kInfF, -kInfF), false);
   EXPECT_EQ(equalto<double>(kInf, kNaN), false);
+
+  testArrayInput("null", "null", std::nullopt);
+  testArrayInput("null", "[1.0]", std::nullopt);
+  testArrayInput("[1.0]", "null", std::nullopt);
+
+  testArrayInput("[]", "[]", true);
+
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 3.0]", true);
+  testArrayInput("[1.0, 2.0, 3.0]", "[1.0, 2.0, 4.0]", false);
+
+  testArrayInput("[1.0, null]", "[6.0, 2.0]", false);
+  testArrayInput("[1.0, null]", "[1.0, 2.0]", false);
+  testArrayInput("[1.0, NaN]", "[1.0, NaN]", true);
+
+  testArrayInput("[]", "[null, null]", false);
+  testArrayInput("[1.0, 2.0]", "[1.0, 2.0, null]", false);
+  testArrayInput("[null, null]", "[null, null, null]", false);
+
+  testArrayInput("[null, null]", "[null, null]", true);
+
+  testRowInput(std::nullopt, std::nullopt, true);
+  testRowInput(std::nullopt, 1, false);
+  testRowInput(1, std::nullopt, false);
+
+  testRowInput(1, 2, false);
+  testRowInput(1, 1, true);
+
+  runAndCompareForRowInput(
+      funcName,
+      constructRowVector(std::nullopt, true),
+      constructRowVector(std::nullopt, true),
+      makeNullableFlatVector<bool>({std::nullopt}));
+  runAndCompareForRowInput(
+      funcName,
+      constructRowVector(std::nullopt, true),
+      constructRowVector(1, false),
+      makeNullableFlatVector<bool>({std::nullopt}));
+  runAndCompareForRowInput(
+      funcName,
+      constructRowVector(1, false),
+      constructRowVector(std::nullopt, true),
+      makeNullableFlatVector<bool>({std::nullopt}));
 }
 
 TEST_F(ComparisonsTest, compareForArray) {
@@ -903,16 +1051,11 @@ TEST_F(ComparisonsTest, dateTypes) {
 
 TEST_F(ComparisonsTest, notSupportedTypes) {
   const auto candidataFuncs = {
-      "equalto",
-      "equalnullsafe",
-      "lessthan",
-      "lessthanorequal",
-      "greaterthan",
-      "greaterthanorequal"};
+      "lessthan", "lessthanorequal", "greaterthan", "greaterthanorequal"};
   auto arrayData = makeArrayVectorFromJson<int64_t>({"[1, 2, 3]"});
   auto mapData = makeMapVectorFromJson<int64_t, int64_t>({"{1: 1}"});
   auto rowData = makeRowVector({arrayData});
-  std::vector<VectorPtr> unsupportedTypeData = {mapData, rowData};
+  std::vector<VectorPtr> unsupportedTypeData = {arrayData, mapData, rowData};
   auto testFails = [&](const std::string& func, const VectorPtr& vector) {
     BOLT_ASSERT_USER_THROW(
         evaluate<SimpleVector<bool>>(
@@ -929,7 +1072,6 @@ TEST_F(ComparisonsTest, notSupportedTypes) {
       testFails(func, data);
     }
   }
-  testFails("equalnullsafe", arrayData);
 }
 } // namespace
 }; // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description


Support complex types for Spark EqualTo and EqualNullSafe functions.                                        
Some samples for special cases:                                                                             
  ```  scala                                                                  
    spark.sql("select struct('Spark', null) = struct('Spark', null)").collect                                 
    res10: Array[org.apache.spark.sql.Row] = Array([true])                                                    
                                                                                                              
    spark.sql("select struct('Spark', null) <=> struct('Spark', null)").collect                               
    res9: Array[org.apache.spark.sql.Row] = Array([true])                                                     
                                                                                                              
    spark.sql("select CAST(NULL AS STRUCT<Field1:INT,Field2:ARRAY<INT>>) == CAST(NULL AS                      
  STRUCT<Field1:INT,Field2:ARRAY<INT>>)").collect                                                             
    res4: Array[org.apache.spark.sql.Row] = Array([null])                                                     
                                                                                                              
    spark.sql("select CAST(NULL AS STRUCT<Field1:INT,Field2:ARRAY<INT>>) <=> CAST(NULL AS                     
  STRUCT<Field1:INT,Field2:ARRAY<INT>>)").collect                                                             
    res13: Array[org.apache.spark.sql.Row] = Array([true])     
```                                               
Corresponding PR:  https://github.com/facebookincubator/velox/pull/10156    

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Support complex types for Spark EqualTo and EqualNullSafe functions
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>

