### PR TITLE
[cp]Fix argument check error message for HistogramAggregate

### DIFF
--- a/bolt/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/bolt/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -387,10 +387,7 @@ void registerHistogramAggregate(const std::string& prefix) {
           const core::QueryConfig&
           /*config*/) -> std::unique_ptr<exec::Aggregate> {
         BOLT_CHECK_EQ(
-            argTypes.size(),
-            1,
-            "{} ({}): unexpected number of arguments",
-            name);
+            argTypes.size(), 1, "{}: unexpected number of arguments", name);
 
         auto inputType = argTypes[0];
         switch (exec::isRawInput(step) ? inputType->kind()

--- a/bolt/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/bolt/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -185,7 +185,7 @@ void registerMapAggAggregate(const std::string& prefix) {
         BOLT_CHECK_EQ(
             argTypes.size(),
             rawInput ? 2 : 1,
-            "{} ({}): unexpected number of arguments",
+            "{}: unexpected number of arguments",
             name);
         const bool throwOnNestedNulls = rawInput;
         const auto typeKind = resultType->childAt(0)->kind();

--- a/bolt/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/bolt/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -110,10 +110,7 @@ void registerMapUnionAggregate(const std::string& prefix) {
           const core::QueryConfig&
           /*config*/) -> std::unique_ptr<exec::Aggregate> {
         BOLT_CHECK_EQ(
-            argTypes.size(),
-            1,
-            "{} ({}): unexpected number of arguments",
-            name);
+            argTypes.size(), 1, "{}: unexpected number of arguments", name);
 
         return createMapAggregate<MapUnionAggregate>(resultType);
       });


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

"{} ({}): unexpected number of arguments", ->
C++ exception with description "argument not found" thrown in the test body.

Corresponding PR:  https://github.com/facebookincubator/velox/pull/10501

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fix argument check error message for HistogramAggregate
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
