### PR TITLE
[cp]Use ClockTimer in dwrf reader

### DIFF
--- a/bolt/dwio/common/SelectiveColumnReaderInternal.h
+++ b/bolt/dwio/common/SelectiveColumnReaderInternal.h
@@ -47,18 +47,6 @@ namespace bytedance::bolt::dwio::common {
 
 bolt::common::AlwaysTrue& alwaysTrue();
 
-class Timer {
- public:
-  Timer() : startClocks_{folly::hardware_timestamp()} {}
-
-  uint64_t elapsedClocks() const {
-    return folly::hardware_timestamp() - startClocks_;
-  }
-
- private:
-  const uint64_t startClocks_;
-};
-
 template <typename T>
 void SelectiveColumnReader::ensureValuesCapacity(vector_size_t numRows) {
   if (values_ && values_->unique() &&

--- a/bolt/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -128,7 +128,7 @@ void SelectiveIntegerDictionaryColumnReader::ensureInitialized() {
     return;
   }
 
-  Timer timer;
+  ClockTimer timer{initTimeClocks_};
   scanState_.dictionary.values = dictInit_();
   if (scanSpec_->hasFilter()) {
     // Make sure there is a cache even for an empty dictionary because of asan
@@ -140,9 +140,8 @@ void SelectiveIntegerDictionaryColumnReader::ensureInitialized() {
         FilterResult::kUnknown,
         scanState_.filterCache.size());
   }
-  initialized_ = true;
-  initTimeClocks_ = timer.elapsedClocks();
   scanState_.updateRawState();
+  initialized_ = true;
 }
 
 } // namespace bytedance::bolt::dwrf

--- a/bolt/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -342,7 +342,7 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
     return;
   }
 
-  Timer timer;
+  ClockTimer timer{initTimeClocks_};
 
   loadDictionary(*blobStream_, *lengthDecoder_, scanState_.dictionary);
 
@@ -370,7 +370,6 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
   }
   scanState_.updateRawState();
   initialized_ = true;
-  initTimeClocks_ = timer.elapsedClocks();
 }
 
 } // namespace bytedance::bolt::dwrf


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Use ClockTimer in the dwrf reader, and remove the redundant Timer in it.

Corresponding PR:  https://github.com/facebookincubator/velox/pull/10931

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Use succinctMillis to print task running time
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









