### PR TITLE
[cp] feat(function): Add Spark dayname function 

### DIFF
--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -1603,6 +1603,40 @@ struct WeekdayFunction : public InitSessionTimezone<T> {
 };
 
 template <typename T>
+struct DayNameFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Date>& date) {
+    const auto tm = getDateTime(date);
+    switch (tm.tm_wday) {
+      case 0:
+        result.append("Sun");
+        break;
+      case 1:
+        result.append("Mon");
+        break;
+      case 2:
+        result.append("Tue");
+        break;
+      case 3:
+        result.append("Wed");
+        break;
+      case 4:
+        result.append("Thu");
+        break;
+      case 5:
+        result.append("Fri");
+        break;
+      default:
+        result.append("Sat");
+        break;
+    }
+  }
+};
+
+template <typename T>
 struct TimestampToMicrosFunction {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 

--- a/bolt/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/bolt/functions/sparksql/registration/RegisterDatetime.cpp
@@ -136,6 +136,8 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<DayFunction, int32_t, Timestamp>(
       {prefix + "day", prefix + "dayofmonth"});
 
+  registerFunction<DayNameFunction, Varchar, Date>({prefix + "dayname"});
+
   registerFunction<DayOfYearFunction, int32_t, Date>(
       {prefix + "doy", prefix + "dayofyear"});
   registerFunction<DayOfYearFunction, int32_t, Timestamp>(

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -216,6 +216,25 @@ TEST_F(SparkSqlDateTimeFunctionsTest, weekdayDate) {
   EXPECT_EQ(4, weekday(parseDate("1582-10-15")));
 }
 
+TEST_F(SparkSqlDateTimeFunctionsTest, dayNameDate) {
+  const auto dayName = [&](std::optional<int32_t> date) {
+    return evaluateOnce<std::string, int32_t>("dayname(c0)", {date}, {DATE()});
+  };
+
+  EXPECT_EQ(std::nullopt, dayName(std::nullopt));
+  EXPECT_EQ("Thu", dayName(0)); // 1970-01-01
+  EXPECT_EQ("Sun", dayName(parseDate("2023-08-20")));
+  EXPECT_EQ("Mon", dayName(parseDate("2023-08-21")));
+  EXPECT_EQ("Tue", dayName(parseDate("2023-08-22")));
+  EXPECT_EQ("Wed", dayName(parseDate("2023-08-23")));
+  EXPECT_EQ("Thu", dayName(parseDate("2023-08-24")));
+  EXPECT_EQ("Fri", dayName(parseDate("2023-08-25")));
+  EXPECT_EQ("Sat", dayName(parseDate("2023-08-26")));
+  EXPECT_EQ(
+      "Fri",
+      dayName(parseDate("1582-10-15"))); // Gregorian calendar start.
+}
+
 TEST_F(SparkSqlDateTimeFunctionsTest, unixSeconds) {
   const auto unixSeconds = [&](const StringView time) {
     return evaluateOnce<int64_t, Timestamp>(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Implements the dayname() function for Spark SQL compatibility that returns the three-letter abbreviated day name (Sun, Mon, Tue, Wed, Thu, Fri, Sat) from a given date.

Corresponding PR: https://github.com/facebookincubator/velox/pull/15957

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat(function): Add Spark dayname function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









