### PR TITLE
 [cp]Add write IO metrics and print physical written bytes in PlanNodeStat…

### DIFF
--- a/bolt/common/io/IoStatistics.cpp
+++ b/bolt/common/io/IoStatistics.cpp
@@ -67,6 +67,10 @@ uint64_t IoStatistics::loadFileMetaDataTimeNs() const {
   return loadFileMetaDataTimeNs_.load(std::memory_order_relaxed);
 }
 
+uint64_t IoStatistics::writeIOTimeUs() const {
+  return writeIOTimeUs_.load(std::memory_order_relaxed);
+}
+
 IoStatistics::ReadStats& IoStatistics::readStats() {
   return readStats_;
 }
@@ -140,6 +144,10 @@ uint64_t IoStatistics::incLoadFileMetaDataTimeNs(int64_t v) {
   return loadFileMetaDataTimeNs_.fetch_add(v, std::memory_order_relaxed);
 }
 
+uint64_t IoStatistics::incWriteIOTimeUs(int64_t v) {
+  return writeIOTimeUs_.fetch_add(v, std::memory_order_relaxed);
+}
+
 void IoStatistics::incOperationCounters(
     const std::string& operation,
     const uint64_t resourceThrottleCount,
@@ -169,6 +177,7 @@ void IoStatistics::merge(const IoStatistics& other) {
   rawBytesWritten_ += other.rawBytesWritten_;
   totalScanTime_ += other.totalScanTime_;
   totalMergeTime_ += other.totalMergeTime_;
+  writeIOTimeUs_ += other.writeIOTimeUs_;
   for (int i = 0; i < 4; ++i) {
     readStats_.rawBytesReads_[i] += other.readStats_.rawBytesReads_[i];
     readStats_.cntReads_[i] += other.readStats_.cntReads_[i];

--- a/bolt/common/io/IoStatistics.h
+++ b/bolt/common/io/IoStatistics.h
@@ -125,6 +125,8 @@ class IoStatistics {
   uint64_t totalMergeTime() const;
   uint64_t loadFileMetaDataTimeNs() const;
 
+  uint64_t writeIOTimeUs() const;
+
   ReadStats& readStats();
 
   std::vector<uint64_t> rawBytesReads() const;
@@ -144,6 +146,8 @@ class IoStatistics {
   int is_greater_than(int x, int threshold) {
     return !((x - threshold) >> 31);
   }
+
+  uint64_t incWriteIOTimeUs(int64_t);
 
   IoCounter& prefetch() {
     return prefetch_;
@@ -197,6 +201,8 @@ class IoStatistics {
   std::atomic<uint64_t> totalScanTime_{0};
   std::atomic<uint64_t> totalMergeTime_{0};
   std::atomic<uint64_t> loadFileMetaDataTimeNs_{0};
+
+  std::atomic<uint64_t> writeIOTimeUs_{0};
 
   ReadStats readStats_{};
 

--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -190,6 +190,7 @@ class DataSink {
   struct Stats {
     uint64_t numWrittenBytes{0};
     uint32_t numWrittenFiles{0};
+    uint64_t writeIOTimeUs{0};
     common::SpillStats spillStats;
 
     bool empty() const;

--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -520,10 +520,13 @@ DataSink::Stats HiveDataSink::stats() const {
   }
 
   int64_t numWrittenBytes{0};
+  int64_t writeIOTimeUs{0};
   for (const auto& ioStats : ioStats_) {
     numWrittenBytes += ioStats->rawBytesWritten();
+    writeIOTimeUs += ioStats->writeIOTimeUs();
   }
   stats.numWrittenBytes = numWrittenBytes;
+  stats.writeIOTimeUs = writeIOTimeUs;
 
   if (state_ != State::kClosed) {
     return stats;

--- a/bolt/dwio/common/FileSink.cpp
+++ b/bolt/dwio/common/FileSink.cpp
@@ -79,13 +79,20 @@ void FileSink::writeImpl(
     std::vector<DataBuffer<char>>& buffers,
     const std::function<uint64_t(const DataBuffer<char>&)>& callback) {
   DWIO_ENSURE(!isClosed(), "Cannot write to closed sink.");
-  uint64_t size = 0;
-  for (auto& buf : buffers) {
-    size += callback(buf);
+  const uint64_t oldSize = size_;
+  uint64_t writeTimeUs{0};
+  {
+    MicrosecondTimer timer(&writeTimeUs);
+    for (auto& buf : buffers) {
+      // NOTE: we need to update 'size_' after each 'callback' invocation as
+      // some file sink implementation like MemorySink depends on the updated
+      // 'size_' for new write.
+      size_ += callback(buf);
+    }
   }
-  size_ += size;
   if (stats_ != nullptr) {
-    stats_->incRawBytesWritten(size);
+    stats_->incRawBytesWritten(size_ - oldSize);
+    stats_->incWriteIOTimeUs(writeTimeUs);
   }
   // Writing buffer is treated as transferring ownership. So clearing the
   // buffers after all buffers are written.

--- a/bolt/exec/PlanNodeStats.cpp
+++ b/bolt/exec/PlanNodeStats.cpp
@@ -205,8 +205,11 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
     }
   }
   out << "Output: " << outputRows << " rows (" << succinctBytes(outputBytes)
-      << ", " << outputVectors << " batches)"
-      << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
+      << ", " << outputVectors << " batches)";
+  if (physicalWrittenBytes > 0) {
+    out << ", Physical written output: " << succinctBytes(physicalWrittenBytes);
+  }
+  out << ", Cpu time: " << succinctNanos(cpuWallTiming.cpuNanos)
       << ", Wall time: " << succinctNanos(cpuWallTiming.wallNanos)
       << ", Blocked wall time: " << succinctNanos(blockedWallNanos)
       << ", Peak memory: " << succinctBytes(peakMemoryBytes)

--- a/bolt/exec/TableWriter.cpp
+++ b/bolt/exec/TableWriter.cpp
@@ -267,6 +267,10 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
     }
     lockedStats->addRuntimeStat(
         "numWrittenFiles", RuntimeCounter(stats.numWrittenFiles));
+    lockedStats->addRuntimeStat(
+        "writeIOTime",
+        RuntimeCounter(
+            stats.writeIOTimeUs * 1000, RuntimeCounter::Unit::kNanos));
   }
   if (!stats.spillStats.empty()) {
     recordSpillStats(stats.spillStats);

--- a/bolt/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/bolt/exec/tests/PrintPlanWithStatsTest.cpp
@@ -32,6 +32,7 @@
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
 
 #include <gtest/gtest.h>
 #include <re2/re2.h>
@@ -323,4 +324,76 @@ TEST_F(PrintPlanWithStatsTest, DISABLED_partialAggregateWithTableScan) {
          {"        totalRemainingFilterTime\\s+sum: .+, count: .+, min: .+, max: .+"},
          {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
   }
+}
+
+TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
+  RowTypePtr rowType{
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
+  auto vectors = makeVectors(rowType, 10, 10);
+
+  const auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  const auto writeDir = TempDirectoryPath::create();
+
+  auto writePlan = PlanBuilder()
+                       .tableScan(rowType)
+                       .tableWrite(writeDir->getPath())
+                       .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  AssertQueryBuilder(writePlan)
+      .splits(makeHiveConnectorSplits({filePath}))
+      .copyResults(pool(), task);
+  ensureTaskCompletion(task.get());
+  compareOutputs(
+      ::testing::UnitTest::GetInstance()->current_test_info()->name(),
+      printPlanWithStats(*writePlan, task->taskStats()),
+      {{R"(-- TableWrite\[1\]\[.+InsertTableHandle .+)"},
+       {"   Output: .+, Physical written output: .+, Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1"},
+       {R"(  -- TableScan\[0\]\[table: hive_table\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR)"},
+       {R"(     Input: 100 rows \(.+\), Output: 100 rows \(.+\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1)"}});
+
+  compareOutputs(
+      ::testing::UnitTest::GetInstance()->current_test_info()->name(),
+      printPlanWithStats(*writePlan, task->taskStats(), true),
+      {{R"(-- TableWrite\[1\]\[.+InsertTableHandle .+)"},
+       {"   Output: .+, Physical written output: .+, Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1"},
+       {"      dataSourceLazyCpuNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
+       {"      dataSourceLazyWallNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
+       {"      numWrittenFiles\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      stripeSize\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      writeIOTime\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {R"(  -- TableScan\[0\]\[table: hive_table\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR)"},
+       {R"(     Input: 100 rows \(.+\), Output: 100 rows \(.+\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1)"},
+       {"        dataSourceAddSplitWallNanos[ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        dataSourceReadWallNanos[ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        flattenStringDictionaryValues [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        ioWaitWallNanos      [ ]* sum: .+, count: .+ min: .+, max: .+"},
+       {"        localReadBytes   [ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+       {"        maxSingleIoWaitWallNanos[ ]*sum: .+, count: 1, min: .+, max: .+"},
+       {"        numLocalRead     [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        numPrefetch      [ ]* sum: .+, count: .+, min: .+, max: .+"},
+       {"        numRamRead       [ ]* sum: 7, count: 1, min: 7, max: 7"},
+       {"        numStorageRead   [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        overreadBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+
+       {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
+        true},
+       {"        ramReadBytes     [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        readyPreloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
+        true},
+       {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        skippedSplitBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+       {"        skippedSplits    [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        skippedStrides   [ ]* sum: 0, count: 1, min: 0, max: 0"},
+       {"        storageReadBytes [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        totalRemainingFilterTime\\s+sum: .+, count: .+, min: .+, max: .+"},
+       {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
 }

--- a/bolt/exec/tests/TableWriteTest.cpp
+++ b/bolt/exec/tests/TableWriteTest.cpp
@@ -2493,6 +2493,8 @@ TEST_P(UnpartitionedTableWriterTest, runtimeStatsCheck) {
         stats[1].runtimeStats["stripeSize"].count, testData.expectedNumStripes);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].sum, 1);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].count, 1);
+    ASSERT_GE(stats[1].runtimeStats["writeIOTime"].sum, 0);
+    ASSERT_EQ(stats[1].runtimeStats["writeIOTime"].count, 1);
   }
 }
 
@@ -3296,6 +3298,9 @@ TEST_P(AllTableWriterTest, tableWriterStats) {
           ->customStats.at("numWrittenFiles")
           .sum,
       numWrittenFiles);
+  ASSERT_GE(
+      stats.operatorStats.at("TableWrite")->customStats.at("writeIOTime").sum,
+      0);
 }
 
 DEBUG_ONLY_TEST_P(


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Count write IO metrics when invoke WriteFile#append, and print physical written bytes when invoke printPlanWithStats.

Fixes: https://github.com/facebookincubator/velox/issues/10794

Corresponding PR:  https://github.com/facebookincubator/velox/pull/10806

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Add write IO metrics and print physical written bytes in PlanNodeStats#toString
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









