### PR TITLE
[cp]feat: Support decimal type for Spark floor function 

### DIFF
--- a/bolt/functions/sparksql/DecimalVectorFunctions.cpp
+++ b/bolt/functions/sparksql/DecimalVectorFunctions.cpp
@@ -380,7 +380,8 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> decimalUnarySignature() {
   return {exec::FunctionSignatureBuilder()
               .integerVariable("a_precision")
               .integerVariable("a_scale")
-              .integerVariable("r_precision", "min(38,a_precision-a_scale+1)")
+              .integerVariable(
+                  "r_precision", "min(38,a_precision-a_scale+min(1,a_scale))")
               .integerVariable("r_scale", "0")
               .returnType("DECIMAL(r_precision, r_scale)")
               .argumentType("DECIMAL(a_precision, a_scale)")

--- a/bolt/functions/sparksql/tests/DecimalVectorFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/DecimalVectorFunctionsTest.cpp
@@ -156,6 +156,10 @@ TEST_F(DecimalVectorFunctionsTest, floor) {
       "floor(c0)",
       {makeFlatVector<int64_t>({123, 552, -999, 0}, DECIMAL(3, 2))});
   testDecimalExpr<TypeKind::BIGINT>(
+      {makeFlatVector<int64_t>({123, 552, -999, 0}, DECIMAL(3, 0))},
+      "floor(c0)",
+      {makeFlatVector<int64_t>({123, 552, -999, 0}, DECIMAL(3, 0))});
+  testDecimalExpr<TypeKind::BIGINT>(
       {makeFlatVector<int64_t>({0, 0, -1, 0}, DECIMAL(1, 0))},
       "floor(c0)",
       {makeFlatVector<int128_t>(


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Gluten removed the registration of Presto sql functions. This PR registers
Presto floor function in Spark for reuse.

Corresponding PR: https://github.com/facebookincubator/velox/pull/11951

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Support decimal type for Spark floor function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>








