### PR TITLE
[cp]feat: Support decimal type for Spark in function

### DIFF
--- a/bolt/functions/sparksql/In.cpp
+++ b/bolt/functions/sparksql/In.cpp
@@ -31,12 +31,15 @@
 #include "folly/container/F14Set.h"
 #include "folly/hash/Hash.h"
 
+#include "bolt/expression/DecodedArgs.h"
 #include "bolt/expression/VectorFunction.h"
+#include "bolt/expression/VectorReaders.h"
 #include "bolt/functions/Macros.h"
 #include "bolt/functions/lib/RegistrationHelpers.h"
 #include "bolt/functions/sparksql/Arena.h"
 #include "bolt/functions/sparksql/Comparisons.h"
 #include "bolt/type/Filter.h"
+#include "bolt/vector/DecodedVector.h"
 namespace bytedance::bolt::functions::sparksql {
 namespace {
 
@@ -132,7 +135,171 @@ void registerInFn(const std::string& prefix) {
       {prefix + "in"});
 }
 
+std::vector<std::shared_ptr<exec::FunctionSignature>> inDecimalSignatures() {
+  // Accept any DECIMAL(p, s). The physical representation depends on
+  // precision: short decimal (<= 18) uses BIGINT, long decimal uses HUGEINT.
+  return {exec::FunctionSignatureBuilder()
+              .integerVariable("p")
+              .integerVariable("s")
+              .returnType("boolean")
+              .argumentType("DECIMAL(p, s)")
+              .argumentType("array(DECIMAL(p, s))")
+              .build()};
+}
+
+template <typename T>
+class DecimalInVectorFunction final : public exec::VectorFunction {
+ public:
+  explicit DecimalInVectorFunction(const VectorPtr& constantArrayVector) {
+    buildConstantSet(constantArrayVector);
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, outputType, result);
+    result->clearNulls(rows);
+    auto* flatResult = result->asUnchecked<FlatVector<bool>>();
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto* decodedLhs = decodedArgs.at(0);
+    auto* decodedRhs = decodedArgs.at(1);
+
+    if (hasConstantRhs_) {
+      if (constantRhsIsNull_) {
+        rows.applyToSelected([&](vector_size_t row) {
+          if (decodedLhs->isNullAt(row)) {
+            result->setNull(row, true);
+            return;
+          }
+          // Non-null lhs IN NULL -> NULL.
+          result->setNull(row, true);
+        });
+        return;
+      }
+
+      rows.applyToSelected([&](vector_size_t row) {
+        if (decodedLhs->isNullAt(row)) {
+          result->setNull(row, true);
+          return;
+        }
+
+        const auto lhs = decodedLhs->valueAt<T>(row);
+        const bool found = constantElements_.contains(lhs);
+        if (found) {
+          flatResult->set(row, true);
+          return;
+        }
+        if (constantHasNull_) {
+          result->setNull(row, true);
+          return;
+        }
+        flatResult->set(row, false);
+      });
+      return;
+    }
+
+    // Fallback for non-constant rhs: scan per row.
+    exec::VectorReader<Array<T>> rhsReader(decodedRhs);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedLhs->isNullAt(row)) {
+        result->setNull(row, true);
+        return;
+      }
+      if (decodedRhs->isNullAt(row)) {
+        result->setNull(row, true);
+        return;
+      }
+
+      const auto lhs = decodedLhs->valueAt<T>(row);
+      const auto arrayView = rhsReader[row];
+      bool hasNull = false;
+      bool found = false;
+      for (const auto& entry : arrayView) {
+        if (!entry.has_value()) {
+          hasNull = true;
+          continue;
+        }
+        if (entry.value() == lhs) {
+          found = true;
+          break;
+        }
+      }
+
+      if (found) {
+        flatResult->set(row, true);
+        return;
+      }
+      if (hasNull) {
+        result->setNull(row, true);
+        return;
+      }
+      flatResult->set(row, false);
+    });
+  }
+
+ private:
+  void buildConstantSet(const VectorPtr& constantArrayVector) {
+    if (constantArrayVector == nullptr) {
+      // Not a constant argument.
+      hasConstantRhs_ = false;
+      return;
+    }
+
+    hasConstantRhs_ = true;
+
+    SelectivityVector oneRow(1);
+    DecodedVector decoded(*constantArrayVector, oneRow);
+    exec::VectorReader<Array<T>> reader(&decoded);
+    if (decoded.isNullAt(0)) {
+      constantRhsIsNull_ = true;
+      return;
+    }
+
+    const auto arrayView = reader[0];
+    constantElements_.reserve(arrayView.size());
+    for (const auto& entry : arrayView) {
+      if (!entry.has_value()) {
+        constantHasNull_ = true;
+        continue;
+      }
+      constantElements_.emplace(entry.value());
+    }
+  }
+
+  bool hasConstantRhs_{false};
+  bool constantHasNull_{false};
+  bool constantRhsIsNull_{false};
+  Set<T> constantElements_;
+};
+
+std::shared_ptr<exec::VectorFunction> makeDecimalIn(
+    const std::string& /*name*/,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
+  const auto& lhsType = inputArgs.at(0).type;
+  const auto& rhsConst = inputArgs.at(1).constantValue;
+
+  if (lhsType->isShortDecimal()) {
+    return std::make_shared<DecimalInVectorFunction<int64_t>>(rhsConst);
+  }
+  if (lhsType->isLongDecimal()) {
+    return std::make_shared<DecimalInVectorFunction<int128_t>>(rhsConst);
+  }
+
+  BOLT_FAIL(
+      "Decimal IN expects DECIMAL input type, but got {}", lhsType->toString());
+}
+
 } // namespace
+
+BOLT_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_in_decimal,
+    inDecimalSignatures(),
+    makeDecimalIn);
 
 void registerIn(const std::string& prefix) {
   registerInFn<int8_t>(prefix);

--- a/bolt/functions/sparksql/In.h
+++ b/bolt/functions/sparksql/In.h
@@ -34,13 +34,13 @@ namespace bytedance::bolt::functions::sparksql {
 // Supported types:
 //   - Bools
 //   - Integer types (byte, short, int, long)
+//   - Decimal
 //   - String, Binary
 //   - Float, Double
 //   - Timestamp
 //   - Date
 //
 // Unsupported:
-//   - Decimal
 //   - Datetime
 //   - Structs, Arrays
 //   - Maps

--- a/bolt/functions/sparksql/registration/RegisterMisc.cpp
+++ b/bolt/functions/sparksql/registration/RegisterMisc.cpp
@@ -55,6 +55,8 @@ void registerMiscFunctions(const std::string& prefix) {
       prefix + "concat_ws", ConcatWsSignatures(), makeConcatWs);
 
   registerIn(prefix);
+  // Register decimal overloads for SparkSQL "in".
+  BOLT_REGISTER_VECTOR_FUNCTION(udf_in_decimal, prefix + "in");
 
   BOLT_REGISTER_VECTOR_FUNCTION(
       udf_input_file_name, prefix + "input_file_name");

--- a/bolt/functions/sparksql/tests/InTest.cpp
+++ b/bolt/functions/sparksql/tests/InTest.cpp
@@ -206,6 +206,42 @@ TEST_F(InTest, Bool) {
   EXPECT_EQ(in<bool>(false, {false}), true);
 }
 
+TEST_F(InTest, shortDecimal) {
+  EXPECT_EQ(in<int64_t>(1, {1, 2}, DECIMAL(2, 1)), true);
+  EXPECT_EQ(in<int64_t>(2, {1, 2}, DECIMAL(10, 5)), true);
+  EXPECT_EQ(in<int64_t>(3, {1, 2}, DECIMAL(17, 11)), false);
+  EXPECT_EQ(
+      in<int64_t>(
+          DecimalUtil::kShortDecimalMin,
+          {DecimalUtil::kShortDecimalMin, DecimalUtil::kShortDecimalMax},
+          DECIMAL(18, 9)),
+      true);
+  EXPECT_EQ(
+      in<int64_t>(
+          DecimalUtil::kShortDecimalMax,
+          {DecimalUtil::kShortDecimalMin, DecimalUtil::kShortDecimalMax},
+          DECIMAL(18, 9)),
+      true);
+}
+
+TEST_F(InTest, longDecimal) {
+  EXPECT_EQ(in<int128_t>(1, {1, 2}, DECIMAL(21, 2)), true);
+  EXPECT_EQ(in<int128_t>(2, {1, 2}, DECIMAL(29, 10)), true);
+  EXPECT_EQ(in<int128_t>(3, {1, 2}, DECIMAL(35, 20)), false);
+  EXPECT_EQ(
+      in<int128_t>(
+          DecimalUtil::kLongDecimalMin,
+          {DecimalUtil::kLongDecimalMin, DecimalUtil::kLongDecimalMax},
+          DECIMAL(38, 19)),
+      true);
+  EXPECT_EQ(
+      in<int128_t>(
+          DecimalUtil::kLongDecimalMax,
+          {DecimalUtil::kLongDecimalMin, DecimalUtil::kLongDecimalMax},
+          DECIMAL(38, 19)),
+      true);
+}
+
 TEST_F(InTest, Const) {
   const auto eval = [&](const std::string& expr) {
     return evaluateOnce<bool, bool>(expr, false);


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

feat: Support decimal type for Spark in function

Corresponding PR: https://github.com/facebookincubator/velox/pull/11947

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Support decimal type for Spark in function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>








