### PR TITLE
[cp]feat: Add a method to specify a custom `InsertTableHandle` in TableWriterBuilder

### DIFF
--- a/bolt/exec/tests/utils/PlanBuilder.cpp
+++ b/bolt/exec/tests/utils/PlanBuilder.cpp
@@ -476,45 +476,52 @@ PlanBuilder& PlanBuilder::tableWrite(
     const dwio::common::FileFormat fileFormat,
     const std::vector<std::string>& aggregates,
     const std::string& connectorId,
-    const std::string& outputFileName) {
+    const std::string& outputFileName,
+    const std::shared_ptr<core::InsertTableHandle>& insertHandle) {
   BOLT_CHECK_NOT_NULL(planNode_, "TableWrite cannot be the source node");
   auto rowType = planNode_->outputType();
 
-  std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
-      columnHandles;
-  for (auto i = 0; i < rowType->size(); ++i) {
-    const auto column = rowType->nameOf(i);
-    const bool isPartitionKey =
-        std::find(partitionBy.begin(), partitionBy.end(), column) !=
-        partitionBy.end();
-    columnHandles.push_back(std::make_shared<connector::hive::HiveColumnHandle>(
-        column,
-        isPartitionKey
-            ? connector::hive::HiveColumnHandle::ColumnType::kPartitionKey
-            : connector::hive::HiveColumnHandle::ColumnType::kRegular,
-        rowType->childAt(i),
-        rowType->childAt(i)));
-  }
+  // If insertHandle is not specified, build a HiveInsertTableHandle along with
+  // columnHandles, bucketProperty and locationHandle.
+  auto insertHandlePtr = insertHandle;
+  if (!insertHandlePtr) {
+    std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+        columnHandles;
+    for (auto i = 0; i < rowType->size(); ++i) {
+      const auto column = rowType->nameOf(i);
+      const bool isPartitionKey =
+          std::find(partitionBy.begin(), partitionBy.end(), column) !=
+          partitionBy.end();
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              column,
+              isPartitionKey
+                  ? connector::hive::HiveColumnHandle::ColumnType::kPartitionKey
+                  : connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              rowType->childAt(i),
+              rowType->childAt(i)));
+    }
 
-  auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
-      outputDirectoryPath,
-      outputDirectoryPath,
-      connector::hive::LocationHandle::TableType::kNew,
-      outputFileName);
-  std::shared_ptr<HiveBucketProperty> bucketProperty;
-  if (!partitionBy.empty() && bucketCount != 0) {
-    bucketProperty =
-        buildHiveBucketProperty(rowType, bucketCount, bucketedBy, sortBy);
-  }
-  auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
-      columnHandles,
-      locationHandle,
-      fileFormat,
-      bucketProperty,
-      common::CompressionKind_NONE);
+    auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
+        outputDirectoryPath,
+        outputDirectoryPath,
+        connector::hive::LocationHandle::TableType::kNew,
+        outputFileName);
+    std::shared_ptr<HiveBucketProperty> bucketProperty;
+    if (!partitionBy.empty() && bucketCount != 0) {
+      bucketProperty =
+          buildHiveBucketProperty(rowType, bucketCount, bucketedBy, sortBy);
+    }
+    auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
+        columnHandles,
+        locationHandle,
+        fileFormat,
+        bucketProperty,
+        common::CompressionKind_NONE);
 
-  auto insertHandle =
-      std::make_shared<core::InsertTableHandle>(connectorId, hiveHandle);
+    insertHandlePtr =
+        std::make_shared<core::InsertTableHandle>(connectorId, hiveHandle);
+  }
 
   std::shared_ptr<core::AggregationNode> aggregationNode;
   if (!aggregates.empty()) {
@@ -536,7 +543,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       rowType,
       rowType->names(),
       aggregationNode,
-      insertHandle,
+      insertHandlePtr,
       false,
       TableWriteTraits::outputType(aggregationNode),
       connector::CommitStrategy::kNoCommit,

--- a/bolt/exec/tests/utils/PlanBuilder.h
+++ b/bolt/exec/tests/utils/PlanBuilder.h
@@ -523,6 +523,9 @@ class PlanBuilder {
   /// @param outputFileName Optional file name of the output. If specified
   /// (non-empty), use it instead of generating the file name in Bolt. Should
   /// only be specified in non-bucketing write.
+  /// @param insertHandle TableInsertHandle (optional). Other arguments such as
+  /// the `connectorId`, `outputDirectoryPath`, `fileFormat` and so on will be
+  /// ignored.
   PlanBuilder& tableWrite(
       const std::string& outputDirectoryPath,
       const std::vector<std::string>& partitionBy,
@@ -533,7 +536,8 @@ class PlanBuilder {
           dwio::common::FileFormat::DWRF,
       const std::vector<std::string>& aggregates = {},
       const std::string& connectorId = "test-hive",
-      const std::string& outputFileName = "");
+      const std::string& outputFileName = "",
+      const std::shared_ptr<core::InsertTableHandle>& insertHandle = nullptr);
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
Closes https://github.com/facebookincubator/velox/issues/12199

This PR adds a method to specify a custom core::InsertTableHandle to TableWriterBuilder via TableWriterBuilder::insertHandle(). The specified core::InsertTableHandle is used in TableWriterBuilder::build() instead of building a new HiveInsertTableHandle

Corresponding PR: https://github.com/facebookincubator/velox/pull/12259

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Add a method to specify a custom InsertTableHandle in TableWriterBuilder
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>


