### PR TITLE
[cp]feat: Register Spark array_min/max functions with orderable types

### DIFF
--- a/bolt/functions/sparksql/ArrayMinMaxFunction.h
+++ b/bolt/functions/sparksql/ArrayMinMaxFunction.h
@@ -42,44 +42,6 @@ struct ArrayMinMaxFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  template <typename T>
-  void update(T& currentValue, const T& candidateValue) {
-    // NaN is greater than any non-NaN elements for double/float type.
-    if constexpr (std::is_floating_point_v<T>) {
-      if constexpr (isMax) {
-        if (std::isnan(candidateValue) ||
-            (!std::isnan(currentValue) && candidateValue > currentValue)) {
-          currentValue = candidateValue;
-        }
-      } else {
-        if (std::isnan(currentValue) ||
-            (!std::isnan(candidateValue) && candidateValue < currentValue)) {
-          currentValue = candidateValue;
-        }
-      }
-      return;
-    }
-
-    if constexpr (isMax) {
-      if (candidateValue > currentValue) {
-        currentValue = candidateValue;
-      }
-    } else {
-      if (candidateValue < currentValue) {
-        currentValue = candidateValue;
-      }
-    }
-  }
-
-  template <typename T>
-  void assign(T& out, const T& value) {
-    out = value;
-  }
-
-  void assign(out_type<Varchar>& out, const arg_type<Varchar>& value) {
-    out.setNoCopy(value);
-  }
-
   template <typename TReturn, typename TInput>
   bool call(TReturn& out, const TInput& array) {
     // Result is null if array is empty.
@@ -119,6 +81,89 @@ struct ArrayMinMaxFunction {
 
     assign(out, currentValue);
     return true;
+  }
+
+  bool call(
+      out_type<Orderable<T1>>& out,
+      const arg_type<Array<Orderable<T1>>>& array) {
+    // Result is null if array is empty.
+    if (array.size() == 0) {
+      return false;
+    }
+
+    int currentIndex = -1;
+    for (auto i = 0; i < array.size(); i++) {
+      if (array[i].has_value()) {
+        if (currentIndex == -1) {
+          currentIndex = i;
+        } else {
+          auto currentValue = array[currentIndex].value();
+          auto candidateValue = array[i].value();
+          if (compare(currentValue, candidateValue)) {
+            currentIndex = i;
+          }
+        }
+      }
+    }
+    if (currentIndex == -1) {
+      // If array contains only NULL elements, return NULL.
+      return false;
+    }
+    out.copy_from(array[currentIndex].value());
+    return true;
+  }
+
+ private:
+  template <typename T>
+  void update(T& currentValue, const T& candidateValue) {
+    // NaN is greater than any non-NaN elements for double/float type.
+    if constexpr (std::is_floating_point_v<T>) {
+      if constexpr (isMax) {
+        if (std::isnan(candidateValue) ||
+            (!std::isnan(currentValue) && candidateValue > currentValue)) {
+          currentValue = candidateValue;
+        }
+      } else {
+        if (std::isnan(currentValue) ||
+            (!std::isnan(candidateValue) && candidateValue < currentValue)) {
+          currentValue = candidateValue;
+        }
+      }
+      return;
+    }
+
+    if constexpr (isMax) {
+      if (candidateValue > currentValue) {
+        currentValue = candidateValue;
+      }
+    } else {
+      if (candidateValue < currentValue) {
+        currentValue = candidateValue;
+      }
+    }
+  }
+
+  template <typename T>
+  void assign(T& out, const T& value) {
+    out = value;
+  }
+
+  void assign(out_type<Varchar>& out, const arg_type<Varchar>& value) {
+    out.setNoCopy(value);
+  }
+
+  bool compare(
+      exec::GenericView currentValue,
+      exec::GenericView candidateValue) {
+    static constexpr CompareFlags kFlags = {
+        .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue};
+
+    auto compareResult = candidateValue.compare(currentValue, kFlags).value();
+    if constexpr (isMax) {
+      return compareResult > 0;
+    } else {
+      return compareResult < 0;
+    }
   }
 };
 

--- a/bolt/functions/sparksql/registration/RegisterArray.cpp
+++ b/bolt/functions/sparksql/registration/RegisterArray.cpp
@@ -82,9 +82,11 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerArrayMinMaxFunctions<float>(prefix);
   registerArrayMinMaxFunctions<double>(prefix);
   registerArrayMinMaxFunctions<bool>(prefix);
+  registerArrayMinMaxFunctions<Varbinary>(prefix);
   registerArrayMinMaxFunctions<Varchar>(prefix);
   registerArrayMinMaxFunctions<Timestamp>(prefix);
   registerArrayMinMaxFunctions<Date>(prefix);
+  registerArrayMinMaxFunctions<Orderable<T1>>(prefix);
 }
 
 template <typename T>

--- a/bolt/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -41,9 +41,11 @@ namespace {
 class ArrayMaxTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
-  std::optional<T> arrayMax(const std::vector<std::optional<T>>& input) {
+  std::optional<T> arrayMax(
+      const std::vector<std::optional<T>>& input,
+      const TypePtr& type = ARRAY(CppToType<T>::create())) {
     auto row = makeRowVector({makeNullableArrayVector(
-        std::vector<std::vector<std::optional<T>>>{input})});
+        std::vector<std::vector<std::optional<T>>>{input}, type)});
     return evaluateOnce<T>("array_max(C0)", row);
   }
 };
@@ -57,6 +59,17 @@ TEST_F(ArrayMaxTest, boolean) {
   EXPECT_EQ(arrayMax<bool>({std::nullopt, true, false, true}), true);
   EXPECT_EQ(arrayMax<bool>({false, false, false}), false);
   EXPECT_EQ(arrayMax<bool>({true, true, true}), true);
+}
+
+TEST_F(ArrayMaxTest, varbinary) {
+  EXPECT_EQ(arrayMax<std::string>({"red", "blue"}, ARRAY(VARBINARY())), "red");
+  EXPECT_EQ(
+      arrayMax<std::string>(
+          {std::nullopt, "blue", "yellow", "orange"}, ARRAY(VARBINARY())),
+      "yellow");
+  EXPECT_EQ(arrayMax<std::string>({}, ARRAY(VARBINARY())), std::nullopt);
+  EXPECT_EQ(
+      arrayMax<std::string>({std::nullopt}, ARRAY(VARBINARY())), std::nullopt);
 }
 
 TEST_F(ArrayMaxTest, varchar) {
@@ -107,6 +120,30 @@ TEST_F(ArrayMaxTest, timestamp) {
       Timestamp::max());
   EXPECT_EQ(arrayMax<Timestamp>({}), std::nullopt);
   EXPECT_EQ(arrayMax<Timestamp>({ts(0), std::nullopt}), ts(0));
+}
+
+TEST_F(ArrayMaxTest, complexTypes) {
+  auto testExpression = [&](const VectorPtr& input, const VectorPtr& expected) {
+    auto result = evaluate("array_max(c0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  };
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, 1, 1], [1, 2, 2], [1, 3, 1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1, 3, 1]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<double>(
+          {"[[2.0, null], [null, 2.0], [NaN, 1.0]]"}),
+      makeArrayVectorFromJson<double>({"[NaN, 1.0]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[[1, null], [null, 2], [1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1, null]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[null, null]"}),
+      makeArrayVectorFromJson<int64_t>({"null"}));
 }
 
 template <typename Type>

--- a/bolt/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayMinTest.cpp
@@ -42,9 +42,11 @@ namespace {
 class ArrayMinTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
-  std::optional<T> arrayMin(const std::vector<std::optional<T>>& input) {
+  std::optional<T> arrayMin(
+      const std::vector<std::optional<T>>& input,
+      const TypePtr& type = ARRAY(CppToType<T>::create())) {
     auto row = makeRowVector({makeNullableArrayVector(
-        std::vector<std::vector<std::optional<T>>>{input})});
+        std::vector<std::vector<std::optional<T>>>{input}, type)});
     return evaluateOnce<T>("array_min(C0)", row);
   }
 };
@@ -58,7 +60,18 @@ TEST_F(ArrayMinTest, boolean) {
   EXPECT_EQ(arrayMin<bool>({std::nullopt, true, false, true}), false);
   EXPECT_EQ(arrayMin<bool>({false, false, false}), false);
   EXPECT_EQ(arrayMin<bool>({true, true, true}), true);
-} // namespace
+}
+
+TEST_F(ArrayMinTest, varbinary) {
+  EXPECT_EQ(arrayMin<std::string>({"red", "blue"}, ARRAY(VARBINARY())), "blue");
+  EXPECT_EQ(
+      arrayMin<std::string>(
+          {std::nullopt, "blue", "yellow", "orange"}, ARRAY(VARBINARY())),
+      "blue");
+  EXPECT_EQ(arrayMin<std::string>({}, ARRAY(VARBINARY())), std::nullopt);
+  EXPECT_EQ(
+      arrayMin<std::string>({std::nullopt}, ARRAY(VARBINARY())), std::nullopt);
+}
 
 TEST_F(ArrayMinTest, varchar) {
   EXPECT_EQ(arrayMin<std::string>({"red", "blue"}), "blue");
@@ -108,6 +121,34 @@ TEST_F(ArrayMinTest, timestamp) {
       Timestamp::min());
   EXPECT_EQ(arrayMin<Timestamp>({}), std::nullopt);
   EXPECT_EQ(arrayMin<Timestamp>({ts(0), std::nullopt}), ts(0));
+}
+
+TEST_F(ArrayMinTest, complexTypes) {
+  auto testExpression = [&](const VectorPtr& input, const VectorPtr& expected) {
+    auto result = evaluate("array_min(c0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  };
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, 1, 1], [1, 1, 2], [1, 3, 1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1, 1, 1]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, null], [null, 2], [null, null]]"}),
+      makeArrayVectorFromJson<int64_t>({"[null, null]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[[1, null], [1, 2], [1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[[1], [null], []]"}),
+      makeArrayVectorFromJson<int64_t>({"[]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[null, null]"}),
+      makeArrayVectorFromJson<int64_t>({"null"}));
 }
 
 template <typename Type>


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

https://github.com/apache/spark/blob/84f5fd99fef1ad3a2b2c41dbee09c60560479c11/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L2341

Corresponding PR: https://github.com/facebookincubator/velox/pull/12576

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Register Spark array_min/max functions with orderable types
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>








