### PR TITLE
[cp]feat: Support intergral types for the index parameter of Spark get function

### DIFF
--- a/bolt/functions/lib/SubscriptUtil.h
+++ b/bolt/functions/lib/SubscriptUtil.h
@@ -232,6 +232,12 @@ class SubscriptImpl : public exec::Subscript {
     auto indexArg = args[1];
 
     switch (indexArg->typeKind()) {
+      case TypeKind::TINYINT:
+        return applyArrayTyped<int8_t>(rows, arrayArg, indexArg, context);
+
+      case TypeKind::SMALLINT:
+        return applyArrayTyped<int16_t>(rows, arrayArg, indexArg, context);
+
       case TypeKind::INTEGER:
         return applyArrayTyped<int32_t>(rows, arrayArg, indexArg, context);
 

--- a/bolt/functions/sparksql/ArrayGetFunction.cpp
+++ b/bolt/functions/sparksql/ArrayGetFunction.cpp
@@ -50,13 +50,19 @@ class ArrayGetFunction : public SubscriptImpl<
   explicit ArrayGetFunction() : SubscriptImpl(false) {}
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    return {// array(T), integer -> T
-            exec::FunctionSignatureBuilder()
-                .typeVariable("T")
-                .returnType("T")
-                .argumentType("array(T)")
-                .argumentType("integer")
-                .build()};
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+
+    // array(T), tinyint|smallint|integer|bigint -> T
+    for (const auto& indexType : {"tinyint", "smallint", "integer", "bigint"}) {
+      signatures.push_back(exec::FunctionSignatureBuilder()
+                               .typeVariable("T")
+                               .returnType("T")
+                               .argumentType("array(T)")
+                               .argumentType(indexType)
+                               .build());
+    }
+
+    return signatures;
   }
 };
 } // namespace

--- a/bolt/functions/sparksql/tests/ArrayGetTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayGetTest.cpp
@@ -40,24 +40,40 @@ namespace {
 
 class ArrayGetTest : public SparkFunctionBaseTest {
  protected:
-  template <typename T>
+  template <typename T, typename IndexType>
   std::optional<T> arrayGet(
       const ArrayVectorPtr& arrayVector,
-      const std::optional<int32_t>& index) {
+      const std::optional<IndexType>& index) {
     auto input =
         makeRowVector({arrayVector, makeConstant(index, arrayVector->size())});
     return evaluateOnce<T>("get(c0, c1)", input);
   }
+
+  template <typename IndexType>
+  void testArrayGet() {
+    auto arrayVector = makeNullableArrayVector<int32_t>({{1, std::nullopt, 2}});
+
+    auto result = arrayGet<int32_t, IndexType>(arrayVector, 0);
+    EXPECT_EQ(result, 1);
+    result = arrayGet<int32_t, IndexType>(arrayVector, 1);
+    EXPECT_EQ(result, std::nullopt);
+    result = arrayGet<int32_t, IndexType>(arrayVector, 2);
+    EXPECT_EQ(result, 2);
+
+    result = arrayGet<int32_t, IndexType>(arrayVector, -1);
+    EXPECT_EQ(result, std::nullopt);
+    result = arrayGet<int32_t, IndexType>(arrayVector, 3);
+    EXPECT_EQ(result, std::nullopt);
+    result = arrayGet<int32_t, IndexType>(arrayVector, std::nullopt);
+    EXPECT_EQ(result, std::nullopt);
+  }
 };
 
 TEST_F(ArrayGetTest, basic) {
-  auto arrayVector = makeNullableArrayVector<int32_t>({{1, 2, std::nullopt}});
-  EXPECT_EQ(arrayGet<int32_t>(arrayVector, -1), std::nullopt);
-  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 0), 1);
-  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 1), 2);
-  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 2), std::nullopt);
-  EXPECT_EQ(arrayGet<int32_t>(arrayVector, 3), std::nullopt);
-  EXPECT_EQ(arrayGet<int32_t>(arrayVector, std::nullopt), std::nullopt);
+  testArrayGet<int8_t>();
+  testArrayGet<int16_t>();
+  testArrayGet<int32_t>();
+  testArrayGet<int64_t>();
 }
 } // namespace
 } // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Support tinyint and smallint types for the index parameter of Spark get function.

Spark's implementation: https://github.com/apache/spark/blob/9bc8cd51b671aeab7f4652698c00a72991e216fb/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala#L248

Corresponding PR: https://github.com/facebookincubator/velox/pull/13004 

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Support intergral types for the index parameter of Spark get function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>








