### PR TITLE
[cp]feat: Eliminate data copy in Spark UnscaledValueFunction

### DIFF
--- a/bolt/functions/sparksql/UnscaledValueFunction.cpp
+++ b/bolt/functions/sparksql/UnscaledValueFunction.cpp
@@ -47,15 +47,23 @@ class UnscaledValueFunction final : public exec::VectorFunction {
         args[0]->type()->isShortDecimal(),
         "Expect short decimal type, but got: {}",
         args[0]->type());
-    exec::DecodedArgs decodedArgs(rows, args, context);
-    auto decimalVector = decodedArgs.at(0);
-    context.ensureWritable(rows, BIGINT(), result);
-    result->clearNulls(rows);
-    auto flatResult =
-        result->asUnchecked<FlatVector<int64_t>>()->mutableRawValues();
-    rows.applyToSelected([&](auto row) {
-      flatResult[row] = decimalVector->valueAt<int64_t>(row);
-    });
+    VectorPtr localResult;
+    const auto& arg = args[0];
+    if (arg->isConstantEncoding()) {
+      auto value = arg->as<ConstantVector<int64_t>>()->valueAt(0);
+      localResult = std::make_shared<ConstantVector<int64_t>>(
+          context.pool(), rows.end(), false, BIGINT(), std::move(value));
+    } else {
+      auto flatInput = arg->asFlatVector<int64_t>();
+      localResult = std::make_shared<FlatVector<int64_t>>(
+          context.pool(),
+          BIGINT(),
+          nullptr,
+          rows.end(),
+          flatInput->values(),
+          std::vector<BufferPtr>());
+    }
+    context.moveOrCopyResult(localResult, rows, result);
   }
 };
 } // namespace

--- a/bolt/functions/sparksql/tests/UnscaledValueFunctionTest.cpp
+++ b/bolt/functions/sparksql/tests/UnscaledValueFunctionTest.cpp
@@ -37,18 +37,18 @@ namespace {
 class UnscaledValueFunctionTest : public SparkFunctionBaseTest {};
 
 TEST_F(UnscaledValueFunctionTest, unscaledValue) {
-  auto testUnscaledValue = [&](const std::vector<int64_t>& unscaledValue,
-                               const TypePtr& decimalType) {
-    auto input = makeFlatVector<int64_t>(unscaledValue, decimalType);
-    auto expected = makeFlatVector<int64_t>(unscaledValue);
-    auto result = evaluate("unscaled_value(c0)", makeRowVector({input}));
-    assertEqualVectors(expected, result);
-  };
+  auto input =
+      makeFlatVector<int64_t>({1000, 2000, -3000, -4000}, DECIMAL(18, 3));
+  auto expected = makeFlatVector<int64_t>({1000, 2000, -3000, -4000});
+  auto invalidInput = makeFlatVector<int64_t>({0, 0, 0, 0}, DECIMAL(20, 3));
 
-  testUnscaledValue({1000, 2000, -3000, -4000}, DECIMAL(18, 3));
+  testEncodings(
+      makeTypedExpr("unscaled_value(c0)", ROW({"c0"}, {input->type()})),
+      {input},
+      expected);
 
-  BOLT_ASSERT_THROW(
-      testUnscaledValue({1000, 2000, -3000, -4000}, DECIMAL(20, 3)),
+  BOLT_ASSERT_USER_THROW(
+      evaluate("unscaled_value(c0)", makeRowVector({invalidInput})),
       "Expect short decimal type, but got: DECIMAL(20, 3)");
 }
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Since the input and output vectors only differ in logical type but share the
same physical type (int64_t), there is no need to always copy data between them.

Corresponding PR: https://github.com/facebookincubator/velox/pull/13023

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Eliminate data copy in Spark UnscaledValueFunction
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









