### PR TITLE
[cp]feat: Support Spark legacy behavior for covariance functions

### DIFF
--- a/bolt/functions/lib/aggregates/CMakeLists.txt
+++ b/bolt/functions/lib/aggregates/CMakeLists.txt
@@ -31,6 +31,7 @@ bolt_add_library(
   BitDaysOrAggregate.cpp
   CentralMomentsAggregatesBase.cpp
   CollectSetAggregate.cpp
+  CovarianceAggregatesBase.cpp
   SingleValueAccumulator.cpp
   ValueList.cpp
   ValueSet.cpp

--- a/bolt/functions/lib/aggregates/CovarianceAggregatesBase.cpp
+++ b/bolt/functions/lib/aggregates/CovarianceAggregatesBase.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/functions/lib/aggregates/CovarianceAggregatesBase.h"
+
+namespace bytedance::bolt::functions::aggregate {
+
+int64_t CovarAccumulator::count() const {
+  return count_;
+}
+
+double CovarAccumulator::c2() const {
+  return c2_;
+}
+
+double CovarAccumulator::meanX() const {
+  return meanX_;
+}
+
+double CovarAccumulator::meanY() const {
+  return meanY_;
+}
+
+void CovarAccumulator::update(double x, double y) {
+  count_ += 1;
+  double deltaX = x - meanX();
+  meanX_ += deltaX / count();
+  double deltaY = y - meanY();
+  meanY_ += deltaY / count();
+  c2_ += deltaX * (y - meanY());
+}
+
+void CovarAccumulator::merge(
+    int64_t countOther,
+    double meanXOther,
+    double meanYOther,
+    double c2Other) {
+  if (countOther == 0) {
+    return;
+  }
+  if (count_ == 0) {
+    count_ = countOther;
+    meanX_ = meanXOther;
+    meanY_ = meanYOther;
+    c2_ = c2Other;
+    return;
+  }
+
+  int64_t newCount = countOther + count();
+  double deltaMeanX = meanXOther - meanX();
+  double deltaMeanY = meanYOther - meanY();
+  c2_ += c2Other +
+      deltaMeanX * deltaMeanY * count() * countOther /
+          static_cast<double>(newCount);
+  meanX_ += deltaMeanX * countOther / static_cast<double>(newCount);
+  meanY_ += deltaMeanY * countOther / static_cast<double>(newCount);
+  count_ = newCount;
+}
+
+double RegrAccumulator::m2X() const {
+  return m2X_;
+}
+
+void RegrAccumulator::update(double x, double y) {
+  double oldMeanX = meanX();
+  CovarAccumulator::update(x, y);
+
+  m2X_ += (x - oldMeanX) * (x - meanX());
+}
+
+void RegrAccumulator::merge(
+    int64_t countOther,
+    double meanXOther,
+    double meanYOther,
+    double c2Other,
+    double m2XOther) {
+  if (countOther == 0) {
+    return;
+  }
+  if (count() == 0) {
+    m2X_ = m2XOther;
+  } else {
+    m2X_ += m2XOther +
+        1.0 * count() / (count() + countOther) * countOther *
+            std::pow(meanX() - meanXOther, 2);
+  }
+  CovarAccumulator::merge(countOther, meanXOther, meanYOther, c2Other);
+}
+
+double ExtendedRegrAccumulator::m2Y() const {
+  return m2Y_;
+}
+
+void ExtendedRegrAccumulator::update(double x, double y) {
+  double oldMeanY = meanY();
+  RegrAccumulator::update(x, y);
+  m2Y_ += (y - oldMeanY) * (y - meanY());
+}
+
+void ExtendedRegrAccumulator::merge(
+    int64_t countOther,
+    double meanXOther,
+    double meanYOther,
+    double c2Other,
+    double m2XOther,
+    double m2YOther) {
+  if (countOther == 0) {
+    return;
+  }
+  if (count() == 0) {
+    m2X_ = m2XOther;
+    m2Y_ = m2YOther;
+  } else {
+    m2X_ += m2XOther +
+        1.0 * count() / (count() + countOther) * countOther *
+            std::pow(meanX() - meanXOther, 2);
+
+    m2Y_ += m2YOther +
+        1.0 * count() / (count() + countOther) * countOther *
+            std::pow(meanY() - meanYOther, 2);
+  }
+  CovarAccumulator::merge(countOther, meanXOther, meanYOther, c2Other);
+}
+
+void CovarIntermediateInput::mergeInto(
+    CovarAccumulator& accumulator,
+    vector_size_t row) {
+  accumulator.merge(
+      count_->valueAt(row),
+      meanX_->valueAt(row),
+      meanY_->valueAt(row),
+      c2_->valueAt(row));
+}
+
+void CovarIntermediateResult::set(
+    vector_size_t row,
+    const CovarAccumulator& accumulator) {
+  count_[row] = accumulator.count();
+  meanX_[row] = accumulator.meanX();
+  meanY_[row] = accumulator.meanY();
+  c2_[row] = accumulator.c2();
+}
+
+void CorrAccumulator::update(double x, double y) {
+  double oldMeanX = meanX();
+  double oldMeanY = meanY();
+  CovarAccumulator::update(x, y);
+
+  m2X_ += (x - oldMeanX) * (x - meanX());
+  m2Y_ += (y - oldMeanY) * (y - meanY());
+}
+
+void CorrAccumulator::merge(
+    int64_t countOther,
+    double meanXOther,
+    double meanYOther,
+    double c2Other,
+    double m2XOther,
+    double m2YOther) {
+  if (countOther == 0) {
+    return;
+  }
+
+  if (count() == 0) {
+    m2X_ = m2XOther;
+    m2Y_ = m2YOther;
+  } else {
+    auto k = 1.0 * count() / (count() + countOther) * countOther;
+    m2X_ += m2XOther + k * std::pow(meanX() - meanXOther, 2);
+    m2Y_ += m2YOther + k * std::pow(meanY() - meanYOther, 2);
+  }
+
+  CovarAccumulator::merge(countOther, meanXOther, meanYOther, c2Other);
+}
+
+void CorrIntermediateInput::mergeInto(
+    CorrAccumulator& accumulator,
+    vector_size_t row) {
+  accumulator.merge(
+      count_->valueAt(row),
+      meanX_->valueAt(row),
+      meanY_->valueAt(row),
+      c2_->valueAt(row),
+      m2X_->valueAt(row),
+      m2Y_->valueAt(row));
+}
+
+void CorrIntermediateResult::set(
+    vector_size_t row,
+    const CorrAccumulator& accumulator) {
+  CovarIntermediateResult::set(row, accumulator);
+  m2X_[row] = accumulator.m2X();
+  m2Y_[row] = accumulator.m2Y();
+}
+
+} // namespace bytedance::bolt::functions::aggregate

--- a/bolt/functions/lib/aggregates/CovarianceAggregatesBase.h
+++ b/bolt/functions/lib/aggregates/CovarianceAggregatesBase.h
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "bolt/exec/Aggregate.h"
+#include "bolt/vector/ComplexVector.h"
+#include "bolt/vector/DecodedVector.h"
+#include "bolt/vector/FlatVector.h"
+
+namespace bytedance::bolt::functions::aggregate {
+template <typename T>
+SimpleVector<T>* asSimpleVector(
+    const RowVector* rowVector,
+    int32_t childIndex) {
+  return rowVector->childAt(childIndex)->as<SimpleVector<T>>();
+}
+
+template <typename T>
+T* mutableRawValues(const RowVector* rowVector, int32_t childIndex) {
+  return rowVector->childAt(childIndex)
+      ->as<FlatVector<T>>()
+      ->mutableRawValues();
+}
+
+// Indices into RowType representing intermediate results of covar_samp and
+// covar_pop. Columns appear in alphabetical order.
+struct CovarIndices {
+  int32_t count;
+  int32_t meanX;
+  int32_t meanY;
+  int32_t c2;
+};
+constexpr CovarIndices kCovarIndices{1, 2, 3, 0};
+
+// Indices into RowType representing intermediate results of corr. Columns
+// appear in alphabetical order.
+struct CorrIndices : public CovarIndices {
+  int32_t m2X;
+  int32_t m2Y;
+};
+constexpr CorrIndices kCorrIndices{{1, 4, 5, 0}, 2, 3};
+
+struct CovarAccumulator {
+  int64_t count() const;
+
+  double meanX() const;
+
+  double meanY() const;
+
+  double c2() const;
+
+  void update(double x, double y);
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other);
+
+ private:
+  int64_t count_{0};
+  double meanX_{0};
+  double meanY_{0};
+  double c2_{0};
+};
+
+struct RegrAccumulator : public CovarAccumulator {
+  double m2X() const;
+
+  void update(double x, double y);
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other,
+      double m2XOther);
+
+ protected:
+  double m2X_{0};
+};
+
+struct ExtendedRegrAccumulator : public RegrAccumulator {
+  double m2Y() const;
+
+  void update(double x, double y);
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other,
+      double m2XOther,
+      double m2YOther);
+
+ private:
+  double m2Y_{0};
+};
+
+class CovarIntermediateInput {
+ public:
+  explicit CovarIntermediateInput(
+      const RowVector* rowVector,
+      const CovarIndices& indices = kCovarIndices)
+      : count_{asSimpleVector<int64_t>(rowVector, indices.count)},
+        meanX_{asSimpleVector<double>(rowVector, indices.meanX)},
+        meanY_{asSimpleVector<double>(rowVector, indices.meanY)},
+        c2_{asSimpleVector<double>(rowVector, indices.c2)} {}
+
+  void mergeInto(CovarAccumulator& accumulator, vector_size_t row);
+
+ protected:
+  SimpleVector<int64_t>* count_;
+  SimpleVector<double>* meanX_;
+  SimpleVector<double>* meanY_;
+  SimpleVector<double>* c2_;
+};
+
+class CovarIntermediateResult {
+ public:
+  explicit CovarIntermediateResult(
+      const RowVector* rowVector,
+      const CovarIndices& indices = kCovarIndices)
+      : count_{mutableRawValues<int64_t>(rowVector, indices.count)},
+        meanX_{mutableRawValues<double>(rowVector, indices.meanX)},
+        meanY_{mutableRawValues<double>(rowVector, indices.meanY)},
+        c2_{mutableRawValues<double>(rowVector, indices.c2)} {}
+
+  static std::string type() {
+    return "row(double,bigint,double,double)";
+  }
+
+  void set(vector_size_t row, const CovarAccumulator& accumulator);
+
+ private:
+  int64_t* count_;
+  double* meanX_;
+  double* meanY_;
+  double* c2_;
+};
+
+struct CorrAccumulator : public CovarAccumulator {
+  double m2X() const {
+    return m2X_;
+  }
+
+  double m2Y() const {
+    return m2Y_;
+  }
+
+  void update(double x, double y);
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other,
+      double m2XOther,
+      double m2YOther);
+
+ private:
+  double m2X_{0};
+  double m2Y_{0};
+};
+
+class CorrIntermediateInput : public CovarIntermediateInput {
+ public:
+  explicit CorrIntermediateInput(const RowVector* rowVector)
+      : CovarIntermediateInput(rowVector, kCorrIndices),
+        m2X_{asSimpleVector<double>(rowVector, kCorrIndices.m2X)},
+        m2Y_{asSimpleVector<double>(rowVector, kCorrIndices.m2Y)} {}
+
+  void mergeInto(CorrAccumulator& accumulator, vector_size_t row);
+
+ private:
+  SimpleVector<double>* m2X_;
+  SimpleVector<double>* m2Y_;
+};
+
+class CorrIntermediateResult : public CovarIntermediateResult {
+ public:
+  explicit CorrIntermediateResult(const RowVector* rowVector)
+      : CovarIntermediateResult(rowVector, kCorrIndices),
+        m2X_{mutableRawValues<double>(rowVector, kCorrIndices.m2X)},
+        m2Y_{mutableRawValues<double>(rowVector, kCorrIndices.m2Y)} {}
+
+  static std::string type() {
+    return "row(double,bigint,double,double,double,double)";
+  }
+
+  void set(vector_size_t row, const CorrAccumulator& accumulator);
+
+ private:
+  double* m2X_;
+  double* m2Y_;
+};
+
+// @tparam T Type of the raw input and final result. Can be double or float.
+template <
+    typename T,
+    typename TAccumulator,
+    typename TIntermediateInput,
+    typename TIntermediateResult,
+    typename TResultAccessor>
+class CovarianceAggregate : public exec::Aggregate {
+ public:
+  explicit CovarianceAggregate(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(TAccumulator);
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    if constexpr (
+        std::is_same_v<TAccumulator, RegrAccumulator> ||
+        std::is_same_v<TAccumulator, ExtendedRegrAccumulator>) {
+      // The args order of linear regression function is (y, x), so we need to
+      // swap the order
+      decodedX_.decode(*args[1], rows);
+      decodedY_.decode(*args[0], rows);
+    } else {
+      decodedX_.decode(*args[0], rows);
+      decodedY_.decode(*args[1], rows);
+    }
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedX_.isNullAt(row) || decodedY_.isNullAt(row)) {
+        return;
+      }
+      auto* group = groups[row];
+      exec::Aggregate::clearNull(group);
+      accumulator(group)->update(
+          decodedX_.valueAt<T>(row), decodedY_.valueAt<T>(row));
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+
+    auto baseRowVector = static_cast<const RowVector*>(decodedPartial_.base());
+    TIntermediateInput input{baseRowVector};
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedPartial_.isNullAt(row)) {
+        return;
+      }
+      auto decodedIndex = decodedPartial_.index(row);
+      auto* group = groups[row];
+      exec::Aggregate::clearNull(group);
+      input.mergeInto(*accumulator(group), decodedIndex);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    if constexpr (
+        std::is_same_v<TAccumulator, RegrAccumulator> ||
+        std::is_same_v<TAccumulator, ExtendedRegrAccumulator>) {
+      // The args order of linear regression function is (y, x), so we need to
+      // swap the order
+      decodedX_.decode(*args[1], rows);
+      decodedY_.decode(*args[0], rows);
+    } else {
+      decodedX_.decode(*args[0], rows);
+      decodedY_.decode(*args[1], rows);
+    }
+
+    exec::Aggregate::clearNull(group);
+    auto* accumulator = this->accumulator(group);
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedX_.isNullAt(row) || decodedY_.isNullAt(row)) {
+        return;
+      }
+      accumulator->update(decodedX_.valueAt<T>(row), decodedY_.valueAt<T>(row));
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+
+    exec::Aggregate::clearNull(group);
+    auto* accumulator = this->accumulator(group);
+
+    auto baseRowVector = static_cast<const RowVector*>(decodedPartial_.base());
+    TIntermediateInput input{baseRowVector};
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedPartial_.isNullAt(row)) {
+        return;
+      }
+      auto decodedIndex = decodedPartial_.index(row);
+      input.mergeInto(*accumulator, decodedIndex);
+    });
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto vector = (*result)->as<FlatVector<T>>();
+    BOLT_CHECK(vector);
+    vector->resize(numGroups);
+    uint64_t* rawNulls = getRawNulls(vector);
+
+    T* rawValues = vector->mutableRawValues();
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        vector->setNull(i, true);
+      } else {
+        auto* accumulator = this->accumulator(group);
+        if (TResultAccessor::hasResult(*accumulator)) {
+          clearNull(rawNulls, i);
+          rawValues[i] = static_cast<T>(TResultAccessor::result(*accumulator));
+        } else {
+          vector->setNull(i, true);
+        }
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    rowVector->resize(numGroups);
+    for (auto& child : rowVector->children()) {
+      child->resize(numGroups);
+    }
+
+    uint64_t* rawNulls = getRawNulls(rowVector);
+
+    TIntermediateResult covarResult{rowVector};
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        rowVector->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        covarResult.set(i, *accumulator(group));
+      }
+    }
+  }
+
+ protected:
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) TAccumulator();
+    }
+  }
+
+ private:
+  inline TAccumulator* accumulator(char* group) {
+    return exec::Aggregate::value<TAccumulator>(group);
+  }
+
+  DecodedVector decodedX_;
+  DecodedVector decodedY_;
+  DecodedVector decodedPartial_;
+};
+
+} // namespace bytedance::bolt::functions::aggregate

--- a/bolt/functions/sparksql/aggregates/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/CMakeLists.txt
@@ -45,6 +45,7 @@ bolt_add_library(
   BloomFilterAggAggregate.cpp
   CentralMomentsAggregate.cpp
   CollectListAggregate.cpp
+  CovarianceAggregate.cpp
   FirstLastAggregate.cpp
   MinMaxByAggregate.cpp
   PercentileApproxAggregate.cpp

--- a/bolt/functions/sparksql/aggregates/CovarianceAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/CovarianceAggregate.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/functions/sparksql/aggregates/CovarianceAggregate.h"
+
+#include <limits>
+#include "bolt/functions/lib/aggregates/CovarianceAggregatesBase.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+namespace {
+
+template <bool nullOnDivideByZero>
+struct CovarSampResultAccessor {
+  static bool hasResult(const CovarAccumulator& accumulator) {
+    if constexpr (nullOnDivideByZero) {
+      return accumulator.count() >= 2;
+    } else {
+      return accumulator.count() >= 1;
+    }
+  }
+
+  static double result(const CovarAccumulator& accumulator) {
+    if (accumulator.count() == 1) {
+      BOLT_CHECK(
+          !nullOnDivideByZero,
+          "NaN is returned only when m2 is 0 and nullOnDivideByZero is false.");
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return accumulator.c2() / (accumulator.count() - 1);
+  }
+};
+
+template <bool nullOnDivideByZero>
+struct CorrResultAccessor {
+  static bool hasResult(const CorrAccumulator& accumulator) {
+    if constexpr (nullOnDivideByZero) {
+      if (accumulator.count() == 1) {
+        return false;
+      }
+      return accumulator.m2X() != 0 && accumulator.m2Y() != 0;
+    } else {
+      if (accumulator.count() == 1) {
+        return true;
+      }
+      return accumulator.m2X() != 0 && accumulator.m2Y() != 0;
+    }
+  }
+
+  static double result(const CorrAccumulator& accumulator) {
+    if (accumulator.count() == 1) {
+      BOLT_CHECK(
+          !nullOnDivideByZero,
+          "NaN is returned only when m2 is 0 and nullOnDivideByZero is false.");
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    double stddevX = std::sqrt(accumulator.m2X());
+    double stddevY = std::sqrt(accumulator.m2Y());
+    return accumulator.c2() / stddevX / stddevY;
+  }
+};
+
+template <
+    typename TAccumulator,
+    typename TIntermediateInput,
+    typename TIntermediateResult,
+    template <bool>
+    class TResultAccessor>
+exec::AggregateRegistrationResult registerCovariance(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType(TIntermediateResult::type())
+          .argumentType("double")
+          .argumentType("double")
+          .build(),
+  };
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+        auto inputType = exec::isRawInput(step)
+            ? argTypes[0]
+            : (exec::isPartialOutput(step) ? DOUBLE() : resultType);
+        BOLT_USER_CHECK_EQ(
+            inputType->kind(),
+            TypeKind::DOUBLE,
+            "Unsupported input type: {}. "
+            "Expected DOUBLE.",
+            inputType->toString());
+
+        if (config.sparkLegacyStatisticalAggregate()) {
+          return std::make_unique<CovarianceAggregate<
+              double,
+              TAccumulator,
+              TIntermediateInput,
+              TIntermediateResult,
+              TResultAccessor<false>>>(resultType);
+        }
+        return std::make_unique<CovarianceAggregate<
+            double,
+            TAccumulator,
+            TIntermediateInput,
+            TIntermediateResult,
+            TResultAccessor<true>>>(resultType);
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+} // namespace
+
+void registerCovarianceAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerCovariance<
+      CovarAccumulator,
+      CovarIntermediateInput,
+      CovarIntermediateResult,
+      CovarSampResultAccessor>(
+      prefix + "covar_samp", withCompanionFunctions, overwrite);
+  registerCovariance<
+      CorrAccumulator,
+      CorrIntermediateInput,
+      CorrIntermediateResult,
+      CorrResultAccessor>(prefix + "corr", withCompanionFunctions, overwrite);
+}
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/CovarianceAggregate.h
+++ b/bolt/functions/sparksql/aggregates/CovarianceAggregate.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <string>
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+void registerCovarianceAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/Register.cpp
+++ b/bolt/functions/sparksql/aggregates/Register.cpp
@@ -37,6 +37,7 @@
 #include "bolt/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
 #include "bolt/functions/sparksql/aggregates/CentralMomentsAggregate.h"
 #include "bolt/functions/sparksql/aggregates/CollectListAggregate.h"
+#include "bolt/functions/sparksql/aggregates/CovarianceAggregate.h"
 #include "bolt/functions/sparksql/aggregates/DecimalSumAggregate.h"
 #include "bolt/functions/sparksql/aggregates/PercentileAggregate.h"
 #include "bolt/functions/sparksql/aggregates/RegrReplacementAggregate.h"
@@ -83,5 +84,6 @@ void registerAggregateFunctions(
   registerCollectSetAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectListAggregate(prefix, withCompanionFunctions, overwrite);
   registerRegrReplacementAggregate(prefix, withCompanionFunctions, overwrite);
+  registerCovarianceAggregates(prefix, withCompanionFunctions, overwrite);
 }
 } // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   CentralMomentsAggregationTest.cpp
   CollectListAggregateTest.cpp
   CollectSetAggregateTest.cpp
+  CovarianceAggregatesTest.cpp
   FirstAggregateTest.cpp
   LastAggregateTest.cpp
   Main.cpp

--- a/bolt/functions/sparksql/aggregates/tests/CovarianceAggregatesTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/CovarianceAggregatesTest.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "bolt/functions/sparksql/aggregates/Register.h"
+
+using namespace bytedance::bolt::exec::test;
+using namespace bytedance::bolt::functions::aggregate::test;
+
+namespace bytedance::bolt::functions::aggregate::sparksql::test {
+
+namespace {
+
+class CovarianceAggregatesTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    registerAggregateFunctions("spark_");
+  }
+
+  void testCovarianceAggResult(
+      const std::string& agg,
+      const RowVectorPtr& input,
+      const RowVectorPtr& expected,
+      bool legacy = false) {
+    auto plan =
+        PlanBuilder()
+            .values({input})
+            .singleAggregation({}, {fmt::format("spark_{}(c0, c1)", agg)})
+            .planNode();
+    AssertQueryBuilder(plan)
+        .config(
+            core::QueryConfig::kSparkLegacyStatisticalAggregate,
+            legacy ? "true" : "false")
+        .assertResults({expected});
+  }
+};
+
+TEST_F(CovarianceAggregatesTest, corr) {
+  auto agg = "corr";
+  auto input = makeRowVector(
+      {makeFlatVector<double>({1, 2, 3}), makeFlatVector<double>({1, 2, 3})});
+  auto expected =
+      makeRowVector({makeFlatVector<double>(std::vector<double>{1.0})});
+  testCovarianceAggResult(agg, input, expected);
+
+  input = makeRowVector(
+      {makeFlatVector<double>({1, 3, 5}), makeFlatVector<double>({2, 4, 6})});
+  expected = makeRowVector({makeFlatVector<double>(std::vector<double>{1.0})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when m2x equals 0.
+  input = makeRowVector(
+      {makeFlatVector<double>({1, 1, 1}), makeFlatVector<double>({2, 2, 2})});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when count equals 1.
+  input = makeRowVector({makeFlatVector<double>(1), makeFlatVector<double>(1)});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when count equals 0.
+  input = makeRowVector(
+      {makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt}),
+       makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt})});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when m2x equals 0 for legacy aggregate.
+  input = makeRowVector(
+      {makeFlatVector<double>({1, 1, 1}), makeFlatVector<double>({2, 2, 2})});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected, true);
+
+  // Output NaN when count equals 1 for legacy aggregate.
+  input = makeRowVector({makeFlatVector<double>(1), makeFlatVector<double>(1)});
+  expected = makeRowVector({makeFlatVector<double>(
+      std::vector<double>{std::numeric_limits<double>::quiet_NaN()})});
+  testCovarianceAggResult(agg, input, expected, true);
+
+  // Output NULL when count equals 0 for legacy aggregate.
+  input = makeRowVector(
+      {makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt}),
+       makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt})});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected, true);
+}
+
+TEST_F(CovarianceAggregatesTest, covarSamp) {
+  auto agg = "covar_samp";
+  auto input = makeRowVector(
+      {makeFlatVector<double>({1, 2, 3}), makeFlatVector<double>({1, 2, 3})});
+  auto expected =
+      makeRowVector({makeFlatVector<double>(std::vector<double>{1.0})});
+  testCovarianceAggResult(agg, input, expected);
+
+  input = makeRowVector(
+      {makeFlatVector<double>({1, 3, 5}), makeFlatVector<double>({2, 4, 6})});
+  expected = makeRowVector({makeFlatVector<double>(std::vector<double>{4.0})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when count equals 0.
+  input = makeRowVector(
+      {makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt}),
+       makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt})});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when count equals 1.
+  input = makeRowVector({makeFlatVector<double>(1), makeFlatVector<double>(1)});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected);
+
+  // Output NULL when count equals 0 for legacy aggregate.
+  input = makeRowVector(
+      {makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt}),
+       makeNullableFlatVector<double>(
+           std::vector<std::optional<double>>{std::nullopt})});
+  expected = makeRowVector({makeNullableFlatVector<double>(
+      std::vector<std::optional<double>>{std::nullopt})});
+  testCovarianceAggResult(agg, input, expected, true);
+
+  // Output NaN when m2 equals 1 for legacy aggregate.
+  input = makeRowVector({makeFlatVector<double>(1), makeFlatVector<double>(1)});
+  expected = makeRowVector({makeFlatVector<double>(
+      std::vector<double>{std::numeric_limits<double>::quiet_NaN()})});
+  testCovarianceAggResult(agg, input, expected, true);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::aggregate::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

In Spark corr and covar_samp functions, the result should be Double.NaN
instead of NULL if spark.legacy_statistical_aggregate is set to true when
dividing by zero during expression evaluation.

Therefore, it is necessary to move CovarianceAggregate to the functions/lib
directory for reuse by both Spark and Presto. Spark and Presto can then
implement their own TAccumulator, TIntermediateInput, TIntermediateResult
and TResultAccessor.

Spark corr:
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Corr.scala#L116
Spark variance:
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Covariance.scala#L129

Part of: https://github.com/facebookincubator/velox/issues/12542

Corresponding PR: https://github.com/facebookincubator/velox/pull/12994

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Support Spark legacy behavior for covariance functions
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









