### PR TITLE
[cp]refactor: Correct the name of operatorSupplier

### DIFF
--- a/bolt/exec/Driver.h
+++ b/bolt/exec/Driver.h
@@ -593,7 +593,7 @@ struct DriverFactory {
   std::vector<std::shared_ptr<const core::PlanNode>> planNodes;
   /// Function that will generate the final operator of a driver being
   /// constructed.
-  OperatorSupplier consumerSupplier;
+  OperatorSupplier operatorSupplier;
   /// Maximum number of drivers that can be run concurrently in this pipeline.
   uint32_t maxDrivers;
   /// Number of drivers that will be run concurrently in this pipeline for one

--- a/bolt/exec/LocalPlanner.cpp
+++ b/bolt/exec/LocalPlanner.cpp
@@ -105,7 +105,7 @@ bool isIndexLookupJoin(core::PlanNodePtr planNode) {
   return indexLookupJoin != nullptr;
 }
 
-OperatorSupplier makeConsumerSupplier(ConsumerSupplier consumerSupplier) {
+OperatorSupplier makeOperatorSupplier(ConsumerSupplier consumerSupplier) {
   if (consumerSupplier) {
     return [consumerSupplier](int32_t operatorId, DriverCtx* ctx) {
       return std::make_unique<CallbackSink>(
@@ -115,7 +115,7 @@ OperatorSupplier makeConsumerSupplier(ConsumerSupplier consumerSupplier) {
   return nullptr;
 }
 
-OperatorSupplier makeConsumerSupplier(
+OperatorSupplier makeOperatorSupplier(
     const std::shared_ptr<const core::PlanNode>& planNode) {
   if (auto localMerge =
           std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {
@@ -189,13 +189,13 @@ void plan(
     const std::shared_ptr<const core::PlanNode>& planNode,
     std::vector<std::shared_ptr<const core::PlanNode>>* currentPlanNodes,
     const std::shared_ptr<const core::PlanNode>& consumerNode,
-    OperatorSupplier consumerSupplier,
+    OperatorSupplier operatorSupplier,
     std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
     const bool morselDriven) {
   if (!currentPlanNodes) {
     driverFactories->push_back(std::make_unique<DriverFactory>());
     currentPlanNodes = &driverFactories->back()->planNodes;
-    driverFactories->back()->consumerSupplier = consumerSupplier;
+    driverFactories->back()->operatorSupplier = std::move(operatorSupplier);
     driverFactories->back()->consumerNode = consumerNode;
     // [morsel-driven] Pass the "morsel driven enabled" switch to driver factory
     if (morselDriven) {
@@ -240,7 +240,7 @@ void plan(
             localPartitionNodeAdded,
             mustStartNewPipeline(planNode, 0) ? nullptr : currentPlanNodes,
             planNode,
-            makeConsumerSupplier(planNode),
+            makeOperatorSupplier(planNode),
             driverFactories,
             morselDriven);
       } else {
@@ -248,7 +248,7 @@ void plan(
             sources[i],
             mustStartNewPipeline(planNode, i) ? nullptr : currentPlanNodes,
             planNode,
-            makeConsumerSupplier(planNode),
+            makeOperatorSupplier(planNode),
             driverFactories,
             morselDriven);
       }
@@ -418,7 +418,7 @@ void LocalPlanner::plan(
       planFragment.planNode,
       nullptr,
       nullptr,
-      detail::makeConsumerSupplier(consumerSupplier),
+      detail::makeOperatorSupplier(consumerSupplier),
       driverFactories,
       morselDriven);
 
@@ -436,7 +436,7 @@ void LocalPlanner::plan(
           planFragment.planNode,
           nullptr,
           nullptr,
-          detail::makeConsumerSupplier(consumerSupplier),
+          detail::makeOperatorSupplier(consumerSupplier),
           driverFactories,
           false);
     }
@@ -940,8 +940,8 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
       operators.push_back(std::move(extended));
     }
   }
-  if (consumerSupplier) {
-    operators.push_back(consumerSupplier(operators.size(), ctx.get()));
+  if (operatorSupplier) {
+    operators.push_back(operatorSupplier(operators.size(), ctx.get()));
   }
 
   driver->init(std::move(ctx), std::move(operators));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Some variable types and method return types are actually
OperatorSupplier, we should use the correct name.

Corresponding PR: https://github.com/facebookincubator/velox/pull/13377

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- refactor: Correct the name of operatorSupplier
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









