### PR TITLE
[cp][fix] Fix the duplicate map key handling for Spark map function

### DIFF
--- a/bolt/functions/sparksql/Map.cpp
+++ b/bolt/functions/sparksql/Map.cpp
@@ -134,10 +134,13 @@ class MapFunction : public exec::VectorFunction {
       resultWriter.setOffset(row);
       auto& mapWriter = resultWriter.current();
 
-      // used in Policy == LAST_WIN
-      std::unordered_map<exec::GenericView, std::optional<exec::GenericView>>
-          keyValues;
       std::unordered_set<exec::GenericView> keys;
+
+      // Only used when Policy == LAST_WIN
+      std::unordered_map<exec::GenericView, vector_size_t> lastIndex;
+      if constexpr (Policy == LAST_WIN) {
+        lastIndex.reserve(mapSize);
+      }
 
       for (auto i = 0; i < mapSize; ++i) {
         const auto& keyReader = *keyReaders[i];
@@ -146,6 +149,12 @@ class MapFunction : public exec::VectorFunction {
         BOLT_USER_CHECK(keyReader.isSet(row), "Cannot use null as map key!");
 
         exec::GenericView key = keyReader[row];
+
+        if constexpr (Policy == LAST_WIN) {
+          lastIndex.insert_or_assign(key, i);
+          continue;
+        }
+
         std::optional<exec::GenericView> value;
 
         if (valueReader.isSet(row)) {
@@ -173,20 +182,25 @@ class MapFunction : public exec::VectorFunction {
               mapWriter.add_null().copy_from(key); // value is null
             }
           }
-        } else if constexpr (Policy == LAST_WIN) {
-          keyValues.erase(key);
-          keyValues.insert({key, value});
         } else {
           BOLT_UNREACHABLE();
         }
       }
 
       if constexpr (Policy == LAST_WIN) {
-        for (const auto& [key, value] : keyValues) {
-          if (value.has_value()) {
+        for (auto i = 0; i < mapSize; ++i) {
+          const auto& keyReader = *keyReaders[i];
+          const auto& valueReader = *valueReaders[i];
+
+          exec::GenericView key = keyReader[row];
+          if (lastIndex.at(key) != i) {
+            continue;
+          }
+
+          if (valueReader.isSet(row)) {
             auto [keyWriter, valueWriter] = mapWriter.add_item();
             keyWriter.copy_from(key);
-            valueWriter.copy_from(*value);
+            valueWriter.copy_from(valueReader[row]);
           } else {
             mapWriter.add_null().copy_from(key); // value is null
           }
@@ -303,27 +317,45 @@ class MapFunction : public exec::VectorFunction {
     auto& valuesResult = mapResult->mapValues();
     vector_size_t offset = keysResult->size();
 
-    folly::F14FastMap<NativeType, vector_size_t> keyToArgsIndex;
-    keyToArgsIndex.reserve(mapSize);
+    folly::F14FastMap<NativeType, vector_size_t> lastIndex;
+    lastIndex.reserve(mapSize);
+    folly::F14FastSet<NativeType> seen;
+    seen.reserve(mapSize);
+    std::vector<NativeType> argKeys;
+    argKeys.reserve(mapSize);
+    std::vector<vector_size_t> selectedArgs;
+    selectedArgs.reserve(mapSize);
+
     // 1. For constant keys, only one time-consuming duplication is required.
     for (vector_size_t i = 0; i < mapSize; i++) {
       auto key =
           decodedArgs.at(i * 2)->base()->as<ConstantVector<NativeType>>();
       BOLT_USER_CHECK(!key->isNullAt(0), "Cannot use null as map key!");
+      argKeys.emplace_back(key->valueAtFast(0));
       if constexpr (Policy == EXCEPTION) {
         BOLT_USER_CHECK(
-            keyToArgsIndex.insert({key->valueAtFast(0), i}).second,
-            DuplicateKeyExceptionInfo);
+            seen.insert(argKeys.back()).second, DuplicateKeyExceptionInfo);
+        selectedArgs.emplace_back(i);
       } else if constexpr (Policy == FIRST_WIN) {
-        keyToArgsIndex.insert({key->valueAtFast(0), i});
+        if (seen.insert(argKeys.back()).second) {
+          selectedArgs.emplace_back(i);
+        }
       } else if constexpr (Policy == LAST_WIN) {
-        keyToArgsIndex.insert_or_assign(key->valueAtFast(0), i);
+        lastIndex.insert_or_assign(argKeys.back(), i);
       } else {
         BOLT_UNREACHABLE();
       }
     }
 
-    auto mapSizeAfterDedup = keyToArgsIndex.size();
+    if constexpr (Policy == LAST_WIN) {
+      for (vector_size_t i = 0; i < mapSize; i++) {
+        if (lastIndex.at(argKeys[i]) == i) {
+          selectedArgs.emplace_back(i);
+        }
+      }
+    }
+
+    const auto mapSizeAfterDedup = selectedArgs.size();
     rows.applyToSelected([&](vector_size_t row) {
       rawSizes[row] = mapSizeAfterDedup;
       rawOffsets[row] = offset;
@@ -346,7 +378,7 @@ class MapFunction : public exec::VectorFunction {
     // For other types of keys, copy first line from the args to the result
     // map, and then directly operate the `rawKeysResult` to memcpy the value of
     // each line.
-    for (const auto& [key, argsIndex] : keyToArgsIndex) {
+    for (auto argsIndex : selectedArgs) {
       rows.applyToSelected([&](vector_size_t row) {
         const auto mapIndex = rawOffsets[row] + targetIdx;
         targetRows.setValid(mapIndex, true);
@@ -359,9 +391,9 @@ class MapFunction : public exec::VectorFunction {
             args[argsIndex * 2].get(), targetRows, toSourceRow.data(), false);
       } else if constexpr (
           Kind == TypeKind::VARBINARY || Kind == TypeKind::VARCHAR) {
-        flatKeysResult->set(resultKeyIndex, key);
+        flatKeysResult->set(resultKeyIndex, argKeys[argsIndex]);
       } else {
-        rawKeysResult[resultKeyIndex] = key;
+        rawKeysResult[resultKeyIndex] = argKeys[argsIndex];
       }
       valuesResult->copy(
           args[argsIndex * 2 + 1].get(), targetRows, toSourceRow.data(), false);

--- a/bolt/functions/sparksql/tests/MapTest.cpp
+++ b/bolt/functions/sparksql/tests/MapTest.cpp
@@ -448,6 +448,149 @@ TEST_F(MapTest, complexTypes) {
   }
 }
 
+TEST_F(MapTest, complexTypesDuplicateMapKey) {
+  auto makeSingleMapVector = [&](const VectorPtr& keyVector,
+                                 const VectorPtr& valueVector) {
+    return makeMapVector(
+        {
+            0,
+        },
+        keyVector,
+        valueVector);
+  };
+  auto arrayKey = makeArrayVectorFromJson<int64_t>({"[1, 2, 3]"});
+  auto arrayValue = makeArrayVectorFromJson<int64_t>({"[1, 3, 5]"});
+  auto nullArrayValue = makeArrayVectorFromJson<int64_t>({"null"});
+
+  setMapKeyDedupPolicy("LAST_WIN");
+  testMap(
+      "map(c0, c1, c2, c3)",
+      {arrayKey, arrayValue, arrayKey, arrayValue},
+      makeSingleMapVector(arrayKey, arrayValue));
+
+  testMap(
+      "map(c0, c1, c2, c3)",
+      {arrayKey, nullArrayValue, arrayKey, nullArrayValue},
+      makeSingleMapVector(arrayKey, nullArrayValue));
+
+  setMapKeyDedupPolicy("EXCEPTION");
+  testMapFails(
+      "map(c0, c1, c2, c3)",
+      {arrayKey, arrayValue, arrayKey, arrayValue},
+      "Duplicate map key was found, please check the input data.");
+}
+
+TEST_F(MapTest, complexTypesWithNestedNullsDuplicateMapKey) {
+  // Create array keys with nulls.
+  auto arrayKeysWithNull1 = makeNullableArrayVector<int64_t>(
+      {{1, std::nullopt, 3}, {4, 5, std::nullopt}, {7, 8, 9}});
+  auto valuesForKey1 = makeArrayVector<StringView>(
+      {{"a"_sv, "b"_sv, "c"_sv},
+       {"d"_sv, "e"_sv, "f"_sv},
+       {"g"_sv, "h"_sv, "i"_sv}});
+
+  // Create duplicate keys with the same null pattern.
+  auto arrayKeysWithNull2 = makeNullableArrayVector<int64_t>(
+      {{1, std::nullopt, 3}, {10, 11, 12}, {13, 14, 15}});
+  auto valuesForKey2 = makeArrayVector<StringView>(
+      {{"x"_sv, "y"_sv, "z"_sv},
+       {"p"_sv, "q"_sv, "r"_sv},
+       {"s"_sv, "t"_sv, "u"_sv}});
+
+  // Create complex type with map containing null values.
+  auto mapKey1 = makeMapVector<int64_t, int64_t>(
+      {{{1, 10}, {2, std::nullopt}},
+       {{3, 30}, {4, std::nullopt}},
+       {{5, 50}, {6, 60}}});
+  auto valueForMapKey1 = makeFlatVector<int64_t>({100, 200, 300});
+
+  // Create duplicate complex map key with the same null pattern.
+  auto mapKey2 = makeMapVector<int64_t, int64_t>(
+      {{{1, 10}, {2, std::nullopt}},
+       {{30, 300}, {40, 400}},
+       {{50, 500}, {60, 600}}});
+  auto valueForMapKey2 = makeFlatVector<int64_t>({1000, 2000, 3000});
+
+  setMapKeyDedupPolicy("LAST_WIN");
+
+  // Test case 1: Array keys with nulls.
+  // Expected: [1, null, 3] appears twice, last value ["x", "y", "z"] wins.
+  auto expectedArrayMap = makeMapVector(
+      {0, 1, 3},
+      makeNullableArrayVector<int64_t>(
+          {{1, std::nullopt, 3},
+           {4, 5, std::nullopt},
+           {10, 11, 12},
+           {7, 8, 9},
+           {13, 14, 15}}),
+      makeArrayVector<StringView>(
+          {{"x"_sv, "y"_sv, "z"_sv},
+           {"d"_sv, "e"_sv, "f"_sv},
+           {"p"_sv, "q"_sv, "r"_sv},
+           {"g"_sv, "h"_sv, "i"_sv},
+           {"s"_sv, "t"_sv, "u"_sv}}));
+
+  testMap(
+      "map(c0, c1, c2, c3)",
+      {arrayKeysWithNull1, valuesForKey1, arrayKeysWithNull2, valuesForKey2},
+      expectedArrayMap);
+
+  // Test case 2: Map keys with nulls.
+  // Expected: {{1, 10}, {2, null}} appears twice, last value 1000 wins.
+  auto expectedMapOfMap = makeMapVector(
+      {0, 1, 3},
+      makeMapVector<int64_t, int64_t>(
+          {{{1, 10}, {2, std::nullopt}},
+           {{3, 30}, {4, std::nullopt}},
+           {{30, 300}, {40, 400}},
+           {{5, 50}, {6, 60}},
+           {{50, 500}, {60, 600}}}),
+      makeFlatVector<int64_t>({1000, 200, 2000, 300, 3000}));
+
+  testMap(
+      "map(c0, c1, c2, c3)",
+      {mapKey1, valueForMapKey1, mapKey2, valueForMapKey2},
+      expectedMapOfMap);
+
+  // Test case 3: Test with deeply nested structures containing nulls.
+  auto rowKey1 = makeRowVector(
+      {makeNullableArrayVector<int64_t>({{1, std::nullopt, 3}}),
+       makeMapVector<int64_t, int64_t>({{{1, 10}, {2, std::nullopt}}})});
+  auto valueForRow1 = makeFlatVector<StringView>({"first"_sv});
+
+  // Duplicate row key with same null pattern.
+  auto rowKey2 = makeRowVector(
+      {makeNullableArrayVector<int64_t>({{1, std::nullopt, 3}}),
+       makeMapVector<int64_t, int64_t>({{{1, 10}, {2, std::nullopt}}})});
+  auto valueForRow2 = makeFlatVector<StringView>({"last"_sv});
+
+  // Expected: Complex row with nulls appears twice, last value "last" wins.
+  auto expectedRowMap = makeMapVector(
+      {0},
+      makeRowVector(
+          {makeNullableArrayVector<int64_t>({{1, std::nullopt, 3}}),
+           makeMapVector<int64_t, int64_t>({{{1, 10}, {2, std::nullopt}}})}),
+      makeFlatVector<StringView>({"last"_sv}));
+
+  testMap(
+      "map(c0, c1, c2, c3)",
+      {rowKey1, valueForRow1, rowKey2, valueForRow2},
+      expectedRowMap);
+
+  // Test case 4: Test with exception throwing enabled.
+  setMapKeyDedupPolicy("EXCEPTION");
+
+  testMapFails(
+      "map(c0, c1, c2, c3)",
+      {arrayKeysWithNull1, valuesForKey1, arrayKeysWithNull2, valuesForKey2},
+      "Duplicate map key was found, please check the input data.");
+
+  testMapFails(
+      "map(c0, c1, c2, c3)",
+      {mapKey1, valueForMapKey1, mapKey2, valueForMapKey2},
+      "Duplicate map key was found, please check the input data.");
+}
+
 TEST_F(MapTest, resultSize) {
   for (const auto& policy : POLICIES) {
     setMapKeyDedupPolicy(policy);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Spark has two policies EXCEPTION and LAST_WIN to deal with duplicate keys
in map functions like CreateMap, MapFromArrays, MapFromEntries, StringToMap,
MapConcat and TransformKeys.

EXCEPTION behaviour: throws exception when a duplicate key is found in map.
LAST_WIN behaviour: the result value comes from the last inserted element. (Default)

Added handling for duplicate map keys in the Spark map function.

Function signature: map(K, V, K, V, ...) -> map(K,V)
where the maximum number of allowed key/value pairs are 3 in Velox.

Corresponding PR: https://github.com/facebookincubator/velox/pull/13183

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: Fix the duplicate map key handling for Spark map function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









