### PR TITLE
[cp]fix: Make Spark abs function ansi-compliant

### DIFF
--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -417,6 +417,9 @@ class QueryConfig {
   static constexpr const char* kSparkMapKeyDedupPolicy =
       "spark.mapKeyDedupPolicy";
 
+  /// If true, Spark functions follow Spark ANSI mode behavior.
+  static constexpr const char* kSparkAnsiEnabled = "spark.sql.ansi.enabled";
+
   /// The current spark partition id.
   static constexpr const char* kSparkPartitionId = "spark.partition_id";
 
@@ -1267,6 +1270,10 @@ class QueryConfig {
       c = std::toupper(static_cast<unsigned char>(c));
     }
     return res;
+  }
+
+  bool sparkAnsiEnabled() const {
+    return get<bool>(kSparkAnsiEnabled, false);
   }
 
   int32_t sparkPartitionId() const {

--- a/bolt/functions/sparksql/Arithmetic.h
+++ b/bolt/functions/sparksql/Arithmetic.h
@@ -36,10 +36,44 @@
 #include <limits>
 #include <system_error>
 #include <type_traits>
+#include <vector>
 #include "bolt/common/base/Doubles.h"
+#include "bolt/core/QueryConfig.h"
 #include "bolt/functions/Macros.h"
 #include "bolt/functions/lib/ToHex.h"
 namespace bytedance::bolt::functions::sparksql {
+
+template <typename TExec>
+struct AbsFunction {
+  template <typename T>
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const T* /*a*/) {
+    ansiEnabled_ = config.sparkAnsiEnabled();
+  }
+
+  template <typename T>
+  FOLLY_ALWAYS_INLINE Status call(T& result, const T& a) {
+    if constexpr (std::is_integral_v<T>) {
+      if (UNLIKELY(a == std::numeric_limits<T>::min())) {
+        if (ansiEnabled_) {
+          if (threadSkipErrorDetails()) {
+            return Status::UserError();
+          }
+          return Status::UserError("Arithmetic overflow: abs({})", a);
+        }
+        result = a;
+        return Status::OK();
+      }
+    }
+    result = std::abs(a);
+    return Status::OK();
+  }
+
+ private:
+  bool ansiEnabled_ = false;
+};
 
 template <typename T>
 struct RemainderFunction {

--- a/bolt/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/bolt/functions/sparksql/tests/ArithmeticTest.cpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <limits>
 
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 namespace bytedance::bolt::functions::sparksql::test {
 namespace {
@@ -195,6 +196,11 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   template <typename T>
   std::optional<T> unaryminus(std::optional<T> arg) {
     return evaluateOnce<T>("unaryminus(c0)", arg);
+  }
+
+  template <typename T>
+  std::optional<T> abs(std::optional<T> arg) {
+    return evaluateOnce<T>("abs(c0)", arg);
   }
 
   std::optional<double> divide(
@@ -796,6 +802,57 @@ TEST_F(ArithmeticTest, checkedDivide) {
       INT64_MIN, -1, "Arithmetic overflow: -9223372036854775808 / -1");
   EXPECT_EQ(checkedDivide<float>(kInf, 1), kInf);
   EXPECT_EQ(checkedDivide<double>(kInfDouble, 1), kInfDouble);
+}
+
+TEST_F(ArithmeticTest, abs) {
+  for (const auto& ansiEnabled : {"false", "true"}) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kSparkAnsiEnabled, ansiEnabled}});
+
+    EXPECT_EQ(abs<int8_t>(-127), 127);
+    EXPECT_EQ(abs<int16_t>(-32767), 32767);
+    EXPECT_EQ(abs<int32_t>(-2147483647), 2147483647);
+    EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
+
+    EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
+    EXPECT_EQ(
+        abs<float>(std::numeric_limits<float>::lowest()),
+        std::numeric_limits<float>::max());
+    EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
+    EXPECT_EQ(
+        abs<double>(std::numeric_limits<double>::lowest()),
+        std::numeric_limits<double>::max());
+  }
+}
+
+TEST_F(ArithmeticTest, absMinValueOverflow) {
+  // Test abs with ANSI off.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kSparkAnsiEnabled, "false"}});
+  EXPECT_EQ(
+      abs<int8_t>(std::numeric_limits<int8_t>::min()),
+      std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(
+      abs<int16_t>(std::numeric_limits<int16_t>::min()),
+      std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(
+      abs<int32_t>(std::numeric_limits<int32_t>::min()),
+      std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()),
+      std::numeric_limits<int64_t>::min());
+
+  // Test abs with ANSI on.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
+  BOLT_ASSERT_THROW(
+      abs<int8_t>(std::numeric_limits<int8_t>::min()), "Arithmetic overflow");
+  BOLT_ASSERT_THROW(
+      abs<int16_t>(std::numeric_limits<int16_t>::min()), "Arithmetic overflow");
+  BOLT_ASSERT_THROW(
+      abs<int32_t>(std::numeric_limits<int32_t>::min()), "Arithmetic overflow");
+  BOLT_ASSERT_THROW(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()), "Arithmetic overflow");
 }
 
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR supports ansi-compliant behavior for the Spark abs function.
Fixes https://github.com/facebookincubator/velox/issues/14345.

Corresponding PR: https://github.com/facebookincubator/velox/pull/14346

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: Make Spark abs function ansi-compliant
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









