### PR TITLE
[cp]refactor: Use BOLT_USER_RETURN in Spark arithmetic functions

### DIFF
--- a/bolt/common/base/Status.h
+++ b/bolt/common/base/Status.h
@@ -495,6 +495,19 @@ void Status::moveFrom(Status& s) {
     BOLT_RETURN_IF(!__s.ok(), __s);                           \
   } while (false)
 
+#define BOLT_USER_RETURN(condition, ...)     \
+  do {                                       \
+    if (UNLIKELY(condition)) {               \
+      if (threadSkipErrorDetails()) {        \
+        return Status::UserError();          \
+      }                                      \
+      return Status::UserError(__VA_ARGS__); \
+    }                                        \
+  } while (false)
+
+#define BOLT_USER_RETURN_EQ(lhs, rhs, ...) \
+  BOLT_USER_RETURN((lhs) == (rhs), __VA_ARGS__)
+
 namespace internal {
 
 /// Common API for extracting Status from either Status or Result<T> (the latter

--- a/bolt/functions/sparksql/Arithmetic.h
+++ b/bolt/functions/sparksql/Arithmetic.h
@@ -572,18 +572,15 @@ struct RIntFunction {
 
 template <typename TExec>
 struct CheckedAddFunction {
-  BOLT_DEFINE_FUNCTION_TYPES(TExec);
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
     if constexpr (std::is_integral_v<T>) {
       T res;
-      bool overflow = __builtin_add_overflow(a, b, &res);
-      if (UNLIKELY(overflow)) {
-        if (threadSkipErrorDetails()) {
-          return Status::UserError();
-        }
-        return Status::UserError("Arithmetic overflow: {} + {}", a, b);
-      }
+      BOLT_USER_RETURN(
+          __builtin_add_overflow(a, b, &res),
+          "Arithmetic overflow: {} + {}",
+          a,
+          b);
       result = res;
     } else {
       result = a + b;
@@ -594,17 +591,14 @@ struct CheckedAddFunction {
 
 template <typename TExec>
 struct CheckedSubtractFunction {
-  BOLT_DEFINE_FUNCTION_TYPES(TExec);
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
     if constexpr (std::is_integral_v<T>) {
-      bool overflow = __builtin_sub_overflow(a, b, &result);
-      if (UNLIKELY(overflow)) {
-        if (threadSkipErrorDetails()) {
-          return Status::UserError();
-        }
-        return Status::UserError("Arithmetic overflow: {} - {}", a, b);
-      }
+      BOLT_USER_RETURN(
+          __builtin_sub_overflow(a, b, &result),
+          "Arithmetic overflow: {} - {}",
+          a,
+          b);
     } else {
       result = a - b;
     }
@@ -614,17 +608,14 @@ struct CheckedSubtractFunction {
 
 template <typename TExec>
 struct CheckedMultiplyFunction {
-  BOLT_DEFINE_FUNCTION_TYPES(TExec);
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
     if constexpr (std::is_integral_v<T>) {
-      bool overflow = __builtin_mul_overflow(a, b, &result);
-      if (UNLIKELY(overflow)) {
-        if (threadSkipErrorDetails()) {
-          return Status::UserError();
-        }
-        return Status::UserError("Arithmetic overflow: {} * {}", a, b);
-      }
+      BOLT_USER_RETURN(
+          __builtin_mul_overflow(a, b, &result),
+          "Arithmetic overflow: {} * {}",
+          a,
+          b);
     } else {
       result = a * b;
     }
@@ -634,22 +625,15 @@ struct CheckedMultiplyFunction {
 
 template <typename TExec>
 struct CheckedDivideFunction {
-  BOLT_DEFINE_FUNCTION_TYPES(TExec);
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(T& result, const T& a, const T& b) {
-    if (b == 0) {
-      if (threadSkipErrorDetails()) {
-        return Status::UserError();
-      }
-      return Status::UserError("division by zero");
-    }
+    BOLT_USER_RETURN_EQ(b, 0, "division by zero");
     if constexpr (std::is_integral_v<T>) {
-      if (UNLIKELY(a == std::numeric_limits<T>::min() && b == -1)) {
-        if (threadSkipErrorDetails()) {
-          return Status::UserError();
-        }
-        return Status::UserError("Arithmetic overflow: {} / {}", a, b);
-      }
+      BOLT_USER_RETURN(
+          a == std::numeric_limits<T>::min() && b == -1,
+          "Arithmetic overflow: {} / {}",
+          a,
+          b);
     }
     result = a / b;
     return Status::OK();


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Refactor Spark checked_arithmetic functions to use VELOX_USER_RETURN for error handling.

Corresponding PR: https://github.com/facebookincubator/velox/pull/14936

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- refactor: Use VELOX_USER_RETURN in Spark arithmetic functions
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









