### PR TITLE
[cp]fix: Crash in constructing null ConstantVector of type ROW()

### DIFF
--- a/bolt/row/tests/UnsafeRowFuzzTest.cpp
+++ b/bolt/row/tests/UnsafeRowFuzzTest.cpp
@@ -191,5 +191,32 @@ TEST_F(UnsafeRowFuzzTests, fast) {
   });
 }
 
+TEST_F(UnsafeRowFuzzTests, constantVector) {
+  clearBuffers();
+
+  auto emptyStructType = ROW({});
+  auto rowType = ROW({emptyStructType});
+  auto data = std::make_shared<RowVector>(
+      pool_.get(),
+      rowType,
+      BufferPtr(nullptr),
+      1,
+      std::vector<VectorPtr>{
+          BaseVector::createNullConstant(emptyStructType, 1, pool_.get())});
+
+  UnsafeRowFast fast(data);
+  auto rowSize = fast.serialize(0, buffers_[0]);
+  BOLT_CHECK_LE(rowSize, kBufferSize);
+
+  std::vector<std::optional<std::string_view>> serialized;
+  serialized.reserve(1);
+  serialized.push_back(std::string_view(buffers_[0], rowSize));
+
+  VectorPtr outputVector =
+      UnsafeRowDeserializer::deserialize(serialized, rowType, pool_.get());
+
+  assertEqualVectors(data, outputVector);
+}
+
 } // namespace
 } // namespace bytedance::bolt::row

--- a/bolt/vector/ConstantVector.h
+++ b/bolt/vector/ConstantVector.h
@@ -84,7 +84,7 @@ class ConstantVector final : public SimpleVector<T> {
         initialized_(true) {
     makeNullsBuffer();
     // Special handling for complex types
-    if (type->size() > 0) {
+    if (type->size() > 0 || type->kind() == TypeKind::ROW) {
       // Only allow null constants to be created through this interface.
       BOLT_CHECK(isNull_);
       valueVector_ = BaseVector::create(type, 1, pool);

--- a/bolt/vector/tests/DecodedVectorTest.cpp
+++ b/bolt/vector/tests/DecodedVectorTest.cpp
@@ -550,6 +550,16 @@ TEST_F(DecodedVectorTest, constantNull) {
   testConstantNull(ARRAY(INTEGER()));
   testConstantNull(MAP(INTEGER(), INTEGER()));
   testConstantNull(ROW({INTEGER()}));
+  testConstantNull(ROW({}));
+}
+
+TEST_F(DecodedVectorTest, emptyStruct) {
+  auto vector = makeRowVector(ROW({}), 1);
+  DecodedVector decoded;
+  decoded.decode(*vector);
+  EXPECT_EQ(decoded.base(), vector.get());
+  EXPECT_EQ(decoded.size(), 1);
+  EXPECT_FALSE(decoded.isNullAt(0));
 }
 
 TEST_F(DecodedVectorTest, constantComplexType) {

--- a/bolt/vector/tests/VectorTest.cpp
+++ b/bolt/vector/tests/VectorTest.cpp
@@ -2018,6 +2018,8 @@ TEST_F(VectorCreateConstantTest, complex) {
   testComplexConstant<TypeKind::ROW>(
       ROW({{"c0", INTEGER()}}),
       makeRowVector({makeFlatVector<int32_t>(1, [](auto i) { return i; })}));
+
+  testComplexConstant<TypeKind::ROW>(ROW({}), makeRowVector(ROW({}), 1));
 }
 
 TEST_F(VectorCreateConstantTest, null) {
@@ -2042,6 +2044,7 @@ TEST_F(VectorCreateConstantTest, null) {
   testNullConstant<TypeKind::VARBINARY>(VARBINARY());
 
   testNullConstant<TypeKind::ROW>(ROW({BIGINT(), REAL()}));
+  testNullConstant<TypeKind::ROW>(ROW({}));
   testNullConstant<TypeKind::ARRAY>(ARRAY(DOUBLE()));
   testNullConstant<TypeKind::MAP>(MAP(INTEGER(), DOUBLE()));
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Fix a crash when creating UnsafeRowFast with a null constant vector for an empty row type (ROW<>).  
`decoded_.base()` returns a constantVector<Row<>>, which causes [`rowBase`](https://github.com/facebookincubator/velox/blob/13310e4efb6dce1de36181057d6addcb47a3f8fc/velox/row/UnsafeRowFast.cpp#L80) to become null.

Repro: [https://github.com/facebookincubator/velox/pull/15018/files#diff-512c8848feccfe3a1cda4596db4682813fcef66cb1b6bf3b22f9087388590d6bR219](https://github.com/facebookincubator/velox/pull/15018/files#diff-512c8848feccfe3a1cda4596db4682813fcef66cb1b6bf3b22f9087388590d6bR219)

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00005dcdbcb6c3fa in facebook::velox::row::UnsafeRowFast::initialize(std::shared_ptr<facebook::velox::Type const> const&) ()
```

The issue was caused by the constant-vector creation logic, which relied on the condition type->size() > 0 and did not correctly handle the empty-row type.

Corresponding PR: https://github.com/facebookincubator/velox/pull/15018

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: Fix a crash when creating UnsafeRowFast with a null constant vector for an empty row type (ROW<>).
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









