### PR TITLE
[wip][cp]feat: Add support for Spark avg(decimal) aggregate function

### DIFF
--- a/bolt/functions/sparksql/DecimalUtil.h
+++ b/bolt/functions/sparksql/DecimalUtil.h
@@ -234,6 +234,33 @@ class DecimalUtil {
     }
   }
 
+  /// When allowing precision loss, computes the result precision and scale
+  /// following Hive's formulas. When denying precision loss, calculates the
+  /// number of whole digits and fraction digits. If the total number of digits
+  /// exceed 38, we reduce both the number of fraction digits and whole digits
+  /// to fit within this limit.
+  template <bool allowPrecisionLoss>
+  static std::pair<uint8_t, uint8_t> computeDivideResultPrecisionScale(
+      uint8_t aPrecision,
+      uint8_t aScale,
+      uint8_t bPrecision,
+      uint8_t bScale) {
+    if constexpr (allowPrecisionLoss) {
+      auto scale = std::max(6, aScale + bPrecision + 1);
+      auto precision = aPrecision - aScale + bScale + scale;
+      return adjustPrecisionScale(precision, scale);
+    } else {
+      auto wholeDigits = std::min(38, aPrecision - aScale + bScale);
+      auto fractionDigits = std::min(38, std::max(6, aScale + bPrecision + 1));
+      auto diff = (wholeDigits + fractionDigits) - 38;
+      if (diff > 0) {
+        fractionDigits -= diff / 2 + 1;
+        wholeDigits = 38 - fractionDigits;
+      }
+      return bounded(wholeDigits + fractionDigits, fractionDigits);
+    }
+  }
+
   template <typename InputType>
   inline static InputType isDivisiable10(const InputType& input) {
     if constexpr (std::is_same_v<InputType, int128_t>) {

--- a/bolt/functions/sparksql/aggregates/DecimalAverageAggregate.h
+++ b/bolt/functions/sparksql/aggregates/DecimalAverageAggregate.h
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "bolt/exec/SimpleAggregateAdapter.h"
+#include "bolt/functions/sparksql/DecimalUtil.h"
+#include "bolt/type/DecimalUtil.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+namespace detail {
+
+inline TypePtr getSumType(const TypePtr& rawInputType) {
+  if (rawInputType->isRow()) {
+    return rawInputType->childAt(0);
+  }
+  auto [p, s] = getDecimalPrecisionScale(*rawInputType.get());
+  // In Spark,
+  // intermediate sum precision = input precision + 10
+  // intermediate sum scale = input scale
+  return DECIMAL(std::min<uint8_t>(LongDecimalType::kMaxPrecision, p + 10), s);
+}
+
+} // namespace detail
+
+/// @tparam TInputType The raw input data type.
+/// @tparam TResultType The type of the output average value.
+template <typename TInputType, typename TResultType>
+class DecimalAverageAggregate {
+ public:
+  using InputType = Row<TInputType>;
+
+  using IntermediateType =
+      Row</*sum*/ int128_t,
+          /*count*/ int64_t>;
+
+  using OutputType = TResultType;
+
+  /// Spark's decimal sum doesn't have the concept of a null group, each group
+  /// is initialized with an initial value, where sum = 0 and count = 0. The
+  /// final agg may fallback to being executed in Spark, so the meaning of the
+  /// intermediate data should be consistent with Spark. Therefore, we need to
+  /// use the parameter nonNullGroup in writeIntermediateResult to output a null
+  /// group as sum = 0, count = 0. nonNullGroup is only available when
+  /// default-null behavior is disabled.
+  static constexpr bool default_null_behavior_ = false;
+
+  void initialize(
+      core::AggregationNode::Step step,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& resultType) {
+    BOLT_CHECK_EQ(argTypes.size(), 1);
+    auto inputType = argTypes[0];
+    this->sumType_ = detail::getSumType(inputType);
+    this->resultType_ = resultType;
+  }
+
+  static bool toIntermediate(
+      exec::out_type<Row<int128_t, int64_t>>& out,
+      exec::optional_arg_type<TInputType> in) {
+    if (in.has_value()) {
+      out.copy_from(std::make_tuple(in.value(), 1));
+    } else {
+      out.copy_from(std::make_tuple(0, 0));
+    }
+    return true;
+  }
+
+  /// This struct stores the sum of input values, overflow during accumulation,
+  /// and the count number of the input values. If the count is not 0, then if
+  /// sum is nullopt that means an overflow has happened. For null group, the
+  /// variables in accumulator should be meaningless, so the values of sum and
+  /// count are ignored in both writeIntermediateResult and writeFinalResult.
+  struct AccumulatorType {
+    std::optional<int128_t> sum{0};
+    int64_t overflow{0};
+    int64_t count{0};
+
+    DecimalAverageAggregate* fn;
+
+    static constexpr bool is_aligned_ = true;
+
+    AccumulatorType() = delete;
+
+    AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        DecimalAverageAggregate* fn)
+        : fn(fn) {}
+
+    bool addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::optional_arg_type<TInputType> data) {
+      if (!data.has_value()) {
+        return false;
+      }
+      if (!sum.has_value()) {
+        // sum is initialized to 0. When it is nullopt, it implies that the
+        // count number of the input values must not be 0.
+        BOLT_CHECK(count != 0);
+        return true;
+      }
+      int128_t result;
+      overflow +=
+          bolt::DecimalUtil::addWithOverflow(result, data.value(), sum.value());
+      sum = result;
+      count += 1;
+      return true;
+    }
+
+    bool combine(
+        HashStringAllocator* /*allocator*/,
+        exec::optional_arg_type<Row<int128_t, int64_t>> other) {
+      if (!other.has_value()) {
+        return false;
+      }
+      auto const otherSum = other.value().template at<0>();
+      auto const otherCount = other.value().template at<1>();
+
+      // otherCount is never null.
+      BOLT_CHECK(otherCount.has_value());
+      if (count == 0 && otherCount.value() == 0) {
+        // Both accumulators have no input values, no need to do the
+        // combination.
+        return false;
+      }
+
+      bool currentOverflow = count > 0 && !sum.has_value();
+      bool otherOverflow = otherCount.value() > 0 && !otherSum.has_value();
+      if (currentOverflow || otherOverflow) {
+        sum = std::nullopt;
+        count += otherCount.value();
+      } else {
+        int128_t result;
+        overflow += bolt::DecimalUtil::addWithOverflow(
+            result, otherSum.value(), sum.value());
+        sum = result;
+        count += otherCount.value();
+      }
+      return true;
+    }
+
+    bool writeIntermediateResult(
+        bool nonNullGroup,
+        exec::out_type<IntermediateType>& out) {
+      if (!nonNullGroup) {
+        // If a group is null, all values in this group are null. In Spark, this
+        // group will be the initial value, where sum is 0 and count is 0.
+        out =
+            std::make_tuple(static_cast<int128_t>(0), static_cast<int64_t>(0));
+      } else {
+        if (!sum.has_value()) {
+          // Sum should be set to null on overflow.
+          out.template set_null_at<0>();
+          out.template get_writer_at<1>() = count;
+        } else {
+          auto adjustedSum =
+              bolt::DecimalUtil::adjustSumForOverflow(sum.value(), overflow);
+          if (adjustedSum.has_value()) {
+            out = std::make_tuple(adjustedSum.value(), count);
+          } else {
+            out.template set_null_at<0>();
+            out.template get_writer_at<1>() = count;
+          }
+        }
+      }
+      return true;
+    }
+
+    bool writeFinalResult(bool nonNullGroup, exec::out_type<OutputType>& out) {
+      if (!nonNullGroup || count == 0) {
+        // In Spark, if all inputs are null, count will be 0, and the result of
+        // average value will be null.
+        return false;
+      }
+      auto finalResult = computeFinalResult();
+      if (finalResult.has_value()) {
+        out = static_cast<TResultType>(finalResult.value());
+        return true;
+      }
+      // Sum should be set to null on overflow.
+      return false;
+    }
+
+   private:
+    std::optional<int128_t> computeFinalResult() const {
+      if (!sum.has_value()) {
+        return std::nullopt;
+      }
+      const auto adjustedSum =
+          bolt::DecimalUtil::adjustSumForOverflow(sum.value(), overflow);
+      if (!adjustedSum.has_value()) {
+        // Found overflow during computing adjusted sum.
+        return std::nullopt;
+      }
+
+      auto [resultPrecision, resultScale] =
+          getDecimalPrecisionScale(*fn->resultType_.get());
+      auto [sumPrecision, sumScale] =
+          getDecimalPrecisionScale(*fn->sumType_.get());
+
+      // Spark use DECIMAL(20,0) to represent long value.
+      static const uint8_t countPrecision = 20;
+      static const uint8_t countScale = 0;
+
+      auto [dividePrecision, divideScale] =
+          functions::sparksql::DecimalUtil::computeDivideResultPrecisionScale<
+              true>(sumPrecision, sumScale, countPrecision, countScale);
+      divideScale = std::max<uint8_t>(divideScale, resultScale);
+      auto sumRescale = divideScale - sumScale + countScale;
+      int128_t avg;
+      bool overflow = false;
+      functions::sparksql::DecimalUtil::
+          divideWithRoundUp<int128_t, int128_t, int128_t>(
+              avg, adjustedSum.value(), count, sumRescale, overflow);
+      if (overflow) {
+        return std::nullopt;
+      }
+      TResultType rescaledValue;
+      const auto status =
+          bolt::DecimalUtil::rescaleWithRoundUp<int128_t, TResultType>(
+              avg,
+              dividePrecision,
+              divideScale,
+              resultPrecision,
+              resultScale,
+              rescaledValue);
+      return status.ok() ? std::optional<int128_t>(rescaledValue)
+                         : std::nullopt;
+    }
+  };
+
+  TypePtr resultType_;
+  TypePtr sumType_;
+};
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/tests/DecimalUtilTest.cpp
+++ b/bolt/functions/sparksql/tests/DecimalUtilTest.cpp
@@ -48,6 +48,19 @@ class DecimalUtilTest : public testing::Test {
     ASSERT_EQ(overflow, expectedOverflow);
     ASSERT_EQ(r, expectedResult);
   }
+
+  template <bool allowPrecisionLoss>
+  void testComputeDivideResultPrecisionScale(
+      const uint8_t aPrecision,
+      const uint8_t aScale,
+      const uint8_t bPrecision,
+      const uint8_t bScale,
+      std::pair<uint8_t, uint8_t> expected) {
+    ASSERT_EQ(
+        DecimalUtil::computeDivideResultPrecisionScale<allowPrecisionLoss>(
+            aPrecision, aScale, bPrecision, bScale),
+        expected);
+  }
 };
 } // namespace
 
@@ -99,5 +112,19 @@ TEST_F(DecimalUtilTest, bounded) {
   result = DecimalUtil::bounded(40, 40);
   ASSERT_EQ(result.first, 38);
   ASSERT_EQ(result.second, 38);
+}
+
+TEST_F(DecimalUtilTest, computeDivideResultPrecisionScale) {
+  // Test with allowPrecisionLoss = true.
+  testComputeDivideResultPrecisionScale<true>(10, 2, 5, 1, {17, 8});
+  testComputeDivideResultPrecisionScale<true>(38, 10, 10, 5, {38, 6});
+  testComputeDivideResultPrecisionScale<true>(1, 0, 1, 0, {7, 6});
+  testComputeDivideResultPrecisionScale<true>(20, 2, 20, 2, {38, 18});
+
+  // Test with allowPrecisionLoss = false.
+  testComputeDivideResultPrecisionScale<false>(10, 2, 5, 1, {17, 8});
+  testComputeDivideResultPrecisionScale<false>(38, 10, 5, 3, {38, 11});
+  testComputeDivideResultPrecisionScale<false>(1, 0, 1, 0, {7, 6});
+  testComputeDivideResultPrecisionScale<false>(30, 5, 10, 5, {38, 11});
 }
 } // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Support Spark avg(decimal) using simple UDAF interface. The current  
implementation adheres to Spark’s default behavior, in which  
`spark.sql.decimalOperations.allowPrecisionLoss` is enabled.

Resolve [#5315](https://github.com/facebookincubator/velox/issues/5315).  
Resolve [#9048](https://github.com/facebookincubator/velox/discussions/9048).

Corresponding PR: https://github.com/facebookincubator/velox/pull/15244

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat: Add support for Spark avg(decimal) aggregate function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









