### PR TITLE
[cp]fix: Support legacy date formatter for Spark date_format function

### DIFF
--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -1650,6 +1650,129 @@ struct TimestampToMillisFunction {
   }
 };
 
+template <typename T>
+struct DateFormatFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Timestamp>* /*timestamp*/,
+      const arg_type<Varchar>* formatString) {
+    isLegacyFormatter_ = (parseTimePolicy(config.timeParserPolicy()) ==
+                          TimePolicy::LEGACY);
+    sessionTimeZone_ = getTimeZoneFromConfig(config);
+    if (formatString != nullptr) {
+      setFormatter(*formatString);
+      isConstFormat_ = true;
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone*/,
+      const arg_type<Varchar>* formatString) {
+    isLegacyFormatter_ = (parseTimePolicy(config.timeParserPolicy()) ==
+                          TimePolicy::LEGACY);
+    sessionTimeZone_ = getTimeZoneFromConfig(config);
+    if (formatString != nullptr) {
+      setFormatter(*formatString);
+      isConstFormat_ = true;
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Timestamp>& timestamp,
+      const arg_type<Varchar>& formatString) {
+    if (!isConstFormat_) {
+      setFormatter(formatString);
+    }
+    format(timestamp, sessionTimeZone_, maxResultSize_, result);
+    return true;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<Varchar>& formatString) {
+    auto timestamp = toTimestamp(timestampWithTimezone);
+    return call(result, timestamp, formatString);
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar>& formatString) {
+    if (isLegacyFormatter_) {
+      formatter_ = buildLegacySparkDateTimeFormatter(
+          std::string_view(formatString.data(), formatString.size()));
+    } else {
+      validateNonLegacyFormat(formatString);
+      ensureFormatLegal(
+          std::string_view(formatString.data(), formatString.size()));
+      formatter_ = buildJodaDateTimeFormatter(
+          std::string_view(formatString.data(), formatString.size()));
+    }
+    maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
+  }
+
+  FOLLY_ALWAYS_INLINE void format(
+      const Timestamp& timestamp,
+      const tz::TimeZone* timeZone,
+      uint32_t maxResultSize,
+      out_type<Varchar>& result) const {
+    result.reserve(maxResultSize);
+    const auto resultSize = formatter_->format(
+        timestamp, timeZone, maxResultSize, result.data(), false);
+    result.resize(resultSize);
+  }
+
+  FOLLY_ALWAYS_INLINE Timestamp toTimestamp(
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
+    const auto milliseconds = *timestampWithTimezone.template at<0>();
+    constexpr int64_t kMaxTimestampWithZoneMillis = (1LL << 51) - 1;
+    constexpr int64_t kMinTimestampWithZoneMillis = -(1LL << 51);
+    if (milliseconds > kMaxTimestampWithZoneMillis ||
+        milliseconds < kMinTimestampWithZoneMillis) {
+      BOLT_USER_FAIL(
+          "Timestamp with timezone overflow: {} ms]", milliseconds);
+    }
+
+    Timestamp timestamp = Timestamp::fromMillis(milliseconds);
+    timestamp.toTimezone(*timestampWithTimezone.template at<1>());
+    return timestamp;
+  }
+
+  FOLLY_ALWAYS_INLINE void validateNonLegacyFormat(
+      const arg_type<Varchar>& formatString) {
+    const char* cur = formatString.data();
+    const char* end = cur + formatString.size();
+    bool inLiteral = false;
+    while (cur < end) {
+      if (*cur == '\'') {
+        if (cur + 1 < end && *(cur + 1) == '\'') {
+          cur += 2;
+          continue;
+        }
+        inLiteral = !inLiteral;
+        ++cur;
+        continue;
+      }
+
+      if (!inLiteral && *cur == 'u') {
+        BOLT_UNSUPPORTED("Specifier {} is not supported.", *cur);
+      }
+      ++cur;
+    }
+  }
+
+  const tz::TimeZone* sessionTimeZone_{nullptr};
+  std::shared_ptr<DateTimeFormatter> formatter_;
+  bool isConstFormat_{false};
+  bool isLegacyFormatter_{false};
+  uint32_t maxResultSize_{0};
+};
+
 template <typename TExec>
 struct MillisToTimestampFunction {
   BOLT_DEFINE_FUNCTION_TYPES(TExec);

--- a/bolt/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/bolt/functions/sparksql/registration/RegisterDatetime.cpp
@@ -180,10 +180,10 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<MillisecondFunction, int32_t, Timestamp>(
       {prefix + "millisecond"});
 
-  registerFunction<JodaDateFormatFunction, Varchar, Timestamp, Varchar>(
+  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
       {prefix + "date_format"});
   registerFunction<
-      JodaDateFormatFunction,
+      DateFormatFunction,
       Varchar,
       TimestampWithTimezone,
       Varchar>({prefix + "date_format"});

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -1649,8 +1649,35 @@ TEST_F(SparkSqlDateTimeFunctionsTest, dateFormat) {
     return resultStringView.getString();
   };
   EXPECT_THROW(
+      dateFormat(fromTimestampString("1970-01-01", nullptr), "u"),
+      BoltUserError);
+  EXPECT_THROW(
+      dateFormat(fromTimestampString("1970-01-01", nullptr), "'abcd"),
+      BoltUserError);
+
+  EXPECT_THROW(
       dateFormat(fromTimestampString("1970-01-01", nullptr), "YYYY-MM-dd"),
       BoltUserError);
+
+  EXPECT_EQ(
+      "AD", dateFormat(fromTimestampString("1970-01-01", nullptr), "G"));
+  EXPECT_EQ(
+      "19", dateFormat(fromTimestampString("1900-01-01", nullptr), "C"));
+  EXPECT_EQ(
+      "2020", dateFormat(fromTimestampString("2020-01-01", nullptr), "Y"));
+  EXPECT_EQ(
+      "1", dateFormat(fromTimestampString("2022-01-01", nullptr), "D"));
+  EXPECT_EQ(
+      "1", dateFormat(fromTimestampString("2022-01-01", nullptr), "d"));
+  EXPECT_EQ(
+      "AM",
+      dateFormat(
+          fromTimestampString("2022-01-01 00:00:00", nullptr), "a"));
+  EXPECT_EQ(
+      "2022-01-01 00:00:00",
+      dateFormat(fromTimestampString("2022-01-01", nullptr),
+                 "yyyy-MM-dd HH:mm:ss"));
+
   EXPECT_EQ(
       "20180314 01:02:03.123",
       dateFormat(
@@ -1670,6 +1697,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, dateFormat) {
       "2018-03-14 01:02:03.123456789",
       dateFormat(
           Timestamp(1520989323L, 123456789L), "yyy-MM-dd HH:mm:ss.SSSSSSSSS"));
+
+  setTimeParserPolicy("legacy");
+  EXPECT_EQ(
+      "4", dateFormat(fromTimestampString("1970-01-01", nullptr), "u"));
 }
 
 #ifdef SPARK_COMPATIBLE


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Support legacy date formatter for Spark date_format function.

Corresponding PR: https://github.com/facebookincubator/velox/pull/15535

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: Support legacy date formatter for Spark date_format function
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









