### PR TITLE
[cp]fix: Handle NULL values in comparison filter generation

### DIFF
--- a/bolt/expression/ExprToSubfieldFilter.cpp
+++ b/bolt/expression/ExprToSubfieldFilter.cpp
@@ -189,6 +189,9 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
   if (!value) {
     return nullptr;
   }
+  if (value->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
 
   std::unique_ptr<common::Filter> lessThanFilter =
       makeLessThanFilter(valueExpr, evaluator);
@@ -238,6 +241,9 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeEqualFilter(
   if (!value) {
     return nullptr;
   }
+  if (value->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
   switch (value->typeKind()) {
     case TypeKind::BOOLEAN:
       return boolEqual(singleValue<bool>(value));
@@ -268,6 +274,9 @@ ExprToSubfieldFilterParser::makeGreaterThanFilter(
   auto lower = toConstant(lowerExpr, evaluator);
   if (!lower) {
     return nullptr;
+  }
+  if (lower->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
   }
   switch (lower->typeKind()) {
     case TypeKind::TINYINT:
@@ -300,6 +309,9 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeLessThanFilter(
   auto upper = toConstant(upperExpr, evaluator);
   if (!upper) {
     return nullptr;
+  }
+  if (upper->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
   }
   switch (upper->typeKind()) {
     case TypeKind::TINYINT:
@@ -334,6 +346,9 @@ ExprToSubfieldFilterParser::makeLessThanOrEqualFilter(
   if (!upper) {
     return nullptr;
   }
+  if (upper->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
   switch (upper->typeKind()) {
     case TypeKind::TINYINT:
       return lessThanOrEqual(singleValue<int8_t>(upper));
@@ -366,6 +381,9 @@ ExprToSubfieldFilterParser::makeGreaterThanOrEqualFilter(
   auto lower = toConstant(lowerExpr, evaluator);
   if (!lower) {
     return nullptr;
+  }
+  if (lower->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
   }
   switch (lower->typeKind()) {
     case TypeKind::TINYINT:

--- a/bolt/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/bolt/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -245,6 +245,176 @@ TEST_F(ExprToSubfieldFilterTest, userError) {
   ASSERT_FALSE(filter);
 }
 
+// Test NULL comparison handling - comparisons with NULL should return
+// AlwaysFalse as per SQL three-valued logic
+TEST_F(ExprToSubfieldFilterTest, eqNull) {
+  auto call =
+      parseCallExpr("a = cast(null as bigint)", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, eqNullVarchar) {
+  auto call =
+      parseCallExpr("a = cast(null as varchar)", ROW({{"a", VARCHAR()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, eqNullTimestamp) {
+  auto call = parseCallExpr(
+      "a = cast(null as timestamp)", ROW({{"a", TIMESTAMP()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, neqNull) {
+  auto call =
+      parseCallExpr("a <> cast(null as bigint)", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, ltNull) {
+  auto call =
+      parseCallExpr("a < cast(null as bigint)", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, ltNullDouble) {
+  auto call =
+      parseCallExpr("a < cast(null as double)", ROW({{"a", DOUBLE()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, ltNullVarchar) {
+  auto call =
+      parseCallExpr("a < cast(null as varchar)", ROW({{"a", VARCHAR()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, lteNull) {
+  auto call =
+      parseCallExpr("a <= cast(null as bigint)", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, lteNullReal) {
+  auto call =
+      parseCallExpr("a <= cast(null as real)", ROW({{"a", REAL()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, gtNull) {
+  auto call =
+      parseCallExpr("a > cast(null as bigint)", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, gtNullInteger) {
+  auto call =
+      parseCallExpr("a > cast(null as integer)", ROW({{"a", INTEGER()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, gteNull) {
+  auto call =
+      parseCallExpr("a >= cast(null as bigint)", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, gteNullSmallint) {
+  auto call = parseCallExpr(
+      "a >= cast(null as smallint)", ROW({{"a", SMALLINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
+TEST_F(ExprToSubfieldFilterTest, gteNullTinyint) {
+  auto call = parseCallExpr(
+      "a >= cast(null as tinyint)", ROW({{"a", TINYINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  ASSERT_TRUE(expected->testingEquals(*filter));
+}
+
 TEST_F(ExprToSubfieldFilterTest, dereferenceWithEmptyField) {
   auto call = std::make_shared<core::CallTypedExpr>(
       BOOLEAN(),


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

#### Summary

This PR fixes an issue discovered in [apache/spark#45202](https://github.com/apache/spark/pull/45202) where Spark pushes down predicates like `b > null` to Velox.

#### Problem

The `ExprToSubfieldFilterParser` currently does not check whether constant expressions are NULL. When NULL values are encountered, they are converted to default values, resulting in incorrect filter generation.

#### Solution

If the constant value is NULL, return AlwaysFalse filter instead of nullptr.

This change correctly implements SQL three-valued logic: comparisons with NULL always result in NULL, which in filter context means no rows match. Returning AlwaysFalse explicitly represents this semantic, allowing optimizers to recognize and optimize away these conditions.

#### Affected Operators

Comparison operators: =, !=, <, <=, >, >=

#### Modified Functions

Modified functions in ExprToSubfieldFilterParser:

- makeNotEqualFilter
- makeEqualFilter
- makeGreaterThanFilter
- makeLessThanFilter
- makeLessThanOrEqualFilter
- makeGreaterThanOrEqualFilter

Corresponding PR: https://github.com/facebookincubator/velox/pull/15676

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: Handle NULL values in comparison filter generation
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









