### PR TITLE
[cp]fix: Fix incorrect scalar optimization in `gatherCopy`

### DIFF
--- a/bolt/exec/OperatorUtils.cpp
+++ b/bolt/exec/OperatorUtils.cpp
@@ -28,6 +28,7 @@
  * --------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <unordered_map>
 
 #include "bolt/buffer/Buffer.h"
@@ -123,7 +124,6 @@ void complexGatherCopy(
         1);
   }
 }
-
 // We want to aggregate some operator runtime metrics per operator rather than
 // per event. This function returns true for such metrics.
 bool shouldAggregateRuntimeMetric(const std::string& name) {
@@ -371,6 +371,38 @@ RowVectorPtr wrapAndCombineDict(
       pool, rowType, nullptr, size, wrappedChildren);
 }
 
+RowVectorPtr
+wrap(vector_size_t size, BufferPtr mapping, const RowVectorPtr& vector) {
+  if (!mapping) {
+    return vector;
+  }
+
+  return wrap(
+      size,
+      std::move(mapping),
+      asRowType(vector->type()),
+      vector->children(),
+      vector->pool());
+}
+
+RowVectorPtr wrap(
+    vector_size_t size,
+    BufferPtr mapping,
+    const RowTypePtr& rowType,
+    const std::vector<VectorPtr>& childVectors,
+    memory::MemoryPool* pool) {
+  if (mapping == nullptr) {
+    return RowVector::createEmpty(rowType, pool);
+  }
+  std::vector<VectorPtr> wrappedChildren;
+  wrappedChildren.reserve(childVectors.size());
+  for (auto& child : childVectors) {
+    wrappedChildren.emplace_back(wrapChild(size, mapping, child));
+  }
+  return std::make_shared<RowVector>(
+      pool, rowType, nullptr, size, wrappedChildren);
+}
+
 void loadColumns(const RowVectorPtr& input, core::ExecCtx& execCtx) {
   LocalDecodedVector decodedHolder(execCtx);
   LocalSelectivityVector baseRowsHolder(&execCtx);
@@ -398,7 +430,11 @@ void gatherCopy(
     const std::vector<const RowVector*>& sources,
     const std::vector<vector_size_t>& sourceIndices,
     column_index_t sourceChannel) {
-  if (target->isScalar()) {
+  const bool flattenSources = std::all_of(
+      sources.begin(), sources.begin() + count, [&](const auto& source) {
+        return source->childAt(sourceChannel)->isFlatEncoding();
+      });
+  if (target->isScalar() && flattenSources) {
     BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
         scalarGatherCopy,
         target->type()->kind(),

--- a/bolt/exec/OperatorUtils.h
+++ b/bolt/exec/OperatorUtils.h
@@ -119,6 +119,22 @@ RowVectorPtr wrapAndCombineDict(
     const std::vector<VectorPtr>& childVectors,
     memory::MemoryPool* FOLLY_NONNULL pool);
 
+/// Wraps all children of the specified row vector into a dictionary using
+/// specified mapping. Returns vector as-is if mapping is null.
+RowVectorPtr
+wrap(vector_size_t size, BufferPtr mapping, const RowVectorPtr& vector);
+
+/// Wraps 'childVectors' into a dictionary with 'rowType' using specified
+/// mapping. Returns an empty vector if mapping is null. This is different than
+/// 'wrap' which takes an input vector. The latter returns the input vector if
+/// mapping is null.
+RowVectorPtr wrap(
+    vector_size_t size,
+    BufferPtr mapping,
+    const RowTypePtr& rowType,
+    const std::vector<VectorPtr>& childVectors,
+    memory::MemoryPool* pool);
+
 // Ensures that all LazyVectors reachable from 'input' are loaded for all
 // rows.
 void loadColumns(const RowVectorPtr& input, core::ExecCtx& execCtx);

--- a/bolt/exec/tests/OperatorUtilsTest.cpp
+++ b/bolt/exec/tests/OperatorUtilsTest.cpp
@@ -71,7 +71,8 @@ class OperatorUtilsTest : public OperatorTestBase {
   void gatherCopyTest(
       const std::shared_ptr<const RowType>& targetType,
       const std::shared_ptr<const RowType>& sourceType,
-      int numSources) {
+      int numSources,
+      bool flattenSources = true) {
     folly::Random::DefaultGenerator rng(1);
     const int kNumRows = 500;
     const int kNumColumns = sourceType->size();
@@ -89,6 +90,23 @@ class OperatorUtilsTest : public OperatorTestBase {
           nullRow +=
               std::max<int>(1, (folly::Random::rand32() % kNumColumns) / 4);
         }
+      }
+    }
+
+    if (!flattenSources) {
+      for (int i = 0; i < numSources; ++i) {
+        const auto source = sources[i];
+        const auto numRows = source->size();
+        std::vector<vector_size_t> sortIndices(numRows, 0);
+        for (auto i = 0; i < numRows; ++i) {
+          sortIndices[i] = i;
+        }
+        BufferPtr indices = allocateIndices(numRows, pool_.get());
+        auto rawIndices = indices->asMutable<vector_size_t>();
+        for (size_t i = 0; i < numRows; ++i) {
+          rawIndices[i] = sortIndices[i];
+        }
+        sources[i] = wrap(numRows, indices, source);
       }
     }
 
@@ -297,6 +315,56 @@ TEST_F(OperatorUtilsTest, gatherCopy) {
       ASSERT_TRUE(vector->equalValueAt(source, j, sourceIndices[j]));
     }
   }
+}
+
+TEST_F(OperatorUtilsTest, gatherCopyEncoding) {
+  std::shared_ptr<const RowType> rowType;
+  std::shared_ptr<const RowType> reversedRowType;
+  {
+    std::vector<std::string> names = {
+        "bool_val",
+        "tiny_val",
+        "small_val",
+        "int_val",
+        "long_val",
+        "ordinal",
+        "float_val",
+        "double_val",
+        "string_val",
+        "array_val",
+        "struct_val",
+        "map_val"};
+    std::vector<std::string> reversedNames = names;
+    std::reverse(reversedNames.begin(), reversedNames.end());
+
+    std::vector<std::shared_ptr<const Type>> types = {
+        BOOLEAN(),
+        TINYINT(),
+        SMALLINT(),
+        INTEGER(),
+        BIGINT(),
+        BIGINT(),
+        REAL(),
+        DOUBLE(),
+        VARCHAR(),
+        ARRAY(VARCHAR()),
+        ROW({{"s_int", INTEGER()}, {"s_array", ARRAY(REAL())}}),
+        MAP(VARCHAR(),
+            MAP(BIGINT(),
+                ROW({{"s2_int", INTEGER()}, {"s2_string", VARCHAR()}})))};
+    std::vector<std::shared_ptr<const Type>> reversedTypes = types;
+    std::reverse(reversedTypes.begin(), reversedTypes.end());
+
+    rowType = ROW(std::move(names), std::move(types));
+    reversedRowType = ROW(std::move(reversedNames), std::move(reversedTypes));
+  }
+
+  // Gather copy with identical column mapping.
+  gatherCopyTest(rowType, rowType, 1, false);
+  gatherCopyTest(rowType, rowType, 5, false);
+  // Gather copy with non-identical column mapping.
+  gatherCopyTest(rowType, reversedRowType, 1, false);
+  gatherCopyTest(rowType, reversedRowType, 5, false);
 }
 
 TEST_F(OperatorUtilsTest, makeOperatorSpillPath) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The optimized path for scalar targets in gatherCopy incorrectly assumed all
source vectors were flat, causing failures with encoded vectors such as DictionaryVector.
This PR adds another check to ensure the fast path is now only taken when the target is
scalar and all the sources are flattened.

Corresponding PR: https://github.com/facebookincubator/velox/pull/15445

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- https://github.com/facebookincubator/velox/pull/15445
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









