### PR TITLE
[cp]refactor: Remove unnecessary sizeof(char)

### DIFF
--- a/bolt/dwio/dwrf/test/TestRle.cpp
+++ b/bolt/dwio/dwrf/test/TestRle.cpp
@@ -101,7 +101,7 @@ TEST_F(RLEv2Test, basicDelta0) {
   }
 
   const unsigned char bytes[] = {0xc0, 0x13, 0x00, 0x02};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, count), 3);
@@ -119,7 +119,7 @@ TEST_F(RLEv2Test, basicDelta1) {
 
   const unsigned char bytes[] = {
       0xce, 0x04, 0xe7, 0x07, 0xc8, 0x01, 0x32, 0x19, 0x0f};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -140,7 +140,7 @@ TEST_F(RLEv2Test, basicDelta2) {
 
   const unsigned char bytes[] = {
       0xce, 0x04, 0xe7, 0x07, 0xc7, 0x01, 0x32, 0x19, 0x23};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -161,7 +161,7 @@ TEST_F(RLEv2Test, basicDelta3) {
 
   const unsigned char bytes[] = {
       0xce, 0x04, 0xe8, 0x07, 0xc7, 0x01, 0x32, 0x19, 0x0f};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -182,7 +182,7 @@ TEST_F(RLEv2Test, basicDelta4) {
 
   const unsigned char bytes[] = {
       0xce, 0x04, 0xe8, 0x07, 0xc8, 0x01, 0x32, 0x19, 0x23};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -232,7 +232,7 @@ TEST_F(RLEv2Test, basicDelta0WithNulls) {
   }
 
   const unsigned char bytes[] = {0xc0, 0x13, 0x00, 0x02};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   const size_t count = values.size();
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, count, nulls), 1, nulls);
@@ -256,7 +256,7 @@ TEST_F(RLEv2Test, shortRepeats) {
   const unsigned char bytes[] = {0x04, 0x00, 0x04, 0x02, 0x04, 0x04, 0x04,
                                  0x06, 0x04, 0x08, 0x04, 0x0a, 0x04, 0x0c,
                                  0x04, 0x0e, 0x04, 0x10, 0x04, 0x12};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, count), 3);
@@ -279,7 +279,7 @@ TEST_F(RLEv2Test, multiByteShortRepeats) {
                                  0x00, 0x00, 0x3c, 0x80, 0x00, 0x00, 0x00,
                                  0x00, 0x00, 0x00, 0x02, 0x3c, 0x80, 0x00,
                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x04};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, count), 3);
@@ -315,7 +315,7 @@ TEST_F(RLEv2Test, bitSize2Direct) {
   }
 
   const unsigned char bytes[] = {0x42, 0x13, 0x22, 0x22, 0x22, 0x22, 0x22};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, count), 3);
@@ -333,7 +333,7 @@ TEST_F(RLEv2Test, bitSize4Direct) {
 
   const unsigned char bytes[] = {
       0x46, 0x13, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
 
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
@@ -373,7 +373,7 @@ TEST_F(RLEv2Test, multipleRunsDirect) {
       0x04,
       0x04,
       0x04};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
 
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
@@ -421,7 +421,7 @@ TEST_F(RLEv2Test, overflowDirect) {
       0x7e, 0x03, 0x7d, 0x45, 0x3c, 0x12, 0x41, 0x48, 0xf4, 0xbe, 0x7d, 0x45,
       0x3c, 0x12, 0x41, 0x48, 0xf4, 0xae, 0x50, 0xce, 0xad, 0x2a, 0x30, 0x0e,
       0xd2, 0x96, 0xfe, 0xd8, 0xd2, 0x38, 0x54, 0x6e, 0x3d, 0x81};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -458,7 +458,7 @@ TEST_F(RLEv2Test, basicPatched0) {
       0x5a,
       0xfc,
       0xe8};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -497,7 +497,7 @@ TEST_F(RLEv2Test, basicPatched1) {
       0xe0, 0x78, 0x00, 0x1c, 0x0f, 0x08, 0x06, 0x81, 0xc6, 0x90, 0x80, 0x68,
       0x24, 0x1b, 0x0b, 0x26, 0x83, 0x21, 0x30, 0xe0, 0x98, 0x3c, 0x6f, 0x06,
       0xb7, 0x03, 0x70};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -557,7 +557,7 @@ TEST_F(RLEv2Test, mixedPatchedAndShortRepeats) {
       0x00, 0x0c, 0x02, 0x08, 0x18, 0x00, 0x40, 0x00, 0x01, 0x00, 0x00, 0x08,
       0x30, 0x33, 0x80, 0x00, 0x02, 0x0c, 0x10, 0x20, 0x20, 0x47, 0x80, 0x13,
       0x4c};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
   // Read 1 at a time, then 3 at a time, etc.
   checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
   checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
@@ -592,7 +592,7 @@ TEST_F(RLEv2Test, basicDirectSeek) {
       0x04,
       0x04,
       0x04};
-  unsigned long l = sizeof(bytes) / sizeof(char);
+  unsigned long l = sizeof(bytes);
 
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change 
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
This PR proposes to remove unnecessary sizeof(char) calls because it is always 1.

Corresponding PR: https://github.com/facebookincubator/velox/pull/15779

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- refactor: Remove unnecessary sizeof(char)

```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.

-->
- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>









