### PR TITLE
[feat][cp] Add mode Spark aggregate function

### DIFF
--- a/bolt/functions/sparksql/aggregates/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/CMakeLists.txt
@@ -48,6 +48,7 @@ bolt_add_library(
   CovarianceAggregate.cpp
   FirstLastAggregate.cpp
   MinMaxByAggregate.cpp
+  ModeAggregate.cpp
   PercentileApproxAggregate.cpp
   Register.cpp
   RegrReplacementAggregate.cpp

--- a/bolt/functions/sparksql/aggregates/ModeAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/ModeAggregate.cpp
@@ -70,6 +70,11 @@ class ModeAggregate {
         : values{AlignedStlAllocator<std::pair<const T, int64_t>, 16>(
               allocator)} {}
 
+    explicit AccumulatorType(
+        HashStringAllocator* allocator,
+        ModeAggregate* /*fn*/)
+        : AccumulatorType(allocator) {}
+
     static constexpr bool is_fixed_size_ = false;
 
     void addInput(HashStringAllocator* /*allocator*/, arg_type<T> data) {
@@ -138,6 +143,11 @@ class StringModeAggregate {
     explicit AccumulatorType(HashStringAllocator* allocator)
         : values{AlignedStlAllocator<std::pair<const StringView, int64_t>, 16>(
               allocator)} {}
+
+    explicit AccumulatorType(
+        HashStringAllocator* allocator,
+        StringModeAggregate* /*fn*/)
+        : AccumulatorType(allocator) {}
 
     static constexpr bool is_fixed_size_ = false;
 
@@ -534,48 +544,56 @@ void registerModeAggregate(
         switch (inputType->kind()) {
           case TypeKind::BOOLEAN:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<bool>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<bool>>>(
+                step, argTypes, resultType);
           case TypeKind::TINYINT:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<int8_t>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<int8_t>>>(
+                step, argTypes, resultType);
           case TypeKind::SMALLINT:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<int16_t>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<int16_t>>>(
+                step, argTypes, resultType);
           case TypeKind::INTEGER:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<int32_t>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<int32_t>>>(
+                step, argTypes, resultType);
           case TypeKind::BIGINT:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<int64_t>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<int64_t>>>(
+                step, argTypes, resultType);
           case TypeKind::HUGEINT:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<int128_t>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<int128_t>>>(
+                step, argTypes, resultType);
           case TypeKind::REAL:
             return std::make_unique<SimpleAggregateAdapter<ModeAggregate<
                 float,
                 bytedance::bolt::util::floating_point::NaNAwareHash<float>,
                 bytedance::bolt::util::floating_point::NaNAwareEquals<float>>>>(
-                resultType);
+                step, argTypes, resultType);
           case TypeKind::DOUBLE:
             return std::make_unique<SimpleAggregateAdapter<ModeAggregate<
                 double,
                 bytedance::bolt::util::floating_point::NaNAwareHash<double>,
                 bytedance::bolt::util::floating_point::NaNAwareEquals<
-                    double>>>>(resultType);
+                    double>>>>(step, argTypes, resultType);
           case TypeKind::TIMESTAMP:
             return std::make_unique<
-                SimpleAggregateAdapter<ModeAggregate<Timestamp>>>(resultType);
+                SimpleAggregateAdapter<ModeAggregate<Timestamp>>>(
+                step, argTypes, resultType);
           case TypeKind::UNKNOWN:
             // Regitsers Mode function with unknown type, this needs hasher for
             // UnknownValue, we use folly::hasher for it.
             return std::make_unique<SimpleAggregateAdapter<ModeAggregate<
                 UnknownValue,
                 folly::hasher<UnknownValue>,
-                std::equal_to<UnknownValue>>>>(resultType);
+                std::equal_to<UnknownValue>>>>(step, argTypes, resultType);
           case TypeKind::VARCHAR:
           case TypeKind::VARBINARY:
             return std::make_unique<
-                SimpleAggregateAdapter<StringModeAggregate>>(resultType);
+                SimpleAggregateAdapter<StringModeAggregate>>(
+                step, argTypes, resultType);
           case TypeKind::ARRAY:
           case TypeKind::MAP:
           case TypeKind::ROW:

--- a/bolt/functions/sparksql/aggregates/ModeAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/ModeAggregate.cpp
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "folly/container/F14Map.h"
+
+#include "bolt/exec/AddressableNonNullValueList.h"
+#include "bolt/exec/SimpleAggregateAdapter.h"
+#include "bolt/exec/Strings.h"
+#include "bolt/type/FloatingPointUtil.h"
+
+using namespace bytedance::bolt::aggregate::prestosql;
+using namespace bytedance::bolt::exec;
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+namespace {
+
+// Mode aggregate function for scalar types.
+template <
+    typename T,
+    typename Hash = std::hash<T>,
+    typename EqualTo = std::equal_to<T>>
+class ModeAggregate {
+ public:
+  using InputType = Row<T>;
+
+  using IntermediateType = Map<T, int64_t>;
+
+  using OutputType = T;
+
+  struct AccumulatorType {
+    using ValueMap = folly::F14FastMap<
+        T,
+        int64_t,
+        Hash,
+        EqualTo,
+        AlignedStlAllocator<std::pair<const T, int64_t>, 16>>;
+
+    // A map of T -> count.
+    ValueMap values;
+
+    explicit AccumulatorType(HashStringAllocator* allocator)
+        : values{AlignedStlAllocator<std::pair<const T, int64_t>, 16>(
+              allocator)} {}
+
+    static constexpr bool is_fixed_size_ = false;
+
+    void addInput(HashStringAllocator* /*allocator*/, arg_type<T> data) {
+      values[data]++;
+    }
+
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        arg_type<IntermediateType> other) {
+      for (const auto& [key, count] : other) {
+        if (count.has_value()) {
+          values[key] += count.value();
+        }
+      }
+    }
+
+    bool writeIntermediateResult(out_type<IntermediateType>& out) {
+      out.reserve(values.size());
+      for (const auto& [value, count] : values) {
+        out.emplace(value, count);
+      }
+      return true;
+    }
+
+    bool writeFinalResult(out_type<OutputType>& out) {
+      auto iterator = std::max_element(
+          std::begin(values),
+          std::end(values),
+          [](const std::pair<T, int64_t>& p1, const std::pair<T, int64_t>& p2) {
+            return p1.second < p2.second;
+          });
+      out = iterator->first;
+      return true;
+    }
+
+    void destroy(HashStringAllocator* /*allocator*/) {
+      using TValues = decltype(values);
+      values.~TValues();
+    }
+  };
+};
+
+// Mode aggregate function for VARCHAR type.
+class StringModeAggregate {
+ public:
+  using InputType = Row<Varchar>;
+
+  using IntermediateType = Map<Varchar, int64_t>;
+
+  using OutputType = Varchar;
+
+  struct AccumulatorType {
+    using ValueMap = folly::F14FastMap<
+        StringView,
+        int64_t,
+        std::hash<StringView>,
+        std::equal_to<StringView>,
+        AlignedStlAllocator<std::pair<const StringView, int64_t>, 16>>;
+
+    // A map of unique StringViews pointing to storage managed by 'strings'.
+    ValueMap values;
+
+    // Stores unique non-null non-inline strings.
+    Strings strings;
+
+    explicit AccumulatorType(HashStringAllocator* allocator)
+        : values{AlignedStlAllocator<std::pair<const StringView, int64_t>, 16>(
+              allocator)} {}
+
+    static constexpr bool is_fixed_size_ = false;
+
+    void addInput(HashStringAllocator* allocator, arg_type<Varchar> data) {
+      values[store(data, allocator)]++;
+    }
+
+    void combine(
+        HashStringAllocator* allocator,
+        arg_type<IntermediateType> other) {
+      for (const auto& [key, count] : other) {
+        if (count.has_value()) {
+          values[store(key, allocator)] += count.value();
+        }
+      }
+    }
+
+    bool writeIntermediateResult(out_type<IntermediateType>& out) {
+      out.reserve(values.size());
+      for (const auto& [value, count] : values) {
+        out.add_item() = std::make_tuple(value, count);
+      }
+      return true;
+    }
+
+    bool writeFinalResult(out_type<OutputType>& out) {
+      auto iterator = std::max_element(
+          std::begin(values),
+          std::end(values),
+          [](const std::pair<StringView, int64_t>& p1,
+             const std::pair<StringView, int64_t>& p2) {
+            return p1.second < p2.second;
+          });
+      out = iterator->first;
+      return true;
+    }
+
+    void destroy(HashStringAllocator* allocator) {
+      strings.free(*allocator);
+      using TValues = decltype(values);
+      values.~TValues();
+    }
+
+   private:
+    // Stores the non-inlined string in memory blocks managed by
+    // HashStringAllocator, if it's not exist in the values map.
+    StringView store(StringView value, HashStringAllocator* allocator) {
+      if (!value.isInline()) {
+        auto it = values.find(value);
+        if (it == values.end()) {
+          value = strings.append(value, *allocator);
+        }
+      }
+      return value;
+    }
+  };
+};
+
+struct ComplexTypeAccumulator {
+  using ValueMap = folly::F14FastMap<
+      AddressableNonNullValueList::Entry,
+      int64_t,
+      AddressableNonNullValueList::Hash,
+      AddressableNonNullValueList::EqualTo,
+      AlignedStlAllocator<
+          std::pair<const AddressableNonNullValueList::Entry, int64_t>,
+          16>>;
+
+  ValueMap values;
+
+  AddressableNonNullValueList serializedValues;
+
+  ComplexTypeAccumulator(const TypePtr& type, HashStringAllocator* allocator)
+      : values{
+            0,
+            AddressableNonNullValueList::Hash{},
+            AddressableNonNullValueList::EqualTo{type},
+            AlignedStlAllocator<
+                std::pair<const AddressableNonNullValueList::Entry, int64_t>,
+                16>(allocator)} {}
+
+  size_t size() const {
+    return values.size();
+  }
+
+  void addValue(
+      DecodedVector& decoded,
+      vector_size_t index,
+      HashStringAllocator* allocator) {
+    addValueWithCount(*decoded.base(), decoded.index(index), 1, allocator);
+  }
+
+  void addValueWithCount(
+      const BaseVector& keys,
+      vector_size_t index,
+      int64_t count,
+      HashStringAllocator* allocator) {
+    auto entry = serializedValues.append(keys, index, allocator);
+
+    auto it = values.find(entry);
+    if (it == values.end()) {
+      // New entry.
+      values[entry] += count;
+    } else {
+      // Existing entry.
+      serializedValues.removeLast(entry);
+
+      it->second += count;
+    }
+  }
+
+  void extractValues(
+      BaseVector& keys,
+      FlatVector<int64_t>& counts,
+      vector_size_t offset) {
+    auto index = offset;
+    for (const auto& [position, count] : values) {
+      AddressableNonNullValueList::read(position, keys, index);
+      counts.set(index, count);
+      ++index;
+    }
+  }
+
+  void extractValues(const VectorPtr& results, vector_size_t offset) {
+    auto iterator = std::max_element(
+        std::begin(values),
+        std::end(values),
+        [](const std::pair<AddressableNonNullValueList::Entry, int64_t>& p1,
+           const std::pair<AddressableNonNullValueList::Entry, int64_t>& p2) {
+          return p1.second < p2.second;
+        });
+    AddressableNonNullValueList::read(iterator->first, *results, offset);
+  }
+
+  void free(HashStringAllocator& allocator) {
+    serializedValues.free(allocator);
+    using TValues = decltype(values);
+    values.~TValues();
+  }
+};
+
+// Mode aggregate function for complex types.
+template <typename T>
+class ComplexTypeModeAggregate : public Aggregate {
+ public:
+  explicit ComplexTypeModeAggregate(TypePtr resultType, TypePtr inputType)
+      : Aggregate(std::move(resultType)), inputType_(std::move(inputType)) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(ComplexTypeAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    BOLT_CHECK(*result);
+    (*result)->resize(numGroups);
+    uint64_t* rawNulls = nullptr;
+    if ((*result)->mayHaveNulls()) {
+      BufferPtr& nulls = (*result)->mutableNulls((*result)->size());
+      rawNulls = nulls->asMutable<uint64_t>();
+    }
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      auto* accumulator = value<ComplexTypeAccumulator>(group);
+      if (accumulator->size() == 0) {
+        (*result)->setNull(i, true);
+      } else {
+        if (rawNulls) {
+          bits::clearBit(rawNulls, i);
+        }
+        accumulator->extractValues(*result, i);
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto* mapVector = (*result)->as<MapVector>();
+    BOLT_CHECK(mapVector);
+    mapVector->resize(numGroups);
+
+    auto& mapKeys = mapVector->mapKeys();
+    auto* flatValues =
+        mapVector->mapValues()->asUnchecked<FlatVector<int64_t>>();
+    BOLT_CHECK_NOT_NULL(mapKeys);
+    BOLT_CHECK_NOT_NULL(flatValues);
+
+    vector_size_t numElements = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      numElements += value<ComplexTypeAccumulator>(groups[i])->size();
+    }
+    mapKeys->resize(numElements);
+    flatValues->resize(numElements);
+
+    auto* rawNulls = mapVector->mutableRawNulls();
+    vector_size_t offset = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      auto* accumulator = value<ComplexTypeAccumulator>(group);
+
+      const auto mapSize = accumulator->size();
+      mapVector->setOffsetAndSize(i, offset, mapSize);
+      if (mapSize == 0) {
+        bits::setNull(rawNulls, i, true);
+      } else {
+        clearNull(rawNulls, i);
+        accumulator->extractValues(*mapKeys, *flatValues, offset);
+        offset += mapSize;
+      }
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedKeys_.decode(*args[0], rows);
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedKeys_.isNullAt(row)) {
+        // Nulls among the values being aggregated are ignored.
+        return;
+      }
+      auto group = groups[row];
+      auto* accumulator = value<ComplexTypeAccumulator>(group);
+
+      auto tracker = trackRowSize(group);
+      accumulator->addValue(decodedKeys_, row, allocator_);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedKeys_.decode(*args[0], rows);
+    auto* accumulator = value<ComplexTypeAccumulator>(group);
+
+    auto tracker = trackRowSize(group);
+    rows.applyToSelected([&](auto row) {
+      // Nulls among the values being aggregated are ignored.
+      if (!decodedKeys_.isNullAt(row)) {
+        accumulator->addValue(decodedKeys_, row, allocator_);
+      }
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedIntermediate_.decode(*args[0], rows);
+    auto* indices = decodedIntermediate_.indices();
+    auto* mapVector = decodedIntermediate_.base()->template as<MapVector>();
+
+    auto& mapKeys = mapVector->mapKeys();
+    auto* flatValues =
+        mapVector->mapValues()->template asUnchecked<FlatVector<int64_t>>();
+    BOLT_CHECK_NOT_NULL(mapKeys);
+    BOLT_CHECK_NOT_NULL(flatValues);
+
+    auto rawSizes = mapVector->rawSizes();
+    auto rawOffsets = mapVector->rawOffsets();
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedIntermediate_.isNullAt(row)) {
+        auto group = groups[row];
+        auto* accumulator = value<ComplexTypeAccumulator>(group);
+
+        auto tracker = trackRowSize(group);
+        addToFinalAggregation(
+            mapKeys.get(),
+            flatValues,
+            indices[row],
+            rawSizes,
+            rawOffsets,
+            accumulator,
+            allocator_);
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedIntermediate_.decode(*args[0], rows);
+    auto* indices = decodedIntermediate_.indices();
+    auto* mapVector = decodedIntermediate_.base()->template as<MapVector>();
+
+    auto& mapKeys = mapVector->mapKeys();
+    auto* flatValues =
+        mapVector->mapValues()->template asUnchecked<FlatVector<int64_t>>();
+    BOLT_CHECK_NOT_NULL(mapKeys);
+    BOLT_CHECK_NOT_NULL(flatValues);
+
+    auto* accumulator = value<ComplexTypeAccumulator>(group);
+
+    auto tracker = trackRowSize(group);
+
+    auto* rawSizes = mapVector->rawSizes();
+    auto* rawOffsets = mapVector->rawOffsets();
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedIntermediate_.isNullAt(row)) {
+        addToFinalAggregation(
+            mapKeys.get(),
+            flatValues,
+            indices[row],
+            rawSizes,
+            rawOffsets,
+            accumulator,
+            allocator_);
+      }
+    });
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto index : indices) {
+      new (groups[index] + offset_)
+          ComplexTypeAccumulator{inputType_, allocator_};
+    }
+  }
+
+  void destroy(folly::Range<char**> groups) override {
+    for (auto* group : groups) {
+      if (!isNull(group)) {
+        value<ComplexTypeAccumulator>(group)->free(*allocator_);
+      }
+    }
+  }
+
+ private:
+  // Combines a partial aggregation represented by the key-value pair at row in
+  // mapKeys and mapValues into groupMap.
+  FOLLY_ALWAYS_INLINE void addToFinalAggregation(
+      const BaseVector* mapKeys,
+      const FlatVector<int64_t>* flatValues,
+      vector_size_t index,
+      const vector_size_t* rawSizes,
+      const vector_size_t* rawOffsets,
+      ComplexTypeAccumulator* accumulator,
+      HashStringAllocator* allocator) {
+    auto size = rawSizes[index];
+    auto offset = rawOffsets[index];
+
+    for (int i = 0; i < size; ++i) {
+      const auto count = flatValues->valueAt(offset + i);
+      accumulator->addValueWithCount(*mapKeys, offset + i, count, allocator);
+    }
+  }
+
+  DecodedVector decodedKeys_;
+  DecodedVector decodedIntermediate_;
+  TypePtr inputType_;
+};
+} // namespace
+
+void registerModeAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures = {
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("T")
+          .intermediateType("map(T,bigint)")
+          .argumentType("T")
+          .build(),
+  };
+
+  auto name = prefix + "mode";
+  registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/) -> std::unique_ptr<Aggregate> {
+        BOLT_CHECK_EQ(
+            argTypes.size(), 1, "{}: unexpected number of arguments", name);
+
+        auto inputType =
+            isRawInput(step) ? argTypes[0] : argTypes[0]->childAt(0);
+        switch (inputType->kind()) {
+          case TypeKind::BOOLEAN:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<bool>>>(resultType);
+          case TypeKind::TINYINT:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<int8_t>>>(resultType);
+          case TypeKind::SMALLINT:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<int16_t>>>(resultType);
+          case TypeKind::INTEGER:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<int32_t>>>(resultType);
+          case TypeKind::BIGINT:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<int64_t>>>(resultType);
+          case TypeKind::HUGEINT:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<int128_t>>>(resultType);
+          case TypeKind::REAL:
+            return std::make_unique<SimpleAggregateAdapter<ModeAggregate<
+                float,
+                bytedance::bolt::util::floating_point::NaNAwareHash<float>,
+                bytedance::bolt::util::floating_point::NaNAwareEquals<float>>>>(
+                resultType);
+          case TypeKind::DOUBLE:
+            return std::make_unique<SimpleAggregateAdapter<ModeAggregate<
+                double,
+                bytedance::bolt::util::floating_point::NaNAwareHash<double>,
+                bytedance::bolt::util::floating_point::NaNAwareEquals<
+                    double>>>>(resultType);
+          case TypeKind::TIMESTAMP:
+            return std::make_unique<
+                SimpleAggregateAdapter<ModeAggregate<Timestamp>>>(resultType);
+          case TypeKind::UNKNOWN:
+            // Regitsers Mode function with unknown type, this needs hasher for
+            // UnknownValue, we use folly::hasher for it.
+            return std::make_unique<SimpleAggregateAdapter<ModeAggregate<
+                UnknownValue,
+                folly::hasher<UnknownValue>,
+                std::equal_to<UnknownValue>>>>(resultType);
+          case TypeKind::VARCHAR:
+          case TypeKind::VARBINARY:
+            return std::make_unique<
+                SimpleAggregateAdapter<StringModeAggregate>>(resultType);
+          case TypeKind::ARRAY:
+          case TypeKind::MAP:
+          case TypeKind::ROW:
+            return std::make_unique<ComplexTypeModeAggregate<ComplexType>>(
+                resultType, inputType);
+          default:
+            BOLT_NYI(
+                "Unknown input type for {} aggregation {}",
+                name,
+                inputType->toString());
+        }
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/Register.cpp
+++ b/bolt/functions/sparksql/aggregates/Register.cpp
@@ -62,6 +62,10 @@ extern void registerPercentileApproxAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
+extern void registerModeAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
 
 void registerAggregateFunctions(
     const std::string& prefix,
@@ -85,5 +89,6 @@ void registerAggregateFunctions(
   registerCollectListAggregate(prefix, withCompanionFunctions, overwrite);
   registerRegrReplacementAggregate(prefix, withCompanionFunctions, overwrite);
   registerCovarianceAggregates(prefix, withCompanionFunctions, overwrite);
+  registerModeAggregate(prefix, withCompanionFunctions, overwrite);
 }
 } // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   LastAggregateTest.cpp
   Main.cpp
   MinMaxByAggregationTest.cpp
+  ModeAggregateTest.cpp
   PercentileAggregateTest.cpp
   PercentileApproxTest.cpp
   RegrReplacementAggregationTest.cpp

--- a/bolt/functions/sparksql/aggregates/tests/ModeAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/ModeAggregateTest.cpp
@@ -1,0 +1,498 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "bolt/functions/sparksql/aggregates/Register.h"
+
+using namespace bytedance::bolt::exec::test;
+using namespace bytedance::bolt::functions::aggregate::test;
+
+namespace bytedance::bolt::functions::aggregate::sparksql::test {
+
+namespace {
+
+class ModeAggregateTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+    registerAggregateFunctions("spark_");
+  }
+
+  void testModeWithDuck(
+      const VectorPtr& vectorKey,
+      const VectorPtr& vectorInput) {
+    auto vectors = makeRowVector({vectorKey, vectorInput});
+    createDuckDbTable({vectors});
+
+    testAggregations(
+        {vectors},
+        {"c0"},
+        {"spark_mode(c1)"},
+        "SELECT c0, mode(c1) FROM tmp GROUP BY c0");
+  }
+
+  void testGlobalModeWithDuck(const VectorPtr& vector) {
+    auto num = vector->size();
+    auto reverseIndices = makeIndicesInReverse(num);
+
+    auto vectors =
+        makeRowVector({vector, wrapInDictionary(reverseIndices, num, vector)});
+
+    createDuckDbTable({vectors});
+    testAggregations(
+        {vectors}, {}, {"spark_mode(c0)"}, "SELECT mode(c0) FROM tmp");
+
+    testAggregations(
+        {vectors}, {}, {"spark_mode(c1)"}, "SELECT mode(c1) FROM tmp");
+  }
+
+  void testMode(
+      const std::string& expression,
+      const std::vector<std::string>& groupKeys,
+      const VectorPtr& vectorKey,
+      const VectorPtr& vectorInput,
+      const RowVectorPtr& expected) {
+    auto vectors = makeRowVector({vectorKey, vectorInput});
+    testAggregations({vectors}, groupKeys, {expression}, {expected});
+  }
+};
+
+TEST_F(ModeAggregateTest, groupByInteger) {
+  vector_size_t num = 37;
+
+  auto vectorKey = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 3; }, nullEvery(4));
+  auto vectorInput = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 2; }, nullEvery(5));
+
+  testModeWithDuck(vectorKey, vectorInput);
+
+  // Test when some group-by keys have only null values.
+  auto vectorKeyNull =
+      makeNullableFlatVector<int32_t>({1, 1, 1, 2, 2, 2, 3, 3, std::nullopt});
+  auto vectorInputNull = makeNullableFlatVector<int64_t>(
+      {10, 10, 10, 20, std::nullopt, 20, std::nullopt, std::nullopt, 20});
+
+  testModeWithDuck(vectorKeyNull, vectorInputNull);
+}
+
+TEST_F(ModeAggregateTest, groupByDouble) {
+  vector_size_t num = 37;
+
+  auto vectorKey = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 3; }, nullEvery(4));
+  auto vectorInput = makeFlatVector<double>(
+      num, [](vector_size_t row) { return row % 2 + 0.05; }, nullEvery(5));
+
+  testModeWithDuck(vectorKey, vectorInput);
+}
+
+TEST_F(ModeAggregateTest, groupByBoolean) {
+  vector_size_t num = 37;
+
+  auto vectorKey = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 3; }, nullEvery(4));
+  auto vectorInput = makeFlatVector<bool>(
+      num, [](vector_size_t row) { return row % 2 == 0; }, nullEvery(5));
+
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<int32_t>({std::nullopt, 0, 1, 2}),
+       makeFlatVector<bool>({true, false, false, false})});
+
+  testMode("spark_mode(c1)", {"c0"}, vectorKey, vectorInput, expected);
+}
+
+TEST_F(ModeAggregateTest, groupByTimestamp) {
+  vector_size_t num = 10;
+
+  auto vectorKey = makeNullableFlatVector<int32_t>(
+      {std::nullopt, 1, 2, 0, std::nullopt, 2, 0, 1, std::nullopt, 0});
+  auto vectorInput = makeFlatVector<Timestamp>(
+      num,
+      [](vector_size_t row) {
+        return Timestamp{row % 2, 17'123'456};
+      },
+      nullEvery(5));
+
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<int32_t>({std::nullopt, 0, 1, 2}),
+       makeFlatVector<Timestamp>(
+           {Timestamp{0, 17'123'456},
+            Timestamp{1, 17'123'456},
+            Timestamp{1, 17'123'456},
+            Timestamp{0, 17'123'456}})});
+
+  testMode("spark_mode(c1)", {"c0"}, vectorKey, vectorInput, expected);
+}
+
+TEST_F(ModeAggregateTest, groupByDate) {
+  vector_size_t num = 10;
+
+  auto vectorKey = makeNullableFlatVector<int32_t>(
+      {std::nullopt, 1, 2, 0, std::nullopt, 2, 0, 1, std::nullopt, 0});
+  auto vectorInput = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 2; }, nullEvery(5), DATE());
+
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<int32_t>({std::nullopt, 0, 1, 2}),
+       makeFlatVector<int32_t>({0, 1, 1, 0}, DATE())});
+
+  testMode("spark_mode(c1)", {"c0"}, vectorKey, vectorInput, expected);
+}
+
+TEST_F(ModeAggregateTest, groupByInterval) {
+  vector_size_t num = 30;
+
+  auto vectorKey = makeFlatVector<int32_t>(num, [](auto row) { return row; });
+  auto vectorInput = makeFlatVector<int64_t>(
+      num,
+      [](auto row) { return row % 5 == 0 ? 2 : row + 1; },
+      nullEvery(5),
+      INTERVAL_DAY_TIME());
+
+  testModeWithDuck(vectorKey, vectorInput);
+}
+
+TEST_F(ModeAggregateTest, groupByString) {
+  std::vector<std::string> strings = {
+      "grapes",
+      "oranges",
+      "sweet fruits: apple",
+      "sweet fruits: banana",
+      "sweet fruits: papaya",
+  };
+
+  auto keys = makeFlatVector<int16_t>(
+      1'002, [](auto row) { return row % 5; }, nullEvery(5));
+  auto data = makeFlatVector<StringView>(
+      1'002,
+      [&](auto row) { return StringView(strings[row % strings.size()]); },
+      nullEvery(5));
+  testModeWithDuck(keys, data);
+}
+
+TEST_F(ModeAggregateTest, globalInteger) {
+  vector_size_t num = 30;
+  auto vector = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 7; }, nullEvery(7));
+
+  testGlobalModeWithDuck(vector);
+}
+
+TEST_F(ModeAggregateTest, globalDecimal) {
+  vector_size_t num = 10;
+  auto longDecimalType = DECIMAL(20, 2);
+  auto vectorLongDecimal = makeFlatVector<int128_t>(
+      num,
+      [](vector_size_t row) { return row % 4; },
+      nullEvery(7),
+      longDecimalType);
+
+  testGlobalModeWithDuck(vectorLongDecimal);
+
+  auto shortDecimalType = DECIMAL(6, 2);
+  auto vectorShortDecimal = makeFlatVector<int64_t>(
+      num,
+      [](vector_size_t row) { return row % 4; },
+      nullEvery(7),
+      shortDecimalType);
+
+  testGlobalModeWithDuck(vectorShortDecimal);
+}
+
+TEST_F(ModeAggregateTest, globalUnknown) {
+  auto vector = makeAllNullFlatVector<UnknownValue>(6);
+
+  auto expected = makeRowVector({
+      BaseVector::createNullConstant(UNKNOWN(), 1, pool()),
+  });
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, globalDouble) {
+  vector_size_t num = 32;
+  auto vector = makeFlatVector<double>(
+      num, [](vector_size_t row) { return row % 5 + 0.05; }, nullEvery(5));
+
+  testGlobalModeWithDuck(vector);
+}
+
+TEST_F(ModeAggregateTest, globalBoolean) {
+  auto vector =
+      makeNullableFlatVector<bool>({false, false, true, std::nullopt});
+
+  auto expected =
+      makeRowVector({makeFlatVector<bool>(std::vector<bool>{false})});
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, globalTimestamp) {
+  vector_size_t num = 10;
+  auto vector = makeFlatVector<Timestamp>(
+      num,
+      [](vector_size_t row) {
+        return Timestamp{row % 4, 100};
+      },
+      nullEvery(7));
+
+  auto expected = makeRowVector(
+      {makeFlatVector<Timestamp>(std::vector<Timestamp>{Timestamp{1, 100}})});
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, globalDate) {
+  vector_size_t num = 10;
+  auto vector = makeFlatVector<int32_t>(
+      num, [](vector_size_t row) { return row % 4; }, nullEvery(7), DATE());
+
+  auto expected =
+      makeRowVector({makeFlatVector<int32_t>(std::vector<int32_t>{1}, DATE())});
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, globalInterval) {
+  auto vector = makeFlatVector<int64_t>(
+      51, [](auto row) { return row % 7; }, nullEvery(7), INTERVAL_DAY_TIME());
+
+  testGlobalModeWithDuck(vector);
+}
+
+TEST_F(ModeAggregateTest, globalEmpty) {
+  auto vector = makeFlatVector<int32_t>({});
+
+  auto expected = makeRowVector({
+      BaseVector::createNullConstant(INTEGER(), 1, pool()),
+  });
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, globalString) {
+  std::vector<std::string> strings = {
+      "grapes",
+      "oranges",
+      "sweet fruits: apple",
+      "sweet fruits: banana",
+      "sweet fruits: papaya",
+  };
+
+  auto data = makeFlatVector<StringView>(1'001, [&](auto row) {
+    return StringView(strings[row % strings.size()]);
+  });
+  testGlobalModeWithDuck(data);
+
+  // Some nulls.
+  data = makeFlatVector<StringView>(
+      1'002,
+      [&](auto row) { return StringView(strings[row % strings.size()]); },
+      nullEvery(strings.size()));
+  testGlobalModeWithDuck(data);
+
+  // All nulls.
+  testGlobalModeWithDuck(makeAllNullFlatVector<StringView>(1'000));
+
+  // Lots of unique strings.
+  std::string scratch;
+  data = makeFlatVector<StringView>(
+      1'002,
+      [&](auto row) {
+        scratch = std::string(50 + row % 1'000, 'A' + (row % 10));
+        return StringView(scratch);
+      },
+      nullEvery(10));
+  testGlobalModeWithDuck(data);
+}
+
+TEST_F(ModeAggregateTest, globalNaNs) {
+  // Verify that NaNs with different binary representations are considered equal
+  // and deduplicated.
+  static const auto kNaN = std::numeric_limits<double>::quiet_NaN();
+  static const auto kSNaN = std::numeric_limits<double>::signaling_NaN();
+  auto vector = makeFlatVector<double>({1, kNaN, kSNaN, 2, 3, kNaN, kSNaN, 3});
+
+  auto expected =
+      makeRowVector({makeFlatVector<double>(std::vector<double>{kNaN})});
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, allNulls) {
+  auto vector = makeAllNullFlatVector<int32_t>(3);
+
+  auto expected = makeRowVector({makeAllNullFlatVector<int32_t>(1)});
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+
+  vector = makeAllNullFlatVector<int32_t>(0);
+
+  testMode("spark_mode(c1)", {}, vector, vector, expected);
+}
+
+TEST_F(ModeAggregateTest, arrays) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}),
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2, 3]",
+          "[1, 2]",
+          "[]",
+          "[1, 2]",
+          "[]",
+          "[1, null, 2, null]",
+          "[1, null, 2, null]",
+          "[]",
+          "[1, null, 2, null]",
+          "null",
+          "[1, null, 2, null]",
+          "null",
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({"[1, null, 2, null]"}),
+  });
+
+  testAggregations({input}, {}, {"spark_mode(c1)"}, {expected});
+
+  // Group by.
+  expected = makeRowVector({
+      makeFlatVector<int64_t>({0, 1}),
+      makeArrayVectorFromJson<int32_t>({
+          "[1, null, 2, null]",
+          "[1, 2]",
+      }),
+  });
+  testAggregations({input}, {"c0"}, {"spark_mode(c1)"}, {expected});
+}
+
+TEST_F(ModeAggregateTest, maps) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}),
+      makeMapVectorFromJson<int32_t, int32_t>({
+          "{1: 10, 2: 20, 3: 30}",
+          "{1: 10, 2: 20}",
+          "{}",
+          "{1: 10, 2: 20}",
+          "{}",
+          "{1: 10, 2: 20, 3: null}",
+          "{1: 10, 2: 20, 3: null}",
+          "{}",
+          "{1: 10, 2: 20, 3: null}",
+          "null",
+          "{1: 10, 2: 20, 3: null}",
+          "null",
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeMapVectorFromJson<int32_t, int32_t>({"{1: 10, 2: 20, 3: null}"}),
+  });
+
+  testAggregations({input}, {}, {"spark_mode(c1)"}, {expected});
+
+  // Group by.
+  expected = makeRowVector({
+      makeFlatVector<int64_t>({0, 1}),
+      makeMapVectorFromJson<int32_t, int32_t>({
+          "{1: 10, 2: 20, 3: null}",
+          "{1: 10, 2: 20}",
+      }),
+  });
+  testAggregations({input}, {"c0"}, {"spark_mode(c1)"}, {expected});
+}
+
+TEST_F(ModeAggregateTest, rows) {
+  auto input = makeRowVector({
+      makeRowVector({
+          makeFlatVector<int32_t>({
+              1,
+              1,
+              2,
+              1,
+          }),
+          makeNullableFlatVector<int32_t>({
+              std::nullopt,
+              1,
+              2,
+              1,
+          }),
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeRowVector({
+          makeConstant(1, 1),
+          makeConstant(1, 1),
+      }),
+  });
+
+  testAggregations({input}, {}, {"spark_mode(c0)"}, {expected});
+
+  // Group by.
+  auto inputGroupBy = makeRowVector({
+      makeFlatVector<int64_t>({1, 0, 1, 0, 1, 1}),
+      makeRowVector({
+          makeFlatVector<int32_t>({
+              1,
+              1,
+              2,
+              1,
+              2,
+              2,
+          }),
+          makeNullableFlatVector<int32_t>({
+              std::nullopt,
+              1,
+              2,
+              1,
+              1,
+              2,
+          }),
+      }),
+  });
+  auto expectedGroupBy = makeRowVector({
+      makeFlatVector<int64_t>({0, 1}),
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<int32_t>({1, 2}),
+      }),
+  });
+  testAggregations(
+      {inputGroupBy}, {"c0"}, {"spark_mode(c1)"}, {expectedGroupBy});
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::aggregate::sparksql::test

--- a/bolt/functions/sparksql/aggregates/tests/ModeAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/ModeAggregateTest.cpp
@@ -76,6 +76,31 @@ class ModeAggregateTest : public AggregationTestBase {
         {vectors}, {}, {"spark_mode(c1)"}, "SELECT mode(c1) FROM tmp");
   }
 
+  void testGlobalModeWithDuckSkipTableScan(const VectorPtr& vector) {
+    auto num = vector->size();
+    auto reverseIndices = makeIndicesInReverse(num);
+
+    auto vectors =
+        makeRowVector({vector, wrapInDictionary(reverseIndices, num, vector)});
+
+    createDuckDbTable({vectors});
+    testAggregations(
+        {vectors},
+        {},
+        {"spark_mode(c0)"},
+        "SELECT mode(c0) FROM tmp",
+        /*config=*/{},
+        /*testWithTableScan=*/false);
+
+    testAggregations(
+        {vectors},
+        {},
+        {"spark_mode(c1)"},
+        "SELECT mode(c1) FROM tmp",
+        /*config=*/{},
+        /*testWithTableScan=*/false);
+  }
+
   void testMode(
       const std::string& expression,
       const std::vector<std::string>& groupKeys,
@@ -84,6 +109,22 @@ class ModeAggregateTest : public AggregationTestBase {
       const RowVectorPtr& expected) {
     auto vectors = makeRowVector({vectorKey, vectorInput});
     testAggregations({vectors}, groupKeys, {expression}, {expected});
+  }
+
+  void testModeSkipTableScan(
+      const std::string& expression,
+      const std::vector<std::string>& groupKeys,
+      const VectorPtr& vectorKey,
+      const VectorPtr& vectorInput,
+      const RowVectorPtr& expected) {
+    auto vectors = makeRowVector({vectorKey, vectorInput});
+    testAggregations(
+        {vectors},
+        groupKeys,
+        {expression},
+        {expected},
+        /*config=*/{},
+        /*testWithTableScan=*/false);
   }
 };
 
@@ -218,7 +259,9 @@ TEST_F(ModeAggregateTest, globalDecimal) {
       nullEvery(7),
       longDecimalType);
 
-  testGlobalModeWithDuck(vectorLongDecimal);
+  // Decimal types cannot be written as DWRF in our TableScan test path.
+  // Keep DuckDB verification, but skip the TableScan (write-to-file) variant.
+  testGlobalModeWithDuckSkipTableScan(vectorLongDecimal);
 
   auto shortDecimalType = DECIMAL(6, 2);
   auto vectorShortDecimal = makeFlatVector<int64_t>(
@@ -227,7 +270,7 @@ TEST_F(ModeAggregateTest, globalDecimal) {
       nullEvery(7),
       shortDecimalType);
 
-  testGlobalModeWithDuck(vectorShortDecimal);
+  testGlobalModeWithDuckSkipTableScan(vectorShortDecimal);
 }
 
 TEST_F(ModeAggregateTest, globalUnknown) {
@@ -237,7 +280,8 @@ TEST_F(ModeAggregateTest, globalUnknown) {
       BaseVector::createNullConstant(UNKNOWN(), 1, pool()),
   });
 
-  testMode("spark_mode(c1)", {}, vector, vector, expected);
+  // UNKNOWN type cannot be written in our TableScan (write-to-file) test path.
+  testModeSkipTableScan("spark_mode(c1)", {}, vector, vector, expected);
 }
 
 TEST_F(ModeAggregateTest, globalDouble) {

--- a/bolt/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/bolt/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -110,6 +110,7 @@ int main(int argc, char** argv) {
           {"min_by", nullptr},
           {"skewness", nullptr},
           {"kurtosis", nullptr},
+          {"mode", nullptr},
           {"collect_list", makeArrayVerifier()},
           {"collect_set", makeArrayVerifier()},
           // Nested nulls are handled as values in Spark. But nested nulls


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: discussion #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Doc: https://spark.apache.org/docs/latest/api/sql/#mode Code: https://github.com/apache/spark/blob/branch-3.5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala#L42

`ComplexTypeAccumulator` needs inputType parameter, which doesn't align with `SimpleAggregateAdapter`'s intializer's signature. So we don't implement the mode function with simple API for complex types.

Corresponding PR: https://github.com/facebookincubator/velox/pull/10462

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
