### PR TITLE
[perf][cp] Support fast path for Spark comparison function in join filter

### DIFF
--- a/bolt/functions/lib/SIMDComparisonUtil.h
+++ b/bolt/functions/lib/SIMDComparisonUtil.h
@@ -29,7 +29,9 @@
  */
 #pragma once
 
+#include "bolt/expression/EvalCtx.h"
 #include "bolt/expression/VectorFunction.h"
+#include "bolt/vector/DecodedVector.h"
 
 namespace bytedance::bolt::functions {
 
@@ -140,6 +142,10 @@ void applyAutoSimdComparisonInternal(
         });
   }
 }
+
+inline bool isDictEncoding(const VectorPtr& arg) {
+  return arg->encoding() == VectorEncoding::Simple::DICTIONARY;
+}
 } // namespace detail
 
 template <
@@ -238,6 +244,7 @@ template <typename A, typename B, typename Compare, typename... Args>
 void applyAutoSimdComparison(
     const SelectivityVector& rows,
     std::vector<VectorPtr>& args,
+    exec::EvalCtx& context,
     VectorPtr& result,
     Args... cmpArgs) {
   const Compare cmp;
@@ -255,6 +262,42 @@ void applyAutoSimdComparison(
             return Compare::apply(rawA[i], rawB[i], cmpArgs...);
           } else {
             return cmp(rawA[i], rawB[i]);
+          }
+        },
+        result);
+  } else if (args[0]->isFlatEncoding() && detail::isDictEncoding(args[1])) {
+    const A* __restrict rawA =
+        args[0]->asUnchecked<FlatVector<A>>()->template rawValues<A>();
+    DecodedVector decodedB(*args[1], rows);
+    const B* __restrict rawB = decodedB.data<B>();
+    const vector_size_t* __restrict indexB = decodedB.indices();
+    detail::applyAutoSimdComparisonInternal(
+        rows,
+        rawA,
+        rawB,
+        [&](const A* __restrict rawA, const B* __restrict rawB, int i) {
+          if constexpr (sizeof...(cmpArgs) > 0) {
+            return Compare::apply(rawA[i], rawB[indexB[i]], cmpArgs...);
+          } else {
+            return cmp(rawA[i], rawB[indexB[i]]);
+          }
+        },
+        result);
+  } else if (detail::isDictEncoding(args[0]) && args[1]->isFlatEncoding()) {
+    DecodedVector decodedA(*args[0], rows);
+    const A* __restrict rawA = decodedA.data<A>();
+    const vector_size_t* __restrict indexA = decodedA.indices();
+    const B* __restrict rawB =
+        args[1]->asUnchecked<FlatVector<B>>()->template rawValues<B>();
+    detail::applyAutoSimdComparisonInternal(
+        rows,
+        rawA,
+        rawB,
+        [&](const A* __restrict rawA, const B* __restrict rawB, int i) {
+          if constexpr (sizeof...(cmpArgs) > 0) {
+            return Compare::apply(rawA[indexA[i]], rawB[i], cmpArgs...);
+          } else {
+            return cmp(rawA[indexA[i]], rawB[i]);
           }
         },
         result);
@@ -312,5 +355,22 @@ void applyAutoSimdComparison(
   } else {
     BOLT_UNREACHABLE();
   }
+}
+
+template <typename A, typename B>
+bool shouldApplyAutoSimdComparison(
+    const SelectivityVector& rows,
+    std::vector<VectorPtr>& args) {
+  if (rows.end() - rows.begin() > 64) {
+    if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
+        (args[1]->isFlatEncoding() || args[1]->isConstantEncoding())) {
+      return true;
+    } else if (args[0]->isFlatEncoding() && detail::isDictEncoding(args[1])) {
+      return true;
+    } else if (detail::isDictEncoding(args[0]) && args[1]->isFlatEncoding()) {
+      return true;
+    }
+  }
+  return false;
 }
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/sparksql/Comparisons.cpp
+++ b/bolt/functions/sparksql/Comparisons.cpp
@@ -55,20 +55,19 @@ class ComparisonFunction final : public exec::VectorFunction {
     const Cmp cmp;
     context.ensureWritable(rows, BOOLEAN(), result);
     result->clearNulls(rows);
-    if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
-        (args[1]->isFlatEncoding() || args[1]->isConstantEncoding())) {
-      if constexpr (
-          kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
-          kind == TypeKind::INTEGER || kind == TypeKind::BIGINT) {
-        if (rows.isAllSelected()) {
-          applySimdComparison<T, Cmp>(rows, args, result);
-          return;
-        }
-      }
-      if (rows.end() - rows.begin() > 64) {
-        applyAutoSimdComparison<T, T, Cmp>(rows, args, result);
+    if constexpr (
+        kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+        kind == TypeKind::INTEGER || kind == TypeKind::BIGINT) {
+      if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
+          (args[1]->isFlatEncoding() || args[1]->isConstantEncoding()) &&
+          rows.isAllSelected()) {
+        applySimdComparison<T, Cmp>(rows, args, result);
         return;
       }
+    }
+    if (shouldApplyAutoSimdComparison<T, T>(rows, args)) {
+      applyAutoSimdComparison<T, T, Cmp>(rows, args, context, result);
+      return;
     }
     auto* flatResult = result->asUnchecked<FlatVector<bool>>();
 

--- a/bolt/functions/sparksql/DecimalCompare.cpp
+++ b/bolt/functions/sparksql/DecimalCompare.cpp
@@ -129,11 +129,9 @@ class DecimalCompareFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     prepareResults(rows, resultType, context, result);
-    if ((args[0]->isFlatEncoding() || args[0]->isConstantEncoding()) &&
-        (args[1]->isFlatEncoding() || args[1]->isConstantEncoding()) &&
-        rows.end() - rows.begin() > 64) {
+    if (shouldApplyAutoSimdComparison<A, B>(rows, args)) {
       applyAutoSimdComparison<A, B, Operation, int8_t, bool>(
-          rows, args, result, deltaScale_, need256_);
+          rows, args, context, result, deltaScale_, need256_);
       return;
     }
 

--- a/bolt/functions/sparksql/benchmarks/SIMDCompareBenchmark.cpp
+++ b/bolt/functions/sparksql/benchmarks/SIMDCompareBenchmark.cpp
@@ -33,6 +33,7 @@
 
 #include "bolt/benchmarks/ExpressionBenchmarkBuilder.h"
 #include "bolt/functions/sparksql/Register.h"
+#include "bolt/vector/fuzzer/VectorFuzzer.h"
 
 using namespace bytedance;
 
@@ -55,12 +56,29 @@ int main(int argc, char** argv) {
   ExpressionBenchmarkBuilder benchmarkBuilder;
   for (auto nullRatio : {0.0, 0.1, 0.9}) {
     for (auto& inputType : inputTypes) {
+      VectorFuzzer::Options opts;
+      opts.vectorSize = 10000;
+      opts.nullRatio = nullRatio;
+      VectorFuzzer fuzzer(opts, benchmarkBuilder.pool());
+      std::vector<VectorPtr> childrenVectors = {
+          fuzzer.fuzzDictionary(fuzzer.fuzzFlat(inputType)),
+          fuzzer.fuzzFlat(inputType)};
       benchmarkBuilder
           .addBenchmarkSet(
               fmt::format(
-                  "{}#{}\%null", inputType->toString(), nullRatio * 100),
+                  "Dict#{}#{}\%null", inputType->toString(), nullRatio * 100),
+              fuzzer.fuzzRow(
+                  std::move(childrenVectors), {"c0", "c1"}, opts.vectorSize))
+          .addExpression("equalto", "equalto(c0, c1)")
+          .addExpression("greaterthan", "greaterthan(c0, c1)")
+          .addExpression("greaterthanorequal", "greaterthanorequal(c0, c1)")
+          .withIterations(100);
+      benchmarkBuilder
+          .addBenchmarkSet(
+              fmt::format(
+                  "Flat#{}#{}\%null", inputType->toString(), nullRatio * 100),
               ROW({"c0", "c1"}, {inputType, inputType}))
-          .withFuzzerOptions({.vectorSize = 10000, .nullRatio = nullRatio})
+          .withFuzzerOptions(opts)
           .addExpression("equalto", "equalto(c0, c1)")
           .addExpression("greaterthan", "greaterthan(c0, c1)")
           .addExpression("greaterthanorequal", "greaterthanorequal(c0, c1)")

--- a/bolt/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/bolt/functions/sparksql/tests/ComparisonsTest.cpp
@@ -30,6 +30,7 @@
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "bolt/vector/DecodedVector.h"
 
 #include <bolt/vector/SimpleVector.h>
 namespace bytedance::bolt::functions::sparksql::test {
@@ -94,6 +95,8 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     auto right = rVector->template as<FlatVector<T>>()->rawValues();
     auto constVector = fuzzer.fuzzConstant(type);
     auto constant = constVector->template as<ConstantVector<T>>()->value();
+    auto lDictVector = fuzzer.fuzzDictionary(lVector);
+    auto rDictVector = fuzzer.fuzzDictionary(rVector);
     SelectivityVector rows(size);
     rows.setValidRange(0, unSelectedRows, false);
 
@@ -112,10 +115,9 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     // Flat, Const
     std::vector<VectorPtr> rConstVectors = {lVector, constVector};
     rowVector = fuzzer.fuzzRow(std::move(rConstVectors), {"c0", "c1"}, size);
-    result =
-        evaluate<SimpleVector<bool>>("greaterthanorequal(c0, c1)", rowVector);
+    result = evaluate<SimpleVector<bool>>("equalto(c0, c1)", rowVector);
     for (auto i = unSelectedRows; i < size; i++) {
-      expectedResult[i] = left[i] >= constant;
+      expectedResult[i] = left[i] == constant;
     }
     bolt::test::assertEqualVectors(
         makeFlatVector<bool>(expectedResult), result, rows);
@@ -123,10 +125,43 @@ class ComparisonsTest : public SparkFunctionBaseTest {
     // Const, Flat
     std::vector<VectorPtr> lConstVectors = {constVector, rVector};
     rowVector = fuzzer.fuzzRow(std::move(lConstVectors), {"c0", "c1"}, size);
-    result =
-        evaluate<SimpleVector<bool>>("greaterthanorequal(c0, c1)", rowVector);
+    result = evaluate<SimpleVector<bool>>("lessthan(c0, c1)", rowVector);
     for (auto i = unSelectedRows; i < size; i++) {
-      expectedResult[i] = constant >= right[i];
+      expectedResult[i] = constant < right[i];
+    }
+    bolt::test::assertEqualVectors(
+        makeFlatVector<bool>(expectedResult), result, rows);
+
+    // Dict(Flat), Flat
+    childrenVectors = {lDictVector, rVector};
+    rowVector = fuzzer.fuzzRow(std::move(childrenVectors), {"c0", "c1"}, size);
+    result = evaluate<SimpleVector<bool>>("lessthanorequal(c0, c1)", rowVector);
+    DecodedVector lDecodedVector(*lDictVector);
+    for (auto i = unSelectedRows; i < size; i++) {
+      expectedResult[i] = lDecodedVector.valueAt<T>(i) <= right[i];
+    }
+    bolt::test::assertEqualVectors(
+        makeFlatVector<bool>(expectedResult), result, rows);
+
+    // Flat, Dict(Flat)
+    childrenVectors = {lVector, rDictVector};
+    rowVector = fuzzer.fuzzRow(std::move(childrenVectors), {"c0", "c1"}, size);
+    result = evaluate<SimpleVector<bool>>("greaterthan(c0, c1)", rowVector);
+    DecodedVector rDecodedVector(*rDictVector);
+    for (auto i = unSelectedRows; i < size; i++) {
+      expectedResult[i] = left[i] > rDecodedVector.valueAt<T>(i);
+    }
+    bolt::test::assertEqualVectors(
+        makeFlatVector<bool>(expectedResult), result, rows);
+
+    // Dict(Dict(Flat)), Flat
+    auto lDictDictVector = fuzzer.fuzzDictionary(lDictVector);
+    childrenVectors = {lDictDictVector, rVector};
+    rowVector = fuzzer.fuzzRow(std::move(childrenVectors), {"c0", "c1"}, size);
+    result = evaluate<SimpleVector<bool>>("lessthanorequal(c0, c1)", rowVector);
+    DecodedVector decodedVector(*lDictDictVector);
+    for (auto i = unSelectedRows; i < size; i++) {
+      expectedResult[i] = decodedVector.valueAt<T>(i) <= right[i];
     }
     bolt::test::assertEqualVectors(
         makeFlatVector<bool>(expectedResult), result, rows);

--- a/bolt/functions/sparksql/tests/DecimalCompareTest.cpp
+++ b/bolt/functions/sparksql/tests/DecimalCompareTest.cpp
@@ -183,6 +183,26 @@ TEST_F(DecimalCompareTest, gt) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? false : true; }),
       row);
+
+  // Dict(Flat), Flat
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? false : true; }));
 }
 
 TEST_F(DecimalCompareTest, gte) {
@@ -318,6 +338,25 @@ TEST_F(DecimalCompareTest, gte) {
       },
       makeFlatVector<bool>(130, [](auto /*row*/) { return true; }),
       row);
+
+  // Dict(Flat), Flat
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(140, [](auto /*row*/) { return true; }));
 }
 
 TEST_F(DecimalCompareTest, eq) {
@@ -455,6 +494,26 @@ TEST_F(DecimalCompareTest, eq) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? true : false; }),
       row);
+
+  // Flat, Dict(Flat)
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? true : false; }));
 }
 
 TEST_F(DecimalCompareTest, neq) {
@@ -591,6 +650,26 @@ TEST_F(DecimalCompareTest, neq) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? false : true; }),
       row);
+
+  // Dict(Flat), Flat
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? false : true; }));
 }
 
 TEST_F(DecimalCompareTest, lt) {
@@ -726,6 +805,25 @@ TEST_F(DecimalCompareTest, lt) {
       },
       makeFlatVector<bool>(130, [](auto /*row*/) { return false; }),
       row);
+
+  // Dict(Flat), Flat
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(140, [](auto /*row*/) { return false; }));
 }
 
 TEST_F(DecimalCompareTest, lte) {
@@ -863,6 +961,26 @@ TEST_F(DecimalCompareTest, lte) {
       makeFlatVector<bool>(
           130, [](auto row) { return row % 2 == 0 ? true : false; }),
       row);
+
+  // Dict(Flat), Flat
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices(140, [](auto row) { return row % 2; }),
+              makeFlatVector<int64_t>(
+                  2,
+                  [](auto row) { return row % 2 == 0 ? 1000 : 3000; },
+                  nullptr,
+                  DECIMAL(6, 2))),
+          makeFlatVector<int64_t>(
+              140,
+              [](auto row) { return row % 2 == 0 ? 100 : 130; },
+              nullptr,
+              DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>(
+          140, [](auto row) { return row % 2 == 0 ? true : false; }));
 }
 
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: discussion #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Support fast path for Spark comparison function in join filter We observed the join filter's inputs are flat encoding(build side) and dictionary encoding(probe side). This PR extends the optimization we did in 10273 to cover the input encoding: dict and flat.

Corresponding PR: https://github.com/facebookincubator/velox/pull/10464

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
