### PR TITLE
feat: Make ReaderOptions serializable

### DIFF
--- a/bolt/common/io/Options.h
+++ b/bolt/common/io/Options.h
@@ -223,7 +223,7 @@ class ReaderOptions : public bolt::ISerializable {
     return obj;
   }
 
-  static ReaderOptions deserialize(
+  static ReaderOptions create(
       const folly::dynamic& obj,
       bolt::memory::MemoryPool* pool) {
     ReaderOptions options(pool);

--- a/bolt/dwio/common/Options.cpp
+++ b/bolt/dwio/common/Options.cpp
@@ -214,7 +214,7 @@ folly::dynamic WriterOptions::serialize() const {
 
 // pool, nonReclaimableSection, and spillConfig callbacks/executor remain at
 // default and must be re-injected by the host.
-std::shared_ptr<WriterOptions> WriterOptions::deserialize(
+std::shared_ptr<WriterOptions> WriterOptions::create(
     const folly::dynamic& obj) {
   auto opts = std::make_shared<WriterOptions>();
 
@@ -266,13 +266,13 @@ void WriterOptions::registerSerDe() {
   bolt::Type::registerSerDe();
   bolt::common::SpillConfig::registerSerDe();
   auto& registry = DeserializationRegistryForSharedPtr();
-  registry.Register("WriterOptions", WriterOptions::deserialize);
+  registry.Register("WriterOptions", WriterOptions::create);
 }
 
-ReaderOptions ReaderOptions::deserialize(
+ReaderOptions ReaderOptions::create(
     const folly::dynamic& obj,
     bolt::memory::MemoryPool* pool) {
-  auto baseOptions = io::ReaderOptions::deserialize(obj, pool);
+  auto baseOptions = io::ReaderOptions::create(obj, pool);
   ReaderOptions options(pool);
   static_cast<io::ReaderOptions&>(options) = baseOptions;
 
@@ -333,7 +333,7 @@ void ReaderOptions::registerSerDe() {
         // In practice, deserialize() should be called directly with a real
         // pool.
         bolt::memory::MemoryPool* dummyPool = nullptr;
-        auto options = ReaderOptions::deserialize(obj, dummyPool);
+        auto options = ReaderOptions::create(obj, dummyPool);
         return std::make_shared<ReaderOptions>(std::move(options));
       });
 }

--- a/bolt/dwio/common/Options.h
+++ b/bolt/dwio/common/Options.h
@@ -732,7 +732,7 @@ class ReaderOptions : public io::ReaderOptions {
   // Serialization support
   folly::dynamic serialize() const override;
 
-  static ReaderOptions deserialize(
+  static ReaderOptions create(
       const folly::dynamic& obj,
       bolt::memory::MemoryPool* pool);
   static void registerSerDe();
@@ -760,7 +760,7 @@ struct WriterOptions : public ISerializable {
   virtual ~WriterOptions() = default;
 
   folly::dynamic serialize() const override;
-  static std::shared_ptr<WriterOptions> deserialize(const folly::dynamic& obj);
+  static std::shared_ptr<WriterOptions> create(const folly::dynamic& obj);
   static void registerSerDe();
 };
 

--- a/bolt/dwio/common/tests/OptionsTests.cpp
+++ b/bolt/dwio/common/tests/OptionsTests.cpp
@@ -94,7 +94,7 @@ TEST_F(WriterOptionsSerDeTest, writerOptionsSerializeDeserializeRoundTrip) {
   folly::dynamic dyn = opts.serialize();
 
   // ---- deserialize ----
-  auto roundTrip = WriterOptions::deserialize(dyn);
+  auto roundTrip = WriterOptions::create(dyn);
 
   // ---- verify ----
 
@@ -126,7 +126,7 @@ TEST_F(WriterOptionsSerDeTest, writerOptionsDefaultsRoundTrip) {
   WriterOptions opts;
 
   folly::dynamic dyn = opts.serialize();
-  auto roundTrip = WriterOptions::deserialize(dyn);
+  auto roundTrip = WriterOptions::create(dyn);
 
   ASSERT_EQ(nullptr, roundTrip->schema);
   ASSERT_FALSE(roundTrip->compressionKind.has_value());
@@ -160,7 +160,7 @@ TEST_F(WriterOptionsSerDeTest, writerOptionsWithSpillConfigRoundTrip) {
   WriterOptions opts;
   opts.spillConfig = &cfg;
 
-  auto rt = WriterOptions::deserialize(opts.serialize());
+  auto rt = WriterOptions::create(opts.serialize());
 
   ASSERT_NE(nullptr, rt->spillConfig);
   ASSERT_NE(nullptr, rt->ownedSpillConfig.get());
@@ -176,7 +176,7 @@ TEST_F(WriterOptionsSerDeTest, writerOptionsNoSpillConfigRoundTrip) {
   WriterOptions opts;
   ASSERT_EQ(nullptr, opts.spillConfig);
 
-  auto rt = WriterOptions::deserialize(opts.serialize());
+  auto rt = WriterOptions::create(opts.serialize());
 
   ASSERT_EQ(nullptr, rt->spillConfig);
   ASSERT_EQ(nullptr, rt->ownedSpillConfig.get());
@@ -188,7 +188,7 @@ TEST_F(WriterOptionsSerDeTest, writerOptionsNoSchemaRoundTrip) {
   opts.serdeParameters["key"] = "value";
 
   folly::dynamic dyn = opts.serialize();
-  auto roundTrip = WriterOptions::deserialize(dyn);
+  auto roundTrip = WriterOptions::create(dyn);
 
   ASSERT_EQ(nullptr, roundTrip->schema);
   ASSERT_TRUE(roundTrip->compressionKind.has_value());
@@ -239,8 +239,8 @@ TEST_F(ReaderOptionsSerDeTest, readerOptionsSerializeDeserializeRoundTrip) {
   folly::dynamic dyn = opts.serialize();
 
   // ---- deserialize ----
-  auto roundTrip = bytedance::bolt::dwio::common::ReaderOptions::deserialize(
-      dyn, pool.get());
+  auto roundTrip =
+      bytedance::bolt::dwio::common::ReaderOptions::create(dyn, pool.get());
 
   // ---- verify ----
   ASSERT_EQ(opts.getTailLocation(), roundTrip.getTailLocation());
@@ -286,8 +286,8 @@ TEST_F(ReaderOptionsSerDeTest, readerOptionsDefaultsRoundTrip) {
   bytedance::bolt::dwio::common::ReaderOptions opts(pool.get());
 
   folly::dynamic dyn = opts.serialize();
-  auto roundTrip = bytedance::bolt::dwio::common::ReaderOptions::deserialize(
-      dyn, pool.get());
+  auto roundTrip =
+      bytedance::bolt::dwio::common::ReaderOptions::create(dyn, pool.get());
 
   ASSERT_EQ(opts.getTailLocation(), roundTrip.getTailLocation());
   ASSERT_EQ(opts.getFileFormat(), roundTrip.getFileFormat());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: One more step towards #250 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

In order to prepare for more connector refactoring, DWIO ReaderOptions needs to be serializable.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Make DWIO ReaderOptions serializable
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)