### PR TITLE
fix(chore): avoid use system wide protoc in arrow recipe

### DIFF
--- a/scripts/conan/patches/arrow.15.0.1-csv-support.patch
+++ b/scripts/conan/patches/arrow.15.0.1-csv-support.patch
@@ -449,7 +449,7 @@ index 24a7af89b..27655cdf4 100644
  
          if self.options.get_safe("skyhook", False):
              raise ConanInvalidConfiguration("CCI has no librados recipe (yet)")
-@@ -248,16 +388,11 @@ class ArrowConan(ConanFile):
+@@ -248,16 +388,13 @@ class ArrowConan(ConanFile):
              if self.dependencies["jemalloc"].options.enable_cxx:
                  raise ConanInvalidConfiguration("jemmalloc.enable_cxx of a static jemalloc must be disabled")
  
@@ -467,6 +467,8 @@ index 24a7af89b..27655cdf4 100644
 -        else:
 +        if Version(self.version) >= "13.0.0":
              self.tool_requires("cmake/[>=3.16 <4]")
++        if self.options.with_protobuf:
++            self.tool_requires("protobuf/<host_version>")
  
      def source(self):
 @@ -292,7 +427,7 @@ class ArrowConan(ConanFile):


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
When a newer system-installed protoc (v27+, e.g., via Homebrew) is present, make release_spark_with_test fails with fatal error: 'google/protobuf/runtime_version.h' file not found during Arrow's substrait proto compilation.

Issue Number: close #367 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

  Arrow declares protobuf as a regular `requires()` but not as a `tool_requires()`. This means the Conan protoc binary is not added to Arrow's build PATH. When Arrow's CMake runs `find_program(protoc)`, it finds the system protoc (e.g., v33.2) before the Conan package's protoc (v3.21.4), generating code that requires runtime_version.h — a header that doesn't exist in protobuf 3.x.

  The fix adds `tool_requires("protobuf/<host_version>")` to Arrow's `build_requirements()` in the existing Arrow patch. `<host_version>` resolves to the same version in `requires()` (3.21.4), and `VirtualBuildEnv` prepends the package's bin/ to PATH so `find_program(protoc)` finds the correct version.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
