### PR TITLE
[perf][cp] Start prefetch from the first split in table scan

### DIFF
--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -624,11 +624,12 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     return nullptr;
   }
   BOLT_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
+  BOLT_CHECK_NOT_NULL(splitReader_, "No split reader present");
 
   BOLT_TEST_ADJUST(
       "bytedance::bolt::connector::hive::HiveDataSource::next", this);
 
-  if (splitReader_ && splitReader_->emptySplit()) {
+  if (splitReader_->emptySplit()) {
     resetSplit();
     return nullptr;
   }
@@ -814,15 +815,11 @@ std::unordered_map<std::string, RuntimeCounter> HiveDataSource::runtimeStats() {
 void HiveDataSource::setFromDataSource(
     std::unique_ptr<DataSource> sourceUnique) {
   auto source = dynamic_cast<HiveDataSource*>(sourceUnique.get());
-  BOLT_CHECK(source, "Bad DataSource type");
+  BOLT_CHECK_NOT_NULL(source, "Bad DataSource type");
 
   split_ = std::move(source->split_);
-  if (source->splitReader_ && source->splitReader_->emptySplit()) {
-    runtimeStats_->skippedSplits += source->runtimeStats_->skippedSplits;
-    runtimeStats_->skippedSplitBytes +=
-        source->runtimeStats_->skippedSplitBytes;
-    return;
-  }
+  runtimeStats_->skippedSplits += source->runtimeStats_->skippedSplits;
+  runtimeStats_->skippedSplitBytes += source->runtimeStats_->skippedSplitBytes;
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);
   scanSpec_ = std::move(source->scanSpec_);
   splitReader_ = std::move(source->splitReader_);

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -130,26 +130,29 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   }
 
   void assertSelect(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const std::string& sql) {
     auto rowType = getRowType(std::move(outputColumnNames));
 
     auto plan = PlanBuilder().tableScan(rowType).planNode();
 
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
   void assertSelectWithDataColumns(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const RowTypePtr& dataColumns,
       const std::string& sql) {
     auto rowType = getRowType(std::move(outputColumnNames));
     auto plan =
         PlanBuilder().tableScan(rowType, {}, "", dataColumns).planNode();
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
   void assertSelectWithFilter(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const std::vector<std::string>& subfieldFilters,
       const std::string& remainingFilter,
@@ -163,10 +166,11 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
                     .tableScan(rowType, subfieldFilters, remainingFilter)
                     .planNode();
 
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
   void assertSelectWithFilter(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const std::vector<std::string>& subfieldFilters,
       const std::string& remainingFilter,
@@ -191,7 +195,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
                         isFilterPushdownEnabled)
                     .planNode();
 
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
   void assertSelectWithAssignments(
@@ -208,6 +212,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   }
 
   void assertSelectWithAgg(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& groupingKeys,
@@ -219,10 +224,11 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
                     .singleAggregation(groupingKeys, aggregates)
                     .planNode();
 
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
   void assertSelectWithFilterAndAgg(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const std::vector<std::string>& filters,
       const std::vector<std::string>& aggregates,
@@ -235,25 +241,15 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
                     .singleAggregation(groupingKeys, aggregates)
                     .planNode();
 
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
-  void loadData(
-      const std::string& filePath,
-      RowTypePtr rowType,
-      RowVectorPtr data,
-      const std::optional<
-          std::unordered_map<std::string, std::optional<std::string>>>&
-          partitionKeys = std::nullopt,
-      const std::optional<std::unordered_map<std::string, std::string>>&
-          infoColumns = std::nullopt) {
-    splits_ = {makeSplit(filePath, partitionKeys, infoColumns)};
+  void loadData(RowTypePtr rowType, RowVectorPtr data) {
     rowType_ = rowType;
     createDuckDbTable({data});
   }
 
   void loadDataWithRowType(const std::string& filePath, RowVectorPtr data) {
-    splits_ = {makeSplit(filePath)};
     auto pool = bytedance::bolt::memory::memoryManager()->addLeafPool();
     dwio::common::ReaderOptions readerOpts{pool.get()};
     auto reader = std::make_unique<ParquetReader>(
@@ -282,11 +278,6 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         dwio::common::FileFormat::PARQUET,
         partitionKeys,
         infoColumns)[0];
-  }
-
-  const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits()
-      const {
-    return splits_;
   }
 
   // Write data to a parquet file on specified path.
@@ -343,34 +334,45 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     auto schema = asRowType(vector->type());
     auto file = TempFilePath::create();
     writeToParquetFile(file->getPath(), {vector}, options);
-    loadData(file->getPath(), schema, vector);
+    loadData(schema, vector);
 
-    assertSelectWithFilter({"t"}, {}, "", "SELECT t from tmp", false);
     assertSelectWithFilter(
+        {makeSplit(file->getPath())},
+        {"t"},
+        {},
+        "",
+        "SELECT t from tmp",
+        false);
+    assertSelectWithFilter(
+        {makeSplit(file->getPath())},
         {"t"},
         {},
         "t < TIMESTAMP '2000-09-12 22:36:29'",
         "SELECT t from tmp where t < TIMESTAMP '2000-09-12 22:36:29'",
         false);
     assertSelectWithFilter(
+        {makeSplit(file->getPath())},
         {"t"},
         {},
         "t <= TIMESTAMP '2000-09-12 22:36:29'",
         "SELECT t from tmp where t <= TIMESTAMP '2000-09-12 22:36:29'",
         false);
     assertSelectWithFilter(
+        {makeSplit(file->getPath())},
         {"t"},
         {},
         "t > TIMESTAMP '1980-01-24 00:23:07'",
         "SELECT t from tmp where t > TIMESTAMP '1980-01-24 00:23:07'",
         false);
     assertSelectWithFilter(
+        {makeSplit(file->getPath())},
         {"t"},
         {},
         "t >= TIMESTAMP '1980-01-24 00:23:07'",
         "SELECT t from tmp where t >= TIMESTAMP '1980-01-24 00:23:07'",
         false);
     assertSelectWithFilter(
+        {makeSplit(file->getPath())},
         {"t"},
         {},
         "t == TIMESTAMP '2022-12-23 03:56:01'",
@@ -389,12 +391,10 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   }
 
   RowTypePtr rowType_;
-  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits_;
 };
 
 TEST_F(ParquetTableScanTest, basic) {
   loadData(
-      getExampleFilePath("sample.parquet"),
       ROW({"a", "b"}, {BIGINT(), DOUBLE()}),
       makeRowVector(
           {"a", "b"},
@@ -404,64 +404,111 @@ TEST_F(ParquetTableScanTest, basic) {
           }));
 
   // Plain select.
-  assertSelect({"a"}, "SELECT a FROM tmp");
-  assertSelect({"b"}, "SELECT b FROM tmp");
-  assertSelect({"a", "b"}, "SELECT a, b FROM tmp");
-  assertSelect({"b", "a"}, "SELECT b, a FROM tmp");
+  const auto filePath = getExampleFilePath("sample.parquet");
+  assertSelect({makeSplit(filePath)}, {"a"}, "SELECT a FROM tmp");
+  assertSelect({makeSplit(filePath)}, {"b"}, "SELECT b FROM tmp");
+  assertSelect({makeSplit(filePath)}, {"a", "b"}, "SELECT a, b FROM tmp");
+  assertSelect({makeSplit(filePath)}, {"b", "a"}, "SELECT b, a FROM tmp");
 
   // With filters.
-  assertSelectWithFilter({"a"}, {"a < 3"}, "", "SELECT a FROM tmp WHERE a < 3");
   assertSelectWithFilter(
-      {"a", "b"}, {"a < 3"}, "", "SELECT a, b FROM tmp WHERE a < 3");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a < 3"},
+      "",
+      "SELECT a FROM tmp WHERE a < 3");
   assertSelectWithFilter(
-      {"b", "a"}, {"a < 3"}, "", "SELECT b, a FROM tmp WHERE a < 3");
+      {makeSplit(filePath)},
+      {"a", "b"},
+      {"a < 3"},
+      "",
+      "SELECT a, b FROM tmp WHERE a < 3");
   assertSelectWithFilter(
-      {"a", "b"}, {"a < 0"}, "", "SELECT a, b FROM tmp WHERE a < 0");
+      {makeSplit(filePath)},
+      {"b", "a"},
+      {"a < 3"},
+      "",
+      "SELECT b, a FROM tmp WHERE a < 3");
+  assertSelectWithFilter(
+      {makeSplit(filePath)},
+      {"a", "b"},
+      {"a < 0"},
+      "",
+      "SELECT a, b FROM tmp WHERE a < 0");
 
   assertSelectWithFilter(
-      {"b"}, {"b < DOUBLE '2.0'"}, "", "SELECT b FROM tmp WHERE b < 2.0");
+      {makeSplit(filePath)},
+      {"b"},
+      {"b < DOUBLE '2.0'"},
+      "",
+      "SELECT b FROM tmp WHERE b < 2.0");
   assertSelectWithFilter(
+      {makeSplit(filePath)},
       {"a", "b"},
       {"b >= DOUBLE '2.0'"},
       "",
       "SELECT a, b FROM tmp WHERE b >= 2.0");
   assertSelectWithFilter(
+      {makeSplit(filePath)},
       {"b", "a"},
       {"b <= DOUBLE '2.0'"},
       "",
       "SELECT b, a FROM tmp WHERE b <= 2.0");
   assertSelectWithFilter(
+      {makeSplit(filePath)},
       {"a", "b"},
       {"b < DOUBLE '0.0'"},
       "",
       "SELECT a, b FROM tmp WHERE b < 0.0");
 
   // With aggregations.
-  assertSelectWithAgg({"a"}, {"sum(a)"}, {}, "SELECT sum(a) FROM tmp");
-  assertSelectWithAgg({"b"}, {"max(b)"}, {}, "SELECT max(b) FROM tmp");
   assertSelectWithAgg(
-      {"a", "b"}, {"min(a)", "max(b)"}, {}, "SELECT min(a), max(b) FROM tmp");
+      {makeSplit(filePath)}, {"a"}, {"sum(a)"}, {}, "SELECT sum(a) FROM tmp");
   assertSelectWithAgg(
-      {"b", "a"}, {"max(b)"}, {"a"}, "SELECT max(b), a FROM tmp GROUP BY a");
+      {makeSplit(filePath)}, {"b"}, {"max(b)"}, {}, "SELECT max(b) FROM tmp");
   assertSelectWithAgg(
-      {"a", "b"}, {"max(a)"}, {"b"}, "SELECT max(a), b FROM tmp GROUP BY b");
+      {makeSplit(filePath)},
+      {"a", "b"},
+      {"min(a)", "max(b)"},
+      {},
+      "SELECT min(a), max(b) FROM tmp");
+  assertSelectWithAgg(
+      {makeSplit(filePath)},
+      {"b", "a"},
+      {"max(b)"},
+      {"a"},
+      "SELECT max(b), a FROM tmp GROUP BY a");
+  assertSelectWithAgg(
+      {makeSplit(filePath)},
+      {"a", "b"},
+      {"max(a)"},
+      {"b"},
+      "SELECT max(a), b FROM tmp GROUP BY b");
 
   // With filter and aggregation.
   assertSelectWithFilterAndAgg(
-      {"a"}, {"a < 3"}, {"sum(a)"}, {}, "SELECT sum(a) FROM tmp WHERE a < 3");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a < 3"},
+      {"sum(a)"},
+      {},
+      "SELECT sum(a) FROM tmp WHERE a < 3");
   assertSelectWithFilterAndAgg(
+      {makeSplit(filePath)},
       {"a", "b"},
       {"a < 3"},
       {"sum(b)"},
       {},
       "SELECT sum(b) FROM tmp WHERE a < 3");
   assertSelectWithFilterAndAgg(
+      {makeSplit(filePath)},
       {"a", "b"},
       {"a < 3"},
       {"min(a)", "max(b)"},
       {},
       "SELECT min(a), max(b) FROM tmp WHERE a < 3");
   assertSelectWithFilterAndAgg(
+      {makeSplit(filePath)},
       {"b", "a"},
       {"a < 3"},
       {"max(b)"},
@@ -493,25 +540,45 @@ TEST_F(ParquetTableScanTest, decimalSubfieldFilter) {
   std::vector<int64_t> unscaledShortValues(20);
   std::iota(unscaledShortValues.begin(), unscaledShortValues.end(), 10001);
   loadData(
-      getExampleFilePath("decimal.parquet"),
       ROW({"a"}, {DECIMAL(5, 2)}),
       makeRowVector(
           {"a"},
           {
               makeFlatVector(unscaledShortValues, DECIMAL(5, 2)),
           }));
-
+  const auto filePath = getExampleFilePath("decimal.parquet");
   assertSelectWithFilter(
-      {"a"}, {"a < 100.07"}, "", "SELECT a FROM tmp WHERE a < 100.07");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a < 100.07"},
+      "",
+      "SELECT a FROM tmp WHERE a < 100.07");
   assertSelectWithFilter(
-      {"a"}, {"a <= 100.07"}, "", "SELECT a FROM tmp WHERE a <= 100.07");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a <= 100.07"},
+      "",
+      "SELECT a FROM tmp WHERE a <= 100.07");
   assertSelectWithFilter(
-      {"a"}, {"a > 100.07"}, "", "SELECT a FROM tmp WHERE a > 100.07");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a > 100.07"},
+      "",
+      "SELECT a FROM tmp WHERE a > 100.07");
   assertSelectWithFilter(
-      {"a"}, {"a >= 100.07"}, "", "SELECT a FROM tmp WHERE a >= 100.07");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a >= 100.07"},
+      "",
+      "SELECT a FROM tmp WHERE a >= 100.07");
   assertSelectWithFilter(
-      {"a"}, {"a = 100.07"}, "", "SELECT a FROM tmp WHERE a = 100.07");
+      {makeSplit(filePath)},
+      {"a"},
+      {"a = 100.07"},
+      "",
+      "SELECT a FROM tmp WHERE a = 100.07");
   assertSelectWithFilter(
+      {makeSplit(filePath)},
       {"a"},
       {"a BETWEEN 100.07 AND 100.12"},
       "",
@@ -519,11 +586,19 @@ TEST_F(ParquetTableScanTest, decimalSubfieldFilter) {
 
   BOLT_ASSERT_THROW(
       assertSelectWithFilter(
-          {"a"}, {"a < 1000.7"}, "", "SELECT a FROM tmp WHERE a < 1000.7"),
+          {makeSplit(filePath)},
+          {"a"},
+          {"a < 1000.7"},
+          "",
+          "SELECT a FROM tmp WHERE a < 1000.7"),
       "Scalar function signature is not supported: lt(DECIMAL(5, 2), DECIMAL(5, 1))");
   BOLT_ASSERT_THROW(
       assertSelectWithFilter(
-          {"a"}, {"a = 1000.7"}, "", "SELECT a FROM tmp WHERE a = 1000.7"),
+          {makeSplit(filePath)},
+          {"a"},
+          {"a = 1000.7"},
+          "",
+          "SELECT a FROM tmp WHERE a = 1000.7"),
       "Scalar function signature is not supported: eq(DECIMAL(5, 2), DECIMAL(5, 1))");
 }
 
@@ -532,7 +607,6 @@ TEST_F(ParquetTableScanTest, map) {
   auto vector = makeMapVector<StringView, StringView>({{{"name", "gluten"}}});
 
   loadData(
-      getExampleFilePath("types.parquet"),
       ROW({"map"}, {MAP(VARCHAR(), VARCHAR())}),
       makeRowVector(
           {"map"},
@@ -540,7 +614,12 @@ TEST_F(ParquetTableScanTest, map) {
               vector,
           }));
 
-  assertSelectWithFilter({"map"}, {}, "", "SELECT map FROM tmp");
+  assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("types.parquet"))},
+      {"map"},
+      {},
+      "",
+      "SELECT map FROM tmp");
 }
 
 TEST_F(ParquetTableScanTest, variantE2EProjectAndAggregation) {
@@ -573,23 +652,25 @@ TEST_F(ParquetTableScanTest, variantE2EProjectAndAggregation) {
 }
 
 TEST_F(ParquetTableScanTest, nullMap) {
-  auto path = getExampleFilePath("null_map.parquet");
   loadData(
-      path,
       ROW({"i", "c"}, {VARCHAR(), MAP(VARCHAR(), VARCHAR())}),
       makeRowVector(
           {"i", "c"},
           {makeConstant<std::string>("1", 1),
            makeNullableMapVector<std::string, std::string>({std::nullopt})}));
 
-  assertSelectWithFilter({"i", "c"}, {}, "", "SELECT i, c FROM tmp");
+  assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("null_map.parquet"))},
+      {"i", "c"},
+      {},
+      "",
+      "SELECT i, c FROM tmp");
 }
 
 // Core dump is fixed.
 TEST_F(ParquetTableScanTest, singleRowStruct) {
   auto vector = makeArrayVector<int32_t>({{}});
   loadData(
-      getExampleFilePath("single_row_struct.parquet"),
       ROW({"s"}, {ROW({"a", "b"}, {BIGINT(), BIGINT()})}),
       makeRowVector(
           {"s"},
@@ -597,23 +678,30 @@ TEST_F(ParquetTableScanTest, singleRowStruct) {
               vector,
           }));
 
-  assertSelectWithFilter({"s"}, {}, "", "SELECT (0, 1)");
+  assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("single_row_struct.parquet"))},
+      {"s"},
+      {},
+      "",
+      "SELECT (0, 1)");
 }
 
 // Core dump and incorrect result are fixed.
 TEST_F(ParquetTableScanTest, DISABLED_array) {
   auto vector = makeArrayVector<int32_t>({});
   loadData(
-      getExampleFilePath("old_repeated_int.parquet"),
       ROW({"repeatedInt"}, {ARRAY(INTEGER())}),
       makeRowVector(
           {"repeatedInt"},
           {
               vector,
           }));
-
   assertSelectWithFilter(
-      {"repeatedInt"}, {}, "", "SELECT UNNEST(array[array[1,2,3]])");
+      {makeSplit(getExampleFilePath("old_repeated_int.parquet"))},
+      {"repeatedInt"},
+      {},
+      "",
+      "SELECT UNNEST(array[array[1,2,3]])");
 }
 
 // Optional array with required elements.
@@ -621,7 +709,6 @@ TEST_F(ParquetTableScanTest, optArrayReqEle) {
   auto vector = makeArrayVector<StringView>({});
 
   loadData(
-      getExampleFilePath("array_0.parquet"),
       ROW({"_1"}, {ARRAY(VARCHAR())}),
       makeRowVector(
           {"_1"},
@@ -630,6 +717,7 @@ TEST_F(ParquetTableScanTest, optArrayReqEle) {
           }));
 
   assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("array_0.parquet"))},
       {"_1"},
       {},
       "",
@@ -641,7 +729,6 @@ TEST_F(ParquetTableScanTest, reqArrayReqEle) {
   auto vector = makeArrayVector<StringView>({});
 
   loadData(
-      getExampleFilePath("array_1.parquet"),
       ROW({"_1"}, {ARRAY(VARCHAR())}),
       makeRowVector(
           {"_1"},
@@ -650,6 +737,7 @@ TEST_F(ParquetTableScanTest, reqArrayReqEle) {
           }));
 
   assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("array_1.parquet"))},
       {"_1"},
       {},
       "",
@@ -661,7 +749,6 @@ TEST_F(ParquetTableScanTest, reqArrayOptEle) {
   auto vector = makeArrayVector<StringView>({});
 
   loadData(
-      getExampleFilePath("array_2.parquet"),
       ROW({"_1"}, {ARRAY(VARCHAR())}),
       makeRowVector(
           {"_1"},
@@ -670,6 +757,7 @@ TEST_F(ParquetTableScanTest, reqArrayOptEle) {
           }));
 
   assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("array_2.parquet"))},
       {"_1"},
       {},
       "",
@@ -688,6 +776,7 @@ TEST_F(ParquetTableScanTest, arrayOfArrayTest) {
           }));
 
   assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("array_of_array1.parquet"))},
       {"_1"},
       {},
       "",
@@ -699,7 +788,6 @@ TEST_F(ParquetTableScanTest, reqArrayLegacy) {
   auto vector = makeArrayVector<StringView>({});
 
   loadData(
-      getExampleFilePath("array_3.parquet"),
       ROW({"element"}, {ARRAY(VARCHAR())}),
       makeRowVector(
           {"element"},
@@ -708,6 +796,7 @@ TEST_F(ParquetTableScanTest, reqArrayLegacy) {
           }));
 
   assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("array_3.parquet"))},
       {"element"},
       {},
       "",
@@ -759,7 +848,6 @@ TEST_F(ParquetTableScanTest, rowIndex) {
   // case 1: file not have `_tmp_metadata_row_index`, scan generate it for user.
   auto filePath = getExampleFilePath("sample.parquet");
   loadData(
-      filePath,
       ROW({"a", "b", "_tmp_metadata_row_index", kPath},
           {BIGINT(), DOUBLE(), BIGINT(), VARCHAR()}),
       makeRowVector(
@@ -770,9 +858,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
               makeFlatVector<int64_t>(20, [](auto row) { return row; }),
               makeFlatVector<std::string>(
                   20, [filePath](auto /*row*/) { return filePath; }),
-          }),
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{{kPath, filePath}});
+	   }));
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
   assignments["a"] = std::make_shared<connector::hive::HiveColumnHandle>(
@@ -793,16 +879,31 @@ TEST_F(ParquetTableScanTest, rowIndex) {
           BIGINT(),
           BIGINT());
 
-  assertSelectWithAssignments({"a"}, assignments, "SELECT a FROM tmp");
+  assertSelectWithAssignments({makeSplit(
+          filePath,
+          std::nullopt,
+          std::unordered_map<std::string, std::string>{{kPath, filePath}})}, {"a"}, assignments, "SELECT a FROM tmp");
   assertSelectWithAssignments(
+		  {makeSplit(
+          filePath,
+          std::nullopt,
+          std::unordered_map<std::string, std::string>{{kPath, filePath}})},
       {"a", "_tmp_metadata_row_index"},
       assignments,
       "SELECT a, _tmp_metadata_row_index FROM tmp");
   assertSelectWithAssignments(
+{makeSplit(
+          filePath,
+          std::nullopt,
+          std::unordered_map<std::string, std::string>{{kPath, filePath}})},
       {"_tmp_metadata_row_index", "a"},
       assignments,
       "SELECT _tmp_metadata_row_index, a FROM tmp");
   assertSelectWithAssignments(
+		  {makeSplit(
+          filePath,
+          std::nullopt,
+          std::unordered_map<std::string, std::string>{{kPath, filePath}})},
       {kPath, "_tmp_metadata_row_index"},
       assignments,
       fmt::format("SELECT {}, _tmp_metadata_row_index FROM tmp", kPath));
@@ -810,7 +911,6 @@ TEST_F(ParquetTableScanTest, rowIndex) {
   // case 2: file has `_tmp_metadata_row_index` column, then use user data
   // insteads of generating it.
   loadData(
-      getExampleFilePath("sample_with_rowindex.parquet"),
       ROW({"a", "b", "_tmp_metadata_row_index"},
           {BIGINT(), DOUBLE(), BIGINT()}),
       makeRowVector(
@@ -822,8 +922,10 @@ TEST_F(ParquetTableScanTest, rowIndex) {
           }));
 
   assignments.erase(kPath);
-  assertSelectWithAssignments({"a"}, assignments, "SELECT a FROM tmp");
+  filePath = getExampleFilePath("sample_with_rowindex.parquet");
+  assertSelect({makeSplit(filePath)}, {"a"}, "SELECT a FROM tmp");
   assertSelectWithAssignments(
+		   {makeSplit(filePath)},
       {"a", "_tmp_metadata_row_index"},
       assignments,
       "SELECT a, _tmp_metadata_row_index FROM tmp");
@@ -831,18 +933,18 @@ TEST_F(ParquetTableScanTest, rowIndex) {
 
 TEST_F(ParquetTableScanTest, DISABLED_structSelection) {
   auto vector = makeArrayVector<StringView>({{}});
+  const auto filePath = getExampleFilePath("contacts.parquet");
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"}, {ROW({"first", "last"}, {VARCHAR(), VARCHAR()})}),
       makeRowVector(
           {"t"},
           {
               vector,
           }));
-  assertSelectWithFilter({"name"}, {}, "", "SELECT ('Janet', 'Jones')");
+  assertSelectWithFilter(
+      {makeSplit(filePath)}, {"name"}, {}, "", "SELECT ('Janet', 'Jones')");
 
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"},
           {ROW(
               {"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()})}),
@@ -851,50 +953,54 @@ TEST_F(ParquetTableScanTest, DISABLED_structSelection) {
           {
               vector,
           }));
-  assertSelectWithFilter({"name"}, {}, "", "SELECT ('Janet', null, 'Jones')");
+  assertSelectWithFilter(
+      {makeSplit(filePath)},
+      {"name"},
+      {},
+      "",
+      "SELECT ('Janet', null, 'Jones')");
 
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"}, {ROW({"first", "middle"}, {VARCHAR(), VARCHAR()})}),
       makeRowVector(
           {"t"},
           {
               vector,
           }));
-  assertSelectWithFilter({"name"}, {}, "", "SELECT ('Janet', null)");
+  assertSelectWithFilter(
+      {makeSplit(filePath)}, {"name"}, {}, "", "SELECT ('Janet', null)");
 
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"}, {ROW({"middle", "last"}, {VARCHAR(), VARCHAR()})}),
       makeRowVector(
           {"t"},
           {
               vector,
           }));
-  assertSelectWithFilter({"name"}, {}, "", "SELECT (null, 'Jones')");
+  assertSelectWithFilter(
+      {makeSplit(filePath)}, {"name"}, {}, "", "SELECT (null, 'Jones')");
 
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"}, {ROW({"middle"}, {VARCHAR()})}),
       makeRowVector(
           {"t"},
           {
               vector,
           }));
-  assertSelectWithFilter({"name"}, {}, "", "SELECT row(null)");
+  assertSelectWithFilter(
+      {makeSplit(filePath)}, {"name"}, {}, "", "SELECT row(null)");
 
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"}, {ROW({"middle", "info"}, {VARCHAR(), VARCHAR()})}),
       makeRowVector(
           {"t"},
           {
               vector,
           }));
-  assertSelectWithFilter({"name"}, {}, "", "SELECT NULL");
+  assertSelectWithFilter(
+      {makeSplit(filePath)}, {"name"}, {}, "", "SELECT NULL");
 
   loadData(
-      getExampleFilePath("contacts.parquet"),
       ROW({"name"}, {ROW({}, {})}),
       makeRowVector(
           {"t"},
@@ -902,7 +1008,8 @@ TEST_F(ParquetTableScanTest, DISABLED_structSelection) {
               vector,
           }));
 
-  assertSelectWithFilter({"name"}, {}, "", "SELECT t from tmp");
+  assertSelectWithFilter(
+      {makeSplit(filePath)}, {"name"}, {}, "", "SELECT t from tmp");
 }
 
 TEST_F(ParquetTableScanTest, timestampInt96Dictionary) {
@@ -926,24 +1033,32 @@ TEST_F(ParquetTableScanTest, timestampINT96) {
 
   auto vector = makeArrayVector<Timestamp>({{}});
   loadData(
-      getExampleFilePath("timestamp_dict_int96.parquet"),
       ROW({"time"}, {TIMESTAMP()}),
       makeRowVector(
           {"time"},
           {
               vector,
           }));
-  assertSelect({"time"}, "SELECT time from expected");
+  assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("timestamp_dict_int96.parquet"))},
+      {"time"},
+      {},
+      "",
+      "SELECT time from expected");
 
   loadData(
-      getExampleFilePath("timestamp_plain_int96.parquet"),
       ROW({"time"}, {TIMESTAMP()}),
       makeRowVector(
           {"time"},
           {
               vector,
           }));
-  assertSelect({"time"}, "SELECT time from expected");
+  assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("timestamp_plain_int96.parquet"))},
+      {"time"},
+      {},
+      "",
+      "SELECT time from expected");
 }
 
 TEST_F(ParquetTableScanTest, timestampInt64Dictionary) {
@@ -984,9 +1099,10 @@ TEST_F(ParquetTableScanTest, timestampConvertedType) {
       });
   const auto schema = asRowType(vector->type());
   const auto path = getExampleFilePath("tmmillis_i64.parquet");
-  loadData(path, schema, vector);
+  loadData(schema, vector);
 
-  assertSelectWithFilter({"time"}, {}, "", "SELECT time from tmp");
+  assertSelectWithFilter(
+      {makeSplit(path)}, {"time"}, {}, "", "SELECT time from tmp");
 }
 
 TEST_F(ParquetTableScanTest, timestampPrecisionMicrosecond) {
@@ -1042,6 +1158,7 @@ TEST_F(ParquetTableScanTest, timestampPrecisionMicrosecond) {
 TEST_F(ParquetTableScanTest, structMatchByName) {
   const auto assertSelectUseColumnNames =
       [this](
+          const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits,
           const RowTypePtr& outputType,
           const std::string& sql,
           const std::string& remainingFilter = "") {
@@ -1055,7 +1172,7 @@ TEST_F(ParquetTableScanTest, structMatchByName) {
             kHiveConnectorId,
             connector::hive::HiveConfig::kParquetUseColumnNamesSession,
             "true");
-        query.splits(splits());
+        query.splits(splits);
         if (remainingFilter.empty()) {
           query.assertResults(sql);
         } else {
@@ -1078,38 +1195,60 @@ TEST_F(ParquetTableScanTest, structMatchByName) {
   auto file = TempFilePath::create();
   writeToParquetFile(file->getPath(), {vector}, {});
 
-  loadData(file->getPath(), asRowType(vector->type()), vector);
-  assertSelect({"id", "name", "address"}, "SELECT id, name, address from tmp");
+  loadData(asRowType(vector->type()), vector);
+  assertSelectWithFilter(
+      {makeSplit(file->getPath())},
+      {"id", "name", "address"},
+      {},
+      "",
+      "SELECT id, name, address from tmp");
 
   auto rowType =
       ROW({"id", "name", "email"},
           {BIGINT(),
            ROW({"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
            VARCHAR()});
-  loadData(file->getPath(), rowType, vector);
+  loadData(rowType, vector);
   assertSelectUseColumnNames(
-      rowType, "SELECT 2, ('Janet', null, 'Jones'), null");
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT 2, ('Janet', null, 'Jones'), null");
 
   assertSelectUseColumnNames(
-      rowType, "SELECT * from tmp where false", "not(is_null(name.middle))");
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT * from tmp where false",
+      "not(is_null(name.middle))");
 
   rowType =
       ROW({"id", "name", "address"},
           {BIGINT(), ROW({"a", "b"}, {VARCHAR(), VARCHAR()}), VARCHAR()});
-  loadData(file->getPath(), rowType, vector);
-  assertSelectUseColumnNames(rowType, "SELECT 2, null, '567 Maple Drive'");
+  loadData(rowType, vector);
+  assertSelectUseColumnNames(
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT 2, null, '567 Maple Drive'");
 
   assertSelectUseColumnNames(
-      rowType, "SELECT * from tmp where false", "not(is_null(name))");
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT * from tmp where false",
+      "not(is_null(name))");
 
   rowType =
       ROW({"id", "name", "address"},
           {BIGINT(), ROW({"full"}, {VARCHAR()}), VARCHAR()});
-  loadData(file->getPath(), rowType, vector);
-  assertSelectUseColumnNames(rowType, "SELECT 2, row(null), '567 Maple Drive'");
+  loadData(rowType, vector);
+  assertSelectUseColumnNames(
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT 2, row(null), '567 Maple Drive'");
 
   assertSelectUseColumnNames(
-      rowType, "SELECT * from tmp where false", "not(is_null(name.full))");
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT * from tmp where false",
+      "not(is_null(name.full))");
 
   rowType = ROW({"id", "name", "address"}, {BIGINT(), ROW({}, {}), VARCHAR()});
   const auto plan = PlanBuilder()
@@ -1149,8 +1288,11 @@ TEST_F(ParquetTableScanTest, structMatchByName) {
           {BIGINT(),
            ROW({"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
            VARCHAR()});
-  loadData(file->getPath(), rowType, vector);
-  assertSelectUseColumnNames(rowType, "SELECT 2, null, '567 Maple Drive'");
+  loadData(rowType, vector);
+  assertSelectUseColumnNames(
+      {makeSplit(file->getPath())},
+      rowType,
+      "SELECT 2, null, '567 Maple Drive'");
 
   auto lowerCasePlan =
       PlanBuilder().tableScan(rowType, {}, "", rowType).planNode();
@@ -1163,7 +1305,7 @@ TEST_F(ParquetTableScanTest, structMatchByName) {
           kHiveConnectorId,
           connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession,
           "true")
-      .splits(splits())
+      .splits({makeSplit(file->getPath())})
       .assertResults("SELECT 2, ('Janet', null, 'Jones'), '567 Maple Drive'");
 }
 
@@ -1180,7 +1322,6 @@ TEST_F(ParquetTableScanTest, testColumnNotExists) {
   //  optional double b;
   // }
   loadData(
-      getExampleFilePath("sample.parquet"),
       rowType,
       makeRowVector(
           {"a", "b"},
@@ -1190,6 +1331,7 @@ TEST_F(ParquetTableScanTest, testColumnNotExists) {
           }));
 
   assertSelectWithDataColumns(
+      {makeSplit(getExampleFilePath("sample.parquet"))},
       {"a", "b", "not_exists", "not_exists_array", "not_exists_map"},
       rowType,
       "SELECT a, b, NULL, NULL, NULL FROM tmp");

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -199,6 +199,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   }
 
   void assertSelectWithAssignments(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits,
       std::vector<std::string>&& outputColumnNames,
       const std::unordered_map<
           std::string,
@@ -208,7 +209,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     auto tableHandle = makeTableHandle({}, nullptr, "hive_table", rowType);
     auto plan =
         PlanBuilder().tableScan(rowType, tableHandle, assignments).planNode();
-    assertQuery(plan, splits_, sql);
+    assertQuery(plan, splits, sql);
   }
 
   void assertSelectWithAgg(
@@ -858,7 +859,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
               makeFlatVector<int64_t>(20, [](auto row) { return row; }),
               makeFlatVector<std::string>(
                   20, [filePath](auto /*row*/) { return filePath; }),
-	   }));
+          }));
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
   assignments["a"] = std::make_shared<connector::hive::HiveColumnHandle>(
@@ -879,12 +880,16 @@ TEST_F(ParquetTableScanTest, rowIndex) {
           BIGINT(),
           BIGINT());
 
-  assertSelectWithAssignments({makeSplit(
+  assertSelectWithAssignments(
+      {makeSplit(
           filePath,
           std::nullopt,
-          std::unordered_map<std::string, std::string>{{kPath, filePath}})}, {"a"}, assignments, "SELECT a FROM tmp");
+          std::unordered_map<std::string, std::string>{{kPath, filePath}})},
+      {"a"},
+      assignments,
+      "SELECT a FROM tmp");
   assertSelectWithAssignments(
-		  {makeSplit(
+      {makeSplit(
           filePath,
           std::nullopt,
           std::unordered_map<std::string, std::string>{{kPath, filePath}})},
@@ -892,7 +897,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
       assignments,
       "SELECT a, _tmp_metadata_row_index FROM tmp");
   assertSelectWithAssignments(
-{makeSplit(
+      {makeSplit(
           filePath,
           std::nullopt,
           std::unordered_map<std::string, std::string>{{kPath, filePath}})},
@@ -900,7 +905,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
       assignments,
       "SELECT _tmp_metadata_row_index, a FROM tmp");
   assertSelectWithAssignments(
-		  {makeSplit(
+      {makeSplit(
           filePath,
           std::nullopt,
           std::unordered_map<std::string, std::string>{{kPath, filePath}})},
@@ -925,7 +930,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
   filePath = getExampleFilePath("sample_with_rowindex.parquet");
   assertSelect({makeSplit(filePath)}, {"a"}, "SELECT a FROM tmp");
   assertSelectWithAssignments(
-		   {makeSplit(filePath)},
+      {makeSplit(filePath)},
       {"a", "_tmp_metadata_row_index"},
       assignments,
       "SELECT a, _tmp_metadata_row_index FROM tmp");

--- a/bolt/exec/TableScan.cpp
+++ b/bolt/exec/TableScan.cpp
@@ -184,6 +184,9 @@ RowVectorPtr TableScan::getOutput() {
       // A point for test code injection.
       BOLT_TEST_ADJUST("bytedance::bolt::exec::TableScan::getOutput", this);
 
+      curStatus_ = "getOutput: checkPreload";
+      checkPreload();
+
       exec::Split split;
       curStatus_ = "getOutput: task->getSplitOrFuture";
       blockingReason_ = driverCtx_->task->getSplitOrFuture(
@@ -363,8 +366,6 @@ RowVectorPtr TableScan::getOutput() {
         maxReadBatchSize_, std::max<int32_t>(minReadBatchSize_, readBatchSize));
     curStatus_ = "getOutput: dataSource_->next";
     auto dataOptional = dataSource_->next(readBatchSize, blockingFuture_);
-    curStatus_ = "getOutput: checkPreload";
-    checkPreload();
 
     estimateBytesPerRow(dataOptional);
 
@@ -488,7 +489,6 @@ void TableScan::checkPreload() {
       !connector_->supportsSplitPreload() || !asyncThreadCtx_->allowPreload()) {
     return;
   }
-  if (dataSource_->allPrefetchIssued()) {
     maxPreloadedSplits_ = driverCtx_->task->numDrivers(driverCtx_->driver) *
         maxSplitPreloadPerDriver_;
     if (!splitPreloader_) {
@@ -509,7 +509,6 @@ void TableScan::checkPreload() {
             });
           };
     }
-  }
 }
 
 bool TableScan::isFinished() {

--- a/bolt/exec/tests/HashJoinTest.cpp
+++ b/bolt/exec/tests/HashJoinTest.cpp
@@ -65,6 +65,9 @@ struct TestParam {
       : numDrivers(_numDrivers), hybridJoin(_hybridJoin) {}
 };
 
+using SplitPath =
+    std::unordered_map<core::PlanNodeId, std::vector<std::string>>;
+
 using SplitInput =
     std::unordered_map<core::PlanNodeId, std::vector<exec::Split>>;
 
@@ -373,8 +376,20 @@ class HashJoinBuilder {
     return *this;
   }
 
-  HashJoinBuilder& inputSplits(const SplitInput& inputSplits) {
-    makeInputSplits_ = [inputSplits] { return inputSplits; };
+  HashJoinBuilder& inputSplits(const SplitPath& splitPaths) {
+    makeInputSplits_ = [splitPaths] {
+      SplitInput inputSplits;
+      for (const auto& [nodeId, paths] : splitPaths) {
+        std::vector<exec::Split> splits;
+        splits.reserve(paths.size());
+        for (const auto& path : paths) {
+          splits.emplace_back(
+              exec::Split(HiveConnectorSplitBuilder(path).build()));
+        }
+        inputSplits[nodeId] = std::move(splits);
+      }
+      return inputSplits;
+    };
     return *this;
   }
 
@@ -887,15 +902,13 @@ class HashJoinTest : public HiveConnectorTestBase {
                       outputLayout,
                       joinType)
                   .planNode();
-    SplitInput splitInput = {
-        {probeScanId,
-         {exec::Split(makeHiveConnectorSplit(probeFile->getPath()))}},
-        {buildScanId,
-         {exec::Split(makeHiveConnectorSplit(buildFile->getPath()))}},
+    SplitPath splitPaths = {
+        {probeScanId, {probeFile->getPath()}},
+        {buildScanId, {buildFile->getPath()}},
     };
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
-        .inputSplits(splitInput)
+        .inputSplits(splitPaths)
         .checkSpillStats(false)
         .referenceQuery(referenceQuery)
         .run();
@@ -1947,21 +1960,21 @@ TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
                       core::JoinType::kLeftSemiFilter)
                   .planNode();
 
-  SplitInput splitInput = {
-      {probeScanId, {exec::Split(makeHiveConnectorSplit(probeFile->path))}},
-      {buildScanId, {exec::Split(makeHiveConnectorSplit(buildFile->path))}},
+  SplitPath splitPaths = {
+      {probeScanId, {probeFile->getPath()}},
+      {buildScanId, {buildFile->getPath()}},
   };
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery("SELECT t0, t1 FROM t WHERE t0 IN (SELECT u0 FROM u)")
       .run();
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery("SELECT t0, t1 FROM t WHERE t0 IN (SELECT u0 FROM u)")
       .run();
@@ -1985,7 +1998,7 @@ TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery(
           "SELECT t0, t1 FROM t WHERE t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0)")
@@ -1993,7 +2006,7 @@ TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery(
           "SELECT t0, t1 FROM t WHERE t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0)")
@@ -3610,14 +3623,14 @@ TEST_F(HashJoinTest, nullAwareRightSemiProjectOverScan) {
                       true /*nullAware*/)
                   .planNode();
 
-  SplitInput splitInput = {
-      {probeScanId, {exec::Split(makeHiveConnectorSplit(probeFile->path))}},
-      {buildScanId, {exec::Split(makeHiveConnectorSplit(buildFile->path))}},
+  SplitPath splitPaths = {
+      {probeScanId, {probeFile->getPath()}},
+      {buildScanId, {buildFile->getPath()}},
   };
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
       .run();
@@ -4209,21 +4222,21 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
                       core::JoinType::kLeftSemiProject)
                   .planNode();
 
-  SplitInput splitInput = {
-      {probeScanId, {exec::Split(makeHiveConnectorSplit(probeFile->path))}},
-      {buildScanId, {exec::Split(makeHiveConnectorSplit(buildFile->path))}},
+  SplitPath splitPaths = {
+      {probeScanId, {probeFile->getPath()}},
+      {buildScanId, {buildFile->getPath()}},
   };
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
@@ -4247,7 +4260,7 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
@@ -4255,7 +4268,7 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .checkSpillStats(false)
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
@@ -5572,13 +5585,23 @@ TEST_F(HashJoinTest, dynamicFiltersAppliedToPreloadedSplits) {
     probeVectors.push_back(rowVector);
     tempFiles.push_back(TempFilePath::create());
     writeToFile(tempFiles.back()->path, rowVector);
-    auto split = HiveConnectorSplitBuilder(tempFiles.back()->path)
-                     .connectorId(kHiveConnectorId)
-                     .fileFormat(dwio::common::FileFormat::DWRF)
-                     .partitionKey("p1", std::to_string(i))
-                     .build();
-    probeSplits.push_back(exec::Split(split));
   }
+
+  auto makeInputSplits = [&](const core::PlanNodeId& nodeId) {
+    return [&] {
+      std::vector<exec::Split> splits;
+      splits.reserve(tempFiles.size());
+      for (int32_t i = 0; i < tempFiles.size(); ++i) {
+        auto split = HiveConnectorSplitBuilder(tempFiles[i]->getPath())
+                         .partitionKey("p1", std::to_string(i))
+                         .build();
+        splits.emplace_back(exec::Split(split));
+      }
+      SplitInput inputSplits;
+      inputSplits.emplace(nodeId, splits);
+      return inputSplits;
+    };
+  };
 
   auto outputType = ROW({"p0", "p1"}, {BIGINT(), BIGINT()});
   ColumnHandleMap assignments = {
@@ -5620,7 +5643,7 @@ TEST_F(HashJoinTest, dynamicFiltersAppliedToPreloadedSplits) {
       .planNode(std::move(op))
       .config(core::QueryConfig::kMaxSplitPreloadPerDriver, "3")
       .injectSpill(false)
-      .inputSplits({{probeScanId, probeSplits}})
+      .makeInputSplits({makeInputSplits(probeScanId)})
       .referenceQuery("select p.p0 from p, b where b.b0 = p.p1")
       .checkSpillStats(false)
       .verifier([&](const std::shared_ptr<Task>& task, bool /*hasSpill*/) {
@@ -5682,11 +5705,10 @@ TEST_F(HashJoinTest, dynamicFiltersPushDownThroughAgg) {
                 .capturePlanNodeId(joinNodeId)
                 .planNode();
 
-  SplitInput splitInput = {
-      {scanNodeId, {Split(makeHiveConnectorSplit(probeFile->getPath()))}}};
+  SplitPath splitPaths = {{scanNodeId, {probeFile->getPath()}}};
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(std::move(op))
-      .inputSplits(splitInput)
+      .inputSplits(splitPaths)
       .injectSpill(false)
       .checkSpillStats(false)
       .referenceQuery("SELECT c0, sum(c1) FROM t, u WHERE c0 = u0 group by c0")
@@ -6184,11 +6206,6 @@ TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
   std::vector<RowVectorPtr> buildVectors{
       makeRowVector({"c0"}, {makeFlatVector<int64_t>({0, 1, 2})})};
   createDuckDbTable("t", buildVectors);
-  auto split = HiveConnectorSplitBuilder(filePaths[0]->path)
-                   .connectorId(kHiveConnectorId)
-                   .fileFormat(dwio::common::FileFormat::DWRF)
-                   .partitionKey("k", "0")
-                   .build();
   auto outputType = ROW({"n1_0", "n1_1"}, {BIGINT(), BIGINT()});
   ColumnHandleMap assignments = {
       {"n1_0", regularColumn("c0", BIGINT())},
@@ -6212,11 +6229,20 @@ TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
               core::JoinType::kInner)
           .project({"c0"})
           .planNode();
-  SplitInput splits = {{probeScanId, {exec::Split(split)}}};
+
+  auto makeInputSplits = [&](const core::PlanNodeId& nodeId) {
+    return [&] {
+      auto split = HiveConnectorSplitBuilder(filePaths[0]->getPath())
+                       .partitionKey("k", "0")
+                       .build();
+      SplitInput splits = {{nodeId, {exec::Split(split)}}};
+      return splits;
+    };
+  };
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(std::move(op))
-      .inputSplits(splits)
+      .makeInputSplits(makeInputSplits(probeScanId))
       .referenceQuery("select t.c0 from t, u where t.c0 = 0")
       .checkSpillStats(false)
       .run();

--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -1688,6 +1688,20 @@ TEST_F(TableScanTest, multipleSplits) {
   }
 }
 
+TEST_F(TableScanTest, preloadSplits) {
+  auto filePaths = makeFilePaths(10);
+  auto vectors = makeVectors(10, 10);
+  for (int32_t i = 0; i < vectors.size(); i++) {
+    writeToFile(filePaths[i]->getPath(), vectors[i]);
+  }
+  createDuckDbTable(vectors);
+
+  auto task = assertQuery(
+      tableScanNode(), filePaths, "SELECT * FROM tmp", /*numPrefetchSplit=*/10);
+  auto stats = getTableScanRuntimeStats(task);
+  ASSERT_EQ(stats.at("preloadedSplits").sum, 10);
+}
+
 TEST_F(TableScanTest, preloadingSplitClose) {
   auto filePaths = makeFilePaths(100);
   auto vectors = makeVectors(100, 100);
@@ -1766,11 +1780,11 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
 }
 
 TEST_F(TableScanTest, fileNotFound) {
+  auto assertMissingFile = [&](bool ignoreMissingFiles) {
   auto split = HiveConnectorSplitBuilder("/path/to/nowhere.orc")
                    .connectorId(kHiveConnectorId)
                    .fileFormat(dwio::common::FileFormat::DWRF)
                    .build();
-  auto assertMissingFile = [&](bool ignoreMissingFiles) {
     AssertQueryBuilder(tableScanNode())
         .connectorSessionProperty(
             kHiveConnectorId,
@@ -3703,13 +3717,19 @@ TEST_F(TableScanTest, reuseRowVector) {
                   .tableScan(rowType, {}, "c0 < 5")
                   .project({"c1.c0"})
                   .planNode();
-  auto split = HiveConnectorSplitBuilder(file->path)
+  auto firstSplit = HiveConnectorSplitBuilder(file->path)
+                   .connectorId(kHiveConnectorId)
+                   .fileFormat(dwio::common::FileFormat::DWRF)
+                   .build();
+  auto secondSplit = HiveConnectorSplitBuilder(file->path)
                    .connectorId(kHiveConnectorId)
                    .fileFormat(dwio::common::FileFormat::DWRF)
                    .build();
   auto expected = makeRowVector(
       {makeFlatVector<int32_t>(10, [](auto i) { return i % 5; })});
-  AssertQueryBuilder(plan).splits({split, split}).assertResults(expected);
+  AssertQueryBuilder(plan)
+      .splits({firstSplit, secondSplit})
+      .assertResults(expected);
 }
 
 // Tests queries that read more row fields than exist in the data.
@@ -3964,6 +3984,7 @@ TEST_F(TableScanTest, readMissingFieldsInMap) {
 
   // Now run query with column mapping using names - we should not be able to
   // find any names.
+  split = makeHiveConnectorSplit(filePath->getPath());
   result = AssertQueryBuilder(op)
                .connectorSessionProperty(
                    kHiveConnectorId,
@@ -4021,6 +4042,7 @@ TEST_F(TableScanTest, readMissingFieldsInMap) {
            .project({"i1"})
            .planNode();
 
+  split = makeHiveConnectorSplit(filePath->getPath());
   EXPECT_THROW(
       AssertQueryBuilder(op).split(split).copyResults(pool()), BoltUserError);
 }
@@ -4189,6 +4211,7 @@ TEST_F(TableScanTest, readMissingFieldsWithMoreColumns) {
 
   // Now run query with column mapping using names - we should not be able to
   // find any names, except for the last string column.
+  split = makeHiveConnectorSplit(filePath->getPath());
   result = AssertQueryBuilder(op)
                .connectorSessionProperty(
                    kHiveConnectorId,

--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -1699,7 +1699,7 @@ TEST_F(TableScanTest, preloadSplits) {
   auto task = assertQuery(
       tableScanNode(), filePaths, "SELECT * FROM tmp", /*numPrefetchSplit=*/10);
   auto stats = getTableScanRuntimeStats(task);
-  ASSERT_EQ(stats.at("preloadedSplits").sum, 10);
+  ASSERT_EQ(stats.at("preloadSplits").sum, 10);
 }
 
 TEST_F(TableScanTest, preloadingSplitClose) {
@@ -1828,6 +1828,18 @@ TEST_F(TableScanTest, emptyFile) {
   } catch (const BoltException& e) {
     EXPECT_EQ("ORC file is empty", e.message());
   }
+}
+
+TEST_F(TableScanTest, preloadEmptySplit) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto emptyVector = makeVectors(1, 0, rowType);
+  auto vector = makeVectors(1, 1'000, rowType);
+  auto filePaths = makeFilePaths(2);
+  writeToFile(filePaths[0]->path, vector[0]);
+  writeToFile(filePaths[1]->path, emptyVector[0]);
+  createDuckDbTable(vector);
+  auto op = tableScanNode(rowType);
+  assertQuery(op, filePaths, "SELECT * FROM tmp", 1);
 }
 
 TEST_F(TableScanTest, partitionedTableVarcharKey) {

--- a/bolt/tool/trace/tests/TableScanReplayerTest.cpp
+++ b/bolt/tool/trace/tests/TableScanReplayerTest.cpp
@@ -328,9 +328,9 @@ TEST_F(TableScanReplayerTest, subfieldPrunning) {
                         .endTableScan()
                         .capturePlanNodeId(traceNodeId_)
                         .planNode();
-  const auto split = makeHiveConnectorSplit(filePath->getPath());
-  const auto results =
-      AssertQueryBuilder(plan).split(split).copyResults(pool());
+  const auto results = AssertQueryBuilder(plan)
+                           .split(makeHiveConnectorSplit(filePath->getPath()))
+                           .copyResults(pool());
 
   const auto testDir = TempDirectoryPath::create();
   const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
@@ -342,7 +342,7 @@ TEST_F(TableScanReplayerTest, subfieldPrunning) {
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
           .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
-          .split(split)
+          .split(makeHiveConnectorSplit(filePath->getPath()))
           .copyResults(pool(), task);
 
   assertEqualResults({results}, {traceResult});


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
`getSplit()` reads a split, while `checkPreload()` preloads one. Previously, prefetching began with the second split. By calling `checkPreload()` before `getSplit()`, prefetching can now start from the first split.

Corresponding PR: https://github.com/facebookincubator/velox/pull/15460

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
