### PR TITLE
fix(ci): reduce contention on conan download in build

### DIFF
--- a/.github/actions/bolt-build-base/action.yml
+++ b/.github/actions/bolt-build-base/action.yml
@@ -13,7 +13,7 @@ runs:
         tools.build:exelinkflags=['-fuse-ld=mold', '-Wl,--allow-multiple-definition']
         tools.build:sharedlinkflags=['-fuse-ld=mold', '-Wl,--allow-multiple-definition']
         EOF
-        echo "core.download:parallel=16" >> ~/.conan2/global.conf
+        echo "core.download:parallel=8" >> ~/.conan2/global.conf
 
     - name: Add CI conan remote
       shell: bash

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Build and Test
+name: build main branch
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
### What problem does this PR solve?

CI sometimes fails with the error that conan fails to acquire a database lock in 20 seconds. This tries to reduce contention to reduce the occurrence of this error.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Reduces the number of parallel downloads to just 8 (from 16) to reduce the frequency at which the conan error occurs. It's likely the CI machines are under some higher load when this happens, so by reducing the amount of work the remote server has to do this should hopefully reduce the frequency.
