### PR TITLE
[fix][cp] Use orderable type in Spark max_by and min_by

### DIFF
--- a/bolt/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -108,7 +108,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .typeVariable("V")
-                           .typeVariable("C")
+                           .orderableTypeVariable("C")
                            .returnType("V")
                            .intermediateType("row(V,C)")
                            .argumentType("V")

--- a/bolt/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -29,6 +29,7 @@
  */
 
 #include <limits>
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
 #include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "bolt/functions/sparksql/aggregates/Register.h"
@@ -150,54 +151,18 @@ TEST_F(MinMaxByAggregateTest, arrayCompare) {
 
 TEST_F(MinMaxByAggregateTest, mapCompare) {
   auto data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeNullableMapVector<int64_t, int64_t>({
-          {{{1, 1}, {2, 2}}},
-          {{{1, 1}, {2, std::nullopt}}},
-          {{{4, 50}}},
-      }),
+      makeArrayVector<int64_t>({}),
+      makeNullableMapVector<int64_t, int64_t>({}),
   });
+  std::vector<RowVectorPtr> expected = {};
 
-  auto expected = makeRowVector({
-      makeArrayVector<int64_t>({
-          {4, 5},
-      }),
-      makeArrayVector<int64_t>({
-          {6, 7, 8},
-      }),
-  });
+  BOLT_ASSERT_USER_THROW(
+      testAggregations({data}, {}, {"spark_min_by(c0, c1)"}, expected),
+      "Aggregate function signature is not supported");
 
-  testAggregations(
-      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
-
-  data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeNullableMapVector<int64_t, int64_t>({
-          {{{1, 1}, {2, 2}}},
-          {{{1, 1}, {2, 3}}},
-          {{{4, 50}}},
-      }),
-  });
-
-  expected = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-      }),
-      makeArrayVector<int64_t>({
-          {6, 7, 8},
-      }),
-  });
-
-  testAggregations(
-      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
+  BOLT_ASSERT_USER_THROW(
+      testAggregations({data}, {}, {"spark_max_by(c0, c1)"}, expected),
+      "Aggregate function signature is not supported");
 }
 
 TEST_F(MinMaxByAggregateTest, rowCompare) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Fixes below exception noticed when running aggregate fuzzer test. Spark's `max_by` and `min_by` do not support ordering on map type.

```
org.apache.spark.sql.AnalysisException: [DATATYPE_MISMATCH.INVALID_ORDERING_TYPE] Cannot resolve "min_by(c0, c1)" due to data type mismatch: The `min_by` does not support ordering on type "MAP<TIMESTAMP_
 TINYINT>".; line 1 pos 15;
'Aggregate [g0#33927, g1#33928], [g0#33927, g1#33928, min_by(c0#33925, c1#33926) AS a0#33924]
+- SubqueryAlias tmp
   +- View (`tmp`, [c0#33925,c1#33926,g0#33927,g1#33928])
      +- Project [cast(c0#33929 as struct<f0:bigint>) AS c0#33925, cast(c1#33930 as map<timestamp_ntz,tinyint>) AS c1#33926, cast(g0#33931 as struct<f0:boolean>) AS g0#33927, cast(g1#33932 as struct<f0:b
an>) AS g1#33928]
         +- Project [c0#33929, c1#33930, g0#33931, g1#33932]
            +- Relation [c0#33929,c1#33930,g0#33931,g1#33932] parquet
```

Corresponding PR: https://github.com/facebookincubator/velox/pull/10525

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
