### PR TITLE
fix(arm): avoid constructing xsimd::batch_bool from xsimd::batch<int8_t>

### DIFF
--- a/bolt/functions/lib/SIMDComparisonUtil.h
+++ b/bolt/functions/lib/SIMDComparisonUtil.h
@@ -56,23 +56,23 @@ inline uint64_t to64Bits(const int8_t* resultData) {
   uint64_t res = 0UL;
   if constexpr (numScalarElements == 64) {
     res = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData)));
+        (d_type::load_unaligned(resultData) != d_type(int8_t(0))));
   } else if constexpr (numScalarElements == 32) {
     auto* addr = reinterpret_cast<uint32_t*>(&res);
     *(addr) = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData)));
+        (d_type::load_unaligned(resultData) != d_type(int8_t(0))));
     *(addr + 1) = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData + 32)));
+        (d_type::load_unaligned(resultData + 32) != d_type(int8_t(0))));
   } else if constexpr (numScalarElements == 16) {
     auto* addr = reinterpret_cast<uint16_t*>(&res);
     *(addr) = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData)));
+        (d_type::load_unaligned(resultData) != d_type(int8_t(0))));
     *(addr + 1) = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData + 16)));
+        (d_type::load_unaligned(resultData + 16) != d_type(int8_t(0))));
     *(addr + 2) = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData + 32)));
+        (d_type::load_unaligned(resultData + 32) != d_type(int8_t(0))));
     *(addr + 3) = simd::toBitMask(
-        xsimd::batch_bool<int8_t>(d_type::load_unaligned(resultData + 48)));
+        (d_type::load_unaligned(resultData + 48) != d_type(int8_t(0))));
   }
   return res;
 }

--- a/bolt/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/bolt/functions/sparksql/tests/ComparisonsTest.cpp
@@ -29,10 +29,12 @@
  */
 
 #include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/lib/SIMDComparisonUtil.h"
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "bolt/vector/DecodedVector.h"
 
 #include <bolt/vector/SimpleVector.h>
+#include <array>
 namespace bytedance::bolt::functions::sparksql::test {
 namespace {
 
@@ -702,6 +704,34 @@ TEST_F(ComparisonsTest, testSIMDComparsion) {
   runSIMDCompareAndAssert<TypeKind::TIMESTAMP>(1024);
   runSIMDCompareAndAssert<TypeKind::VARCHAR>(686);
   runSIMDCompareAndAssert<TypeKind::VARBINARY>(777);
+}
+
+TEST_F(ComparisonsTest, to64BitsTreatsNonZeroAsTrue) {
+  std::array<int8_t, 64> resultData{};
+  resultData.fill(0);
+
+  resultData[0] = 1;
+  resultData[1] = -1;
+  resultData[7] = 2;
+  resultData[8] = -3;
+  resultData[15] = 4;
+  resultData[16] = -5;
+  resultData[23] = 6;
+  resultData[31] = -7;
+  resultData[32] = 8;
+  resultData[47] = -9;
+  resultData[63] = 10;
+
+  uint64_t expectedMask = 0;
+  for (size_t i = 0; i < resultData.size(); ++i) {
+    if (resultData[i] != 0) {
+      expectedMask |= (1ULL << i);
+    }
+  }
+
+  EXPECT_EQ(
+      bytedance::bolt::functions::detail::to64Bits(resultData.data()),
+      expectedMask);
 }
 
 TEST_F(ComparisonsTest, lessthan) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #274 


Fix AArch64/NEON compilation failure by avoiding direct construction of `xsimd::batch_bool<int8_t>` from `xsimd::batch<int8_t>` in `bolt/functions/lib/SIMDComparisonUtil.h` (function `to64Bits`).

Instead, we explicitly convert the loaded `int8` lanes into a boolean mask via `!= 0`, and then feed that mask into `simd::toBitMask(...)`.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

On AArch64 (NEON64), `xsimd::batch_bool<T>` is a predicate/mask type and does not provide a constructor that accepts `xsimd::batch<T>` as an argument. This causes errors like:

```
no matching function for call to xsimd::batch_bool<..., neon64>::batch_bool(xsimd::batch<signed char>)
```

x86 builds may succeed due to backend representation details, but the original code is not portable and fails on NEON.

The new approach is both type-correct and more robust: `!= 0` produces a proper `batch_bool` mask regardless of whether "true" bytes are encoded as `1` or `-1`.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
