### PR TITLE
[fix][cp] Support date-type partition filter

### DIFF
--- a/bolt/connectors/hive/HiveConnectorUtil.cpp
+++ b/bolt/connectors/hive/HiveConnectorUtil.cpp
@@ -40,6 +40,7 @@
 #include "bolt/dwio/common/Reader.h"
 #include "bolt/expression/Expr.h"
 #include "bolt/expression/ExprToSubfieldFilter.h"
+#include "bolt/type/TimestampConversion.h"
 
 namespace bytedance::bolt::connector::hive {
 
@@ -566,11 +567,18 @@ void configureRowReaderOptions(
 
 namespace {
 bool applyPartitionFilter(
-    TypeKind kind,
+    const TypePtr& type,
     const std::string& partitionValue,
     common::Filter* filter) {
   try {
-    switch (kind) {
+    if (type->isDate()) {
+      const auto result = util::castFromDateString(
+          StringView(partitionValue), false /*isIso8601*/);
+      BOLT_CHECK(result.has_value());
+      return applyFilter(*filter, result.value());
+    }
+
+    switch (type->kind()) {
       case TypeKind::BIGINT:
       case TypeKind::INTEGER:
       case TypeKind::SMALLINT:
@@ -588,14 +596,17 @@ bool applyPartitionFilter(
         return applyFilter(*filter, partitionValue);
       }
       default:
-        BOLT_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
+        BOLT_FAIL(
+            "Bad type {} for partition value: {}",
+            type->kind(),
+            partitionValue);
         break;
     }
   } catch (const std::exception& ex) {
     BOLT_FAIL(
         "applyPartitionFilter throw exception while convert partition value {} from string to {}, errmsg {}",
         partitionValue,
-        kind,
+        type->kind(),
         ex.what());
   }
 }
@@ -629,7 +640,7 @@ bool testFilters(
             }
           } else {
             if (!applyPartitionFilter(
-                    (*partitionKeysHandle)[name]->dataType()->kind(),
+                    (*partitionKeysHandle)[name]->dataType(),
                     iter->second.value(),
                     child->filter())) {
               return false;

--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -1880,6 +1880,45 @@ TEST_F(TableScanTest, partitionedTableDoubleKey) {
   testPartitionedTable(filePath->path, DOUBLE(), "3.5");
 }
 
+TEST_F(TableScanTest, partitionedTableDateKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+  const std::string partitionValue = "2023-10-27";
+  testPartitionedTable(filePath->getPath(), DATE(), partitionValue);
+
+  // Test partition filter on date column.
+  {
+    auto split = HiveConnectorSplitBuilder(filePath->getPath())
+                     .partitionKey("pkey", partitionValue)
+                     .build();
+    auto outputType = ROW({"pkey", "c0", "c1"}, {DATE(), BIGINT(), DOUBLE()});
+    ColumnHandleMap assignments = {
+        {"pkey", partitionKey("pkey", DATE())},
+        {"c0", regularColumn("c0", BIGINT())},
+        {"c1", regularColumn("c1", DOUBLE())}};
+
+    SubfieldFilters filters;
+    // pkey > 2020-09-01.
+    filters[common::Subfield("pkey")] = std::make_unique<common::BigintRange>(
+        18506, std::numeric_limits<int64_t>::max(), false);
+
+    auto tableHandle = std::make_shared<HiveTableHandle>(
+        "test-hive", "hive_table", true, std::move(filters), nullptr, nullptr);
+    auto op = std::make_shared<TableScanNode>(
+        "0",
+        std::move(outputType),
+        std::move(tableHandle),
+        std::move(assignments));
+
+    std::string partitionValueStr = "'" + partitionValue + "'";
+    assertQuery(
+        op, split, fmt::format("SELECT {}, * FROM tmp", partitionValueStr));
+  }
+}
+
 std::vector<StringView> toStringViews(const std::vector<std::string>& values) {
   std::vector<StringView> views;
   views.reserve(values.size());


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

When the partition column is of date type and a filter is applied on it, below error occurs when trying to convert date string as int. This PR fixes this exception by utilizing castFromDateString with standard cast behavior.
```
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Operator::getOutput failed for [operator: TableScan, plan node ID: 0]: Non-whitespace character found after end of conversion: "-10-27"
```
Corresponding PR: https://github.com/facebookincubator/velox/pull/9937

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
