### PR TITLE
[fix] fix computation logic for casting timestamp to integer

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -473,25 +473,7 @@ class Converter {
     } else if constexpr (fromBool) {
       return tryToWithFolly(from, to);
     } else if constexpr (fromKind == PrimitiveKind::TIMESTAMP) {
-      // Timestamp -> integral seconds, rounding away from zero.
-      int64_t secs64 = 0;
-      try {
-        int128_t micros = static_cast<int128_t>(from.toMicros());
-        int128_t secs128 =
-            micros / static_cast<int128_t>(1'000'000); // trunc toward zero
-        int128_t rem = micros % static_cast<int128_t>(1'000'000);
-        // sec128 + 1 when rem != 0 and micros > 0, sec128 - 1 when rem != 0
-        // and micros < 0
-        secs128 += (rem != 0) * ((micros > 0) - (micros < 0));
-        secs64 = std::clamp(
-            secs128,
-            static_cast<int128_t>(std::numeric_limits<int64_t>::min()),
-            static_cast<int128_t>(std::numeric_limits<int64_t>::max()));
-      } catch (...) {
-        return ConvertStatus::OTHER_FAILURE;
-      }
-
-      return tryIntegerToInteger<int64_t, ToType>(secs64, to);
+      return tryIntegerToInteger<int64_t, ToType>(from.getSeconds(), to);
     } else {
       // INTEGER
       return tryIntegerToInteger<FromType, ToType>(from, to);

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -384,9 +384,23 @@ TEST_F(SparkCastExprTest, timestampToBigint) {
            Timestamp(1727181032, 0),
            Timestamp(-1727181032, 0),
            Timestamp(9223372036854, 775'807'000),
-           Timestamp(-9223372036855, 224'192'000)}),
+           Timestamp(-9223372036855, 224'192'000),
+           Timestamp(15, 3'000'000),
+           Timestamp(-16, 3'000'000),
+           Timestamp(15, 499'000'000),
+           Timestamp(15, 500'000'000),
+           Timestamp(15, 999'000'000)}),
       makeNullableFlatVector<int64_t>(
-          {0, 1727181032, -1727181032, 9223372036855, -9223372036855}));
+          {0,
+           1727181032,
+           -1727181032,
+           9223372036854,
+           -9223372036855,
+           15,
+           -16,
+           15,
+           15,
+           15}));
 }
 
 TEST_F(SparkCastExprTest, primitiveInvalidCornerCases) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #358 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The original computation logic is imprecise and overly complicated. The result is not consistent to Spark in some cases.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
-  Fix computation logic for casting timestamp to integer
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
