### PR TITLE
[fix][cp] Reserves memory for output processing in SortBuffer

### DIFF
--- a/bolt/exec/SortBuffer.cpp
+++ b/bolt/exec/SortBuffer.cpp
@@ -98,6 +98,10 @@ SortBuffer::SortBuffer(
       ROW(std::move(sortedSpillColumnNames), std::move(sortedSpillColumnTypes));
 }
 
+SortBuffer::~SortBuffer() {
+  pool_->release();
+}
+
 void SortBuffer::addInput(const VectorPtr& input) {
   BOLT_CHECK(!noMoreInput_);
   ensureInputFits(input);
@@ -127,6 +131,8 @@ void SortBuffer::addInput(const VectorPtr& input) {
 }
 
 void SortBuffer::noMoreInput() {
+  bolt::common::testutil::TestValue::adjust(
+      "bytedance::bolt::exec::SortBuffer::noMoreInput", this);
   BOLT_CHECK(!noMoreInput_);
   noMoreInput_ = true;
 
@@ -212,6 +218,7 @@ RowVectorPtr SortBuffer::getOutput(uint32_t maxOutputRows) {
     return nullptr;
   }
 
+  ensureOutputFits();
   prepareOutput(maxOutputRows);
   // bool oldNonReclaimableSection = *nonReclaimableSection_;
   // auto guard = folly::makeGuard([this, oldNonReclaimableSection]() {
@@ -318,6 +325,35 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
                << " for memory pool " << pool()->name()
                << ", usage: " << succinctBytes(pool()->currentBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
+}
+
+void SortBuffer::ensureOutputFits() {
+  // Check if spilling is enabled or not.
+  if (spillConfig_ == nullptr) {
+    return;
+  }
+
+  // Test-only spill path.
+  if (testingTriggerSpill()) {
+    spill();
+    return;
+  }
+
+  if (estimatedOutputRowSize_.has_value()) {
+    const uint64_t outputBufferSizeToReserve =
+        estimatedOutputRowSize_.value() * 1.2;
+    {
+      memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+      if (pool_->maybeReserve(outputBufferSizeToReserve)) {
+        return;
+      }
+    }
+    LOG(WARNING) << "Failed to reserve "
+                 << succinctBytes(outputBufferSizeToReserve)
+                 << " for memory pool " << pool_->name()
+                 << ", usage: " << succinctBytes(pool_->usedBytes())
+                 << ", reservation: " << succinctBytes(pool_->reservedBytes());
+  }
 }
 
 void SortBuffer::updateEstimatedOutputRowSize() {

--- a/bolt/exec/SortBuffer.h
+++ b/bolt/exec/SortBuffer.h
@@ -59,6 +59,8 @@ class SortBuffer {
       uint64_t spillMemoryThreshold = 0,
       OperatorCtx* operatorCtx = nullptr);
 
+  ~SortBuffer();
+
   void addInput(const VectorPtr& input);
 
   /// Indicates no more input and triggers either of:
@@ -147,6 +149,9 @@ class SortBuffer {
  private:
   // Ensures there is sufficient memory reserved to process 'input'.
   void ensureInputFits(const VectorPtr& input);
+  // Reserves memory for output processing. If reservation cannot be increased,
+  // spills enough to make output fit.
+  void ensureOutputFits();
   void updateEstimatedOutputRowSize();
   // Invoked to initialize or reset the reusable output buffer to get output.
   void prepareOutput(uint32_t maxOutputRows);

--- a/bolt/exec/tests/SortBufferTest.cpp
+++ b/bolt/exec/tests/SortBufferTest.cpp
@@ -465,6 +465,68 @@ TEST_F(SortBufferTest, spill) {
   }
 }
 
+DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemoryGetOutput) {
+  auto spillDirectory = exec::test::TempDirectoryPath::create();
+  auto spillConfig = common::SpillConfig(
+      [&]() -> const std::string& { return spillDirectory->getPath(); },
+      [&](uint64_t) {},
+      "0.0.0",
+      1000,
+      false,
+      1 << 20,
+      executor_.get(),
+      100,
+      100000,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "none",
+      "",
+      "disabled",
+      "",
+      true);
+  folly::Synchronized<common::SpillStats> spillStats;
+  auto sortBuffer = std::make_unique<SortBuffer>(
+      inputType_,
+      sortColumnIndices_,
+      sortCompareFlags_,
+      pool_.get(),
+      &nonReclaimableSection_,
+      &spillConfig);
+
+  const std::shared_ptr<memory::MemoryPool> fuzzerPool =
+      memory::memoryManager()->addLeafPool("spillSource");
+  VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool.get());
+
+  TestScopedSpillInjection scopedSpillInjection(0);
+  for (int i = 0; i < 3; ++i) {
+    sortBuffer->addInput(fuzzer.fuzzRow(inputType_));
+  }
+
+  std::atomic_bool noMoreInput{false};
+  SCOPED_TESTVALUE_SET(
+      "bytedance::bolt::exec::SortBuffer::noMoreInput",
+      std::function<void(SortBuffer*)>(
+          ([&](SortBuffer* sortBuffer) { noMoreInput.store(true); })));
+
+  std::atomic_int numInputs{0};
+  SCOPED_TESTVALUE_SET(
+      "bytedance::bolt::common::memory::MemoryPoolImpl::maybeReserve",
+      std::function<void(memory::MemoryPoolImpl*)>(
+          ([&](memory::MemoryPoolImpl* pool) {
+            if (noMoreInput) {
+              ++numInputs;
+            }
+          })));
+
+  sortBuffer->noMoreInput();
+  sortBuffer->getOutput(10000);
+  ASSERT_EQ(numInputs, 1);
+}
+
 TEST_F(SortBufferTest, emptySpill) {
   const std::shared_ptr<memory::MemoryPool> fuzzerPool =
       memory::memoryManager()->addLeafPool("emptySpillSource");


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Fix https://github.com/facebookincubator/velox/issues/10940 to reserve memory for output processing in SortBuffer.

Corresponding PR: https://github.com/facebookincubator/velox/pull/10958

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
