### PR TITLE
[fix][cp] Fix SortBuffer ensureOutputFits estimateOutputSize inaccurate

### DIFF
--- a/bolt/exec/SortBuffer.cpp
+++ b/bolt/exec/SortBuffer.cpp
@@ -218,8 +218,12 @@ RowVectorPtr SortBuffer::getOutput(uint32_t maxOutputRows) {
     return nullptr;
   }
 
-  ensureOutputFits();
-  prepareOutput(maxOutputRows);
+  BOLT_CHECK_GT(maxOutputRows, 0);
+  BOLT_CHECK_GT(numInputRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
+  ensureOutputFits(batchSize);
+  prepareOutput(batchSize);
   // bool oldNonReclaimableSection = *nonReclaimableSection_;
   // auto guard = folly::makeGuard([this, oldNonReclaimableSection]() {
   // *nonReclaimableSection_ = oldNonReclaimableSection; });
@@ -327,7 +331,8 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
 }
 
-void SortBuffer::ensureOutputFits() {
+void SortBuffer::ensureOutputFits(vector_size_t batchSize) {
+  BOLT_CHECK_GT(batchSize, 0);
   // Check if spilling is enabled or not.
   if (spillConfig_ == nullptr) {
     return;
@@ -339,9 +344,9 @@ void SortBuffer::ensureOutputFits() {
     return;
   }
 
-  if (estimatedOutputRowSize_.has_value()) {
+  if (estimatedOutputRowSize_.has_value() || spiller_ != nullptr) {
     const uint64_t outputBufferSizeToReserve =
-        estimatedOutputRowSize_.value() * 1.2;
+        estimatedOutputRowSize_.value() * batchSize * 1.2;
     {
       memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
       if (pool_->maybeReserve(outputBufferSizeToReserve)) {
@@ -427,13 +432,7 @@ void SortBuffer::spillOutput() {
   finishSpill();
 }
 
-void SortBuffer::prepareOutput(uint32_t maxOutputRows) {
-  BOLT_CHECK_GT(maxOutputRows, 0);
-  BOLT_CHECK_GT(numInputRows_, numOutputRows_);
-
-  const size_t batchSize =
-      std::min<size_t>(numInputRows_ - numOutputRows_, maxOutputRows);
-
+void SortBuffer::prepareOutput(uint32_t batchSize) {
   if (output_ != nullptr) {
     VectorPtr output = std::move(output_);
     BaseVector::prepareForReuse(output, batchSize);
@@ -448,12 +447,11 @@ void SortBuffer::prepareOutput(uint32_t maxOutputRows) {
   }
 
   if (spiller_ != nullptr) {
-    spillSources_.resize(maxOutputRows);
-    spillSourceRows_.resize(maxOutputRows);
+    spillSources_.resize(batchSize);
+    spillSourceRows_.resize(batchSize);
   }
 
   BOLT_CHECK_GT(output_->size(), 0);
-  BOLT_DCHECK_LE(output_->size(), maxOutputRows);
   BOLT_CHECK_LE(output_->size() + numOutputRows_, numInputRows_);
 }
 

--- a/bolt/exec/SortBuffer.h
+++ b/bolt/exec/SortBuffer.h
@@ -151,10 +151,10 @@ class SortBuffer {
   void ensureInputFits(const VectorPtr& input);
   // Reserves memory for output processing. If reservation cannot be increased,
   // spills enough to make output fit.
-  void ensureOutputFits();
+  void ensureOutputFits(vector_size_t outputBatchSize);
   void updateEstimatedOutputRowSize();
   // Invoked to initialize or reset the reusable output buffer to get output.
-  void prepareOutput(uint32_t maxOutputRows);
+  void prepareOutput(uint32_t outputBatchSize);
   void getOutputWithoutSpill();
   void getOutputWithSpill();
   // Spill during input stage.


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
The output batch reserved size should be rowSize * numRows, missed numRows before.

Corresponding PR: https://github.com/facebookincubator/velox/pull/11534

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
