### PR TITLE
[feature][cp][DynamicMerge] Add ConcatenateFilesSpillMergeStream

### DIFF
--- a/bolt/exec/Spill.cpp
+++ b/bolt/exec/Spill.cpp
@@ -337,6 +337,47 @@ uint32_t FileSpillMergeStream::id() const {
   return spillFile_->id();
 }
 
+std::unique_ptr<SpillMergeStream> ConcatFilesSpillMergeStream::create(
+    uint32_t id,
+    std::vector<std::unique_ptr<SpillReadFile>> spillFiles) {
+  auto spillStream = std::unique_ptr<ConcatFilesSpillMergeStream>(
+      new ConcatFilesSpillMergeStream(id, std::move(spillFiles)));
+  spillStream->nextBatch();
+  return spillStream;
+}
+
+uint32_t ConcatFilesSpillMergeStream::id() const {
+  return id_;
+}
+
+void ConcatFilesSpillMergeStream::nextBatch() {
+  BOLT_CHECK(!closed_);
+  index_ = 0;
+  for (; fileIndex_ < spillFiles_.size(); ++fileIndex_) {
+    BOLT_CHECK_NOT_NULL(spillFiles_[fileIndex_]);
+    if (spillFiles_[fileIndex_]->nextBatch(rowVector_)) {
+      BOLT_CHECK_NOT_NULL(rowVector_);
+      size_ = rowVector_->size();
+      return;
+    }
+    spillFiles_[fileIndex_].reset();
+  }
+  size_ = 0;
+  close();
+}
+
+void ConcatFilesSpillMergeStream::close() {
+  BOLT_CHECK(!closed_);
+  SpillMergeStream::close();
+  spillFiles_.clear();
+}
+
+const std::vector<SpillSortKey>& ConcatFilesSpillMergeStream::sortingKeys()
+    const {
+  BOLT_CHECK(!closed_);
+  return spillFiles_[fileIndex_]->sortingKeys();
+}
+
 void FileSpillMergeStream::nextBatch() {
   BOLT_CHECK(!closed_);
   MicrosecondTimer timer(&spillReadTimeUs_);

--- a/bolt/exec/Spill.h
+++ b/bolt/exec/Spill.h
@@ -534,6 +534,33 @@ class RowBasedFileSpillBatchStream : public BatchStream {
   std::unique_ptr<RowBasedSpillReadFile> spillFile_;
 };
 
+/// A SpillMergeStream that contains a sequence of sorted spill files, the
+/// sorted keys are ordered both within each file and across files.
+class ConcatFilesSpillMergeStream final : public SpillMergeStream {
+ public:
+  static std::unique_ptr<SpillMergeStream> create(
+      uint32_t id,
+      std::vector<std::unique_ptr<SpillReadFile>> spillFiles);
+
+ private:
+  ConcatFilesSpillMergeStream(
+      uint32_t id,
+      std::vector<std::unique_ptr<SpillReadFile>> spillFiles)
+      : id_(id), spillFiles_(std::move(spillFiles)) {}
+
+  uint32_t id() const override;
+
+  void nextBatch() override;
+
+  void close() override;
+
+  const std::vector<SpillSortKey>& sortingKeys() const override;
+
+  const uint32_t id_;
+  std::vector<std::unique_ptr<SpillReadFile>> spillFiles_;
+  size_t fileIndex_{0};
+};
+
 /// Identifies a spill partition generated from a given spilling operator. It
 /// consists of partition start bit offset and the actual partition number. The
 /// start bit offset is used to calculate the partition number of spill data. It

--- a/bolt/exec/tests/CMakeLists.txt
+++ b/bolt/exec/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(
   ArrowStreamTest.cpp
   AssignUniqueIdTest.cpp
   AsyncConnectorTest.cpp
+  ConcatFilesSpillMergeStreamTest.cpp
   ContainerRowSerdeTest.cpp
   CustomJoinTest.cpp
   EnforceSingleRowTest.cpp

--- a/bolt/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/bolt/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/common/file/FileSystems.h"
+#include "bolt/exec/SortBuffer.h"
+#include "bolt/exec/Spill.h"
+#include "bolt/exec/tests/utils/OperatorTestBase.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/type/Type.h"
+#include "bolt/vector/fuzzer/VectorFuzzer.h"
+#include "bolt/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+using namespace bytedance::bolt::exec;
+using namespace bytedance::bolt::exec::test;
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::memory;
+
+namespace bytedance::bolt::exec::test {
+
+class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+  }
+
+  void TearDown() override {
+    sortBuffer_.reset();
+    OperatorTestBase::TearDown();
+  }
+
+  std::vector<RowVectorPtr> generateSortedVectors(
+      const int32_t numVectors,
+      const size_t maxOutputRows) {
+    const VectorFuzzer::Options fuzzerOpts{.vectorSize = maxOutputRows};
+    const auto vectors = createVectors(numVectors, inputType_, fuzzerOpts);
+    const auto sortBuffer = std::make_unique<SortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        nullptr);
+    for (const auto& vector : vectors) {
+      sortBuffer->addInput(vector);
+    }
+    sortBuffer->noMoreInput();
+    std::vector<RowVectorPtr> sortedVectors;
+    sortedVectors.reserve(numVectors);
+    for (auto i = 0; i < numVectors; ++i) {
+      sortedVectors.emplace_back(sortBuffer->getOutput(maxOutputRows));
+    }
+    return sortedVectors;
+  }
+
+  SpillFiles generateSortedSpillFiles(
+      const std::vector<RowVectorPtr>& sortedVectors) {
+    const auto spiller = std::make_unique<Spiller>(
+        Spiller::Type::kHashJoinProbe,
+        inputType_,
+        HashBitRange{},
+        &spillConfig_,
+        spillConfig_.maxFileSize);
+    spiller->setPartitionsSpilled(SpillPartitionNumSet{0});
+    for (const auto& vector : sortedVectors) {
+      spiller->spill(0, vector);
+    }
+    SpillPartitionSet spillPartitionSet;
+    spiller->finishSpill(spillPartitionSet);
+    EXPECT_EQ(spillPartitionSet.size(), 1);
+    return spillPartitionSet.cbegin()->second->files();
+  }
+
+  std::pair<
+      std::vector<RowVectorPtr>,
+      std::vector<std::unique_ptr<SpillMergeStream>>>
+  generateInputs(size_t numStreams, size_t maxOutputRows) {
+    std::vector<RowVectorPtr> totalVectors;
+    std::vector<std::unique_ptr<SpillMergeStream>> spillStreams;
+    for (auto i = 1; i <= numStreams; ++i) {
+      const auto vectors = generateSortedVectors(i * 3 + 1, maxOutputRows);
+      for (const auto& vector : vectors) {
+        totalVectors.push_back(vector);
+      }
+      const auto spillFiles = generateSortedSpillFiles(vectors);
+      EXPECT_EQ(spillFiles.size(), vectors.size());
+      std::vector<std::unique_ptr<SpillReadFile>> spillReadFiles;
+      spillReadFiles.reserve(spillFiles.size());
+      for (const auto& spillFile : spillFiles) {
+        spillReadFiles.emplace_back(
+            SpillReadFile::create(spillFile, pool_.get(), false));
+      }
+      auto stream =
+          ConcatFilesSpillMergeStream::create(i - 1, std::move(spillReadFiles));
+      spillStreams.push_back(std::move(stream));
+    }
+    return std::make_pair(std::move(totalVectors), std::move(spillStreams));
+  }
+
+  std::vector<RowVectorPtr> mergeSpillStreams(
+      std::vector<std::unique_ptr<SpillMergeStream>> spillStreams,
+      size_t numVectors,
+      size_t maxOutputRows) const {
+    std::vector<RowVectorPtr> results;
+    const auto spillMerger = std::make_unique<TreeOfLosers<SpillMergeStream>>(
+        std::move(spillStreams));
+    for (auto i = 0; i < numVectors; ++i) {
+      auto output = std::static_pointer_cast<RowVector>(
+          BaseVector::create(inputType_, maxOutputRows, pool_.get()));
+      for (auto& child : output->children()) {
+        child->resize(maxOutputRows);
+      }
+      // Records the source rows to copy to 'output_' in order.
+      std::vector<const RowVector*> spillSources(maxOutputRows);
+      std::vector<vector_size_t> spillSourceRows(maxOutputRows);
+      int32_t outputRow = 0;
+      int32_t outputSize = 0;
+      bool isEndOfBatch = false;
+      while (outputRow + outputSize < output->size()) {
+        SpillMergeStream* stream = spillMerger->next();
+        spillSources[outputSize] = &stream->current();
+        spillSourceRows[outputSize] = stream->currentIndex(&isEndOfBatch);
+        ++outputSize;
+        if (FOLLY_UNLIKELY(isEndOfBatch)) {
+          // The stream is at end of input batch. Need to copy out the rows
+          // before fetching next batch in 'pop'.
+          gatherCopy(
+              output.get(),
+              outputRow,
+              outputSize,
+              spillSources,
+              spillSourceRows);
+          outputRow += outputSize;
+          outputSize = 0;
+        }
+        // Advance the stream.
+        stream->pop();
+      }
+      if (FOLLY_LIKELY(outputSize != 0)) {
+        gatherCopy(
+            output.get(), outputRow, outputSize, spillSources, spillSourceRows);
+      }
+      results.push_back(output);
+    }
+    EXPECT_EQ(spillMerger->next(), nullptr);
+    return results;
+  }
+
+  std::vector<RowVectorPtr> makeExpectedResults(
+      const std::vector<RowVectorPtr>& vectors,
+      size_t maxOutputRows) {
+    const auto sortBuffer = std::make_unique<SortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        nullptr);
+    for (const auto& vector : vectors) {
+      sortBuffer->addInput(vector);
+    }
+    sortBuffer->noMoreInput();
+    std::vector<RowVectorPtr> sortedVectors;
+    sortedVectors.reserve(vectors.size());
+    for (auto i = 0; i < vectors.size(); ++i) {
+      sortedVectors.emplace_back(sortBuffer->getOutput(maxOutputRows));
+    }
+    return sortedVectors;
+  }
+
+ private:
+  const RowTypePtr inputType_ = ROW(
+      {{"c0", BIGINT()},
+       {"c1", INTEGER()},
+       {"c2", SMALLINT()},
+       {"c3", VARCHAR()}});
+  const std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
+  const std::vector<column_index_t> sortColumnIndices_{0, 2};
+  const std::vector<CompareFlags> sortCompareFlags_{
+      CompareFlags{},
+      CompareFlags{.ascending = false}};
+  const std::vector<SpillSortKey> sortingKeys_ =
+      SpillState::makeSortingKeys(sortColumnIndices_, sortCompareFlags_);
+  const std::shared_ptr<TempDirectoryPath> spillDirectory_ =
+      exec::test::TempDirectoryPath::create();
+  const common::SpillConfig spillConfig_{
+      [&]() -> const std::string& { return spillDirectory_->getPath(); },
+      [&](uint64_t) {},
+      "0.0.0",
+      10, // Force to create a file per spill to mock multiple files per stream
+      false, // _spillUringEnabled
+      0,
+      executor_.get(),
+      100,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "none"};
+
+  folly::Synchronized<common::SpillStats> spillStats_;
+  tsan_atomic<bool> nonReclaimableSection_{false};
+  std::unique_ptr<SortBuffer> sortBuffer_ = std::make_unique<SortBuffer>(
+      inputType_,
+      sortColumnIndices_,
+      sortCompareFlags_,
+      pool_.get(),
+      &nonReclaimableSection_,
+      nullptr);
+  std::unique_ptr<TreeOfLosers<SpillMergeStream>> spillMerger_;
+};
+} // namespace bytedance::bolt::exec::test
+
+TEST_F(ConcatFilesSpillMergeStreamTest, stream) {
+  struct {
+    size_t maxOutputRows;
+    size_t numStreams;
+
+    std::string debugString() const {
+      return fmt::format(
+          "maxOutputRows:{} numStreams:{}", maxOutputRows, numStreams);
+    }
+  } testSettings[] = {
+      {1, 1},
+      {1, 3},
+      {1, 8},
+      {7, 1},
+      {7, 3},
+      {7, 8},
+      {16, 1},
+      {16, 3},
+      {16, 8},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto [totalVectors, spillStreams] =
+        generateInputs(testData.numStreams, testData.maxOutputRows);
+    std::vector<RowVectorPtr> results = mergeSpillStreams(
+        std::move(spillStreams), totalVectors.size(), testData.maxOutputRows);
+    ASSERT_EQ(totalVectors.size(), results.size());
+    const auto expectedResults =
+        makeExpectedResults(totalVectors, testData.maxOutputRows);
+    ASSERT_EQ(expectedResults.size(), results.size());
+    ASSERT_TRUE(assertEqualResults(expectedResults, results));
+  }
+}


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Add `ConcatenateFilesSpillMergeStream` to handle multiple sorted spilled files produced by the same merge run in the `LocalMerge` operator. Utilize a concatenate iterator to read from these files one at a time, in order hence we can use multiple streams to do sort-merge.

Part of https://github.com/facebookincubator/velox/issues/13260

Corresponding PR: https://github.com/facebookincubator/velox/pull/13289

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
