### PR TITLE
[feat][cp] Add merge source start processing mechanism for pyspark-velox

### DIFF
--- a/bolt/exec/CallbackSink.h
+++ b/bolt/exec/CallbackSink.h
@@ -40,14 +40,16 @@ class CallbackSink : public Operator {
       int32_t operatorId,
       DriverCtx* driverCtx,
       std::function<BlockingReason(RowVectorPtr, ContinueFuture*, uint32_t)>
-          callback)
+          consumeCb,
+      std::function<BlockingReason(ContinueFuture*)> startedCb = nullptr)
       : Operator(driverCtx, nullptr, operatorId, "N/A", "CallbackSink"),
-        callback_{callback} {}
+        startedCb_{std::move(startedCb)},
+        consumeCb_{std::move(consumeCb)} {}
 
   void addInput(RowVectorPtr input) override {
     loadColumns(input, *operatorCtx_->execCtx());
     blockingReason_ =
-        callback_(input, &future_, operatorCtx_->driverCtx()->partitionId);
+        consumeCb_(input, &future_, operatorCtx_->driverCtx()->partitionId);
   }
 
   RowVectorPtr getOutput() override {
@@ -55,7 +57,7 @@ class CallbackSink : public Operator {
   }
 
   bool needsInput() const override {
-    return callback_ != nullptr;
+    return consumeCb_ != nullptr;
   }
 
   void noMoreInput() override {
@@ -64,6 +66,10 @@ class CallbackSink : public Operator {
   }
 
   BlockingReason isBlocked(ContinueFuture* future) override {
+    if (startedCb_ != nullptr) {
+      blockingReason_ = startedCb_(&future_);
+      startedCb_ = nullptr;
+    }
     if (blockingReason_ != BlockingReason::kNotBlocked) {
       *future = std::move(future_);
       blockingReason_ = BlockingReason::kNotBlocked;
@@ -78,16 +84,17 @@ class CallbackSink : public Operator {
 
  private:
   void close() override {
-    if (callback_) {
-      callback_(nullptr, nullptr, 0);
-      callback_ = nullptr;
+    if (consumeCb_) {
+      consumeCb_(nullptr, nullptr, 0);
+      consumeCb_ = nullptr;
     }
   }
 
   ContinueFuture future_;
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+  std::function<BlockingReason(ContinueFuture*)> startedCb_;
   std::function<BlockingReason(RowVectorPtr, ContinueFuture*, uint32_t)>
-      callback_;
+      consumeCb_;
 };
 
 } // namespace bytedance::bolt::exec

--- a/bolt/exec/Driver.cpp
+++ b/bolt/exec/Driver.cpp
@@ -287,6 +287,8 @@ std::ostream& operator<<(std::ostream& out, const StopReason& reason) {
   return out << stopReasonString(reason);
 }
 Driver::Driver() = default;
+
+Driver::~Driver() = default;
 // static
 void Driver::enqueue(std::shared_ptr<Driver> driver) {
   process::ScopedThreadDebugInfo scopedInfo(

--- a/bolt/exec/Driver.h
+++ b/bolt/exec/Driver.h
@@ -369,6 +369,10 @@ class Driver : public std::enable_shared_from_this<Driver> {
  public:
   static void enqueue(std::shared_ptr<Driver> instance);
 
+  // Declare out-of-line destructor to ensure std::unique_ptr<Operator> is
+  // destroyed in a TU where Operator is a complete type.
+  ~Driver();
+
   /// Run the pipeline until it produces a batch of data or gets blocked.
   /// Return the data produced or nullptr if pipeline finished processing and
   /// will not produce more data. Return nullptr and set 'blockingState' if

--- a/bolt/exec/LocalPlanner.cpp
+++ b/bolt/exec/LocalPlanner.cpp
@@ -123,13 +123,17 @@ OperatorSupplier makeConsumerSupplier(
       auto mergeSource = ctx->task->addLocalMergeSource(
           ctx->splitGroupId, localMerge->id(), localMerge->outputType());
 
-      auto consumer = [mergeSource](
-                          RowVectorPtr input,
-                          ContinueFuture* future,
-                          uint32_t partitionId) {
+      auto consumerCb = [mergeSource](
+                            RowVectorPtr input,
+                            ContinueFuture* future,
+                            uint32_t partitionId) {
         return mergeSource->enqueue(input, future);
       };
-      return std::make_unique<CallbackSink>(operatorId, ctx, consumer);
+      auto startCb = [mergeSource](ContinueFuture* future) {
+        return mergeSource->started(future);
+      };
+      return std::make_unique<CallbackSink>(
+          operatorId, ctx, std::move(consumerCb), std::move(startCb));
     };
   }
 

--- a/bolt/exec/Merge.cpp
+++ b/bolt/exec/Merge.cpp
@@ -89,7 +89,7 @@ void Merge::initializeTreeOfLosers() {
 BlockingReason Merge::isBlocked(ContinueFuture* future) {
   BOLT_TEST_ADJUST("bytedance::bolt::exec::Merge::isBlocked", this);
 
-  auto reason = addMergeSources(future);
+  const auto reason = addMergeSources(future);
   if (reason != BlockingReason::kNotBlocked) {
     return reason;
   }
@@ -100,6 +100,8 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
     finished_ = true;
     return BlockingReason::kNotBlocked;
   }
+
+  startSources();
 
   // No merging is needed if there is only one source.
   if (streams_.empty() && sources_.size() > 1) {
@@ -112,13 +114,30 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
     }
   }
 
-  if (!sourceBlockingFutures_.empty()) {
-    *future = std::move(sourceBlockingFutures_.back());
-    sourceBlockingFutures_.pop_back();
-    return BlockingReason::kWaitForProducer;
+  if (sourceBlockingFutures_.empty()) {
+    return BlockingReason::kNotBlocked;
   }
 
-  return BlockingReason::kNotBlocked;
+  *future = std::move(sourceBlockingFutures_.back());
+  sourceBlockingFutures_.pop_back();
+  return BlockingReason::kWaitForProducer;
+}
+
+void Merge::startSources() {
+  BOLT_CHECK_LE(numStartedSources_, sources_.size());
+  // Start the merge source once.
+  if (numStartedSources_ >= sources_.size()) {
+    return;
+  }
+  BOLT_CHECK_EQ(numStartedSources_, 0);
+  BOLT_CHECK(streams_.empty());
+  BOLT_CHECK(sourceBlockingFutures_.empty());
+  // TODO: support lazy start for local merge with a large number of sources
+  // to cap the memory usage.
+  for (auto& source : sources_) {
+    source->start();
+  }
+  numStartedSources_ = sources_.size();
 }
 
 bool Merge::isFinished() {
@@ -129,6 +148,8 @@ RowVectorPtr Merge::getOutput() {
   if (finished_) {
     return nullptr;
   }
+
+  BOLT_CHECK_EQ(numStartedSources_, sources_.size());
 
   // No merging is needed if there is only one source.
   if (sources_.size() == 1) {
@@ -331,48 +352,45 @@ BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
     exec::Split split;
     auto reason = operatorCtx_->task()->getSplitOrFuture(
         operatorCtx_->driverCtx()->splitGroupId, planNodeId(), split, *future);
-    if (reason == BlockingReason::kNotBlocked) {
-      if (split.hasConnectorSplit()) {
-        auto remoteSplit = std::dynamic_pointer_cast<RemoteConnectorSplit>(
-            split.connectorSplit);
-        BOLT_CHECK(remoteSplit, "Wrong type of split");
-        remoteSourceTaskIds_.push_back(remoteSplit->taskId);
-      } else {
-        noMoreSplits_ = true;
-        if (!remoteSourceTaskIds_.empty()) {
-          const auto maxMergeExchangeBufferSize =
-              operatorCtx_->driverCtx()
-                  ->queryConfig()
-                  .maxMergeExchangeBufferSize();
-          const auto maxQueuedBytesPerSource = std::min<int64_t>(
-              std::max<int64_t>(
-                  maxMergeExchangeBufferSize / remoteSourceTaskIds_.size(),
-                  MergeSource::kMaxQueuedBytesLowerLimit),
-              MergeSource::kMaxQueuedBytesUpperLimit);
-          for (uint32_t remoteSourceIndex = 0;
-               remoteSourceIndex < remoteSourceTaskIds_.size();
-               ++remoteSourceIndex) {
-            auto* pool = operatorCtx_->task()->addMergeSourcePool(
-                operatorCtx_->planNodeId(),
-                operatorCtx_->driverCtx()->pipelineId,
-                remoteSourceIndex);
-            sources_.emplace_back(MergeSource::createMergeExchangeSource(
-                this,
-                remoteSourceTaskIds_[remoteSourceIndex],
-                operatorCtx_->task()->destination(),
-                maxQueuedBytesPerSource,
-                pool,
-                operatorCtx_->task()->queryCtx()->executor()));
-          }
-        }
-        // TODO Delay this call until all input data has been processed.
-        operatorCtx_->task()->multipleSplitsFinished(
-            remoteSourceTaskIds_.size());
-        return BlockingReason::kNotBlocked;
-      }
-    } else {
+    if (reason != BlockingReason::kNotBlocked) {
       return reason;
     }
+    if (split.hasConnectorSplit()) {
+      auto remoteSplit =
+          std::dynamic_pointer_cast<RemoteConnectorSplit>(split.connectorSplit);
+      BOLT_CHECK_NOT_NULL(remoteSplit, "Wrong type of split");
+      remoteSourceTaskIds_.push_back(remoteSplit->taskId);
+      continue;
+    }
+
+    noMoreSplits_ = true;
+    if (!remoteSourceTaskIds_.empty()) {
+      const auto maxMergeExchangeBufferSize =
+          operatorCtx_->driverCtx()->queryConfig().maxMergeExchangeBufferSize();
+      const auto maxQueuedBytesPerSource = std::min<int64_t>(
+          std::max<int64_t>(
+              maxMergeExchangeBufferSize / remoteSourceTaskIds_.size(),
+              MergeSource::kMaxQueuedBytesLowerLimit),
+          MergeSource::kMaxQueuedBytesUpperLimit);
+      for (uint32_t remoteSourceIndex = 0;
+           remoteSourceIndex < remoteSourceTaskIds_.size();
+           ++remoteSourceIndex) {
+        auto* pool = operatorCtx_->task()->addMergeSourcePool(
+            operatorCtx_->planNodeId(),
+            operatorCtx_->driverCtx()->pipelineId,
+            remoteSourceIndex);
+        sources_.emplace_back(MergeSource::createMergeExchangeSource(
+            this,
+            remoteSourceTaskIds_[remoteSourceIndex],
+            operatorCtx_->task()->destination(),
+            maxQueuedBytesPerSource,
+            pool,
+            operatorCtx_->task()->queryCtx()->executor()));
+      }
+    }
+    // TODO Delay this call until all input data has been processed.
+    operatorCtx_->task()->multipleSplitsFinished(remoteSourceTaskIds_.size());
+    return BlockingReason::kNotBlocked;
   }
 }
 

--- a/bolt/exec/Merge.h
+++ b/bolt/exec/Merge.h
@@ -69,8 +69,11 @@ class Merge : public SourceOperator {
   virtual BlockingReason addMergeSources(ContinueFuture* future) = 0;
 
   std::vector<std::shared_ptr<MergeSource>> sources_;
+  size_t numStartedSources_{0};
 
  private:
+  void startSources();
+
   void initializeTreeOfLosers();
 
   /// Maximum number of rows in the output batch.

--- a/bolt/exec/MergeSource.cpp
+++ b/bolt/exec/MergeSource.cpp
@@ -32,25 +32,79 @@
 
 #include <boost/circular_buffer.hpp>
 #include "bolt/common/compression/Compression.h"
+#include "bolt/common/testutil/TestValue.h"
 #include "bolt/exec/Merge.h"
 #include "bolt/serializers/PrestoSerializer.h"
 #include "bolt/vector/VectorStream.h"
+
+using bytedance::bolt::common::testutil::TestValue;
 namespace bytedance::bolt::exec {
 namespace {
+namespace {
+class ScopedPromiseNotification {
+ public:
+  explicit ScopedPromiseNotification(size_t initSize) {
+    promises_.reserve(initSize);
+  }
+
+  ~ScopedPromiseNotification() {
+    for (auto& promise : promises_) {
+      promise.setValue();
+    }
+  }
+
+  void add(std::vector<ContinuePromise>&& promises) {
+    promises_.reserve(promises_.size() + promises.size());
+    for (auto& promise : promises) {
+      promises_.emplace_back(std::move(promise));
+    }
+    promises.clear();
+  }
+
+  void add(ContinuePromise&& promise) {
+    promises_.emplace_back(std::move(promise));
+  }
+
+ private:
+  std::vector<ContinuePromise> promises_;
+};
+
+void deferNotify(
+    std::optional<ContinuePromise>& deferPromise,
+    ScopedPromiseNotification& promiseNotifier) {
+  if (deferPromise.has_value()) {
+    promiseNotifier.add(std::move(deferPromise.value()));
+    deferPromise.reset();
+  }
+}
+} // namespace
 
 class LocalMergeSource : public MergeSource {
  public:
   explicit LocalMergeSource(int queueSize)
       : queue_(LocalMergeSourceQueue(queueSize)) {}
 
+  void start() override {
+    TestValue::adjust("facebook::velox::exec::LocalMergeSource::start", this);
+    ScopedPromiseNotification notification(1);
+    queue_.withWLock([&](auto& queue) { queue.start(notification); });
+  }
+
+  BlockingReason started(ContinueFuture* future) override {
+    return queue_.withWLock([&](auto& queue) { return queue.started(future); });
+  }
+
   BlockingReason next(RowVectorPtr& data, ContinueFuture* future) override {
+    ScopedPromiseNotification notification(1);
     return queue_.withWLock(
-        [&](auto& queue) { return queue.next(data, future); });
+        [&](auto& queue) { return queue.next(data, future, notification); });
   }
 
   BlockingReason enqueue(RowVectorPtr input, ContinueFuture* future) override {
-    return queue_.withWLock(
-        [&](auto& queue) { return queue.enqueue(input, future); });
+    ScopedPromiseNotification notification(1);
+    return queue_.withWLock([&](auto& queue) {
+      return queue.enqueue(input, future, notification);
+    });
   }
 
   void close() override {}
@@ -60,7 +114,26 @@ class LocalMergeSource : public MergeSource {
    public:
     explicit LocalMergeSourceQueue(int queueSize) : data_(queueSize) {}
 
-    BlockingReason next(RowVectorPtr& data, ContinueFuture* future) {
+    void start(ScopedPromiseNotification& notification) {
+      BOLT_CHECK(!started_);
+      started_ = true;
+      notifyProducers(notification);
+    }
+
+    BlockingReason started(ContinueFuture* future) {
+      if (started_) {
+        return BlockingReason::kNotBlocked;
+      }
+      producerPromises_.emplace_back("LocalMergeSourceQueue::started");
+      *future = producerPromises_.back().getSemiFuture();
+      return BlockingReason::kWaitForConsumer;
+    }
+
+    BlockingReason next(
+        RowVectorPtr& data,
+        ContinueFuture* future,
+        ScopedPromiseNotification& notification) {
+      BOLT_CHECK(started_);
       data.reset();
 
       if (data_.empty()) {
@@ -77,17 +150,21 @@ class LocalMergeSource : public MergeSource {
       // advance to next batch.
       data_.pop_front();
 
-      notifyProducers();
+      notifyProducers(notification);
 
       return BlockingReason::kNotBlocked;
     }
 
-    BlockingReason enqueue(RowVectorPtr input, ContinueFuture* future) {
+    BlockingReason enqueue(
+        RowVectorPtr input,
+        ContinueFuture* future,
+        ScopedPromiseNotification& notification) {
       if (!input) {
         atEnd_ = true;
-        notifyConsumers();
+        notifyConsumers(notification);
         return BlockingReason::kNotBlocked;
       }
+      BOLT_CHECK(started_);
       BOLT_CHECK(!data_.full(), "LocalMergeSourceQueue is full");
 
       for (auto& child : input->children()) {
@@ -95,7 +172,7 @@ class LocalMergeSource : public MergeSource {
       }
 
       data_.push_back(input);
-      notifyConsumers();
+      notifyConsumers(notification);
 
       if (data_.full()) {
         producerPromises_.emplace_back("LocalMergeSourceQueue::enqueue");
@@ -106,20 +183,17 @@ class LocalMergeSource : public MergeSource {
     }
 
    private:
-    void notifyConsumers() {
-      for (auto& promise : consumerPromises_) {
-        promise.setValue();
-      }
-      consumerPromises_.clear();
+    void notifyConsumers(ScopedPromiseNotification& notification) {
+      notification.add(std::move(consumerPromises_));
+      BOLT_CHECK(consumerPromises_.empty());
     }
 
-    void notifyProducers() {
-      for (auto& promise : producerPromises_) {
-        promise.setValue();
-      }
-      producerPromises_.clear();
+    void notifyProducers(ScopedPromiseNotification& notification) {
+      notification.add(std::move(producerPromises_));
+      BOLT_CHECK(producerPromises_.empty());
     }
 
+    bool started_{false};
     bool atEnd_{false};
     boost::circular_buffer<RowVectorPtr> data_;
     std::vector<ContinuePromise> consumerPromises_;
@@ -147,6 +221,12 @@ class MergeExchangeSource : public MergeSource {
             executor)) {
     client_->addRemoteTaskId(taskId);
     client_->noMoreRemoteTasks();
+  }
+
+  void start() override {}
+
+  BlockingReason started(ContinueFuture* /*unused*/) override {
+    BOLT_NYI();
   }
 
   BlockingReason next(RowVectorPtr& data, ContinueFuture* future) override {
@@ -206,15 +286,14 @@ class MergeExchangeSource : public MergeSource {
   }
 
  private:
+  BlockingReason enqueue(RowVectorPtr input, ContinueFuture* future) override {
+    BOLT_FAIL();
+  }
   MergeExchange* const mergeExchange_;
   std::shared_ptr<ExchangeClient> client_;
   std::unique_ptr<ByteInputStream> inputStream_;
   std::unique_ptr<SerializedPage> currentPage_;
   bool atEnd_ = false;
-
-  BlockingReason enqueue(RowVectorPtr input, ContinueFuture* future) override {
-    BOLT_FAIL();
-  }
 };
 } // namespace
 
@@ -236,22 +315,14 @@ std::shared_ptr<MergeSource> MergeSource::createMergeExchangeSource(
       mergeExchange, taskId, destination, maxQueuedBytes, pool, executor);
 }
 
-namespace {
-void notify(std::optional<ContinuePromise>& promise) {
-  if (promise) {
-    promise->setValue();
-    promise.reset();
-  }
-}
-} // namespace
-
 BlockingReason MergeJoinSource::next(
     ContinueFuture* future,
     RowVectorPtr* data) {
+  ScopedPromiseNotification notification(1);
   return state_.withWLock([&](auto& state) {
     if (state.data != nullptr) {
       *data = std::move(state.data);
-      notify(producerPromise_);
+      deferNotify(producerPromise_, notification);
       return BlockingReason::kNotBlocked;
     }
 
@@ -269,23 +340,25 @@ BlockingReason MergeJoinSource::next(
 BlockingReason MergeJoinSource::enqueue(
     RowVectorPtr data,
     ContinueFuture* future) {
+  ScopedPromiseNotification notification(1);
   return state_.withWLock([&](auto& state) {
     if (state.atEnd) {
       // This can happen if consumer called close() because it doesn't need any
       // more data.
       // TODO Finish the pipeline early and avoid unnecessary computing.
+      deferNotify(consumerPromise_, notification);
       return BlockingReason::kNotBlocked;
     }
 
     if (data == nullptr) {
       state.atEnd = true;
-      notify(consumerPromise_);
+      deferNotify(consumerPromise_, notification);
       return BlockingReason::kNotBlocked;
     }
 
     BOLT_CHECK_NULL(state.data);
     state.data = std::move(data);
-    notify(consumerPromise_);
+    deferNotify(consumerPromise_, notification);
 
     producerPromise_ = ContinuePromise("MergeJoinSource::enqueue");
     *future = producerPromise_->getSemiFuture();
@@ -294,10 +367,12 @@ BlockingReason MergeJoinSource::enqueue(
 }
 
 void MergeJoinSource::close() {
+  ScopedPromiseNotification notification(2);
   state_.withWLock([&](auto& state) {
     state.data = nullptr;
     state.atEnd = true;
-    notify(producerPromise_);
+    deferNotify(producerPromise_, notification);
+    deferNotify(consumerPromise_, notification);
   });
 }
 } // namespace bytedance::bolt::exec

--- a/bolt/exec/MergeSource.h
+++ b/bolt/exec/MergeSource.h
@@ -40,7 +40,16 @@ class MergeSource {
   static constexpr int32_t kMaxQueuedBytesUpperLimit = 32 << 20; // 32 MB.
   static constexpr int32_t kMaxQueuedBytesLowerLimit = 1 << 20; // 1 MB.
 
-  virtual ~MergeSource() {}
+  virtual ~MergeSource() = default;
+
+  /// Called by the consumer to signal the producer the start of the source
+  /// processing. This is used to implement lazy local source start mechanism to
+  /// cap the source memory usage.
+  virtual void start() = 0;
+
+  /// Called by the producer to wait for the start signal of source processing
+  /// from the consumer.
+  virtual BlockingReason started(ContinueFuture* future) = 0;
 
   virtual BlockingReason next(RowVectorPtr& data, ContinueFuture* future) = 0;
 

--- a/bolt/exec/Spill.h
+++ b/bolt/exec/Spill.h
@@ -51,6 +51,10 @@
 #include "bolt/vector/VectorStream.h"
 namespace bytedance::bolt::exec {
 
+// Forward declarations
+class SpillReadFile;
+class RowBasedSpillReadFile;
+
 // A source of sorted spilled RowVectors coming either from a file or memory.
 class SpillMergeStream : public MergeStream {
  public:

--- a/bolt/exec/tests/MergeTest.cpp
+++ b/bolt/exec/tests/MergeTest.cpp
@@ -28,10 +28,14 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/common/testutil/TestValue.h"
 #include "bolt/exec/tests/utils/OperatorTestBase.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "folly/experimental/EventCount.h"
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec::test;
+using namespace bytedance::bolt::common::testutil;
 
 class MergeTest : public OperatorTestBase {
  protected:
@@ -164,6 +168,59 @@ TEST_F(MergeTest, localMerge) {
 
   testTwoKeys(vectors, "c0", "c3");
   testTwoKeys(vectors, "c3", "c0");
+}
+
+DEBUG_ONLY_TEST_F(MergeTest, localMergeStart) {
+  const auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({0, 1, 10}),
+  });
+  const auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({2, 3, 4, 5}),
+  });
+
+  folly::EventCount sourceStartCallWait;
+  std::atomic_bool sourceStartCallWaitFlag{true};
+  folly::EventCount sourceStartWait;
+  std::atomic_bool sourceStartWaitFlag{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::LocalMergeSource::start",
+      std::function<void(exec::MergeSource*)>(
+          ([&](exec::MergeSource* /*unused*/) {
+            sourceStartCallWaitFlag = false;
+            sourceStartCallWait.notifyAll();
+            sourceStartWait.await(
+                [&]() { return !sourceStartWaitFlag.load(); });
+          })));
+  std::atomic_bool getOutput{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Values::getOutput",
+      std::function<void(exec::MergeSource*)>(
+          ([&](exec::MergeSource* /*unused*/) { getOutput = true; })));
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {
+                  PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+                  PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+              })
+          .planNode();
+
+  std::thread queryThread([&]() {
+    CursorParameters params;
+    params.planNode = plan;
+    params.queryCtx = core::QueryCtx::create(executor_.get());
+    assertQueryOrdered(
+        params, "VALUES (0), (1), (2), (3), (4), (5), (10)", {0});
+  });
+  sourceStartCallWait.await([&]() { return !sourceStartCallWaitFlag.load(); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(1'000)); // NOLINT
+  ASSERT_FALSE(getOutput);
+  sourceStartWaitFlag = false;
+  sourceStartWait.notifyAll();
+  queryThread.join();
+  ASSERT_TRUE(getOutput);
 }
 
 /// Verifies an edge case where output batch fills up when one of the sources

--- a/bolt/serializers/benchmarks/RowSerializerBenchmark.cpp
+++ b/bolt/serializers/benchmarks/RowSerializerBenchmark.cpp
@@ -30,10 +30,10 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
-#include "velox/serializers/CompactRowSerializer.h"
-#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "bolt/serializers/CompactRowSerializer.h"
+#include "bolt/vector/fuzzer/VectorFuzzer.h"
 
-namespace facebook::velox::test {
+namespace bytedance::bolt::test {
 namespace {
 class RowSerializerBenchmark {
  public:
@@ -154,11 +154,11 @@ VECTOR_SERDE_BENCHMARKS(
     ROW({BIGINT(), ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()})}));
 
 } // namespace
-} // namespace facebook::velox::test
+} // namespace bytedance::bolt::test
 
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
-  facebook::velox::memory::MemoryManager::initialize({});
+  bytedance::bolt::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Extend MergeSource to support merge source start control mechanism used to implement lazy source start to cap the local merge source memory usage. The merge operator needs to call start on each MergeSource to signal producer the start of source processing. Each source producer, CallbackSink operator check if the corresponding merge source is started or not in isBlocked method. The exchange the source start signal is expected to happen once. Unit test is added to verify this behavior. This PR also move the producer/consumer signal out of locks to prevent potential deadlock plus some code cleanup in the relevant code path.

The followup is to add recursive spill based on the lazy start mechanism built to cap the merge source memory usage when there are a large number of sources such in pyspark-velox use case.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
