### PR TITLE
Support unknown type for collect set

### DIFF
--- a/bolt/functions/lib/aggregates/CollectSetAggregate.cpp
+++ b/bolt/functions/lib/aggregates/CollectSetAggregate.cpp
@@ -99,6 +99,8 @@ void registerCollectSetAggregate(
                 resultType);
           case TypeKind::ARRAY:
             [[fallthrough]];
+          case TypeKind::UNKNOWN:
+            [[fallthrough]];
           case TypeKind::ROW:
             // Nested nulls are allowed by setting 'throwOnNestedNulls' as
             // false.

--- a/bolt/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
@@ -83,6 +83,35 @@ TEST_F(CollectSetAggregateTest, global) {
       {data}, {}, {"collect_set(c0)"}, {"spark_array_sort(a0)"}, {expected});
 }
 
+TEST_F(CollectSetAggregateTest, unknownType) {
+  // All inputs are null.
+  auto data = makeRowVector({makeNullConstant(TypeKind::UNKNOWN, 1)});
+  auto expected = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({"[]"}),
+  });
+  testAggregations({data}, {}, {"collect_set(c0)"}, {"a0"}, {expected});
+  // Null inputs.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 2, 2, 2, 1, 2, 1, 2, 1}),
+      makeNullConstant(TypeKind::UNKNOWN, 10),
+  });
+  expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeArrayVectorFromJson<int32_t>({
+          "[]",
+          "[]",
+      }),
+  });
+  testAggregations(
+      {data, data, data},
+      {"c0"},
+      {"collect_set(c1)"},
+      {"c0", "a0"},
+      {expected},
+      {},
+      false);
+}
+
 TEST_F(CollectSetAggregateTest, noInputRow) {
   // Empty input.
   auto data = makeRowVector({makeFlatVector<int32_t>({})});


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close https://github.com/bytedance/bolt/issues/412

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
Support `collect_set` for UNKNOWN (constant null) input type.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
