### PR TITLE
fix(ci): Make run-clang-tidy respect CI_NUM_THREADS

### DIFF
--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -503,8 +503,8 @@ def tidy(args):
         cmd_base.append(f"--line-filter={line_filter_json}")
 
     cmd_base.append("--extra-arg=-Wno-unknown-warning-option")
-
-    jobs = args.jobs if args.jobs else max(1, multiprocessing.cpu_count() // 2)
+    max_cpus = int(os.environ.get("CI_NUM_THREADS", multiprocessing.cpu_count() // 2))
+    jobs = args.jobs if args.jobs else max(1, max_cpus)
     chunk_size = 1
     file_chunks = [
         files_to_process[i : i + chunk_size]


### PR DESCRIPTION
### What problem does this PR solve?

pre-commit checks can OOM due to too many parallel processes, this prevents the OOMs by limiting the jobs.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Check for `CI_NUM_THREADS` in `run-clang-tidy.py` before defaulting to `multiprocessing.cpu_count()`
