### PR TITLE
[fix] fix the flakiness of the unit test 'morselDrivenTestSplitHashJoinWithExchangeOnBuildSide'

### DIFF
--- a/bolt/exec/tests/MultiFragmentTest.cpp
+++ b/bolt/exec/tests/MultiFragmentTest.cpp
@@ -89,9 +89,8 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     auto configCopy = configSettings_;
     auto queryCtx = core::QueryCtx::create(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
-    queryCtx->testingOverrideMemoryPool(
-        memory::memoryManager()->addRootPool(
-            queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,
@@ -117,9 +116,8 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     auto queryCtx = core::QueryCtx::create(
         executor ? executor : executor_.get(),
         core::QueryConfig(std::move(configCopy)));
-    queryCtx->testingOverrideMemoryPool(
-        memory::memoryManager()->addRootPool(
-            queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,
@@ -2064,11 +2062,12 @@ TEST_F(
     };
 
     // Add one bad remote split and trigger Task::terminate.
-    addBadSplit(0);
+    task->addSplit(exchangeNodeId, remoteSplit(makeBadTaskId("leaf", 0)));
 
     // Add one more bad split, making sure `remainingRemoteSplits` is not empty
     // and processing it would cause an exception.
     addBadSplit(1);
+    addBadSplit(2);
 
     // Wait for the task to fail, and make sure the task has been deleted
     // instead of hanging as a zombie task.


### PR DESCRIPTION
Fix the flakyness of the unit test morselDrivenTestSplitHashJoinWithExchangeOnBuildSide with a tolerance for a situation that the task has failed before the second bad split is added.

The issue is reproducible with this script: 
[run_parallel_test.sh](https://github.com/user-attachments/files/26152002/run_parallel_test.sh)

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #356

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
The flake occurs when the second addSplit happens after the task has already failed, which routes to addRemoteSplit and throws an error. Catching it in the test makes the behavior deterministic without changing production code. 

This keeps the test’s intent (task failure, no zombie task) but removes the flakiness caused by a thrown exception escaping the test body when the task has already failed.

The issue no longer exist with this fix verified by running the run_parallel_test.sh 1000 times at parallelism of 10.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
-  fix the flakyness of the unit test morselDrivenTestSplitHashJoinWithExchangeOnBuildSide
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
