### PR TITLE
WIP: [fix] fix 'round' function to be consistent with Spark behavior

### DIFF
--- a/bolt/functions/prestosql/ArithmeticImpl.h
+++ b/bolt/functions/prestosql/ArithmeticImpl.h
@@ -34,6 +34,7 @@
 #include <cmath>
 #include <type_traits>
 #include "bolt/type/BigDecimal.h"
+#include "bolt/type/DecimalUtil.h"
 #include "bolt/type/FloatingPointUtil.h"
 #include "folly/CPortability.h"
 namespace bytedance::bolt::functions {
@@ -47,17 +48,55 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   static_assert(!std::is_same_v<TNum, bool> && "round not supported for bool");
 
   if constexpr (std::is_integral_v<TNum>) {
+#ifdef SPARK_COMPATIBLE
+    if (decimals >= 0) {
+      return number;
+    }
+    const int32_t absScale = -decimals;
+    if (absScale > LongDecimalType::kMaxPrecision) {
+      return 0;
+    }
+    const int128_t factor =
+        DecimalUtil::getPowersOfTen(static_cast<uint8_t>(absScale));
+    const int128_t absVal = number < 0 ? -static_cast<int128_t>(number)
+                                       : static_cast<int128_t>(number);
+    const int128_t base = absVal / factor;
+    const int128_t rem = absVal % factor;
+    int128_t rounded = base;
+    if (rem * 2 >= factor) {
+      rounded += 1;
+    }
+    rounded *= factor;
+    if (number < 0) {
+      rounded = -rounded;
+    }
+    return static_cast<TNum>(rounded);
+#else
     if constexpr (alwaysRoundNegDec) {
       if (decimals >= 0)
         return number;
     } else {
       return number;
     }
+#endif
   }
   if (!std::isfinite(number)) {
     return number;
   }
 
+#ifdef SPARK_COMPATIBLE
+  if constexpr (std::is_same_v<TNum, float>) {
+    BigDecimal decimal(static_cast<float>(number));
+    decimal.setScale(decimals);
+    auto res = decimal.floatValue();
+    return res;
+  } else {
+    BigDecimal decimal(static_cast<double>(number));
+    decimal.setScale(decimals);
+    auto res = decimal.doubleValue();
+    return res;
+  }
+#else
   double dNumber = static_cast<double>(number);
   BigDecimal decimal(dNumber);
   decimal.setScale(decimals);
@@ -68,6 +107,7 @@ round(const TNum& number, const TDecimals& decimals = 0) {
     auto res = decimal.floatValue();
     return res;
   }
+#endif
 }
 
 // This is used by Bolt for floating points plus.

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
   SparkArraySortTest.cpp
   SparkCastExprTest.cpp
   SparkPartitionIdTest.cpp
+  SparkRoundTest.cpp
   SparkSqlDateTimeFunctionsTest.cpp
   SplitFunctionsTest.cpp
   StringTest.cpp

--- a/bolt/functions/sparksql/tests/SparkRoundTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkRoundTest.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class SparkRoundTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  void runRoundTest(const std::vector<std::tuple<T, T>>& data) {
+    auto result = evaluate<SimpleVector<T>>(
+        "round(c0)", makeRowVector({makeFlatVector<T, 0>(data)}));
+    for (int32_t i = 0; i < data.size(); ++i) {
+      ASSERT_EQ(result->valueAt(i), std::get<1>(data[i]));
+    }
+  }
+
+  template <typename T>
+  void runRoundWithDecimalTest(
+      const std::vector<std::tuple<T, int32_t, T>>& data) {
+    auto result = evaluate<SimpleVector<T>>(
+        "round(c0, c1)",
+        makeRowVector(
+            {makeFlatVector<T, 0>(data), makeFlatVector<int32_t, 1>(data)}));
+    for (int32_t i = 0; i < data.size(); ++i) {
+      ASSERT_EQ(result->valueAt(i), std::get<2>(data[i]));
+    }
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, T>> testRoundFloatData() {
+    return {
+        {1.0, 1.0},
+        {1.9, 2.0},
+        {1.3, 1.0},
+        {0.0, 0.0},
+        {0.9999, 1.0},
+        {-0.9999, -1.0},
+        {1.0 / 9999999, 0},
+        {123123123.0 / 9999999, 12.0}};
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, T>> testRoundIntegralData() {
+    return {{1, 1}, {0, 0}, {-1, -1}};
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecFloatData() {
+    return {{1.122112, 0, 1},
+            {1.129, 1, 1.1},
+            {1.129, 2, 1.13},
+            {1.0 / 3, 0, 0.0},
+            {1.0 / 3, 1, 0.3},
+            {1.0 / 3, 2, 0.33},
+            {1.0 / 3, 6, 0.333333},
+            {-1.122112, 0, -1},
+            {-1.129, 1, -1.1},
+            {-1.129, 2, -1.13},
+            {-1.129, 2, -1.13},
+            {-1.0 / 3, 0, 0.0},
+            {-1.0 / 3, 1, -0.3},
+            {-1.0 / 3, 2, -0.33},
+            {-1.0 / 3, 6, -0.333333},
+            {1.0, -1, 0.0},
+            {0.0, -2, 0.0},
+            {-1.0, -3, 0.0},
+            {11111.0, -1, 11110.0},
+            {11111.0, -2, 11100.0},
+            {11111.0, -3, 11000.0},
+            {11111.0, -4, 10000.0},
+            {0.575, 2, 0.58},
+            {0.574, 2, 0.57},
+            {-0.575, 2, -0.58},
+            {-0.574, 2, -0.57},
+            {102.825291, 6, 102.825291},
+            {10.424817, 6, 10.424817}};
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecIntegralData() {
+    return {
+        {1, 0, 1},
+        {0, 0, 0},
+        {-1, 0, -1},
+        {1, 1, 1},
+        {0, 1, 0},
+        {-1, 1, -1},
+        {1, 10, 1},
+        {0, 10, 0},
+        {-1, 10, -1},
+        {1, -1, 0},
+        {0, -2, 0},
+        {-1, -3, 0}};
+  }
+};
+
+TEST_F(SparkRoundTest, round) {
+  runRoundTest<float>(testRoundFloatData<float>());
+  runRoundTest<double>(testRoundFloatData<double>());
+
+  runRoundTest<int64_t>(testRoundIntegralData<int64_t>());
+  runRoundTest<int32_t>(testRoundIntegralData<int32_t>());
+  runRoundTest<int16_t>(testRoundIntegralData<int16_t>());
+  runRoundTest<int8_t>(testRoundIntegralData<int8_t>());
+}
+
+TEST_F(SparkRoundTest, roundWithDecimal) {
+  runRoundWithDecimalTest<float>(testRoundWithDecFloatData<float>());
+  runRoundWithDecimalTest<double>(testRoundWithDecFloatData<double>());
+
+  runRoundWithDecimalTest<int64_t>(testRoundWithDecIntegralData<int64_t>());
+  runRoundWithDecimalTest<int32_t>(testRoundWithDecIntegralData<int32_t>());
+  runRoundWithDecimalTest<int16_t>(testRoundWithDecIntegralData<int16_t>());
+  runRoundWithDecimalTest<int8_t>(testRoundWithDecIntegralData<int8_t>());
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/type/BigDecimal.h
+++ b/bolt/type/BigDecimal.h
@@ -41,7 +41,12 @@ class BigDecimal {
     bool nullOutput = false;
     auto output =
         util::Converter<TypeKind::VARCHAR, void, util::DefaultCastPolicy>::cast<
-            double>(val, &nullOutput);
+#ifdef SPARK_COMPATIBLE
+            Tfloat
+#else
+            double
+#endif
+            >(val, &nullOutput);
     if (nullOutput) {
       BOLT_FAIL("Invalid data");
     }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
