### PR TITLE
[fix][cp] Fix the state.data == nullptr exception in smj

### DIFF
--- a/bolt/exec/MergeSource.cpp
+++ b/bolt/exec/MergeSource.cpp
@@ -357,13 +357,14 @@ BlockingReason MergeJoinSource::enqueue(
       return BlockingReason::kNotBlocked;
     }
 
-    BOLT_CHECK_NULL(state.data);
+    if (state.data != nullptr) {
+      return waitForConsumer(future);
+    }
+
     state.data = std::move(data);
     deferNotify(consumerPromise_, notification);
 
-    producerPromise_ = ContinuePromise("MergeJoinSource::enqueue");
-    *future = producerPromise_->getSemiFuture();
-    return BlockingReason::kWaitForConsumer;
+    return waitForConsumer(future);
   });
 }
 

--- a/bolt/exec/MergeSource.h
+++ b/bolt/exec/MergeSource.h
@@ -87,6 +87,13 @@ class MergeJoinSource {
   void close();
 
  private:
+  // Wait consumer to fetch next batch of data.
+  BlockingReason waitForConsumer(ContinueFuture* future) {
+    producerPromise_ = ContinuePromise("MergeJoinSource::waitForConsumer");
+    *future = producerPromise_->getSemiFuture();
+    return BlockingReason::kWaitForConsumer;
+  }
+
   struct State {
     bool atEnd;
     RowVectorPtr data;


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

### Bug description

When we enable smj join in 2TB Q4 TPC-DS using Gluten, we encounter the following exception.

```
Error Source: RUNTIME
Error Code: INVALID_STATE
Retriable: False
Expression: state.data == nullptr
Context: Operator: CallbackSink[N/A] 2
Function: operator()
File: /mnt/DP_disk3/jk/projects/gluten/ep/build-velox/build/velox_ep/velox/exec/MergeSource.cpp
Line: 278
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, facebook::velox::detail::CompileTimeEmptyString>(facebook::velox::detail::VeloxCheckFailArgs const&, facebook::velox::detail::CompileTimeEmptyString)
# 2  facebook::velox::exec::MergeJoinSource::enqueue(std::shared_ptr<facebook::velox::RowVector>, folly::SemiFuture<folly::Unit>*)
# 3  std::_Function_handler<facebook::velox::exec::BlockingReason (std::shared_ptr<facebook::velox::RowVector>, folly::SemiFuture<folly::Unit>*), facebook::velox::exec::detail::makeConsumerSupplier(std::shared_ptr<facebook::velox::core::PlanNode const> const&)::{lambda(int, facebook::velox::exec::DriverCtx*)#5}::operator()(int, facebook::velox::exec::DriverCtx*) const::{lambda(std::shared_ptr<facebook::velox::RowVector>, folly::SemiFuture<folly::Unit>*)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<facebook::velox::RowVector>&&, folly::SemiFuture<folly::Unit>*&&)
# 4  facebook::velox::exec::CallbackSink::addInput(std::shared_ptr<facebook::velox::RowVector>)
# 5  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 6  facebook::velox::exec::Driver::next(std::shared_ptr<facebook::velox::exec::BlockingState>&)
# 7  facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
# 8  gluten::WholeStageResultIterator::next()
# 9  Java_org_apache_gluten_vectorized_ColumnarBatchOutIterator_nativeHasNext
# 10 0x00007f10d6574427
# 11 0x00007f10d7611fb7
```

### System information

Velox System Info v0.0.2
Commit: 245606e74111a75172c1ff55822dbaf67f5d8f42
CMake Version: 3.28.3
System: Linux-5.4.0-167-generic
Arch: x86_64
C++ Compiler: /usr/bin/c++
C++ Compiler Version: 9.4.0
C Compiler: /usr/bin/cc
C Compiler Version: 9.4.0
CMake Prefix Path: /usr/local;/usr;/;/usr/local/lib/python3.8/dist-packages/cmake/data;/usr/local;/usr/X11R6;/usr/pkg;/opt

Corresponding PR: https://github.com/facebookincubator/velox/pull/10509/

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
