### PR TITLE
[fix][cp] Fix Operator outputBatchRows may overflow

### DIFF
--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
+#include <limits>
 #include "bolt/common/config/Config.h"
 #include "bolt/core/Config.h"
+#include "bolt/vector/TypeAliases.h"
 namespace bytedance::bolt::core {
 /// A simple wrapper around bolt::Config. Defines constants for query
 /// config properties and accessor methods.
@@ -902,12 +904,16 @@ class QueryConfig {
     return get<uint64_t>(kPreferredOutputBatchBytes, kDefault);
   }
 
-  uint32_t preferredOutputBatchRows() const {
-    return get<uint32_t>(kPreferredOutputBatchRows, 1024);
+  vector_size_t preferredOutputBatchRows() const {
+    const uint32_t batchRows = get<uint32_t>(kPreferredOutputBatchRows, 1024);
+    BOLT_USER_CHECK_LE(batchRows, std::numeric_limits<vector_size_t>::max());
+    return batchRows;
   }
 
-  uint32_t maxOutputBatchRows() const {
-    return get<uint32_t>(kMaxOutputBatchRows, 10'000);
+  vector_size_t maxOutputBatchRows() const {
+    const uint32_t batchRows = get<uint32_t>(kMaxOutputBatchRows, 10'000);
+    BOLT_USER_CHECK_LE(batchRows, std::numeric_limits<vector_size_t>::max());
+    return batchRows;
   }
 
   uint32_t minOutputBatchRows() const {
@@ -1668,4 +1674,5 @@ class QueryConfig {
  private:
   std::unique_ptr<bolt::config::ConfigBase> config_;
 };
+
 } // namespace bytedance::bolt::core

--- a/bolt/dwio/common/SortingWriter.cpp
+++ b/bolt/dwio/common/SortingWriter.cpp
@@ -29,12 +29,13 @@
  */
 
 #include "bolt/dwio/common/SortingWriter.h"
+#include <limits>
 namespace bytedance::bolt::dwio::common {
 
 SortingWriter::SortingWriter(
     std::unique_ptr<Writer> writer,
     std::unique_ptr<exec::SortBuffer> sortBuffer,
-    uint32_t maxOutputRowsConfig,
+    vector_size_t maxOutputRowsConfig,
     uint64_t maxOutputBytesConfig,
     bolt::common::SpillStats* spillStats)
     : outputWriter_(std::move(writer)),
@@ -133,12 +134,19 @@ uint64_t SortingWriter::reclaim(
   return reclaimBytes;
 }
 
-uint32_t SortingWriter::outputBatchRows() {
-  uint32_t estimatedMaxOutputRows = UINT_MAX;
+vector_size_t SortingWriter::outputBatchRows() {
+  vector_size_t estimatedMaxOutputRows =
+      std::numeric_limits<vector_size_t>::max();
   if (sortBuffer_->estimateOutputRowSize().has_value() &&
       sortBuffer_->estimateOutputRowSize().value() != 0) {
-    estimatedMaxOutputRows =
+    const uint64_t maxOutputRows =
         maxOutputBytesConfig_ / sortBuffer_->estimateOutputRowSize().value();
+
+    if (UNLIKELY(maxOutputRows > std::numeric_limits<vector_size_t>::max())) {
+      return maxOutputRowsConfig_;
+    }
+
+    estimatedMaxOutputRows = maxOutputRows;
   }
   return std::min(estimatedMaxOutputRows, maxOutputRowsConfig_);
 }

--- a/bolt/dwio/common/SortingWriter.h
+++ b/bolt/dwio/common/SortingWriter.h
@@ -33,6 +33,7 @@
 #include "bolt/dwio/common/Writer.h"
 #include "bolt/exec/MemoryReclaimer.h"
 #include "bolt/exec/SortBuffer.h"
+#include "bolt/vector/TypeAliases.h"
 namespace bytedance::bolt::dwio::common {
 
 /// Sorting Writer object is used to write sorted data into a single file.
@@ -41,7 +42,7 @@ class SortingWriter : public Writer {
   SortingWriter(
       std::unique_ptr<Writer> writer,
       std::unique_ptr<exec::SortBuffer> sortBuffer,
-      uint32_t maxOutputRowsConfig,
+      vector_size_t maxOutputRowsConfig,
       uint64_t maxOutputBytesConfig,
       bolt::common::SpillStats* spillStats);
 
@@ -87,10 +88,10 @@ class SortingWriter : public Writer {
 
   uint64_t reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats);
 
-  uint32_t outputBatchRows();
+  vector_size_t outputBatchRows();
 
   const std::unique_ptr<Writer> outputWriter_;
-  const uint32_t maxOutputRowsConfig_;
+  const vector_size_t maxOutputRowsConfig_;
   const uint64_t maxOutputBytesConfig_;
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;

--- a/bolt/exec/HashProbe.h
+++ b/bolt/exec/HashProbe.h
@@ -271,7 +271,7 @@ class HashProbe : public Operator {
 
   void resetHashTable();
   // TODO: Define batch size as bytes based on RowContainer row sizes.
-  const uint32_t outputBatchSize_;
+  const vector_size_t outputBatchSize_;
 
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 

--- a/bolt/exec/Merge.h
+++ b/bolt/exec/Merge.h
@@ -105,7 +105,7 @@ class Merge : public SourceOperator {
   RowVectorPtr getOutputFromSource();
 
   /// Maximum number of rows in the output batch.
-  const uint32_t outputBatchSize_;
+  const vector_size_t outputBatchSize_;
 
   std::vector<SpillSortKey> sortingKeys_;
 

--- a/bolt/exec/MergeJoin.cpp
+++ b/bolt/exec/MergeJoin.cpp
@@ -50,7 +50,7 @@ MergeJoin::MergeJoin(
           operatorId,
           joinNode->id(),
           "MergeJoin"),
-      outputBatchSize_{static_cast<vector_size_t>(outputBatchRows())},
+      outputBatchSize_{outputBatchRows()},
       joinType_{joinNode->joinType()},
       numKeys_{joinNode->leftKeys().size()},
       joinNode_(joinNode) {

--- a/bolt/exec/NestedLoopJoinProbe.h
+++ b/bolt/exec/NestedLoopJoinProbe.h
@@ -303,7 +303,7 @@ class NestedLoopJoinProbe : public Operator {
   // Output buffer members.
 
   // Maximum number of rows in the output batch.
-  const uint32_t outputBatchSize_;
+  const vector_size_t outputBatchSize_;
 
   // The current output batch being populated.
   RowVectorPtr output_;

--- a/bolt/exec/Operator.cpp
+++ b/bolt/exec/Operator.cpp
@@ -468,7 +468,7 @@ OperatorStats Operator::stats(bool clear) {
   return stats;
 }
 
-uint32_t Operator::outputBatchRows(
+vector_size_t Operator::outputBatchRows(
     std::optional<uint64_t> averageRowSize) const {
   const auto& queryConfig = operatorCtx_->task()->queryCtx()->queryConfig();
 
@@ -484,12 +484,16 @@ uint32_t Operator::outputBatchRows(
       operatorType(),
       operatorId());
 
-  if (rowSize * queryConfig.maxOutputBatchRows() <
-      queryConfig.preferredOutputBatchBytes()) {
+  if (rowSize == 0) {
     return queryConfig.maxOutputBatchRows();
   }
-  return std::max<uint32_t>(
-      queryConfig.preferredOutputBatchBytes() / rowSize, 1);
+  const uint64_t batchSize =
+
+      queryConfig.preferredOutputBatchBytes() / rowSize;
+  if (batchSize > queryConfig.maxOutputBatchRows()) {
+    return queryConfig.maxOutputBatchRows();
+  }
+  return std::max<vector_size_t>(batchSize, 1);
 }
 
 int32_t Operator::getMaxReadBatchSize(

--- a/bolt/exec/Operator.h
+++ b/bolt/exec/Operator.h
@@ -609,7 +609,7 @@ class Operator : public BaseRuntimeStatWriter {
   /// must not be negative. If the averageRowSize is 0 which is not advised,
   /// returns maxOutputBatchRows. If the averageRowSize is not given, returns
   /// preferredOutputBatchRows.
-  uint32_t outputBatchRows(
+  vector_size_t outputBatchRows(
       std::optional<uint64_t> averageRowSize = std::nullopt) const;
 
   // Return the number of rows for the output batch by considering the output

--- a/bolt/exec/OrderBy.h
+++ b/bolt/exec/OrderBy.h
@@ -91,6 +91,6 @@ class OrderBy : public Operator {
 
   std::unique_ptr<SortBuffer> sortBuffer_;
   bool finished_ = false;
-  uint32_t maxOutputRows_;
+  vector_size_t maxOutputRows_;
 };
 } // namespace bytedance::bolt::exec

--- a/bolt/exec/SortBuffer.cpp
+++ b/bolt/exec/SortBuffer.cpp
@@ -212,7 +212,7 @@ void SortBuffer::noMoreInput() {
   pool_->release();
 }
 
-RowVectorPtr SortBuffer::getOutput(uint32_t maxOutputRows) {
+RowVectorPtr SortBuffer::getOutput(vector_size_t maxOutputRows) {
   BOLT_CHECK(noMoreInput_);
 
   if (numOutputRows_ == numInputRows_) {
@@ -433,7 +433,7 @@ void SortBuffer::spillOutput() {
   finishSpill();
 }
 
-void SortBuffer::prepareOutput(uint32_t batchSize) {
+void SortBuffer::prepareOutput(vector_size_t batchSize) {
   if (output_ != nullptr) {
     VectorPtr output = std::move(output_);
     BaseVector::prepareForReuse(output, batchSize);

--- a/bolt/exec/SortBuffer.h
+++ b/bolt/exec/SortBuffer.h
@@ -70,7 +70,7 @@ class SortBuffer {
   void noMoreInput();
 
   /// Returns the sorted output rows in batch.
-  RowVectorPtr getOutput(uint32_t maxOutputRows);
+  RowVectorPtr getOutput(vector_size_t maxOutputRows);
 
   /// Indicates if this sort buffer can spill or not.
   bool canSpill() const {
@@ -154,7 +154,7 @@ class SortBuffer {
   void ensureOutputFits(vector_size_t outputBatchSize);
   void updateEstimatedOutputRowSize();
   // Invoked to initialize or reset the reusable output buffer to get output.
-  void prepareOutput(uint32_t outputBatchSize);
+  void prepareOutput(vector_size_t outputBatchSize);
   void getOutputWithoutSpill();
   void getOutputWithSpill();
   // Spill during input stage.

--- a/bolt/exec/StreamingAggregation.h
+++ b/bolt/exec/StreamingAggregation.h
@@ -98,7 +98,7 @@ class StreamingAggregation : public Operator {
   void initializeAggregates(uint32_t numKeys);
 
   /// Maximum number of rows in the output batch.
-  const uint32_t outputBatchSize_;
+  const vector_size_t outputBatchSize_;
 
   // Will hold on accept new input if groups_ size large than
   // groupNumberThreshold_

--- a/bolt/exec/TableScan.h
+++ b/bolt/exec/TableScan.h
@@ -144,8 +144,8 @@ class TableScan : public SourceOperator {
 
   uint64_t prepareSplitTimeNs_{0};
 
-  int32_t readBatchSize_;
-  int32_t maxReadBatchSize_;
+  vector_size_t readBatchSize_;
+  vector_size_t maxReadBatchSize_;
   int32_t minReadBatchSize_;
 
   // Exits getOutput() method after this many milliseconds.


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The computation of function outputBatchRows() may overflow, fix it. And refactor the relevant output batch size config from uint32_t to vector_size_t(int32_t) because the RowVector numRows type is vector_size_t.

Corresponding PR: https://github.com/facebookincubator/velox/pull/10868

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
