### PR TITLE
[fix][cp] Fix Sort and Spill std::vector for rows memory not tracked causing OOM

### DIFF
--- a/bolt/exec/SortBuffer.cpp
+++ b/bolt/exec/SortBuffer.cpp
@@ -55,7 +55,9 @@ SortBuffer::SortBuffer(
       nonReclaimableSection_(nonReclaimableSection),
       spillConfig_(spillConfig),
       spillMemoryThreshold_(spillMemoryThreshold),
-      operatorCtx_(operatorCtx) {
+      operatorCtx_(operatorCtx),
+      // Track std::vector<char*> allocations in memory pool.
+      sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
   BOLT_CHECK_GE(input_->size(), sortCompareFlags_.size());
   BOLT_CHECK_GT(sortCompareFlags_.size(), 0);
   BOLT_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
@@ -172,7 +174,7 @@ void SortBuffer::noMoreInput() {
 #endif
 
 #ifdef ENABLE_META_SORT
-      MetaRowsSorterWraper<BufferRows>::MetaCodegenSort(
+      MetaRowsSorterWraper<SpillRows>::MetaCodegenSort(
           sortedRows_,
           data_.get(),
           sorter_,
@@ -418,8 +420,10 @@ void SortBuffer::spillOutput() {
       spillConfig_);
   spiller_->setSpillConfig(spillConfig_);
 
-  auto spillRows = std::vector<char*>(
-      sortedRows_.begin() + numOutputRows_, sortedRows_.end());
+  Spiller::SpillRows spillRows(
+      sortedRows_.begin() + numOutputRows_,
+      sortedRows_.end(),
+      sortedRows_.get_allocator());
   spiller_->spill(spillRows);
   LOG(INFO) << (operatorCtx_ ? operatorCtx_->toString() : "SortBuffer")
             << " spill output, data size: "

--- a/bolt/exec/SortBuffer.h
+++ b/bolt/exec/SortBuffer.h
@@ -193,7 +193,7 @@ class SortBuffer {
   size_t numInputRows_ = 0;
   // Used to store the input data in row format.
   std::unique_ptr<RowContainer> data_;
-  std::vector<char*> sortedRows_;
+  Spiller::SpillRows sortedRows_;
 
   // The data type of the rows stored in 'data_' and spilled on disk. The
   // sort key columns are stored first then the non-sorted data columns.

--- a/bolt/exec/SpillableWindowBuild.cpp
+++ b/bolt/exec/SpillableWindowBuild.cpp
@@ -141,7 +141,9 @@ void SpillableWindowBuild<needSort>::spill() {
     }
     doInitialize_ = false;
 
-    spillers_[currentSpilledPartition_]->spill(inputRows_, lastRun_);
+    Spiller::SpillRows spillRows(
+        inputRows_.begin(), inputRows_.end(), memory::StlAllocator<char*>(*pool_));
+    spillers_[currentSpilledPartition_]->spill(spillRows, lastRun_);
 
     spilledNumRows_ += inputRows_.size();
 
@@ -204,7 +206,9 @@ void SpillableWindowBuild<needSort>::spill() {
     doInitialize_ = false;
 
     spillers_[currentSpilledPartition_]->setRowFormatInfo(true);
-    spillers_[currentSpilledPartition_]->spill(inputRows_, lastRun_);
+    Spiller::SpillRows spillRows2(
+        inputRows_.begin(), inputRows_.end(), memory::StlAllocator<char*>(*pool_));
+    spillers_[currentSpilledPartition_]->spill(spillRows2, lastRun_);
 
     spilledNumRows_ += inputRows_.size();
 

--- a/bolt/exec/Spiller.cpp
+++ b/bolt/exec/Spiller.cpp
@@ -762,7 +762,7 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
   updateSpillTotalTime(totalTimeUs);
 }
 
-void Spiller::spill(std::vector<char*>& rows, bool lastRun) {
+void Spiller::spill(SpillRows& rows, bool lastRun) {
   CHECK_NOT_FINALIZED();
   BOLT_CHECK(!rows.empty());
   uint64_t totalTimeUs{0};
@@ -918,14 +918,14 @@ bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
   return lastRun;
 }
 
-void Spiller::fillSpillRun(std::vector<char*>& rows) {
+void Spiller::fillSpillRun(SpillRows& rows) {
   BOLT_CHECK_EQ(bits_.numPartitions(), 1);
   checkEmptySpillRuns();
   uint64_t execTimeUs{0};
   {
     MicrosecondTimer timer(&execTimeUs);
-    spillRuns_[0].rows =
-        SpillRows(rows.begin(), rows.end(), spillRuns_[0].rows.get_allocator());
+    spillRuns_[0].rows = SpillRows(
+        rows.begin(), rows.end(), spillRuns_[0].rows.get_allocator());
     for (const auto* row : rows) {
       spillRuns_[0].numBytes += container_->rowSize(row);
     }

--- a/bolt/exec/Spiller.h
+++ b/bolt/exec/Spiller.h
@@ -150,7 +150,7 @@ class Spiller {
   /// 'kOrderByOutput' spiller type to spill during the order by
   /// output processing. Similarly, the spilled rows still stays in the row
   /// container. The caller needs to erase them from the row container.
-  void spill(std::vector<char*>& rows, bool lastRun = true);
+  void spill(SpillRows& rows, bool lastRun = true);
 
   /// Append 'spillVector' into the spill file of given 'partition'. It is now
   /// only used by the spilling operator which doesn't need data sort, such as
@@ -377,7 +377,7 @@ class Spiller {
 
   // Prepares spill run of a single partition for the spillable data from the
   // rows.
-  void fillSpillRun(std::vector<char*>& rows);
+  void fillSpillRun(SpillRows& rows);
 
   // Writes out all the rows collected in spillRuns_.
   void runSpill(bool lastRun);

--- a/bolt/exec/tests/AsyncSpillerTest.cpp
+++ b/bolt/exec/tests/AsyncSpillerTest.cpp
@@ -1079,7 +1079,9 @@ TEST_P(AllTypes, nonSortedSpillFunctionsWithUring) {
         int numListedRows{0};
         numListedRows = rowContainer_->listRows(&rowIter, 5000, rows.data());
         ASSERT_EQ(numListedRows, 5000);
-        spiller_->spill(rows);
+        Spiller::SpillRows spillRows(
+            rows.begin(), rows.end(), memory::StlAllocator<char*>(*memory::spillMemoryPool()));
+        spiller_->spill(spillRows);
       } else {
         spiller_->spill();
       }
@@ -1604,7 +1606,9 @@ TEST_P(MaxSpillRunTest, basicWithUring) {
       int numListedRows{0};
       numListedRows = rowContainer_->listRows(&rowIter, numRows, rows.data());
       ASSERT_EQ(numListedRows, numRows);
-      spiller_->spill(rows);
+      Spiller::SpillRows spillRows(
+          rows.begin(), rows.end(), memory::StlAllocator<char*>(*memory::spillMemoryPool()));
+      spiller_->spill(spillRows);
     } else {
       spiller_->spill();
     }

--- a/bolt/exec/tests/SpillerTest.cpp
+++ b/bolt/exec/tests/SpillerTest.cpp
@@ -1081,7 +1081,9 @@ TEST_P(AllTypes, nonSortedSpillFunctions) {
         int numListedRows{0};
         numListedRows = rowContainer_->listRows(&rowIter, 5000, rows.data());
         ASSERT_EQ(numListedRows, 5000);
-        spiller_->spill(rows);
+        Spiller::SpillRows spillRows(
+            rows.begin(), rows.end(), memory::StlAllocator<char*>(*memory::spillMemoryPool()));
+        spiller_->spill(spillRows);
       } else {
         spiller_->spill();
       }
@@ -1507,8 +1509,9 @@ TEST_P(OrderByOutputOnly, basic) {
       std::vector<char*> emptyRows;
       BOLT_ASSERT_THROW(spiller_->spill(emptyRows), "");
     }
-    auto spillRows =
-        std::vector<char*>(rows.begin(), rows.begin() + numListedRows);
+    Spiller::SpillRows spillRows(
+        rows.begin(), rows.begin() + numListedRows,
+        memory::StlAllocator<char*>(*memory::spillMemoryPool()));
     spiller_->spill(spillRows);
     ASSERT_EQ(rowContainer_->numRows(), numRows);
     rowContainer_->clear();
@@ -1572,9 +1575,10 @@ TEST_P(RowBasedSpillTest, row_based_spill) {
   int numListedRows{0};
   numListedRows = rowContainer_->listRows(&rowIter, numRows, rows.data());
   ASSERT_EQ(numListedRows, numRows);
-  auto spillRows =
-      std::vector<char*>(rows.begin(), rows.begin() + numListedRows);
-  spiller_->spill(spillRows);
+    Spiller::SpillRows spillRows(
+        rows.begin(), rows.begin() + numListedRows,
+        memory::StlAllocator<char*>(*memory::spillMemoryPool()));
+    spiller_->spill(spillRows);
   ASSERT_EQ(rowContainer_->numRows(), numRows);
 
   auto spillPartition = spiller_->finishSpill();
@@ -1704,7 +1708,9 @@ TEST_P(MaxSpillRunTest, basic) {
       int numListedRows{0};
       numListedRows = rowContainer_->listRows(&rowIter, numRows, rows.data());
       ASSERT_EQ(numListedRows, numRows);
-      spiller_->spill(rows);
+      Spiller::SpillRows spillRows(
+          rows.begin(), rows.end(), memory::StlAllocator<char*>(*memory::spillMemoryPool()));
+      spiller_->spill(spillRows);
     } else {
       spiller_->spill();
     }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Spark query failed by killed by yarn because the memory overhead exceeds the threshold.
std::vector for rows should be tracked by memory pool.
Need to refactor everywhere if the std::vector is allocated by rows, this is a first PR.
Reserve the memory for the std::vector for rows and prefix sort required buffer.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->


### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
