### PR TITLE
[fix][cp] Fix withIntDistributionForField copy

### DIFF
--- a/bolt/dwio/common/tests/utils/DataSetBuilder.h
+++ b/bolt/dwio/common/tests/utils/DataSetBuilder.h
@@ -111,7 +111,7 @@ class DataSetBuilder {
         if (counter % 100 < repeats) {
           numbers->set(row, T(counter % repeats));
         } else if (counter % 100 > 90 && row > 0) {
-          numbers->copy(numbers, row - 1, row, 1);
+          numbers->copy(numbers, row, row - 1, 1);
         } else {
           int64_t value;
           if (rareFrequency && counter % rareFrequency == 0) {

--- a/bolt/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -344,9 +344,11 @@ TEST_F(E2EFilterTest, floatAndDouble) {
 }
 
 TEST_F(E2EFilterTest, shortDecimalDictionary) {
+  // decimal(8, 5) maps to 4 bytes FLBA in Parquet.
   // decimal(10, 5) maps to 5 bytes FLBA in Parquet.
   // decimal(17, 5) maps to 8 bytes FLBA in Parquet.
   for (const auto& type : {
+           "shortdecimal_val:decimal(8, 5)",
            "shortdecimal_val:decimal(10, 5)",
            "shortdecimal_val:decimal(17, 5)",
        }) {
@@ -373,9 +375,11 @@ TEST_F(E2EFilterTest, shortDecimalDirect) {
   options_.enableDictionary = false;
   options_.dataPageSize = 4 * 1024;
 
+  // decimal(8, 5) maps to 4 bytes FLBA in Parquet.
   // decimal(10, 5) maps to 5 bytes FLBA in Parquet.
   // decimal(17, 5) maps to 8 bytes FLBA in Parquet.
   for (const auto& type : {
+           "shortdecimal_val:decimal(8, 5)",
            "shortdecimal_val:decimal(10, 5)",
            "shortdecimal_val:decimal(17, 5)",
        }) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

For decimal(8, 5) data build, Arrow reports below error due to out of range. The reason is in the copy of 'withIntDistributionForField', the target index and source index are reversed.
```
`C++ exception with description "Invalid: Invalid cast from Decimal128 to 4 byte integer" thrown in the test body.
```

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->


### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
