### PR TITLE
[fix][cp] misc: Fix the typos found in the aggregate

### DIFF
--- a/bolt/exec/AggregateCompanionAdapter.cpp
+++ b/bolt/exec/AggregateCompanionAdapter.cpp
@@ -397,7 +397,7 @@ bool CompanionFunctionsRegistrar::registerMergeExtractFunctionWithSuffix(
               const auto& [originalResultType, _] =
                   resolveAggregateFunction(mergeExtractFunctionName, argTypes);
               if (!originalResultType) {
-                // TODO: limitation -- result type must be resolveable given
+                // TODO: limitation -- result type must be resolvable given
                 // intermediate type of the original UDAF.
                 BOLT_UNREACHABLE(
                     "Signatures whose result types are not resolvable given intermediate types should have been excluded.");
@@ -504,7 +504,7 @@ bool CompanionFunctionsRegistrar::registerExtractFunctionWithSuffix(
 
       auto resultType = resolveVectorFunction(name, argTypes);
       if (!resultType) {
-        // TODO: limitation -- result type must be resolveable given
+        // TODO: limitation -- result type must be resolvable given
         // intermediate type of the original UDAF.
         BOLT_UNREACHABLE(
             "Signatures whose result types are not resolvable given intermediate types should have been excluded.");
@@ -561,7 +561,7 @@ bool CompanionFunctionsRegistrar::registerExtractFunction(
 
     auto resultType = resolveVectorFunction(name, argTypes);
     if (!resultType) {
-      // TODO: limitation -- result type must be resolveable given
+      // TODO: limitation -- result type must be resolvable given
       // intermediate type of the original UDAF.
       BOLT_UNREACHABLE(
           "Signatures whose result types are not resolvable given intermediate types should have been excluded.");

--- a/bolt/exec/AggregateCompanionAdapter.h
+++ b/bolt/exec/AggregateCompanionAdapter.h
@@ -227,7 +227,7 @@ class CompanionFunctionsRegistrar {
   // with the same intermediate type, register extract functions with suffix
   // of their result types in the function names for each of them. Otherwise,
   // register one extract function of all supported signatures. The result
-  // type of the original aggregation function is required to be resolveable
+  // type of the original aggregation function is required to be resolvable
   // given its intermediate type. When there is already a function of the same
   // name as the extract companion function, if `overwrite` is true, the
   // registration is replaced. Otherwise, return false without overwriting the
@@ -238,7 +238,7 @@ class CompanionFunctionsRegistrar {
       bool overwrite = false);
 
   // Similar to registerExtractFunction(), the result type of the original
-  // aggregation function is required to be resolveable given its intermediate
+  // aggregation function is required to be resolvable given its intermediate
   // type. If there are multiple signatures of the original aggregation function
   // with the same intermediate type, register merge-extract functions with
   // suffix of their result types in the function names for each of them. When

--- a/bolt/exec/AggregateCompanionSignatures.cpp
+++ b/bolt/exec/AggregateCompanionSignatures.cpp
@@ -170,12 +170,12 @@ bool CompanionSignatures::hasSameIntermediateTypesAcrossSignatures(
     const std::vector<AggregateFunctionSignaturePtr>& signatures) {
   std::unordered_set<TypeSignature> seenTypes;
   for (const auto& signature : signatures) {
-    auto normalizdType =
+    auto normalizedType =
         normalizeType(signature->intermediateType(), signature->variables());
-    if (seenTypes.count(normalizdType)) {
+    if (seenTypes.count(normalizedType)) {
       return true;
     }
-    seenTypes.insert(normalizdType);
+    seenTypes.insert(normalizedType);
   }
   return false;
 }

--- a/bolt/exec/AggregateCompanionSignatures.h
+++ b/bolt/exec/AggregateCompanionSignatures.h
@@ -116,12 +116,12 @@ class CompanionSignatures {
     std::vector<T> processedSignatures;
 
     for (const auto& signature : signatures) {
-      auto normalizdIntermediateType =
+      auto normalizedIntermediateType =
           normalizeType(signature->intermediateType(), signature->variables());
       auto normalizedReturnType =
           normalizeType(signature->returnType(), signature->variables());
       if (distinctIntermediateAndResultTypes.count(std::make_pair(
-              normalizdIntermediateType, normalizedReturnType))) {
+              normalizedIntermediateType, normalizedReturnType))) {
         continue;
       }
 
@@ -135,7 +135,7 @@ class CompanionSignatures {
         // cannot. We only need one processed signature for each pair of
         // intermediate and result types.
         distinctIntermediateAndResultTypes.emplace(
-            normalizdIntermediateType, normalizedReturnType);
+            normalizedIntermediateType, normalizedReturnType);
       }
     }
     return processedSignatures;
@@ -152,9 +152,9 @@ class CompanionSignatures {
     std::vector<AggregateFunctionSignaturePtr> processedSignatures;
 
     for (const auto& signature : signatures) {
-      auto normalizdIntermediateType =
+      auto normalizedIntermediateType =
           normalizeType(signature->intermediateType(), signature->variables());
-      if (distinctIntermediateTypes.count(normalizdIntermediateType)) {
+      if (distinctIntermediateTypes.count(normalizedIntermediateType)) {
         continue;
       }
 
@@ -166,7 +166,7 @@ class CompanionSignatures {
         // There may be multiple signatures of the same intermediate type, some
         // can be processed successfully while some cannot. We only need one
         // processed signature for each intermediate type.
-        distinctIntermediateTypes.emplace(normalizdIntermediateType);
+        distinctIntermediateTypes.emplace(normalizedIntermediateType);
       }
     }
     return processedSignatures;
@@ -183,7 +183,7 @@ std::unordered_map<std::string, SignatureVariable> usedTypeVariables(
 bool isResultTypeResolvableGivenIntermediateType(
     const AggregateFunctionSignaturePtr& signature);
 
-// Return a string that is preorder traveral of `type`. For example, for
+// Return a string that is preorder traversal of `type`. For example, for
 // row(bigint, array(double)), return a string "row_bigint_array_double".
 std::string toSuffixString(const TypeSignature& type);
 

--- a/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -340,7 +340,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
   auto groupingKeysWithPartialKey = groupingKeys;
   groupingKeysWithPartialKey.push_back("k0");
 
-  std::vector<std::string> paritialAggregates;
+  std::vector<std::string> partialAggregates;
   std::vector<std::string> mergeAggregates;
   std::vector<std::string> extractExpressions;
   extractExpressions.insert(
@@ -352,14 +352,14 @@ void AggregationTestBase::testAggregationsWithCompanion(
         exec::getCompanionFunctionSignatures(functionNames[i]);
     BOLT_CHECK(companionSignatures.has_value());
 
-    const auto& [paritialAggregate, mergeAggregate, extractAggregate] =
+    const auto& [partialAggregate, mergeAggregate, extractAggregate] =
         getCompanionAggregates(
             i,
             *companionSignatures,
             functionNames[i],
             aggregateArgs[i],
             aggregatesArgTypes[i]);
-    paritialAggregates.push_back(paritialAggregate);
+    partialAggregates.push_back(partialAggregate);
     mergeAggregates.push_back(mergeAggregate);
     extractExpressions.push_back(extractAggregate);
   }
@@ -369,7 +369,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     PlanBuilder builder(pool());
     builder.values(dataWithExtraGroupingKey);
     preAggregationProcessing(builder);
-    builder.partialAggregation(groupingKeysWithPartialKey, paritialAggregates)
+    builder.partialAggregation(groupingKeysWithPartialKey, partialAggregates)
         .finalAggregation()
         .partialAggregation(groupingKeys, mergeAggregates)
         .finalAggregation()
@@ -394,7 +394,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     // repartitioning to split input into multiple batches.
     core::PlanNodeId partialNodeId;
     builder.localPartitionRoundRobinRow()
-        .partialAggregation(groupingKeysWithPartialKey, paritialAggregates)
+        .partialAggregation(groupingKeysWithPartialKey, partialAggregates)
         .capturePlanNodeId(partialNodeId)
         .localPartition(groupingKeysWithPartialKey)
         .finalAggregation()
@@ -434,7 +434,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     PlanBuilder builder(pool());
     builder.values(dataWithExtraGroupingKey);
     preAggregationProcessing(builder);
-    builder.singleAggregation(groupingKeysWithPartialKey, paritialAggregates)
+    builder.singleAggregation(groupingKeysWithPartialKey, partialAggregates)
         .singleAggregation(groupingKeys, mergeAggregates)
         .project(extractExpressions);
 
@@ -452,7 +452,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     PlanBuilder builder(pool());
     builder.values(dataWithExtraGroupingKey);
     preAggregationProcessing(builder);
-    builder.partialAggregation(groupingKeysWithPartialKey, paritialAggregates)
+    builder.partialAggregation(groupingKeysWithPartialKey, partialAggregates)
         .intermediateAggregation()
         .finalAggregation()
         .partialAggregation(groupingKeys, mergeAggregates)
@@ -474,7 +474,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     PlanBuilder builder(pool());
     builder.values(dataWithExtraGroupingKey);
     preAggregationProcessing(builder);
-    builder.partialAggregation(groupingKeysWithPartialKey, paritialAggregates)
+    builder.partialAggregation(groupingKeysWithPartialKey, partialAggregates)
         .localPartition(groupingKeysWithPartialKey)
         .finalAggregation()
         .partialAggregation(groupingKeys, mergeAggregates)
@@ -497,7 +497,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     PlanBuilder builder(pool());
     builder.values(dataWithExtraGroupingKey);
     preAggregationProcessing(builder);
-    builder.partialAggregation(groupingKeysWithPartialKey, paritialAggregates)
+    builder.partialAggregation(groupingKeysWithPartialKey, partialAggregates)
         .localPartition(groupingKeysWithPartialKey)
         .intermediateAggregation()
         .localPartition(groupingKeysWithPartialKey)
@@ -530,7 +530,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
       SCOPED_TRACE("Streaming partial");
       auto partialResult = validateStreamingInTestAggregations(
           [&](auto& builder) { builder.values(dataWithExtraGroupingKey); },
-          paritialAggregates,
+          partialAggregates,
           config);
 
       validateStreamingInTestAggregations(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Fix the typos found in the aggregate

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
