### PR TITLE
[fix][cp] fix: Fix DwrfStreamIdentifier compilation on `operator==`

### DIFF
--- a/bolt/dwio/dwrf/common/Common.h
+++ b/bolt/dwio/dwrf/common/Common.h
@@ -205,14 +205,19 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
             static_cast<StreamKind>(pkind)) {}
 
   ~DwrfStreamIdentifier() = default;
-  using dwio::common::StreamIdentifier::operator==;
-  bool operator==(const DwrfStreamIdentifier& other) const {
-    // column == other.column may be join the expression if all files
-    // share the same new version that has column field filled
-    return encodingKey_ == other.encodingKey_ && kind_ == other.kind_;
+
+  bool operator==(const StreamIdentifier& other) const override {
+    if (const auto* otherDwrf =
+            dynamic_cast<const DwrfStreamIdentifier*>(&other)) {
+      // column == other.column may be join the expression if all files
+      // share the same new version that has column field filled.
+      return encodingKey_ == otherDwrf->encodingKey_ &&
+          kind_ == otherDwrf->kind_;
+    }
+    return false;
   }
 
-  std::size_t hash() const {
+  std::size_t hash() const override {
     return encodingKey_.hash() ^ std::hash<uint32_t>()(kind_);
   }
 
@@ -228,7 +233,7 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
     return encodingKey_;
   }
 
-  std::string toString() const {
+  std::string toString() const override {
     return fmt::format(
         "[id={}, node={}, sequence={}, column={}, kind={}]",
         id_,


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Fixes DwrfStreamIdentifier compilation by overriding the `operator==` of StreamIdentifier.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
