### PR TITLE
[fix][cp] fix: Fix reading table with non-ascii names

### DIFF
--- a/bolt/dwio/dwrf/reader/ReaderBase.cpp
+++ b/bolt/dwio/dwrf/reader/ReaderBase.cpp
@@ -33,6 +33,7 @@
 #include <fmt/format.h>
 
 #include "bolt/dwio/common/exception/Exception.h"
+#include "bolt/functions/lib/string/StringImpl.h"
 namespace bytedance::bolt::dwrf {
 
 using dwio::common::ColumnStatistics;
@@ -352,7 +353,7 @@ std::shared_ptr<const Type> ReaderBase::convertType(
             footer, type.subtypes(i), fileColumnNamesReadAsLowerCase);
         auto childName = type.fieldNames(i);
         if (fileColumnNamesReadAsLowerCase) {
-          folly::toLowerAscii(childName);
+          childName = functions::stringImpl::utf8StrToLowerCopy(childName);
         }
         names.push_back(std::move(childName));
         tl.push_back(std::move(child));

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -44,6 +44,7 @@
 #include "bolt/dwio/parquet/thrift/ThriftInternal.h"
 #include "bolt/dwio/parquet/thrift/ThriftTransport.h"
 #include "bolt/dwio/parquet/thrift/codegen/parquet_types.h"
+#include "bolt/functions/lib/string/StringImpl.h"
 
 namespace bytedance::bolt::parquet {
 
@@ -431,7 +432,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
 
   auto name = schemaElement.name;
   if (isFileColumnNamesReadAsLowerCase()) {
-    folly::toLowerAscii(name);
+    name = functions::stringImpl::utf8StrToLowerCopy(name);
   }
   if (!schemaElement.__isset.type) { // inner node
     BOLT_CHECK(
@@ -448,7 +449,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       ++schemaIdx;
       auto childName = schema[schemaIdx].name;
       if (isFileColumnNamesReadAsLowerCase()) {
-        folly::toLowerAscii(childName);
+        childName = functions::stringImpl::utf8StrToLowerCopy(childName);
       }
 
       TypePtr childRequestedType = nullptr;
@@ -998,7 +999,7 @@ std::shared_ptr<const RowType> ReaderBase::createRowType(
     auto childName =
         std::static_pointer_cast<const ParquetTypeWithId>(child)->name_;
     if (fileColumnNamesReadAsLowerCase) {
-      folly::toLowerAscii(childName);
+      childName = functions::stringImpl::utf8StrToLowerCopy(childName);
     }
     childNames.push_back(std::move(childName));
     childTypes.push_back(child->type());

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -591,43 +591,55 @@ TEST_F(ParquetTableScanTest, reqArrayLegacy) {
 }
 
 TEST_F(ParquetTableScanTest, readAsLowerCase) {
-  auto plan = PlanBuilder(pool_.get())
-                  .tableScan(ROW({"a"}, {BIGINT()}), {}, "")
-                  .planNode();
-  CursorParameters params;
-  std::shared_ptr<folly::Executor> executor =
-      std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency());
-  std::shared_ptr<core::QueryCtx> queryCtx =
-      core::QueryCtx::create(executor.get());
-  std::unordered_map<std::string, std::string> session = {
-      {std::string(
-           connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession),
-       "true"}};
-  queryCtx->setConnectorSessionOverridesUnsafe(
-      kHiveConnectorId, std::move(session));
-  params.queryCtx = queryCtx;
-  params.planNode = plan;
-  const int numSplitsPerFile = 1;
+  auto vectors = {makeRowVector(
+      {"A", "b"},
+      {
+          makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
+          makeFlatVector<double>(20, [](auto row) { return row + 1; }),
+      })};
+  auto filePath = TempFilePath::create();
+  WriterOptions options;
+  writeToParquetFile(filePath->getPath(), vectors, options);
+  createDuckDbTable(vectors);
 
-  bool noMoreSplits = false;
-  auto addSplits = [&](exec::Task* task) {
-    if (!noMoreSplits) {
-      auto const splits = HiveConnectorTestBase::makeHiveConnectorSplits(
-          {getExampleFilePath("upper.parquet")},
-          numSplitsPerFile,
-          dwio::common::FileFormat::PARQUET);
-      for (const auto& split : splits) {
-        task->addSplit("0", exec::Split(split));
-      }
-      task->noMoreSplits("0");
-    }
-    noMoreSplits = true;
-  };
-  auto result = readCursor(params, addSplits);
-  ASSERT_TRUE(waitForTaskCompletion(result.first->task().get()));
-  assertEqualResults(
-      result.second, {makeRowVector({"a"}, {makeFlatVector<int64_t>({0, 1})})});
+  auto plan = PlanBuilder().tableScan(ROW({"a"}, {BIGINT()})).planNode();
+  auto split = makeSplit(filePath->getPath());
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession,
+          "true")
+      .split(split)
+      .assertResults("SELECT A FROM tmp");
+
+  // Test reading table with non-ascii names.
+  auto vectorsNonAsciiNames = {makeRowVector(
+      {"Товары", "国Ⅵ", "\uFF21", "\uFF22"},
+      {
+          makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
+          makeFlatVector<double>(20, [](auto row) { return row + 1; }),
+          makeFlatVector<float>(20, [](auto row) { return row + 1; }),
+          makeFlatVector<int32_t>(20, [](auto row) { return row + 1; }),
+      })};
+  filePath = TempFilePath::create();
+  writeToParquetFile(filePath->getPath(), vectorsNonAsciiNames, options);
+  createDuckDbTable(vectorsNonAsciiNames);
+
+  plan = PlanBuilder()
+             .tableScan(
+                 ROW({"товары", "国ⅵ", "\uFF41", "\uFF42"},
+                     {BIGINT(), DOUBLE(), REAL(), INTEGER()}))
+             .planNode();
+  split = makeSplit(filePath->getPath());
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession,
+          "true")
+      .split(split)
+      .assertResults("SELECT * FROM tmp");
 }
 
 TEST_F(ParquetTableScanTest, DISABLED_structSelection) {

--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -1807,6 +1807,33 @@ TEST_F(TableScanTest, emptyFile) {
   }
 }
 
+TEST_F(TableScanTest, readAsLowerCase) {
+  auto rowType =
+      ROW({"Товары", "国Ⅵ", "\uFF21", "\uFF22"},
+          {BIGINT(), DOUBLE(), REAL(), INTEGER()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+
+  // Test reading table with non-ascii names.
+  auto op = PlanBuilder()
+                .tableScan(
+                    ROW({"товары", "国ⅵ", "\uFF41", "\uFF42"},
+                        {BIGINT(), DOUBLE(), REAL(), INTEGER()}))
+                .planNode();
+  auto split =
+      exec::test::HiveConnectorSplitBuilder(filePath->getPath()).build();
+
+  AssertQueryBuilder(op, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession,
+          "true")
+      .split(split)
+      .assertResults("SELECT * FROM tmp");
+}
+
 TEST_F(TableScanTest, partitionedTableVarcharKey) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);

--- a/bolt/functions/lib/string/StringImpl.h
+++ b/bolt/functions/lib/string/StringImpl.h
@@ -101,6 +101,13 @@ FOLLY_ALWAYS_INLINE bool upperAsciiInPlace(T& str) {
   return true;
 }
 
+// Return the lower-case string of a UTF8 string.
+FOLLY_ALWAYS_INLINE std::string utf8StrToLowerCopy(const std::string& str) {
+  std::string lowerStr;
+  functions::stringImpl::lower<false>(lowerStr, str);
+  return lowerStr;
+}
+
 /// Apply a set of appenders on an output string, an appender is a lambda
 /// that takes an output string and append a string to it. This can be used by
 /// code-gen to reduce copying in concat by evaluating nested expressions


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

`folly::toLowerAscii` only works for ascii characters, which causes inconsistency when `fileColumnNamesReadAsLowerCase` is set as true where non-ascii names in the `fileType` are still in upper case while the schema is in lower case. This PR uses `stringImpl::lower` to convert UTF-8 string as lower case in the DWRF and Parquet readers.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
