### PR TITLE
UT only for 'Fix CAST(tinyint/smallint/integer/bigint as varbinary) for Spark'

### DIFF
--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -2042,6 +2042,19 @@ TEST_F(CastExprTest, decimalToDecimal) {
       "Cannot cast DECIMAL '-99999999999999999999999999999999999999' to DECIMAL(38, 1)");
 }
 
+#ifndef SPARK_COMPATIBLE
+TEST_F(CastExprTest, integerToBinary) {
+  testInvalidCast<int8_t>(
+      "varbinary", {12}, "Cannot cast TINYINT to VARBINARY.");
+  testInvalidCast<int16_t>(
+      "varbinary", {12}, "Cannot cast SMALLINT to VARBINARY.");
+  testInvalidCast<int32_t>(
+      "varbinary", {12}, "Cannot cast INTEGER to VARBINARY.");
+  testInvalidCast<int64_t>(
+      "varbinary", {12}, "Cannot cast BIGINT to VARBINARY.");
+}
+#endif
+
 TEST_F(CastExprTest, integerToDecimal) {
   testIntToDecimalCasts<int8_t>();
   testIntToDecimalCasts<int16_t>();

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -787,6 +787,78 @@ TEST_F(SparkCastExprTest, testBinary) {
   testUnsupportedCast<float>("binary", {1.2}, "");
 }
 
+TEST_F(SparkCastExprTest, tinyintToBinary) {
+  testCast<int8_t, std::string>(
+      TINYINT(),
+      VARBINARY(),
+      {18,
+       -26,
+       0,
+       110,
+       std::numeric_limits<int8_t>::max(),
+       std::numeric_limits<int8_t>::min()},
+      {std::string("\x12", 1),
+       std::string("\xE6", 1),
+       std::string("\0", 1),
+       std::string("\x6E", 1),
+       std::string("\x7F", 1),
+       std::string("\x80", 1)});
+}
+
+TEST_F(SparkCastExprTest, smallintToBinary) {
+  testCast<int16_t, std::string>(
+      SMALLINT(),
+      VARBINARY(),
+      {180,
+       -199,
+       0,
+       12300,
+       std::numeric_limits<int16_t>::max(),
+       std::numeric_limits<int16_t>::min()},
+      {std::string("\0\xB4", 2),
+       std::string("\xFF\x39", 2),
+       std::string("\0\0", 2),
+       std::string("\x30\x0C", 2),
+       std::string("\x7F\xFF", 2),
+       std::string("\x80\00", 2)});
+}
+
+TEST_F(SparkCastExprTest, integerToBinary) {
+  testCast<int32_t, std::string>(
+      INTEGER(),
+      VARBINARY(),
+      {18,
+       -26,
+       0,
+       180000,
+       std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min()},
+      {std::string("\0\0\0\x12", 4),
+       std::string("\xFF\xFF\xFF\xE6", 4),
+       std::string("\0\0\0\0", 4),
+       std::string("\0\x02\xBF\x20", 4),
+       std::string("\x7F\xFF\xFF\xFF", 4),
+       std::string("\x80\0\0\0", 4)});
+}
+
+TEST_F(SparkCastExprTest, bigintToBinary) {
+  testCast<int64_t, std::string>(
+      BIGINT(),
+      VARBINARY(),
+      {123456,
+       -256789,
+       0,
+       180000,
+       std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min()},
+      {std::string("\0\0\0\0\0\x01\xE2\x40", 8),
+       std::string("\xFF\xFF\xFF\xFF\xFF\xFC\x14\xEB", 8),
+       std::string("\0\0\0\0\0\0\0\0", 8),
+       std::string("\0\0\0\0\0\x02\xBF\x20", 8),
+       std::string("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8),
+       std::string("\x80\x00\x00\x00\x00\x00\x00\x00", 8)});
+}
+
 #endif
 } // namespace
 } // namespace bytedance::bolt::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
Summary:
    Fixes https://github.com/facebookincubator/velox/issues/9820. 
    Corresponding PR: https://github.com/facebookincubator/velox/pull/9819

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
