### PR TITLE
[feat][cp] Add decimal column writer for ORC file format

### DIFF
--- a/bolt/common/encode/Coding.h
+++ b/bolt/common/encode/Coding.h
@@ -287,6 +287,9 @@ class ZigZag {
     return (static_cast<uint64_t>(val) << 1) ^ (val >> 63);
   }
 
+  static __uint128_t encodeInt128(__int128_t val) {
+    return (static_cast<__uint128_t>(val) << 1) ^ (val >> 127);
+  }
   template <typename U, typename T = typename std::make_signed<U>::type>
   static T decode(U val) {
     return static_cast<T>((val >> 1) ^ -(val & 1));

--- a/bolt/common/encode/tests/CMakeLists.txt
+++ b/bolt/common/encode/tests/CMakeLists.txt
@@ -25,7 +25,7 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_common_coding_test Base64Test.cpp CodingTest.cpp)
+add_executable(bolt_common_coding_test Base64Test.cpp CodingTest.cpp ZigZagTest.cpp)
 add_test(bolt_common_coding_test bolt_common_coding_test)
 target_link_libraries(
   bolt_common_coding_test PRIVATE bolt_testutils GTest::gtest

--- a/bolt/common/encode/tests/ZigZagTest.cpp
+++ b/bolt/common/encode/tests/ZigZagTest.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/common/encode/Coding.h"
+#include "bolt/type/HugeInt.h"
+
+namespace bytedance::bolt::encode::test {
+
+class ZigZagTest : public ::testing::Test {};
+
+TEST_F(ZigZagTest, hugeInt) {
+  auto assertZigZag = [](int128_t value) {
+    auto encoded = ZigZag::encodeInt128(value);
+    auto decoded = ZigZag::decode(encoded);
+    EXPECT_EQ(value, decoded);
+  };
+
+  assertZigZag(0);
+  assertZigZag(HugeInt::parse("1234567890123456789"));
+  assertZigZag(HugeInt::parse("-1234567890123456789"));
+  assertZigZag(HugeInt::parse(std::string(38, '9')));
+  assertZigZag(std::numeric_limits<__int128_t>::max());
+  assertZigZag(std::numeric_limits<__int128_t>::min());
+}
+
+} // namespace bytedance::bolt::encode::test

--- a/bolt/dwio/dwrf/common/IntEncoder.h
+++ b/bolt/dwio/dwrf/common/IntEncoder.h
@@ -130,6 +130,21 @@ class IntEncoder {
     }
   }
 
+  /// Write a huge int value at a time. This method could be optimized to encode
+  /// a batch of values at a time and avoid condition checking for each write
+  /// following 'addImpl'.
+  virtual void writeHugeInt(int128_t value) {
+    if (!useVInts_) {
+      BOLT_NYI("Huge int encoding not supported for fixed length.");
+    } else {
+      if constexpr (isSigned) {
+        writeVsHugeInt(value);
+      } else {
+        writeVuHugeInt(value);
+      }
+    }
+  }
+
   /**
    * Get size of buffer used so far.
    */
@@ -192,6 +207,12 @@ class IntEncoder {
     writeVulong(ZigZag::encode(val));
   }
   FOLLY_ALWAYS_INLINE void writeLongLE(int64_t val);
+
+  FOLLY_ALWAYS_INLINE void writeVuHugeInt(uint128_t val);
+
+  FOLLY_ALWAYS_INLINE void writeVsHugeInt(int128_t val) {
+    writeVuHugeInt(ZigZag::encodeInt128(val));
+  }
 
  private:
   template <typename T>
@@ -379,6 +400,19 @@ void IntEncoder<isSigned>::writeLongLE(int64_t val) {
   for (int32_t i = 0; i < numBytes_; i++) {
     writeByte(static_cast<char>(val & dwio::common::BASE_256_MASK));
     val >>= 8;
+  }
+}
+
+template <bool isSigned>
+void IntEncoder<isSigned>::writeVuHugeInt(uint128_t val) {
+  while (true) {
+    if ((val & ~0x7f) == 0) {
+      writeByte(static_cast<char>(val));
+      return;
+    }
+    writeByte(static_cast<char>(0x80 | (val & dwio::common::BASE_128_MASK)));
+    // Cast val to unsigned so as to force 0-fill right shift.
+    val >>= 7;
   }
 }
 

--- a/bolt/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/bolt/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -209,9 +209,21 @@ constexpr uint32_t ITERATIONS = 100'000;
 template <typename T>
 VectorPtr populateBatch(
     std::vector<std::optional<T>> const& data,
-    MemoryPool* pool) {
+    MemoryPool* pool,
+    const TypePtr& type = CppToType<T>::create()) {
   BufferPtr values = AlignedBuffer::allocate<T>(data.size(), pool);
   auto valuesPtr = values->asMutableRange<T>();
+
+  const size_t nulloptCount =
+      std::count(data.begin(), data.end(), std::nullopt);
+  if (nulloptCount == 0) {
+    size_t index = 0;
+    for (auto val : data) {
+      valuesPtr[index++] = val.value();
+    }
+    return std::make_shared<FlatVector<T>>(
+        pool, type, nullptr, data.size(), values, std::vector<BufferPtr>{});
+  }
 
   BufferPtr nulls = allocateNulls(data.size(), pool);
   auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -229,12 +241,7 @@ VectorPtr populateBatch(
   }
 
   auto batch = std::make_shared<FlatVector<T>>(
-      pool,
-      CppToType<T>::create(),
-      nulls,
-      data.size(),
-      values,
-      std::vector<BufferPtr>{});
+      pool, type, nulls, data.size(), values, std::vector<BufferPtr>{});
   batch->setNullCount(nullCount);
   return batch;
 }
@@ -284,8 +291,14 @@ void verifyBatch(
     const uint32_t seed) {
   auto size = data.size();
   ASSERT_EQ(out->size(), size) << "Batch size mismatch with seed " << seed;
-  ASSERT_EQ(nullCount, out->getNullCount())
-      << "nullCount mismatch with seed " << seed;
+  if (nullCount == std::nullopt) {
+    const auto outNullCount = out->getNullCount();
+    ASSERT_TRUE(outNullCount == std::nullopt || outNullCount == 0)
+        << "nullCount mismatch with seed " << seed;
+  } else {
+    ASSERT_EQ(nullCount, out->getNullCount())
+        << "nullCount mismatch with seed " << seed;
+  }
 
   auto outFv = std::dynamic_pointer_cast<FlatVector<T>>(out);
   size_t index = 0;
@@ -320,7 +333,8 @@ template <typename T>
 void testDataTypeWriter(
     const TypePtr& type,
     std::vector<std::optional<T>>& data,
-    const uint32_t sequence = 0) {
+    const uint32_t sequence = 0,
+    DwrfFormat format = DwrfFormat::kDwrf) {
   // Generate a seed and randomly shuffle the data
   uint32_t seed = Random::rand32();
   std::shuffle(data.begin(), data.end(), std::default_random_engine(seed));
@@ -333,9 +347,10 @@ void testDataTypeWriter(
   auto dataTypeWithId = TypeWithId::create(type, 1);
 
   // write
-  auto writer = BaseColumnWriter::create(context, *dataTypeWithId, sequence);
+  auto writer = BaseColumnWriter::create(
+      context, *dataTypeWithId, sequence, nullptr, format);
   auto size = data.size();
-  auto batch = populateBatch(data, pool.get());
+  auto batch = populateBatch(data, pool.get(), type);
   const size_t stripeCount = 2;
   const size_t strideCount = 3;
 
@@ -419,6 +434,43 @@ TEST_F(ColumnWriterTest, TestNullBooleanWriter) {
     data.emplace_back();
   }
   testDataTypeWriter(BOOLEAN(), data);
+}
+
+TEST_F(ColumnWriterTest, testDecimalWriter) {
+  const auto format = DwrfFormat::kOrc;
+  auto genShortDecimals = [&](bool hasNull) {
+    std::vector<std::optional<int64_t>> shortDecimals;
+    for (auto i = 0; i < ITERATIONS; ++i) {
+      if (!hasNull || i % 15) {
+        shortDecimals.emplace_back(i);
+      } else {
+        shortDecimals.emplace_back(std::nullopt);
+      }
+    }
+    return shortDecimals;
+  };
+
+  auto shortValues = genShortDecimals(false);
+  testDataTypeWriter(DECIMAL(10, 2), shortValues, /*sequence=*/0, format);
+  shortValues = genShortDecimals(true);
+  testDataTypeWriter(DECIMAL(10, 2), shortValues, /*sequence=*/0, format);
+
+  auto genLongDecimals = [&](bool hasNull) {
+    std::vector<std::optional<int128_t>> longDecimals;
+    for (auto i = 0; i < ITERATIONS; ++i) {
+      if (!hasNull || i % 15) {
+        longDecimals.emplace_back(HugeInt::build(123 * i, 456 * i + 789));
+      } else {
+        longDecimals.emplace_back(std::nullopt);
+      }
+    }
+    return longDecimals;
+  };
+
+  auto longValues = genLongDecimals(false);
+  testDataTypeWriter(DECIMAL(38, 4), longValues, /*sequence=*/0, format);
+  longValues = genLongDecimals(true);
+  testDataTypeWriter(DECIMAL(38, 4), longValues, /*sequence=*/0, format);
 }
 
 TEST_F(ColumnWriterTest, TestTimestampEpochWriter) {

--- a/bolt/dwio/dwrf/test/TestIntDirect.cpp
+++ b/bolt/dwio/dwrf/test/TestIntDirect.cpp
@@ -147,6 +147,39 @@ void testInts(std::function<T()> generator) {
   }
 }
 
+// Test round-trip writing and reading of huge ints. Only vInts are supported.
+template <bool isSigned>
+void testHugeInts(const std::vector<int128_t>& vec) {
+  auto pool = memory::memoryManager()->addLeafPool();
+  const size_t count = vec.size();
+
+  const size_t capacity = count * folly::kMaxVarintLength64 * 2;
+  MemorySink sink{capacity, {.pool = pool.get()}};
+  DataBufferHolder holder{*pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
+  auto output =
+      std::make_unique<bytedance::bolt::dwio::common::BufferedOutputStream>(
+          holder);
+  auto encoder = createDirectEncoder<isSigned>(
+      std::move(output), /*useVInts=*/true, sizeof(int128_t));
+
+  for (size_t i = 0; i < count; ++i) {
+    encoder->writeHugeInt(vec[i]);
+  }
+  encoder->flush();
+
+  const size_t expectedSize = capacity;
+  auto input = std::make_unique<SeekableArrayInputStream>(
+      sink.data(), expectedSize, expectedSize);
+  auto decoder = std::make_unique<dwio::common::DirectDecoder<isSigned>>(
+      std::move(input), /*useVInts=*/true, sizeof(int128_t));
+
+  std::vector<int128_t> vals(count);
+  decoder->nextValues(vals.data(), count, nullptr);
+  for (size_t i = 0; i < count; ++i) {
+    ASSERT_EQ(vec[i], vals[i]);
+  }
+}
+
 class DirectTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
@@ -241,4 +274,16 @@ void testCorruptedVarInts() {
 TEST_F(DirectTest, corruptedInts) {
   testCorruptedVarInts<false>();
   testCorruptedVarInts<true>();
+}
+
+TEST_F(DirectTest, hugeInts) {
+  folly::Random::DefaultGenerator rng;
+  std::vector<int128_t> vec;
+  constexpr size_t count = 10240;
+  for (auto i = 0; i < count; ++i) {
+    vec.emplace_back(
+        HugeInt::build(folly::Random::rand64(), folly::Random::rand64()));
+  }
+  testHugeInts<true>(vec);
+  testHugeInts<false>(vec);
 }

--- a/bolt/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/bolt/dwio/dwrf/writer/ColumnWriter.cpp
@@ -710,7 +710,7 @@ class DecimalColumnWriter : public BaseColumnWriter {
       std::function<void(IndexBuilder&)> onRecordPosition)
       : BaseColumnWriter{context, type, sequence, std::move(onRecordPosition)},
         type_{type.type()},
-        scale_{getDecimalPrecisionScale(*type_).second},
+        scale_{static_cast<uint8_t>(getDecimalPrecisionScale(*type_).second)},
         isShortDecimal_{type_->isShortDecimal()},
         unscaledValues_{createDirectEncoder</*isSigned=*/true>(
             newStream(StreamKind::StreamKind_DATA),

--- a/bolt/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/bolt/dwio/dwrf/writer/ColumnWriter.cpp
@@ -701,6 +701,118 @@ class TimestampColumnWriter : public BaseColumnWriter {
   std::unique_ptr<IntEncoder<false>> nanos_;
 };
 
+class DecimalColumnWriter : public BaseColumnWriter {
+ public:
+  DecimalColumnWriter(
+      WriterContext& context,
+      const TypeWithId& type,
+      uint32_t sequence,
+      std::function<void(IndexBuilder&)> onRecordPosition)
+      : BaseColumnWriter{context, type, sequence, std::move(onRecordPosition)},
+        type_{type.type()},
+        scale_{getDecimalPrecisionScale(*type_).second},
+        isShortDecimal_{type_->isShortDecimal()},
+        unscaledValues_{createDirectEncoder</*isSigned=*/true>(
+            newStream(StreamKind::StreamKind_DATA),
+            // IntDecoder and IntEncoder only support vInts for huge ints.
+            isShortDecimal_ ? getConfig(Config::USE_VINTS) : /*useVInts=*/true,
+            isShortDecimal_ ? LONG_BYTE_SIZE : 2 * LONG_BYTE_SIZE)},
+        scales_{createRleEncoder</*isSigned=*/true>(
+            RleVersion_1,
+            // DWRF's NANO_DATA has the same enum value as ORC's SECONDARY.
+            newStream(StreamKind::StreamKind_NANO_DATA),
+            getConfig(Config::USE_VINTS),
+            LONG_BYTE_SIZE)} {
+    reset();
+  }
+
+  uint64_t write(const VectorPtr& slice, const common::Ranges& ranges)
+      override {
+    BOLT_CHECK(
+        slice->type()->equivalent(*type_),
+        "Unexpected vector type: {}.",
+        slice->type()->toString());
+
+    // Always decode to reduce the number of branches. Fast paths for flat and
+    // constant encodings can be added for further optimization.
+    auto localDecoded = decode(slice, ranges);
+    auto& decodedVector = localDecoded.get();
+    writeNulls(decodedVector, ranges);
+
+    size_t count = 0;
+    if (isShortDecimal_) {
+      if (!decodedVector.mayHaveNulls()) {
+        for (auto pos : ranges) {
+          const auto val = decodedVector.valueAt<int64_t>(pos);
+          unscaledValues_->writeValue(val);
+          scales_->writeValue(scale_);
+        }
+        count += ranges.size();
+      } else {
+        for (auto pos : ranges) {
+          if (!decodedVector.isNullAt(pos)) {
+            const auto val = decodedVector.valueAt<int64_t>(pos);
+            unscaledValues_->writeValue(val);
+            scales_->writeValue(scale_);
+            ++count;
+          }
+        }
+      }
+    } else {
+      if (!decodedVector.mayHaveNulls()) {
+        for (auto pos : ranges) {
+          const auto val = decodedVector.valueAt<int128_t>(pos);
+          unscaledValues_->writeHugeInt(val);
+          scales_->writeValue(scale_);
+        }
+        count += ranges.size();
+      } else {
+        for (auto pos : ranges) {
+          if (!decodedVector.isNullAt(pos)) {
+            const auto val = decodedVector.valueAt<int128_t>(pos);
+            unscaledValues_->writeHugeInt(val);
+            scales_->writeValue(scale_);
+            ++count;
+          }
+        }
+      }
+    }
+
+    indexStatsBuilder_->increaseValueCount(count);
+    if (count != ranges.size()) {
+      indexStatsBuilder_->setHasNull();
+    }
+
+    const uint32_t decimalSize =
+        isShortDecimal_ ? 2 * LONG_BYTE_SIZE : 3 * LONG_BYTE_SIZE;
+    const auto rawSize =
+        count * decimalSize + (ranges.size() - count) * NULL_SIZE;
+    indexStatsBuilder_->increaseRawSize(rawSize);
+    return rawSize;
+  }
+
+  void flush(
+      std::function<proto::ColumnEncoding&(uint32_t)> encodingFactory,
+      std::function<void(proto::ColumnEncoding&)> encodingOverride) override {
+    BaseColumnWriter::flush(encodingFactory, encodingOverride);
+    unscaledValues_->flush();
+    scales_->flush();
+  }
+
+  void recordPosition() override {
+    BaseColumnWriter::recordPosition();
+    unscaledValues_->recordPosition(*indexBuilder_);
+    scales_->recordPosition(*indexBuilder_);
+  }
+
+ private:
+  const TypePtr type_;
+  const uint8_t scale_;
+  const bool isShortDecimal_;
+  std::unique_ptr<IntEncoder<true>> unscaledValues_;
+  std::unique_ptr<IntEncoder<true>> scales_;
+};
+
 namespace {
 FOLLY_ALWAYS_INLINE int64_t formatTime(int64_t seconds, uint64_t nanos) {
   DWIO_ENSURE(seconds >= MIN_SECONDS);
@@ -1989,7 +2101,8 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
     WriterContext& context,
     const TypeWithId& type,
     uint32_t sequence,
-    std::function<void(IndexBuilder&)> onRecordPosition) {
+    std::function<void(IndexBuilder&)> onRecordPosition,
+    DwrfFormat format) {
   const auto flatMapEnabled = context.getConfig(Config::FLATTEN_MAP) &&
       type.parent() != nullptr && (type.parent()->id() == 0);
   bool isFlatMapColumn{false};
@@ -2039,9 +2152,20 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
     case TypeKind::INTEGER:
       return std::make_unique<IntegerColumnWriter<int32_t>>(
           context, type, sequence, onRecordPosition);
-    case TypeKind::BIGINT:
+    case TypeKind::BIGINT: {
+      if (format == DwrfFormat::kOrc && type.type()->isDecimal()) {
+        return std::make_unique<DecimalColumnWriter>(
+            context, type, sequence, onRecordPosition);
+      }
       return std::make_unique<IntegerColumnWriter<int64_t>>(
           context, type, sequence, onRecordPosition);
+    }
+    case TypeKind::HUGEINT: {
+      BOLT_CHECK_EQ(
+          format, DwrfFormat::kOrc, "Decimal is not supported for DWRF.");
+      return std::make_unique<DecimalColumnWriter>(
+          context, type, sequence, onRecordPosition);
+    }
     case TypeKind::REAL:
       return std::make_unique<FloatColumnWriter<float>>(
           context, type, sequence, onRecordPosition);

--- a/bolt/dwio/dwrf/writer/ColumnWriter.h
+++ b/bolt/dwio/dwrf/writer/ColumnWriter.h
@@ -164,7 +164,8 @@ class BaseColumnWriter : public ColumnWriter {
       WriterContext& context,
       const dwio::common::TypeWithId& type,
       const uint32_t sequence = 0,
-      std::function<void(IndexBuilder&)> onRecordPosition = nullptr);
+      std::function<void(IndexBuilder&)> onRecordPosition = nullptr,
+      DwrfFormat format = DwrfFormat::kDwrf);
 
  protected:
   BaseColumnWriter(

--- a/bolt/dwio/dwrf/writer/Writer.h
+++ b/bolt/dwio/dwrf/writer/Writer.h
@@ -60,6 +60,7 @@ struct WriterOptions {
   std::shared_ptr<encryption::EncryptionSpecification> encryptionSpec;
   std::shared_ptr<dwio::common::encryption::EncrypterFactory> encrypterFactory;
   int64_t memoryBudget = std::numeric_limits<int64_t>::max();
+  DwrfFormat format{DwrfFormat::kDwrf};
   std::function<std::unique_ptr<ColumnWriter>(
       WriterContext& context,
       const bolt::dwio::common::TypeWithId& type)>


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
'SelectiveDecimalColumnReader' is typically used for reading decimal column in ORC file. This PR supports corresponding writer for decimal column in ORC file. Adds 'format' in 'WriterOptions' to distinguish between DWRF and ORC when writing.

https://github.com/facebookincubator/velox/pull/11067#issuecomment-2374368954

Corresponding PR: https://github.com/facebookincubator/velox/pull/11431

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
