### PR TITLE
[fix][cp] fix(function): Fix the timestamp precision of Spark 'in' function

### DIFF
--- a/bolt/functions/sparksql/In.cpp
+++ b/bolt/functions/sparksql/In.cpp
@@ -76,6 +76,39 @@ class Set<StringView> {
   folly::F14FastSet<std::string_view> set_;
 };
 
+// Specialization for Timestamp to store micros.
+template <>
+class Set<Timestamp> {
+ public:
+  using value_type = int64_t;
+
+  void emplace(const Timestamp& ts) {
+    const value_type micros = ts.toMicros();
+    if (!set_.contains(micros)) {
+      set_.emplace(micros);
+    }
+  }
+
+  bool contains(const Timestamp& ts) const {
+    return set_.contains(ts.toMicros());
+  }
+
+  void reserve(size_t size) {
+    set_.reserve(size);
+  }
+
+  size_t size() const {
+    return set_.size();
+  }
+
+  auto begin() const {
+    return set_.begin();
+  }
+
+ private:
+  folly::F14FastSet<value_type> set_;
+};
+
 template <typename TInput>
 struct InFunctionOuter {
   template <typename TExecCtx>

--- a/bolt/functions/sparksql/tests/InTest.cpp
+++ b/bolt/functions/sparksql/tests/InTest.cpp
@@ -190,6 +190,17 @@ TEST_F(InTest, Timestamp) {
       std::nullopt);
   EXPECT_EQ(
       in<Timestamp>(Timestamp(0, 0), {Timestamp(0, 0), Timestamp()}), true);
+  // The precision of Spark 'in' is microseconds.
+  EXPECT_EQ(
+      in<Timestamp>(
+          Timestamp(0, 123'456'000),
+          {Timestamp(0, 123'000'000), Timestamp(0, 123'123'000)}),
+      false);
+  EXPECT_EQ(
+      in<Timestamp>(
+          Timestamp(0, 123'456'789),
+          {Timestamp(0, 123'456'000), Timestamp(0, 123'456'123)}),
+      true);
 }
 
 TEST_F(InTest, Date) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Changes the timestamp precision of Spark 'in' function to microseconds. Fixes: https://github.com/facebookincubator/velox/issues/11755.

Corresponding PR: https://github.com/facebookincubator/velox/pull/11812

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
