### PR TITLE
build: support compiling with clang 19

### DIFF
--- a/.devcontainer/clang/Dockerfile.clang
+++ b/.devcontainer/clang/Dockerfile.clang
@@ -1,0 +1,140 @@
+FROM debian:bookworm
+
+ENV CMAKE_VERSION=3.31.8
+ENV MOLD_VERSION=2.40.4
+
+ARG DEB_REGION=""
+ARG https_proxy=""
+ARG no_proxy=""
+
+# check if deb region is not empty string. If it is, replace the default debian repository with the one for the region.
+RUN if [ "$DEB_REGION" != "" ]; then \
+    sed -i "s|http://deb.debian.org/debian|http://ftp.${DEB_REGION}.debian.org/debian|g" /etc/apt/sources.list.d/debian.sources; \
+fi
+
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    tar
+
+RUN arch=$(arch) && \
+    https_proxy=${https_proxy} \
+    curl -L -# -o /tmp/cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-${arch}.tar.gz  && \
+    tar -xzvf /tmp/cmake.tar.gz -C /opt && \
+    ln -s /opt/cmake-$CMAKE_VERSION-linux-${arch}/bin/cmake /usr/local/bin/cmake && \
+    ln -s /opt/cmake-$CMAKE_VERSION-linux-${arch}/bin/ctest /usr/local/bin/ctest && \
+    rm /tmp/cmake.tar.gz
+
+RUN apt-get update && apt-get install -y \
+    sudo \
+    bash \
+    vim-tiny \
+    vim \
+    sudo \
+    git \
+    gdb \
+    python3 \
+    python3-pip \
+    python3-virtualenv \
+    ssh-client \
+    ninja-build \
+    bison \
+    maven \
+    net-tools \
+    telnet \
+    ssh \
+    rsync \
+    openssh-server \
+    lld \
+    ccache \
+    binutils-dev \
+    make \
+    automake \
+    autoconf \
+    htop \
+    less \
+    man \
+    nodejs \
+    npm \
+    bsdextrautils \
+    locales \
+    clang-19 \
+    clang++-19 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -sf /bin/bash /bin/sh
+
+RUN https_proxy=${https_proxy} curl -L -O --output-dir /tmp https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-$(arch)-linux.tar.gz
+RUN cd /tmp && \
+    sudo tar -C /usr/local --strip-components=1 -xzf mold-$MOLD_VERSION-$(arch)-linux.tar.gz
+
+# Add mold's ld as the first on the path
+env PATH=/usr/local/libexec/mold:$PATH
+
+# License header check tool
+RUN https_proxy=${https_proxy} curl -L -# -o /tmp/skywalking-eyes-bin.tgz https://dlcdn.apache.org/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-bin.tgz && \
+    mkdir -p /opt/skywalking-license-eye && \
+    sudo tar -C /opt/skywalking-license-eye --strip-components=1 -xzf /tmp/skywalking-eyes-bin.tgz
+
+ENV PATH="/opt/skywalking-license-eye/bin/linux:${PATH}"
+
+RUN export arch=$(arch | sed 's/^aarch64$/arm64/; s/^x86_64$/amd64/') && \
+    export https_proxy=${https_proxy} && \
+    export filename=go1.25.5.linux-${arch}.tar.gz && \
+    curl -L -O --output-dir /tmp https://go.dev/dl/${filename} && \
+    sudo rm -rf /usr/local/bin/go && tar -C /usr/local -xzf /tmp/${filename} && \
+    rm /tmp/${filename}
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Set up default python virtualenv, and make it the default on PATH
+RUN virtualenv -p python3 /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt && \
+    rm -f requirements.txt
+
+ARG USERNAME=code
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
+
+# Configure default conan profile to use the mold linker
+RUN arch=$(uname -m) && mkdir -p ~/.conan2/profiles && cat > ~/.conan2/profiles/default <<EOF
+[settings]
+arch=$( [ "$arch" = "aarch64" ] && echo "armv8" || echo "$arch" )
+build_type=Release
+compiler=clang
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=19
+os=Linux
+
+[conf]
+tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}
+tools.build:exelinkflags=['-fuse-ld=mold', '-Wl,--allow-multiple-definition']
+tools.build:sharedlinkflags=['-fuse-ld=mold', '-Wl,--allow-multiple-definition']
+
+EOF
+
+# Generate Locales
+RUN sudo sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && \
+    sudo locale-gen && \
+    echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc && \
+    echo "export LANG=en_US.UTF-8" >> ~/.bashrc && \
+    echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
+
+
+ENV SHELL=/bin/bash
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/.devcontainer/clang/devcontainer.json
+++ b/.devcontainer/clang/devcontainer.json
@@ -31,6 +31,13 @@
         "--security-opt",
         "label=disable"
     ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "llvm-vs-code-extensions.vscode-clangd"
+            ]
+        }
+    },
     // Configure tool-specific properties.
     "features": {},
     "postCreateCommand": ".devcontainer/post_create_command.sh"

--- a/.devcontainer/clang/devcontainer.json
+++ b/.devcontainer/clang/devcontainer.json
@@ -1,0 +1,37 @@
+{
+    "name": "Bolt Clang Development Container",
+    "build": {
+        "dockerfile": "Dockerfile.clang",
+        "context": "../../.github/runners",
+        "args": {
+            "DEB_REGION": "",
+            "https_proxy": "",
+            "no_proxy": ""
+        }
+    },
+    "containerEnv": {
+        "https_proxy": "",
+        "no_proxy": "",
+        "SHELL": "/bin/bash"
+    },
+    "remoteUser": "code",
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [],
+    // Use 'portsAttributes' to set default properties for specific forwarded ports.
+    "portsAttributes": {},
+    // Use 'remoteEnv' to set environment variables that are only available inside the container.
+    "remoteEnv": {},
+    // Use 'mounts' to make files or directories from your local machine available inside the container.
+    "mounts": [
+        "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+        "source=conan-cache,target=/home/code/.conan2/p",
+        "source=ccache-cache,target=/home/code/.ccache"
+    ],
+    "runArgs": [
+        "--security-opt",
+        "label=disable"
+    ],
+    // Configure tool-specific properties.
+    "features": {},
+    "postCreateCommand": ".devcontainer/post_create_command.sh"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   add_definitions(-D OS_MACOSX)
 endif()
 
+# Only use compiler-rt when building with Clang on Linux for ARM/AArch64
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND OS_LINUX AND (ARCH_AARCH64 OR ARCH_ARM))
+  add_compile_options(-rtlib=compiler-rt)
+  add_link_options(-rtlib=compiler-rt)
+endif()
+
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
      "${PROJECT_SOURCE_DIR}/CMake/third-party"
 )

--- a/bolt/duckdb/conversion/DuckParser.cpp
+++ b/bolt/duckdb/conversion/DuckParser.cpp
@@ -35,7 +35,7 @@
 #include "bolt/parse/Expressions.h"
 #include "bolt/type/Variant.h"
 
-#include <sstream>
+#include <cmath>
 
 #include <duckdb.hpp> // @manual
 #include <duckdb/parser/expression/between_expression.hpp> // @manual
@@ -253,116 +253,6 @@ std::shared_ptr<const core::ConstantExpr> tryParseInterval(
       INTERVAL_DAY_TIME(), variant(value.value() * multiplier), alias);
 }
 
-std::shared_ptr<const core::ConstantExpr> tryParseIntervalWithUnit(
-    const std::shared_ptr<const core::IExpr>& input,
-    const std::shared_ptr<const core::IExpr>& unit,
-    const std::optional<std::string>& alias) {
-  std::optional<int64_t> value;
-  if (const auto* constInput =
-          dynamic_cast<const core::ConstantExpr*>(input.get())) {
-    if (constInput->type()->isBigint() && !constInput->value().isNull()) {
-      value = constInput->value().value<int64_t>();
-    }
-  } else if (
-      const auto* castInput =
-          dynamic_cast<const core::CastExpr*>(input.get())) {
-    if (castInput->type()->isBigint()) {
-      if (const auto* constInput = dynamic_cast<const core::ConstantExpr*>(
-              castInput->getInput().get())) {
-        if (constInput->type()->isBigint() && !constInput->value().isNull()) {
-          value = constInput->value().value<int64_t>();
-        }
-      }
-    }
-  }
-
-  if (!value.has_value()) {
-    return nullptr;
-  }
-
-  const auto* unitExpr = dynamic_cast<const core::ConstantExpr*>(unit.get());
-  if (!unitExpr || !unitExpr->type()->isVarchar() ||
-      unitExpr->value().isNull()) {
-    return nullptr;
-  }
-
-  const auto unitName =
-      StringUtil::Lower(unitExpr->value().value<std::string>());
-  int64_t multiplier;
-  if (unitName == "hour" || unitName == "hours") {
-    multiplier = 60 * 60 * 1'000;
-  } else if (unitName == "minute" || unitName == "minutes") {
-    multiplier = 60 * 1'000;
-  } else if (unitName == "second" || unitName == "seconds") {
-    multiplier = 1'000;
-  } else if (unitName == "millisecond" || unitName == "milliseconds") {
-    multiplier = 1;
-  } else {
-    return nullptr;
-  }
-
-  return std::make_shared<core::ConstantExpr>(
-      INTERVAL_DAY_TIME(), variant(value.value() * multiplier), alias);
-}
-
-std::shared_ptr<const core::ConstantExpr> tryParseIntervalLiteral(
-    const std::string& exprString) {
-  std::string trimmed = exprString;
-  StringUtil::Trim(trimmed);
-  auto lower = StringUtil::Lower(trimmed);
-  if (!StringUtil::StartsWith(lower, "interval ")) {
-    return nullptr;
-  }
-
-  std::istringstream iss(trimmed);
-  std::string keyword;
-  iss >> keyword;
-  if (StringUtil::Lower(keyword) != "interval") {
-    return nullptr;
-  }
-
-  std::string valueToken;
-  std::string unitToken;
-  if (!(iss >> valueToken >> unitToken)) {
-    return nullptr;
-  }
-
-  int64_t value;
-  try {
-    value = std::stoll(valueToken);
-  } catch (const std::exception&) {
-    return nullptr;
-  }
-
-  std::optional<std::string> alias;
-  std::string maybeAs;
-  if (iss >> maybeAs) {
-    if (StringUtil::Lower(maybeAs) == "as") {
-      std::string aliasToken;
-      if (iss >> aliasToken) {
-        alias = aliasToken;
-      }
-    }
-  }
-
-  const auto unitName = StringUtil::Lower(unitToken);
-  int64_t multiplier;
-  if (unitName == "hour" || unitName == "hours") {
-    multiplier = 60 * 60 * 1'000;
-  } else if (unitName == "minute" || unitName == "minutes") {
-    multiplier = 60 * 1'000;
-  } else if (unitName == "second" || unitName == "seconds") {
-    multiplier = 1'000;
-  } else if (unitName == "millisecond" || unitName == "milliseconds") {
-    multiplier = 1;
-  } else {
-    return nullptr;
-  }
-
-  return std::make_shared<core::ConstantExpr>(
-      INTERVAL_DAY_TIME(), variant(value * multiplier), alias);
-}
-
 // Parse a function call (avg(a), func(1, b), etc).
 // Arithmetic operators also follow this path (a + b, a * b, etc).
 std::shared_ptr<const core::IExpr> parseFunctionExpr(
@@ -379,13 +269,6 @@ std::shared_ptr<const core::IExpr> parseFunctionExpr(
 
   if (params.size() == 1) {
     if (auto interval = tryParseInterval(func, params[0], getAlias(expr))) {
-      return interval;
-    }
-  }
-
-  if (func == "interval" && params.size() == 2) {
-    if (auto interval =
-            tryParseIntervalWithUnit(params[0], params[1], getAlias(expr))) {
       return interval;
     }
   }
@@ -799,9 +682,6 @@ std::unique_ptr<::duckdb::ParsedExpression> parseSingleExpression(
 std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& exprString,
     const ParseOptions& options) {
-  if (auto interval = tryParseIntervalLiteral(exprString)) {
-    return interval;
-  }
   auto parsed = parseSingleExpression(exprString);
   return parseExpr(*parsed, options);
 }

--- a/bolt/duckdb/conversion/DuckParser.cpp
+++ b/bolt/duckdb/conversion/DuckParser.cpp
@@ -35,6 +35,8 @@
 #include "bolt/parse/Expressions.h"
 #include "bolt/type/Variant.h"
 
+#include <sstream>
+
 #include <duckdb.hpp> // @manual
 #include <duckdb/parser/expression/between_expression.hpp> // @manual
 #include <duckdb/parser/expression/case_expression.hpp> // @manual
@@ -251,6 +253,116 @@ std::shared_ptr<const core::ConstantExpr> tryParseInterval(
       INTERVAL_DAY_TIME(), variant(value.value() * multiplier), alias);
 }
 
+std::shared_ptr<const core::ConstantExpr> tryParseIntervalWithUnit(
+    const std::shared_ptr<const core::IExpr>& input,
+    const std::shared_ptr<const core::IExpr>& unit,
+    const std::optional<std::string>& alias) {
+  std::optional<int64_t> value;
+  if (const auto* constInput =
+          dynamic_cast<const core::ConstantExpr*>(input.get())) {
+    if (constInput->type()->isBigint() && !constInput->value().isNull()) {
+      value = constInput->value().value<int64_t>();
+    }
+  } else if (
+      const auto* castInput =
+          dynamic_cast<const core::CastExpr*>(input.get())) {
+    if (castInput->type()->isBigint()) {
+      if (const auto* constInput = dynamic_cast<const core::ConstantExpr*>(
+              castInput->getInput().get())) {
+        if (constInput->type()->isBigint() && !constInput->value().isNull()) {
+          value = constInput->value().value<int64_t>();
+        }
+      }
+    }
+  }
+
+  if (!value.has_value()) {
+    return nullptr;
+  }
+
+  const auto* unitExpr = dynamic_cast<const core::ConstantExpr*>(unit.get());
+  if (!unitExpr || !unitExpr->type()->isVarchar() ||
+      unitExpr->value().isNull()) {
+    return nullptr;
+  }
+
+  const auto unitName =
+      StringUtil::Lower(unitExpr->value().value<std::string>());
+  int64_t multiplier;
+  if (unitName == "hour" || unitName == "hours") {
+    multiplier = 60 * 60 * 1'000;
+  } else if (unitName == "minute" || unitName == "minutes") {
+    multiplier = 60 * 1'000;
+  } else if (unitName == "second" || unitName == "seconds") {
+    multiplier = 1'000;
+  } else if (unitName == "millisecond" || unitName == "milliseconds") {
+    multiplier = 1;
+  } else {
+    return nullptr;
+  }
+
+  return std::make_shared<core::ConstantExpr>(
+      INTERVAL_DAY_TIME(), variant(value.value() * multiplier), alias);
+}
+
+std::shared_ptr<const core::ConstantExpr> tryParseIntervalLiteral(
+    const std::string& exprString) {
+  std::string trimmed = exprString;
+  StringUtil::Trim(trimmed);
+  auto lower = StringUtil::Lower(trimmed);
+  if (!StringUtil::StartsWith(lower, "interval ")) {
+    return nullptr;
+  }
+
+  std::istringstream iss(trimmed);
+  std::string keyword;
+  iss >> keyword;
+  if (StringUtil::Lower(keyword) != "interval") {
+    return nullptr;
+  }
+
+  std::string valueToken;
+  std::string unitToken;
+  if (!(iss >> valueToken >> unitToken)) {
+    return nullptr;
+  }
+
+  int64_t value;
+  try {
+    value = std::stoll(valueToken);
+  } catch (const std::exception&) {
+    return nullptr;
+  }
+
+  std::optional<std::string> alias;
+  std::string maybeAs;
+  if (iss >> maybeAs) {
+    if (StringUtil::Lower(maybeAs) == "as") {
+      std::string aliasToken;
+      if (iss >> aliasToken) {
+        alias = aliasToken;
+      }
+    }
+  }
+
+  const auto unitName = StringUtil::Lower(unitToken);
+  int64_t multiplier;
+  if (unitName == "hour" || unitName == "hours") {
+    multiplier = 60 * 60 * 1'000;
+  } else if (unitName == "minute" || unitName == "minutes") {
+    multiplier = 60 * 1'000;
+  } else if (unitName == "second" || unitName == "seconds") {
+    multiplier = 1'000;
+  } else if (unitName == "millisecond" || unitName == "milliseconds") {
+    multiplier = 1;
+  } else {
+    return nullptr;
+  }
+
+  return std::make_shared<core::ConstantExpr>(
+      INTERVAL_DAY_TIME(), variant(value * multiplier), alias);
+}
+
 // Parse a function call (avg(a), func(1, b), etc).
 // Arithmetic operators also follow this path (a + b, a * b, etc).
 std::shared_ptr<const core::IExpr> parseFunctionExpr(
@@ -267,6 +379,13 @@ std::shared_ptr<const core::IExpr> parseFunctionExpr(
 
   if (params.size() == 1) {
     if (auto interval = tryParseInterval(func, params[0], getAlias(expr))) {
+      return interval;
+    }
+  }
+
+  if (func == "interval" && params.size() == 2) {
+    if (auto interval =
+            tryParseIntervalWithUnit(params[0], params[1], getAlias(expr))) {
       return interval;
     }
   }
@@ -680,6 +799,9 @@ std::unique_ptr<::duckdb::ParsedExpression> parseSingleExpression(
 std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& exprString,
     const ParseOptions& options) {
+  if (auto interval = tryParseIntervalLiteral(exprString)) {
+    return interval;
+  }
   auto parsed = parseSingleExpression(exprString);
   return parseExpr(*parsed, options);
 }

--- a/bolt/duckdb/conversion/DuckParser.cpp
+++ b/bolt/duckdb/conversion/DuckParser.cpp
@@ -35,8 +35,6 @@
 #include "bolt/parse/Expressions.h"
 #include "bolt/type/Variant.h"
 
-#include <cmath>
-
 #include <duckdb.hpp> // @manual
 #include <duckdb/parser/expression/between_expression.hpp> // @manual
 #include <duckdb/parser/expression/case_expression.hpp> // @manual

--- a/bolt/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/bolt/duckdb/conversion/tests/DuckParserTest.cpp
@@ -301,16 +301,29 @@ TEST(DuckParserTest, interval) {
     return parsed->toString();
   };
 
-  EXPECT_EQ("to_hours(cast(trunc(cast(5, DOUBLE)), BIGINT))", parseInterval("INTERVAL 5 HOURS"));
-  EXPECT_EQ("to_minutes(cast(trunc(cast(36, DOUBLE)), BIGINT))", parseInterval("INTERVAL 36 MINUTES"));
+  EXPECT_EQ(
+      "to_hours(cast(trunc(cast(5, DOUBLE)), BIGINT))",
+      parseInterval("INTERVAL 5 HOURS"));
+  EXPECT_EQ(
+      "to_minutes(cast(trunc(cast(36, DOUBLE)), BIGINT))",
+      parseInterval("INTERVAL 36 MINUTES"));
   EXPECT_EQ("to_seconds(cast(7, DOUBLE))", parseInterval("INTERVAL 7 SECONDS"));
-  EXPECT_EQ("to_milliseconds(cast(123, DOUBLE))", parseInterval("INTERVAL 123 MILLISECONDS"));
-  EXPECT_EQ("to_milliseconds(cast(12345, DOUBLE))", parseInterval("INTERVAL 12345 MILLISECONDS"));
-  EXPECT_EQ("to_milliseconds(cast(12345678, DOUBLE))", parseInterval("INTERVAL 12345678 MILLISECONDS"));
-  EXPECT_EQ("to_milliseconds(cast(100100100, DOUBLE))", parseInterval("INTERVAL 100100100 MILLISECONDS"));
+  EXPECT_EQ(
+      "to_milliseconds(cast(123, DOUBLE))",
+      parseInterval("INTERVAL 123 MILLISECONDS"));
+  EXPECT_EQ(
+      "to_milliseconds(cast(12345, DOUBLE))",
+      parseInterval("INTERVAL 12345 MILLISECONDS"));
+  EXPECT_EQ(
+      "to_milliseconds(cast(12345678, DOUBLE))",
+      parseInterval("INTERVAL 12345678 MILLISECONDS"));
+  EXPECT_EQ(
+      "to_milliseconds(cast(100100100, DOUBLE))",
+      parseInterval("INTERVAL 100100100 MILLISECONDS"));
 
   EXPECT_EQ(
-      "to_milliseconds(cast(11, DOUBLE)) AS x", parseInterval("INTERVAL 11 MILLISECONDS AS x"));
+      "to_milliseconds(cast(11, DOUBLE)) AS x",
+      parseInterval("INTERVAL 11 MILLISECONDS AS x"));
 }
 
 TEST(DuckParserTest, cast) {

--- a/bolt/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/bolt/duckdb/conversion/tests/DuckParserTest.cpp
@@ -37,8 +37,8 @@ using namespace bytedance::bolt::duckdb;
 
 namespace {
 std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString) {
-  ParseOptions options;
-  return parseExpr(exprString, options);
+  duckdb::ParseOptions options;
+  return duckdb::parseExpr(exprString, options);
 }
 } // namespace
 
@@ -297,30 +297,20 @@ TEST(DuckParserTest, between) {
 
 TEST(DuckParserTest, interval) {
   auto parseInterval = [](const std::string& sql) {
-    auto expr =
-        std::dynamic_pointer_cast<const core::ConstantExpr>(parseExpr(sql));
-    BOLT_CHECK_NOT_NULL(expr);
-
-    auto value =
-        INTERVAL_DAY_TIME()->valueToString(expr->value().value<int64_t>());
-    if (expr->alias()) {
-      return fmt::format("{} AS {}", value, expr->alias().value());
-    }
-
-    return value;
+    auto parsed = parseExpr(sql);
+    return parsed->toString();
   };
 
-  EXPECT_EQ("0 05:00:00.000", parseInterval("INTERVAL 5 HOURS"));
-  EXPECT_EQ("0 00:36:00.000", parseInterval("INTERVAL 36 MINUTES"));
-  EXPECT_EQ("0 00:00:07.000", parseInterval("INTERVAL 7 SECONDS"));
-  EXPECT_EQ("0 00:00:00.123", parseInterval("INTERVAL 123 MILLISECONDS"));
-
-  EXPECT_EQ("0 00:00:12.345", parseInterval("INTERVAL 12345 MILLISECONDS"));
-  EXPECT_EQ("0 03:25:45.678", parseInterval("INTERVAL 12345678 MILLISECONDS"));
-  EXPECT_EQ("1 03:48:20.100", parseInterval("INTERVAL 100100100 MILLISECONDS"));
+  EXPECT_EQ("to_hours(cast(trunc(cast(5, DOUBLE)), BIGINT))", parseInterval("INTERVAL 5 HOURS"));
+  EXPECT_EQ("to_minutes(cast(trunc(cast(36, DOUBLE)), BIGINT))", parseInterval("INTERVAL 36 MINUTES"));
+  EXPECT_EQ("to_seconds(cast(7, DOUBLE))", parseInterval("INTERVAL 7 SECONDS"));
+  EXPECT_EQ("to_milliseconds(cast(123, DOUBLE))", parseInterval("INTERVAL 123 MILLISECONDS"));
+  EXPECT_EQ("to_milliseconds(cast(12345, DOUBLE))", parseInterval("INTERVAL 12345 MILLISECONDS"));
+  EXPECT_EQ("to_milliseconds(cast(12345678, DOUBLE))", parseInterval("INTERVAL 12345678 MILLISECONDS"));
+  EXPECT_EQ("to_milliseconds(cast(100100100, DOUBLE))", parseInterval("INTERVAL 100100100 MILLISECONDS"));
 
   EXPECT_EQ(
-      "0 00:00:00.011 AS x", parseInterval("INTERVAL 11 MILLISECONDS AS x"));
+      "to_milliseconds(cast(11, DOUBLE)) AS x", parseInterval("INTERVAL 11 MILLISECONDS AS x"));
 }
 
 TEST(DuckParserTest, cast) {

--- a/bolt/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/bolt/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <optional>
+#include <type_traits>
 #include <vector>
 #include "bolt/common/memory/Memory.h"
 #include "bolt/dwio/common/IntDecoder.h"
@@ -47,6 +48,7 @@
 #include "bolt/dwio/dwrf/writer/Writer.h"
 #include "bolt/type/Type.h"
 #include "bolt/vector/DictionaryVector.h"
+#include "bolt/vector/SelectivityVector.h"
 #include "bolt/vector/tests/utils/VectorMaker.h"
 
 using namespace ::testing;
@@ -57,6 +59,30 @@ using namespace bytedance::bolt;
 using namespace bytedance::bolt::memory;
 using folly::Random;
 namespace bytedance::bolt::dwrf {
+
+template <typename T>
+struct IsArrayType : std::false_type {};
+
+template <typename ELEMENT>
+struct IsArrayType<Array<ELEMENT>> : std::true_type {};
+
+template <typename T>
+struct IsMapType : std::false_type {};
+
+template <typename K, typename V>
+struct IsMapType<Map<K, V>> : std::true_type {};
+
+template <typename T>
+struct IsRowType : std::false_type {};
+
+template <typename... T>
+struct IsRowType<Row<T...>> : std::true_type {};
+
+template <typename T>
+struct IsComplexType
+    : std::bool_constant<
+          IsArrayType<T>::value || IsMapType<T>::value || IsRowType<T>::value> {
+};
 
 class MockStrideIndexProvider : public StrideIndexProvider {
  public:
@@ -868,10 +894,16 @@ void mapToStruct(
     // initialize children of batch size filled with nulls
     VectorMaker maker{&pool};
     for (auto column = 0; column < uniqueKeys.size(); column++) {
-      childrenVectors[column] =
-          maker.allNullFlatVector<TVALUE>(origBatch->size());
-      // only flat for scalar types
-      // create function to handle nested complex types
+      if constexpr (IsComplexType<TVALUE>::value) {
+        auto valueType = CppToType<TVALUE>::create();
+        auto child = BaseVector::create(valueType, origBatch->size(), &pool);
+        SelectivityVector nullRows(origBatch->size(), true);
+        child->addNulls(nullRows);
+        childrenVectors[column] = child;
+      } else {
+        childrenVectors[column] =
+            maker.allNullFlatVector<TVALUE>(origBatch->size());
+      }
     }
     batches[i] = maker.rowVector(childrenVectors);
     auto batchStruct = std::dynamic_pointer_cast<RowVector>(batches[i]);
@@ -883,26 +915,47 @@ void mapToStruct(
     auto flatKeys = std::dynamic_pointer_cast<FlatVector<TKEY>>(keys);
     ASSERT_TRUE(flatKeys);
     auto values = mapBatch->mapValues();
-    auto flatValues = std::dynamic_pointer_cast<FlatVector<TVALUE>>(values);
-    ASSERT_TRUE(flatValues);
+    if constexpr (IsComplexType<TVALUE>::value) {
+      auto offsets = mapBatch->offsets()->as<vector_size_t>();
+      auto sizes = mapBatch->sizes()->as<vector_size_t>();
 
-    auto offsets = mapBatch->offsets()->as<vector_size_t>();
-    auto sizes = mapBatch->sizes()->as<vector_size_t>();
+      // for each row in current batch
+      for (vector_size_t row = 0; row < mapBatch->size(); row++) {
+        // for each key in row (single map)
+        for (vector_size_t index = offsets[row],
+                           endOffset = offsets[row] + sizes[row];
+             index < endOffset;
+             index++) {
+          ASSERT_FALSE(flatKeys->isNullAt(index));
+          // set value in correct row
+          auto key = flatKeys->valueAt(index);
+          auto element = batchStruct->childAt(keyColIndex[key]);
+          ASSERT_TRUE(element);
+          element->copy(values.get(), row, index, 1);
+        }
+      }
+    } else {
+      auto flatValues = std::dynamic_pointer_cast<FlatVector<TVALUE>>(values);
+      ASSERT_TRUE(flatValues);
 
-    // for each row in current batch
-    for (vector_size_t row = 0; row < mapBatch->size(); row++) {
-      // for each key in row (single map)
-      for (vector_size_t index = offsets[row],
-                         endOffset = offsets[row] + sizes[row];
-           index < endOffset;
-           index++) {
-        ASSERT_FALSE(flatKeys->isNullAt(index));
-        // set value in correct row
-        auto key = flatKeys->valueAt(index);
-        auto element = std::dynamic_pointer_cast<FlatVector<TVALUE>>(
-            batchStruct->childAt(keyColIndex[key]));
-        ASSERT_TRUE(element);
-        element->set(row, flatValues->valueAt(index));
+      auto offsets = mapBatch->offsets()->as<vector_size_t>();
+      auto sizes = mapBatch->sizes()->as<vector_size_t>();
+
+      // for each row in current batch
+      for (vector_size_t row = 0; row < mapBatch->size(); row++) {
+        // for each key in row (single map)
+        for (vector_size_t index = offsets[row],
+                           endOffset = offsets[row] + sizes[row];
+             index < endOffset;
+             index++) {
+          ASSERT_FALSE(flatKeys->isNullAt(index));
+          // set value in correct row
+          auto key = flatKeys->valueAt(index);
+          auto element = std::dynamic_pointer_cast<FlatVector<TVALUE>>(
+              batchStruct->childAt(keyColIndex[key]));
+          ASSERT_TRUE(element);
+          element->set(row, flatValues->valueAt(index));
+        }
       }
     }
   }
@@ -4405,10 +4458,12 @@ struct DictColumnWriterTestCase {
     VectorPtr dictionaryVector;
 
     VectorPtr flatVector;
-    if (complexRowType == nullptr) {
-      flatVector = makeFlatVector(size, valueAt, isNullAt);
-    } else {
+    if constexpr (IsComplexType<T>::value) {
+      BOLT_CHECK_NOT_NULL(
+          complexRowType, "Expected complex row type for complex vectors");
       flatVector = makeComplexVectors(complexRowType, size, isNullAt);
+    } else {
+      flatVector = makeFlatVector(size, valueAt, isNullAt);
     }
 
     auto wrappedVector = BaseVector::wrapInDictionary(
@@ -4428,11 +4483,8 @@ struct DictColumnWriterTestCase {
     context.initBuffer();
 
     // complexVectorType will be nullptr if the vector is not complex.
-    bool isComplexType = std::dynamic_pointer_cast<const RowType>(type_) ||
-        std::dynamic_pointer_cast<const MapType>(type_) ||
-        std::dynamic_pointer_cast<const ArrayType>(type_);
-
-    auto complexVectorType = isComplexType ? rowType : nullptr;
+    auto complexVectorType =
+        IsComplexType<T>::value ? rowType : std::shared_ptr<const RowType>();
     auto batch =
         createDictionaryBatch(size_, valueAt, isNullAt, complexVectorType);
 

--- a/bolt/exec/StreamingAggregation.cpp
+++ b/bolt/exec/StreamingAggregation.cpp
@@ -45,7 +45,7 @@ StreamingAggregation::StreamingAggregation(
               : "StreamingAggregation"),
       outputBatchSize_{outputBatchRows()},
       outputBytes_(outputBatchByteSize()),
-      groupNumberThreshold_{static_cast<uint32_t>(2 * outputBatchSize_)},
+      groupNumberThreshold_{static_cast<vector_size_t>(2 * outputBatchSize_)},
       aggregationNode_{aggregationNode},
       step_{aggregationNode->step()} {
   if (aggregationNode_->ignoreNullKeys()) {

--- a/bolt/exec/StreamingAggregation.cpp
+++ b/bolt/exec/StreamingAggregation.cpp
@@ -45,7 +45,7 @@ StreamingAggregation::StreamingAggregation(
               : "StreamingAggregation"),
       outputBatchSize_{outputBatchRows()},
       outputBytes_(outputBatchByteSize()),
-      groupNumberThreshold_{2 * outputBatchSize_},
+      groupNumberThreshold_{static_cast<uint32_t>(2 * outputBatchSize_)},
       aggregationNode_{aggregationNode},
       step_{aggregationNode->step()} {
   if (aggregationNode_->ignoreNullKeys()) {

--- a/bolt/parse/DuckLogicalOperator.h
+++ b/bolt/parse/DuckLogicalOperator.h
@@ -57,6 +57,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #include <duckdb.hpp> // @manual
+#include <duckdb/common/insertion_order_preserving_map.hpp> // @manual
 
 namespace duckdb {
 
@@ -106,24 +107,29 @@ class LogicalGet : public LogicalOperator {
   vector<LogicalType> returned_types;
   //! The names of ALL columns that can be returned by the table function
   vector<string> names;
-  //! Bound column IDs
-  vector<column_t> column_ids;
+  //! Columns that are used outside the scan
+  vector<idx_t> projection_ids;
   //! Filters pushed down for table scan
   TableFilterSet table_filters;
-
+  //! The set of input parameters for the table function
+  vector<Value> parameters;
   string GetName() const override;
-  string ParamsToString() const override;
+  InsertionOrderPreservingMap<string> ParamsToString() const override;
   //! Returns the underlying table that is being scanned, or nullptr if there is
   //! none
-  TableCatalogEntry* GetTable() const;
+  optional_ptr<TableCatalogEntry> GetTable() const;
 
  public:
+  const vector<column_t>& GetColumnIds() const;
   vector<ColumnBinding> GetColumnBindings() override;
 
   idx_t EstimateCardinality(ClientContext& context) override;
 
  protected:
   void ResolveTypes() override;
+
+ private:
+  LogicalGet();
 };
 
 //! LogicalFilter represents a filter operation (e.g. WHERE or HAVING clause)
@@ -133,8 +139,6 @@ class LogicalFilter : public LogicalOperator {
   LogicalFilter();
 
   vector<idx_t> projection_map;
-
- public:
   vector<ColumnBinding> GetColumnBindings() override;
 
   bool SplitPredicates() {
@@ -191,7 +195,7 @@ class LogicalAggregate : public LogicalOperator {
   vector<unique_ptr<BaseStatistics>> group_stats;
 
  public:
-  string ParamsToString() const override;
+  InsertionOrderPreservingMap<string> ParamsToString() const override;
 
   vector<ColumnBinding> GetColumnBindings() override;
 

--- a/bolt/parse/QueryPlanner.cpp
+++ b/bolt/parse/QueryPlanner.cpp
@@ -31,8 +31,10 @@
 #include "bolt/parse/QueryPlanner.h"
 #include "bolt/duckdb/conversion/DuckConversion.h"
 #include "bolt/parse/DuckLogicalOperator.h"
+#include "bolt/vector/VariantToVector.h"
 
 #include <duckdb.hpp> // @manual
+#include <duckdb/function/aggregate_function.hpp> // @manual
 #include <duckdb/main/connection.hpp> // @manual
 #include <duckdb/planner/expression/bound_aggregate_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_cast_expression.hpp> // @manual
@@ -140,23 +142,71 @@ PlanNodePtr toBoltPlan(
     std::vector<PlanNodePtr> sources,
     QueryContext& queryContext) {
   if (logicalGet.function.name == "unnest") {
-    BOLT_CHECK_EQ(1, sources.size());
+    // DuckDB 1.1.3 represents UNNEST as a standalone LOGICAL_GET with
+    // parameters embedded in the LogicalGet.
+    BOLT_CHECK_EQ(0, sources.size());
+
+    BOLT_CHECK_EQ(
+        logicalGet.parameters.size(),
+        1,
+        "UNNEST expects a single parameter, got {}",
+        logicalGet.parameters.size());
+
+    const auto& param = logicalGet.parameters[0];
+    BOLT_CHECK(
+        param.type().id() == ::duckdb::LogicalTypeId::LIST,
+        "UNNEST parameter must be a LIST, got {}",
+        param.type().ToString());
+
+    const auto& listType = param.type();
+    auto elementType =
+        duckdb::toBoltType(::duckdb::ListType::GetChildType(listType));
+    auto arrayType = ARRAY(elementType);
+
+    std::vector<variant> elements;
+    const auto& listValues = ::duckdb::ListValue::GetChildren(param);
+    elements.reserve(listValues.size());
+    for (const auto& value : listValues) {
+      elements.emplace_back(duckdb::duckValueToVariant(value));
+    }
+
+    auto arrayVector = variantArrayToVector(arrayType, elements, pool);
+    auto rowType = ROW({queryContext.nextColumnName()}, {arrayType});
+    auto rowVector = std::make_shared<RowVector>(
+        pool, rowType, nullptr, 1, std::vector<VectorPtr>{arrayVector});
+
+    std::vector<RowVectorPtr> vectors = {rowVector};
+    auto valuesNode =
+        std::make_shared<ValuesNode>(queryContext.nextNodeId(), vectors);
+
+    std::vector<TypedExprPtr> projections{
+        std::make_shared<FieldAccessTypedExpr>(
+            valuesNode->outputType()->childAt(0),
+            valuesNode->outputType()->asRow().nameOf(0))};
+    std::vector<std::string> projectionNames{queryContext.nextColumnName()};
+    auto projectNode = std::make_shared<ProjectNode>(
+        queryContext.nextNodeId(),
+        std::move(projectionNames),
+        std::move(projections),
+        std::move(valuesNode));
+
     return std::make_shared<UnnestNode>(
         queryContext.nextNodeId(),
         std::vector<FieldAccessTypedExprPtr>{}, // replicateVariables
         std::vector<FieldAccessTypedExprPtr>{
             std::make_shared<FieldAccessTypedExpr>(
-                sources[0]->outputType()->childAt(0),
-                sources[0]->outputType()->asRow().nameOf(0))},
-        std::vector<std::string>{"a"},
+                projectNode->outputType()->childAt(0),
+                projectNode->outputType()->asRow().nameOf(0))},
+        std::vector<std::string>{
+            logicalGet.names.empty() ? "a" : logicalGet.names[0]},
         std::nullopt, // ordinalityName
-        std::move(sources[0]));
+        std::move(projectNode));
   }
 
   BOLT_CHECK_EQ(logicalGet.function.name, "seq_scan");
   BOLT_CHECK_EQ(0, sources.size());
 
-  const auto& columnIds = logicalGet.column_ids;
+  const auto& columnIds = logicalGet.GetColumnIds();
   std::vector<std::string> names(columnIds.size());
   std::vector<TypePtr> types(columnIds.size());
 
@@ -464,6 +514,18 @@ PlanNodePtr toBoltPlan(
           pool,
           std::move(sources),
           queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_UNNEST:
+      BOLT_CHECK_EQ(1, sources.size());
+      return std::make_shared<UnnestNode>(
+          queryContext.nextNodeId(),
+          std::vector<FieldAccessTypedExprPtr>{}, // replicateVariables
+          std::vector<FieldAccessTypedExprPtr>{
+              std::make_shared<FieldAccessTypedExpr>(
+                  sources[0]->outputType()->childAt(0),
+                  sources[0]->outputType()->asRow().nameOf(0))},
+          std::vector<std::string>{"a"},
+          std::nullopt, // ordinalityName
+          std::move(sources[0]));
     default:
       BOLT_NYI(
           "Plan node is not supported yet: {}",
@@ -478,11 +540,14 @@ static void customScalarFunction(
   BOLT_UNREACHABLE();
 }
 
-static ::duckdb::idx_t customAggregateState() {
+::duckdb::idx_t customAggregateState(
+    const ::duckdb::AggregateFunction& /*function*/) {
   BOLT_UNREACHABLE();
 }
 
-static void customAggregateInitialize(::duckdb::data_ptr_t state) {
+void customAggregateInitialize(
+    const ::duckdb::AggregateFunction& /*function*/,
+    ::duckdb::data_ptr_t /* state */) {
   BOLT_UNREACHABLE();
 }
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -325,10 +325,10 @@ class BoltConan(ConanFile):
         llvm_targets = None
         if str(self.settings.arch) in ["x86", "x86_64"]:
             arrow_simd_level = "avx2"
-            llvm_targets = 'X86'
+            llvm_targets = "X86"
         elif str(self.settings.arch) in ["armv8", "arm", "armv9"]:
             arrow_simd_level = "neon"
-            llvm_targets = 'AArch64'
+            llvm_targets = "AArch64"
         self.options[arrow].parquet = True
         self.options[arrow].filesystem_layer = True
         self.options[arrow].simd_level = arrow_simd_level

--- a/conanfile.py
+++ b/conanfile.py
@@ -275,9 +275,7 @@ class BoltConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             if self.options.get_safe("enable_perf"):
                 self.requires("gperftools/2.16")
-                self.requires("libunwind/1.8.0", override=True)
-            else:
-                self.requires("libunwind/1.8.0")
+            self.requires("libunwind/1.8.3", override=True)
         self.requires("utf8proc/2.11.0", transitive_headers=True, transitive_libs=True)
         self.requires("date/3.0.4-bolt", transitive_headers=True, transitive_libs=True)
         self.requires("libbacktrace/cci.20210118")
@@ -287,7 +285,7 @@ class BoltConan(ConanFile):
             self.requires("paimon-cpp/0.0.4-bolt")
         if self.options.get_safe("enable_testutil"):
             self.requires("gtest/1.17.0", force=True)
-            self.requires("duckdb/0.8.1")
+            self.requires("duckdb/1.1.3")
 
     def build_requirements(self):
         self.tool_requires("m4/1.4.19")
@@ -360,6 +358,7 @@ class BoltConan(ConanFile):
             self.options[llvm_core].with_zstd = False
             self.options[llvm_core].with_ffi = False
             self.options[llvm_core].with_clang = True
+            self.options[llvm_core].targets = "AArch64;ARM;X86"
 
         if self.options.get_safe("enable_hdfs") and self.options.get_safe(
             "use_arrow_hdfs"

--- a/conanfile.py
+++ b/conanfile.py
@@ -322,10 +322,13 @@ class BoltConan(ConanFile):
         self.options[paimon_cpp].with_avro = True
 
         arrow_simd_level = "default"
+        llvm_targets = None
         if str(self.settings.arch) in ["x86", "x86_64"]:
             arrow_simd_level = "avx2"
+            llvm_targets = 'X86'
         elif str(self.settings.arch) in ["armv8", "arm", "armv9"]:
             arrow_simd_level = "neon"
+            llvm_targets = 'AArch64'
         self.options[arrow].parquet = True
         self.options[arrow].filesystem_layer = True
         self.options[arrow].simd_level = arrow_simd_level
@@ -358,7 +361,9 @@ class BoltConan(ConanFile):
             self.options[llvm_core].with_zstd = False
             self.options[llvm_core].with_ffi = False
             self.options[llvm_core].with_clang = True
-            self.options[llvm_core].targets = "AArch64;ARM;X86"
+            if llvm_targets is None:
+                raise RuntimeError("Unsupported target for JIT feature")
+            self.options[llvm_core].targets = llvm_targets
 
         if self.options.get_safe("enable_hdfs") and self.options.get_safe(
             "use_arrow_hdfs"

--- a/scripts/conan/patches/arrow.15.0.1-csv-support.patch
+++ b/scripts/conan/patches/arrow.15.0.1-csv-support.patch
@@ -356,7 +356,7 @@ index 24a7af89b..27655cdf4 100644
              self.requires("grpc/1.50.0")
          if self._requires_rapidjson():
 -            self.requires("rapidjson/1.1.0")
-+            self.requires("rapidjson/[>=cci.20230929]")
++            self.requires("rapidjson/cci.20250205")
          if self.options.with_llvm:
              self.requires("llvm-core/13.0.0")
          if self.options.with_openssl:

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -318,7 +318,9 @@ def process_gha_output(stdout):
 
 
 def tidy(args):
-    extensions = (".cc", ".cpp", ".cxx", ".c", ".h", ".hpp", ".hxx")
+    source_extensions = (".cc", ".cpp", ".cxx", ".c")
+    header_extensions = (".h", ".hpp", ".hxx")
+    extensions = source_extensions + header_extensions
     candidate_files = []
     # get file list to check
     if args.directory:
@@ -476,9 +478,21 @@ def tidy(args):
             print("No changed C/C++ lines detected for clang-tidy.")
             return 0
 
+        # Keep headers in --line-filter so diagnostics can be reported there,
+        # but run clang-tidy only on translation units that have compile DB entries.
+        all_changed_for_filter = list(files_to_process)
+        files_to_process = [
+            f for f in files_to_process if f.endswith(source_extensions)
+        ]
+        if not files_to_process:
+            print(
+                "Only header changes detected; no source files to run clang-tidy on in this mode."
+            )
+            return 0
+
         # Use absolute paths in --line-filter for better compatibility with compile DBs.
         final_map_abs = {}  # type: Dict[str, List[List[int]]]
-        for f in files_to_process:
+        for f in all_changed_for_filter:
             abs_f = to_repo_abs(f, git_root)
             final_map_abs[abs_f] = changed_lines[f]
         line_filter_json = json.dumps(


### PR DESCRIPTION
### What problem does this PR solve?

Brings our project's compatibility with later compilers up to more modern standards. Clang 19 was released in Septemer of 2024.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Updates project to bring compatibility with clang 19. This is important for a number of reasons

1. Clang is much less resource-intensive than GCC, specifically 50% less memory usage compiling many of the units in this project. Allows more developers access to the project.
2. Clang generally has better compile times than GCC
3. More modern compilers mean we can slowly bump the cpp standard used, meaning access to new C++ language features from C++20 and beyond.

Specific changes are outlined here:

1. duckdb fails to compile on clang 19 until the 1.1.X line. The duckdb dependency and related plan parsing code has been updated to support the duckdb API changes.
2. Some template code was erroring on clang 19. The code has been fixed to prevent the errors.
3. Added a new clang-based dev container + dockerfile to support developers in setting up an environment to build with clang
4. Adds a necessary rt-lib=compiler-rt compilation argument when building on aarch64 with clang
5. Upgrades libunwind to 1.8.3 across all build configurations to allow building on aarch64
6. Forces arrow recipe to use rapidjson/cci.20250205 which fixes an issue with incorrectly-resolved rapidjson dependency compared to the previous version specified.
7. Changes clang-tidy to only compile `.c**` files that are in the compilation DB to prevent header include errors. The line filters for headers are should still be propagated to users as long as the headers are used in a modified compilation unit.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Add support for building with clang 19
- Upgrade DuckDB to 1.1.3
- Upgrade rapidjson to cci.20250205
- Upgrade libunwind to 1.8.3
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

