### PR TITLE
build: Reduce cost of heavy compilation units

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -823,6 +823,38 @@ template <PrimitiveKind fromKind, PrimitiveKind toKind>
 class VectorConverter : public ConverterBase {
  public:
   virtual ~VectorConverter() = default;
+
+ private:
+  static constexpr bool isIntegerKind(PrimitiveKind kind) {
+    return (
+        kind == PrimitiveKind::TINYINT || kind == PrimitiveKind::SMALLINT ||
+        kind == PrimitiveKind::INTEGER || kind == PrimitiveKind::BIGINT);
+  }
+
+  static constexpr bool isFloatKind(PrimitiveKind kind) {
+    return kind == PrimitiveKind::REAL || kind == PrimitiveKind::DOUBLE;
+  }
+
+  static constexpr bool isDecimalKind(PrimitiveKind kind) {
+    return (
+        kind == PrimitiveKind::SHORT_DECIMAL ||
+        kind == PrimitiveKind::LONG_DECIMAL);
+  }
+
+  static constexpr bool kLegacySensitive = toKind == PrimitiveKind::STRING &&
+      (fromKind == PrimitiveKind::TIMESTAMP || isFloatKind(fromKind));
+
+  static constexpr bool kTruncateSensitive =
+      // integer -> boolean
+      (toKind == PrimitiveKind::BOOLEAN && isIntegerKind(fromKind)) ||
+      // string/float/decimal -> integer
+      (isIntegerKind(toKind) &&
+       (fromKind == PrimitiveKind::STRING || isFloatKind(fromKind) ||
+        isDecimalKind(fromKind))) ||
+      // float -> float
+      (isFloatKind(toKind) && isFloatKind(fromKind));
+
+ public:
   template <bool legacy, bool truncate>
   FLATTEN void convertWithPolicy(
       const SelectivityVector& rows,
@@ -880,20 +912,44 @@ class VectorConverter : public ConverterBase {
       convertWithPolicy<legacy, truncate>(
           rows, input, context, result, errorPolicy);
     } else {
-      bool legacy = context.execCtx()->queryCtx()->queryConfig().isLegacyCast();
-      bool truncate =
-          context.execCtx()->queryCtx()->queryConfig().isCastToIntByTruncate();
-      if (legacy && truncate) {
-        convertWithPolicy<true, true>(
-            rows, input, context, result, errorPolicy);
-      } else if (legacy && !truncate) {
-        convertWithPolicy<true, false>(
-            rows, input, context, result, errorPolicy);
-      } else if (!legacy && truncate) {
-        convertWithPolicy<false, true>(
-            rows, input, context, result, errorPolicy);
+      const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
+
+      if constexpr (kLegacySensitive && kTruncateSensitive) {
+        bool legacy = queryConfig.isLegacyCast();
+        bool truncate = queryConfig.isCastToIntByTruncate();
+        if (legacy && truncate) {
+          convertWithPolicy<true, true>(
+              rows, input, context, result, errorPolicy);
+        } else if (legacy && !truncate) {
+          convertWithPolicy<true, false>(
+              rows, input, context, result, errorPolicy);
+        } else if (!legacy && truncate) {
+          convertWithPolicy<false, true>(
+              rows, input, context, result, errorPolicy);
+        } else {
+          // !legacy && !truncate
+          convertWithPolicy<false, false>(
+              rows, input, context, result, errorPolicy);
+        }
+      } else if constexpr (kLegacySensitive) {
+        bool legacy = queryConfig.isLegacyCast();
+        if (legacy) {
+          convertWithPolicy<true, false>(
+              rows, input, context, result, errorPolicy);
+        } else {
+          convertWithPolicy<false, false>(
+              rows, input, context, result, errorPolicy);
+        }
+      } else if constexpr (kTruncateSensitive) {
+        bool truncate = queryConfig.isCastToIntByTruncate();
+        if (truncate) {
+          convertWithPolicy<false, true>(
+              rows, input, context, result, errorPolicy);
+        } else {
+          convertWithPolicy<false, false>(
+              rows, input, context, result, errorPolicy);
+        }
       } else {
-        // !legacy && !truncate
         convertWithPolicy<false, false>(
             rows, input, context, result, errorPolicy);
       }

--- a/bolt/functions/prestosql/aggregates/CMakeLists.txt
+++ b/bolt/functions/prestosql/aggregates/CMakeLists.txt
@@ -79,7 +79,9 @@ bolt_add_library(
   MapUnionSumAggregate.cpp
   MaxSizeForStatsAggregate.cpp
   MinMaxAggregates.cpp
+  MaxByAggregateRegistration.cpp
   MinMaxByAggregates.cpp
+  MinByAggregateRegistration.cpp
   MultiMapAggAggregate.cpp
   PrestoHasher.cpp
   ReduceAgg.cpp

--- a/bolt/functions/prestosql/aggregates/MaxByAggregateRegistration.cpp
+++ b/bolt/functions/prestosql/aggregates/MaxByAggregateRegistration.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h"
+
+namespace bytedance::bolt::aggregate::prestosql {
+
+void registerMaxByAggregate( // NOLINT(misc-use-internal-linkage)
+    const std::string& prefix) {
+  detail::registerMinMaxBy<
+      functions::aggregate::MinMaxByAggregateBase,
+      true,
+      MaxByNAggregate>(prefix + kMaxBy);
+}
+
+} // namespace bytedance::bolt::aggregate::prestosql

--- a/bolt/functions/prestosql/aggregates/MinByAggregateRegistration.cpp
+++ b/bolt/functions/prestosql/aggregates/MinByAggregateRegistration.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h"
+
+namespace bytedance::bolt::aggregate::prestosql {
+
+void registerMinByAggregate( // NOLINT(misc-use-internal-linkage)
+    const std::string& prefix) {
+  detail::registerMinMaxBy<
+      functions::aggregate::MinMaxByAggregateBase,
+      false,
+      MinByNAggregate>(prefix + kMinBy);
+}
+
+} // namespace bytedance::bolt::aggregate::prestosql

--- a/bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h
+++ b/bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <sstream>
+
+#include "bolt/functions/prestosql/aggregates/MinMaxByAggregates.h"
+
+namespace bytedance::bolt::aggregate::prestosql::detail {
+
+inline std::string toString(const std::vector<TypePtr>& types) {
+  std::ostringstream out;
+  for (auto i = 0; i < types.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << types[i]->toString();
+  }
+  return out.str();
+}
+
+template <
+    template <
+        typename U,
+        typename V,
+        bool B1,
+        template <bool B2, typename C1, typename C2>
+        class C>
+    class Aggregate,
+    bool IsMaxFunc,
+    template <typename U, typename V>
+    class NAggregate>
+exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .typeVariable("V")
+                           .orderableTypeVariable("C")
+                           .returnType("V")
+                           .intermediateType("row(V,C)")
+                           .argumentType("V")
+                           .argumentType("C")
+                           .build());
+  const std::vector<std::string> supportedCompareTypes = {
+      "boolean",
+      "tinyint",
+      "smallint",
+      "integer",
+      "bigint",
+      "real",
+      "double",
+      "varchar",
+      "date",
+      "timestamp"};
+
+  for (const auto& compareType : supportedCompareTypes) {
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .typeVariable("V")
+                             .returnType("array(V)")
+                             .intermediateType(fmt::format(
+                                 "row(bigint,array({}),array(V))", compareType))
+                             .argumentType("V")
+                             .argumentType(compareType)
+                             .argumentType("bigint")
+                             .build());
+  }
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig&
+          /*config*/) -> std::unique_ptr<exec::Aggregate> {
+        const std::string errorMessage = fmt::format(
+            "Unknown input types for {} ({}) aggregation: {}",
+            name,
+            mapAggregationStepToName(step),
+            toString(argTypes));
+
+        const bool nAgg = (argTypes.size() == 3) ||
+            (argTypes.size() == 1 && argTypes[0]->size() == 3);
+
+        if (nAgg) {
+          return createNArg<NAggregate>(
+              resultType, argTypes[0], argTypes[1], errorMessage);
+        }
+        return functions::aggregate::create<Aggregate, Comparator, IsMaxFunc>(
+            resultType, argTypes[0], argTypes[1], errorMessage, true);
+      });
+}
+
+} // namespace bytedance::bolt::aggregate::prestosql::detail

--- a/bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h
+++ b/bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h
@@ -54,7 +54,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
                            .argumentType("V")
                            .argumentType("C")
                            .build());
-  const std::vector<std::string> supportedCompareTypes = {
+  static constexpr std::array<const char*, 10> kSupportedCompareTypes = {
       "boolean",
       "tinyint",
       "smallint",
@@ -66,7 +66,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
       "date",
       "timestamp"};
 
-  for (const auto& compareType : supportedCompareTypes) {
+  for (const auto& compareType : kSupportedCompareTypes) {
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .typeVariable("V")
                              .returnType("array(V)")

--- a/bolt/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/bolt/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -30,102 +30,16 @@
 
 #include "bolt/functions/prestosql/aggregates/MinMaxByAggregates.h"
 namespace bytedance::bolt::aggregate::prestosql {
-std::string toString(const std::vector<TypePtr>& types) {
-  std::ostringstream out;
-  for (auto i = 0; i < types.size(); ++i) {
-    if (i > 0) {
-      out << ", ";
-    }
-    out << types[i]->toString();
-  }
-  return out.str();
-}
 
-template <
-    template <
-        typename U,
-        typename V,
-        bool B1,
-        template <bool B2, typename C1, typename C2>
-        class C>
-    class Aggregate,
-    bool isMaxFunc,
-    template <typename U, typename V>
-    class NAggregate>
-exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  // V, C -> row(V, C) -> V.
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .typeVariable("V")
-                           .orderableTypeVariable("C")
-                           .returnType("V")
-                           .intermediateType("row(V,C)")
-                           .argumentType("V")
-                           .argumentType("C")
-                           .build());
-  const std::vector<std::string> supportedCompareTypes = {
-      "boolean",
-      "tinyint",
-      "smallint",
-      "integer",
-      "bigint",
-      "real",
-      "double",
-      "varchar",
-      "date",
-      "timestamp"};
+void registerMaxByAggregate( // NOLINT(misc-use-internal-linkage)
+    const std::string& prefix);
+void registerMinByAggregate( // NOLINT(misc-use-internal-linkage)
+    const std::string& prefix);
 
-  // Add support for all value types to 3-arg version of the aggregate.
-  for (const auto& compareType : supportedCompareTypes) {
-    // V, C, bigint -> row(bigint, array(C), array(V)) -> array(V).
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .typeVariable("V")
-                             .returnType("array(V)")
-                             .intermediateType(fmt::format(
-                                 "row(bigint,array({}),array(V))", compareType))
-                             .argumentType("V")
-                             .argumentType(compareType)
-                             .argumentType("bigint")
-                             .build());
-  }
-
-  return exec::registerAggregateFunction(
-      name,
-      std::move(signatures),
-      [name](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig&
-          /*config*/) -> std::unique_ptr<exec::Aggregate> {
-        const std::string errorMessage = fmt::format(
-            "Unknown input types for {} ({}) aggregation: {}",
-            name,
-            mapAggregationStepToName(step),
-            toString(argTypes));
-
-        const bool nAgg = (argTypes.size() == 3) ||
-            (argTypes.size() == 1 && argTypes[0]->size() == 3);
-
-        if (nAgg) {
-          return createNArg<NAggregate>(
-              resultType, argTypes[0], argTypes[1], errorMessage);
-        } else {
-          return functions::aggregate::create<Aggregate, Comparator, isMaxFunc>(
-              resultType, argTypes[0], argTypes[1], errorMessage, true);
-        }
-      });
-}
-
-void registerMinMaxByAggregates(const std::string& prefix) {
-  registerMinMaxBy<
-      functions::aggregate::MinMaxByAggregateBase,
-      true,
-      MaxByNAggregate>(prefix + kMaxBy);
-  registerMinMaxBy<
-      functions::aggregate::MinMaxByAggregateBase,
-      false,
-      MinByNAggregate>(prefix + kMinBy);
+void registerMinMaxByAggregates( // NOLINT(misc-use-internal-linkage)
+    const std::string& prefix) {
+  registerMaxByAggregate(prefix);
+  registerMinByAggregate(prefix);
 }
 
 } // namespace bytedance::bolt::aggregate::prestosql


### PR DESCRIPTION
### What problem does this PR solve?

Reduces compilation cost (CPU and peak RSS) of most expensive compilation units: MinMaxByAggregates.cpp and CastExpr-tpl.cpp

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Reduces CastExpr-tpl compilation cost by ~67% by reducing the number of required template instantiations
- Parallelizes MinMaxBy registration to a MinBy/MaxBy unit to cut cost and memory consumption in half for each. Total cost is not really reduced here but splitting lowers peak memory and helps improve compilation wall time

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

N/A (changes only affect compilation)

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
