### PR TITLE
docs: Add bolt-build skill

### DIFF
--- a/.agents/skills/bolt-build/SKILL.md
+++ b/.agents/skills/bolt-build/SKILL.md
@@ -10,10 +10,9 @@ tests, or benchmarks
 
 ## Workflow
 
-- Configure the repository using instructions from the "Configure" section ONLY if necessary
-- Compile the project using instructions from "Compile" section
+- **Configure** the repository using instructions from the "Configure" section ONLY if necessary
+- **Compile** the project using instructions from "Compile" section
   - Wait for all units to finish. If compilation exits early, check the error
-  - If syntax error, consider the users' previous instructions and fix it
   - If killed (e.g. due to OOM), restart the build, but lower the number of jobs
   by adding the `--parallel` flag and specify a lower number than the machine's available cores.
   If the build is repeatedly killed to due OOMs, decrease it after each failure.
@@ -84,17 +83,14 @@ Use this to decide whether you can reuse the existing preset or need to reconfig
 
 - Prefer the narrowest target that validates the change.
 - Reuse the current configured preset whenever possible.
-- If a compile fails, fix the smallest coherent issue and re-run the same narrow build first.
-- In status updates and final summaries, state whether you reused an existing configured preset or had to reconfigure.
 
 ## Finding the narrowest target
 
 To identify the smallest target that contains an edited compilation unit:
 
 1. Locate the edited `*.cpp` file's directory.
-2. Find the `CMakeLists.txt` in that directory (or the nearest parent directory).
-3. Search for the target that lists the edited `*.cpp` file in its source list.
-4. Build that target.
+2. Find `CMakeLists.txt` in that directory (or the nearest parent directory).
+3. Find the target with the edited `*.cpp` file in its source list.
 
 Example:
 - Edited file: `bolt/core/execution/ExecutionPlan.cpp`

--- a/.agents/skills/bolt-build/SKILL.md
+++ b/.agents/skills/bolt-build/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: bolt-build
+description: Use when working on the Bolt repository and you need to configure or compile code correctly and efficiently. This skill defines the canonical Bolt build workflow, including when to run `make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1`, when to switch to `cmake --build --preset conan-<build type> --target <TARGET>`, and when reconfiguration is required because the build type or test inclusion has changed.
+---
+
+# Bolt Build
+
+Use this skill for any Bolt task that requires configuring or compiling the repository.
+
+## Core rule
+
+Do not use `make` for routine incremental compilation once the build is configured.
+
+## Configure
+
+To configure a build, run:
+
+```bash
+make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1
+```
+
+This chooses the active configuration, including:
+- Build type: `debug`, `release`, or `relwithdebinfo`
+- Whether tests are included for that target/configuration
+
+## Build
+
+If the build is already configured for the needed target and build type, compile with:
+
+```bash
+cmake --build --preset conan-<build type> --target <TARGET>
+```
+
+Valid preset suffixes:
+- `debug`
+- `release`
+- `relwithdebinfo`
+
+## When to reconfigure
+
+Run `make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1` again only if:
+- The required build type is different from the current one
+- The desired target does not exist in the current configuration
+- You need to include or exclude tests and the current configuration does not match
+
+## Detecting the current build type
+
+Check `_build/.build_type` to determine the currently configured build type:
+
+```bash
+cat _build/.build_type
+```
+
+This returns one of: `debug`, `release`, or `relwithdebinfo`.
+
+Use this to decide whether you can reuse the existing preset or need to reconfigure for a different build type.
+
+## Working rules
+
+- Prefer the narrowest target that validates the change.
+- Reuse the current configured preset whenever possible.
+- If a compile fails, fix the smallest coherent issue and re-run the same narrow build first.
+- In status updates and final summaries, state whether you reused an existing configured preset or had to reconfigure.
+
+## Finding the narrowest target
+
+To identify the smallest target that contains an edited compilation unit:
+
+1. Locate the edited `*.cpp` file's directory.
+2. Find the `CMakeLists.txt` in that directory (or the nearest parent directory).
+3. Search for the target that lists the edited `*.cpp` file in its source list.
+4. Build that target.
+
+Example:
+- Edited file: `bolt/core/execution/ExecutionPlan.cpp`
+- Check: `bolt/core/execution/CMakeLists.txt` (or `bolt/core/CMakeLists.txt`)
+- Look for: `add_library(bolt_core ... ExecutionPlan.cpp ...)` or `add_executable(bolt_core_tests ...)`
+- Build: `cmake --build --preset conan-release --target bolt_core`
+
+This ensures you compile only what's necessary to validate your change.

--- a/.agents/skills/bolt-build/SKILL.md
+++ b/.agents/skills/bolt-build/SKILL.md
@@ -1,17 +1,46 @@
 ---
 name: bolt-build
-description: Use when working on the Bolt repository and you need to configure or compile code correctly and efficiently. This skill defines the canonical Bolt build workflow, including when to run `make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1`, when to switch to `cmake --build --preset conan-<build type> --target <TARGET>`, and when reconfiguration is required because the build type or test inclusion has changed.
+description: Use when working on the Bolt repository and you need to configure or compile code correctly and efficiently. This skill defines the canonical Bolt build workflow, including when and how to run `make`, `cmake --build ...`, and when build reconfiguration is necessary due to added files and test or build target changes.
 ---
 
 # Bolt Build
 
-Use this skill for any Bolt task that requires configuring or compiling the repository.
+Use this skill for any Bolt task that requires configuring or compiling the repository for binaries
+tests, or benchmarks
+
+## Workflow
+
+- Configure the repository using instructions from the "Configure" section ONLY if necessary
+- Compile the project using instructions from "Compile" section
+  - Wait for all units to finish. If compilation exits early, check the error
+  - If syntax error, consider the users' previous instructions and fix it
+  - If killed (e.g. due to OOM), restart the build, but lower the number of jobs
+  by adding the `--parallel` flag and specify a lower number than the machine's available cores.
+  If the build is repeatedly killed to due OOMs, decrease it after each failure.
+
 
 ## Core rule
 
-Do not use `make` for routine incremental compilation once the build is configured.
+- Use `cmake --build --preset conan-${BUILD_TYPE} --target ${TARGET}` for all routine compilations
 
 ## Configure
+
+Configuration sets up the `_build` directory with the correct files to allow
+cmake and ninja to compile all files in the project.
+
+## When to reconfigure
+
+Run `make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1` again only if:
+- The required build type is different from the current one
+- The desired target does not exist in the current configuration
+- You need to include or exclude tests and the current configuration does not match
+Configure only if any of these conditions are met
+- debug info is not available in the existing binary and the goal is to debug
+with GDB, or the user requests debug build.
+
+Otherwise, just use the existing configured build.
+
+## Configuration Command
 
 To configure a build, run:
 
@@ -22,26 +51,22 @@ make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1
 This chooses the active configuration, including:
 - Build type: `debug`, `release`, or `relwithdebinfo`
 - Whether tests are included for that target/configuration
+- Available targets are listed in the `Makefile` in the root of the project.
+  - If building tests, usually need `*_with_test`
+  - If building benchmarks, usually need `benchmarks-*`
 
-## Build
+## Compile
 
 If the build is already configured for the needed target and build type, compile with:
 
 ```bash
-cmake --build --preset conan-<build type> --target <TARGET>
+cmake --build --preset conan-${BUILD_TYPE} --target ${TARGET}
 ```
 
 Valid preset suffixes:
 - `debug`
 - `release`
 - `relwithdebinfo`
-
-## When to reconfigure
-
-Run `make <TARGET> BOLT_CONAN_CONFIGURE_ONLY=1` again only if:
-- The required build type is different from the current one
-- The desired target does not exist in the current configuration
-- You need to include or exclude tests and the current configuration does not match
 
 ## Detecting the current build type
 


### PR DESCRIPTION
### What problem does this PR solve?

Allows AI agents to gain more autonomy by instructing them how to compile bolt efficiently. 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [x] 📝 Documentation only

### Description

Adds a bolt-build agent skill, compatible with tools like Codex or Claude to instruct agents how to compile bolt properly. It gives AI agents more autonomy to iterate and test changes without user input.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

N/A

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes


- [x] No
- [ ] Yes (Description: ...)
