### PR TITLE
[fix][cp] Fix Greek final sigma and rename forSpark parameter to turkishCasing

### DIFF
--- a/bolt/functions/lib/string/StringCore.h
+++ b/bolt/functions/lib/string/StringCore.h
@@ -1059,40 +1059,17 @@ FOLLY_ALWAYS_INLINE static std::string toLower(
   icu::UnicodeString unicodeStr =
       icu::UnicodeString::fromUTF8({str, static_cast<int32_t>(length)});
 
-  // Handle Greek final sigma if needed
-  if constexpr (greekFinalSigma) {
-    int32_t i = 0;
-    int32_t unicodeStrLength = unicodeStr.length();
-    while (i < unicodeStrLength) {
-      UChar32 ch;
-      U16_NEXT(unicodeStr.getBuffer(), i, unicodeStrLength, ch);
-      if (ch == 0x03A3) { // Greek capital letter Sigma
-        bool isFinal = true;
-        if (i < unicodeStrLength) {
-          UChar32 lookaheadCh;
-          int32_t lookaheadI = i;
-          U16_NEXT(
-              unicodeStr.getBuffer(),
-              lookaheadI,
-              unicodeStrLength,
-              lookaheadCh);
-          if (detail::isCased(lookaheadCh)) {
-            isFinal = false;
-          }
-        }
-        // Replace with final sigma or regular sigma
-        UChar32 lowerSigma = isFinal ? 0x03C2 : 0x03C3;
-        // Replace the character in the UnicodeString
-        unicodeStr.replace(i - 1, 1, lowerSigma);
-      }
-    }
-  }
+  // Rely on ICU's default conditional casing for Greek sigma.
+  // ICU implements Unicode SpecialCasing rules for final sigma, so we do not
+  // override it here. The previous manual implementation caused incorrect
+  // handling for single-letter words like "Σ".
 
-  // Handle Turkish casing if needed
+  // Handle Turkish-related expectations (Spark behavior): do NOT use Turkish
+  // locale-specific casing. Spark expects one-to-many mapping for 'İ' to
+  // "i\u0307" based on general Unicode SpecialCasing, so use root/default
+  // locale here.
   if constexpr (turkishCasing) {
-    // Use Turkish locale for Turkish-specific casing
-    icu::Locale turkishLocale("tr", "TR");
-    unicodeStr.toLower(turkishLocale);
+    unicodeStr.toLower(getDefaultLocale());
   } else {
     unicodeStr.toLower(locale);
   }
@@ -1165,11 +1142,10 @@ FOLLY_ALWAYS_INLINE static std::string toUpper(
   icu::UnicodeString unicodeStr =
       icu::UnicodeString::fromUTF8({str, static_cast<int32_t>(length)});
 
-  // Handle Turkish casing if needed
+  // Spark behavior: avoid Turkish locale-specific casing so that 'i\u0307'
+  // uppercases to 'I\u0307' (one-to-many) per Unicode SpecialCasing.
   if constexpr (turkishCasing) {
-    // Use Turkish locale for Turkish-specific casing
-    icu::Locale turkishLocale("tr", "TR");
-    unicodeStr.toUpper(turkishLocale);
+    unicodeStr.toUpper(getDefaultLocale());
   } else {
     unicodeStr.toUpper(locale);
   }
@@ -1354,5 +1330,6 @@ utf8proc_codepoint_length(utf8proc_int32_t uc) {
     return 0;
   }
 }
+
 } // namespace stringCore
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/string/StringCore.h
+++ b/bolt/functions/lib/string/StringCore.h
@@ -73,6 +73,30 @@
 #define VECTORIZE_LOOP_IF_POSSIBLE
 #endif
 namespace bytedance::bolt::functions {
+namespace detail {
+
+// Helper function to check if a character is cased. Compatible with the
+// 'isCased' implementation in 'ConditionalSpecialCasting.java' of JDK, which is
+// used by 'toLowerCase' function in Spark SQL.
+FOLLY_ALWAYS_INLINE bool isCased(UChar32 ch) {
+  auto type = u_charType(ch);
+  // Lowercase letter, uppercase letter or titlecase letter.
+  if (type == U_LOWERCASE_LETTER || type == U_UPPERCASE_LETTER ||
+      type == U_TITLECASE_LETTER) {
+    return true;
+  }
+  // Modifier letters and special cases.
+  if ((ch >= 0x02B0 && ch <= 0x02B8) || (ch >= 0x02C0 && ch <= 0x02C1) ||
+      (ch >= 0x02E0 && ch <= 0x02E4) || ch == 0x0345 || ch == 0x037A ||
+      (ch >= 0x1D2C && ch <= 0x1D61) || (ch >= 0x2160 && ch <= 0x217F) ||
+      (ch >= 0x24B6 && ch <= 0x24E9)) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace detail
+
 namespace stringCore {
 
 /// Check if a given string is ascii
@@ -1005,7 +1029,10 @@ FOLLY_ALWAYS_INLINE static const icu::Locale& getDefaultLocale() {
   return locale;
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const char* str,
     size_t length,
@@ -1031,34 +1058,87 @@ FOLLY_ALWAYS_INLINE static std::string toLower(
   }
   icu::UnicodeString unicodeStr =
       icu::UnicodeString::fromUTF8({str, static_cast<int32_t>(length)});
-  unicodeStr.toLower(locale);
+
+  // Handle Greek final sigma if needed
+  if constexpr (greekFinalSigma) {
+    int32_t i = 0;
+    int32_t unicodeStrLength = unicodeStr.length();
+    while (i < unicodeStrLength) {
+      UChar32 ch;
+      U16_NEXT(unicodeStr.getBuffer(), i, unicodeStrLength, ch);
+      if (ch == 0x03A3) { // Greek capital letter Sigma
+        bool isFinal = true;
+        if (i < unicodeStrLength) {
+          UChar32 lookaheadCh;
+          int32_t lookaheadI = i;
+          U16_NEXT(
+              unicodeStr.getBuffer(),
+              lookaheadI,
+              unicodeStrLength,
+              lookaheadCh);
+          if (detail::isCased(lookaheadCh)) {
+            isFinal = false;
+          }
+        }
+        // Replace with final sigma or regular sigma
+        UChar32 lowerSigma = isFinal ? 0x03C2 : 0x03C3;
+        // Replace the character in the UnicodeString
+        unicodeStr.replace(i - 1, 1, lowerSigma);
+      }
+    }
+  }
+
+  // Handle Turkish casing if needed
+  if constexpr (turkishCasing) {
+    // Use Turkish locale for Turkish-specific casing
+    icu::Locale turkishLocale("tr", "TR");
+    unicodeStr.toLower(turkishLocale);
+  } else {
+    unicodeStr.toLower(locale);
+  }
+
   result.clear();
   unicodeStr.toUTF8String(result);
   return result;
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const std::string& str,
     const icu::Locale& locale = getDefaultLocale()) {
-  return toLower<isAscii>(str.data(), str.size(), locale);
+  return toLower<isAscii, turkishCasing, greekFinalSigma>(
+      str.data(), str.size(), locale);
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const std::string_view& str,
     const icu::Locale& locale = getDefaultLocale()) {
-  return toLower<isAscii>(str.data(), str.size(), locale);
+  return toLower<isAscii, turkishCasing, greekFinalSigma>(
+      str.data(), str.size(), locale);
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toLower(
     const StringView& str,
     const icu::Locale& locale = getDefaultLocale()) {
-  return toLower<isAscii>(str.data(), str.size(), locale);
+  return toLower<isAscii, turkishCasing, greekFinalSigma>(
+      str.data(), str.size(), locale);
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const char* str,
     size_t length,
@@ -1084,31 +1164,52 @@ FOLLY_ALWAYS_INLINE static std::string toUpper(
   }
   icu::UnicodeString unicodeStr =
       icu::UnicodeString::fromUTF8({str, static_cast<int32_t>(length)});
-  unicodeStr.toUpper(locale);
+
+  // Handle Turkish casing if needed
+  if constexpr (turkishCasing) {
+    // Use Turkish locale for Turkish-specific casing
+    icu::Locale turkishLocale("tr", "TR");
+    unicodeStr.toUpper(turkishLocale);
+  } else {
+    unicodeStr.toUpper(locale);
+  }
+
   result.clear();
   unicodeStr.toUTF8String(result);
   return result;
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const std::string& str,
     const icu::Locale& locale = getDefaultLocale()) {
-  return toUpper<isAscii>(str.data(), str.size(), locale);
+  return toUpper<isAscii, turkishCasing, greekFinalSigma>(
+      str.data(), str.size(), locale);
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const std::string_view& str,
     const icu::Locale& locale = getDefaultLocale()) {
-  return toUpper<isAscii>(str.data(), str.size(), locale);
+  return toUpper<isAscii, turkishCasing, greekFinalSigma>(
+      str.data(), str.size(), locale);
 }
 
-template <bool isAscii = true>
+template <
+    bool isAscii = true,
+    bool turkishCasing = false,
+    bool greekFinalSigma = false>
 FOLLY_ALWAYS_INLINE static std::string toUpper(
     const StringView& str,
     const icu::Locale& locale = getDefaultLocale()) {
-  return toUpper<isAscii>(str.data(), str.size(), locale);
+  return toUpper<isAscii, turkishCasing, greekFinalSigma>(
+      str.data(), str.size(), locale);
 }
 
 FOLLY_ALWAYS_INLINE static std::string toTitle(
@@ -1253,6 +1354,5 @@ utf8proc_codepoint_length(utf8proc_int32_t uc) {
     return 0;
   }
 }
-
 } // namespace stringCore
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/string/StringImpl.h
+++ b/bolt/functions/lib/string/StringImpl.h
@@ -50,7 +50,7 @@ namespace bytedance::bolt::functions::stringImpl {
 using namespace stringCore;
 
 /// Perform upper for a UTF8 string
-template <bool ascii, typename TOutString, typename TInString>
+template <bool ascii, bool turkishCasing = false, bool greekFinalSigma = false, typename TOutString, typename TInString>
 FOLLY_ALWAYS_INLINE bool upper(TOutString& output, const TInString& input) {
   if constexpr (ascii) {
     output.resize(input.size());
@@ -69,7 +69,7 @@ FOLLY_ALWAYS_INLINE bool upper(TOutString& output, const TInString& input) {
 }
 
 /// Perform lower for a UTF8 string
-template <bool ascii, typename TOutString, typename TInString>
+template <bool ascii, bool turkishCasing = false, bool greekFinalSigma = false, typename TOutString, typename TInString>
 FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
   if constexpr (ascii) {
     output.resize(input.size());
@@ -77,10 +77,10 @@ FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
   } else {
     // output.resize(input.size() * 4);
     // auto size =
-    //     lowerUnicode(output.data(), output.size(), input.data(),
+    //     lowerUnicode<turkishCasing, greekFinalSigma>(output.data(), output.size(), input.data(),
     //     input.size());
     // output.resize(size);
-    std::string lowerStr = toLower<ascii>(input);
+    std::string lowerStr = toLower<ascii, turkishCasing, greekFinalSigma>(input);
     output.resize(lowerStr.size());
     std::memcpy(output.data(), lowerStr.data(), lowerStr.size());
   }

--- a/bolt/functions/prestosql/StringFunctions.cpp
+++ b/bolt/functions/prestosql/StringFunctions.cpp
@@ -51,7 +51,7 @@ namespace {
  * Upper and Lower functions have a fast path for ascii where the functions
  * can be applied in place.
  * */
-template <bool isLower /*instantiate for upper or lower*/>
+template <bool isLower /*instantiate for upper or lower*/, bool turkishCasing = false, bool greekFinalSigma = false>
 class UpperLowerTemplateFunction : public exec::VectorFunction {
  private:
   /// String encoding wrappable function
@@ -64,10 +64,10 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
       rows.applyToSelected([&](int row) {
         auto proxy = exec::StringWriter<>(results, row);
         if constexpr (isLower) {
-          stringImpl::lower<isAscii>(
+          stringImpl::lower<isAscii, turkishCasing, greekFinalSigma>(
               proxy, decodedInput->valueAt<StringView>(row));
         } else {
-          stringImpl::upper<isAscii>(
+          stringImpl::upper<isAscii, turkishCasing, greekFinalSigma>(
               proxy, decodedInput->valueAt<StringView>(row));
         }
         proxy.finalize();
@@ -797,15 +797,32 @@ class PrintfFunction : public exec::VectorFunction {
   }
 };
 
+// Using declarations to avoid commas in macro arguments
+using UpperFunction = UpperLowerTemplateFunction<false /*isLower*/, false /*turkishCasing*/, false /*greekFinalSigma*/>;
+using LowerFunction = UpperLowerTemplateFunction<true /*isLower*/, false /*turkishCasing*/, false /*greekFinalSigma*/>;
+using UpperSparkFunction = UpperLowerTemplateFunction<false /*isLower*/, true /*turkishCasing*/, true /*greekFinalSigma*/>;
+using LowerSparkFunction = UpperLowerTemplateFunction<true /*isLower*/, true /*turkishCasing*/, true /*greekFinalSigma*/>;
+
 BOLT_DECLARE_VECTOR_FUNCTION(
     udf_upper,
-    UpperLowerTemplateFunction<false /*isLower*/>::signatures(),
-    std::make_unique<UpperLowerTemplateFunction<false /*isLower*/>>());
+    UpperFunction::signatures(),
+    std::make_unique<UpperFunction>());
 
 BOLT_DECLARE_VECTOR_FUNCTION(
     udf_lower,
-    UpperLowerTemplateFunction<true /*isLower*/>::signatures(),
-    std::make_unique<UpperLowerTemplateFunction<true /*isLower*/>>());
+    LowerFunction::signatures(),
+    std::make_unique<LowerFunction>());
+
+// Spark-specific versions with turkishCasing=true and greekFinalSigma=true
+BOLT_DECLARE_VECTOR_FUNCTION(
+    udf_upper_spark,
+    UpperSparkFunction::signatures(),
+    std::make_unique<UpperSparkFunction>());
+
+BOLT_DECLARE_VECTOR_FUNCTION(
+    udf_lower_spark,
+    LowerSparkFunction::signatures(),
+    std::make_unique<LowerSparkFunction>());
 
 BOLT_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(
     udf_concat,

--- a/bolt/functions/sparksql/registration/RegisterString.cpp
+++ b/bolt/functions/sparksql/registration/RegisterString.cpp
@@ -39,8 +39,8 @@
 namespace bytedance::bolt::functions {
 void registerSparkStringFunctions(const std::string& prefix) {
   BOLT_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_upper, prefix + "upper");
+  BOLT_REGISTER_VECTOR_FUNCTION(udf_lower_spark, prefix + "lower");
+  BOLT_REGISTER_VECTOR_FUNCTION(udf_upper_spark, prefix + "upper");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_str_to_map, prefix + "str_to_map");
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Fix Greek final sigma

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
