### PR TITLE
fix: sanitize null const char* in errorMessage to prevent fmt exception

### DIFF
--- a/bolt/common/base/Exceptions.h
+++ b/bolt/common/base/Exceptions.h
@@ -155,16 +155,27 @@ inline CompileTimeEmptyString errorMessage() {
 }
 
 inline const char* errorMessage(const char* s) {
-  return s;
+  return s ? s : "(nullptr)";
 }
 
 inline std::string errorMessage(const std::string& str) {
   return str;
 }
 
+template <typename T>
+decltype(auto) sanitizeArg(const T& arg) {
+  return (arg);
+}
+
+// Replaces null const char* with "(nullptr)" so fmt::vformat won't throw
+// "string pointer is null" when argument is nullptr.
+inline const char* sanitizeArg(const char* arg) {
+  return arg ? arg : "(nullptr)";
+}
+
 template <typename... Args>
 std::string errorMessage(fmt::string_view fmt, const Args&... args) {
-  return fmt::vformat(fmt, fmt::make_format_args(args...));
+  return fmt::vformat(fmt, fmt::make_format_args(sanitizeArg(args)...));
 }
 
 } // namespace detail

--- a/bolt/common/base/tests/ExceptionTest.cpp
+++ b/bolt/common/base/tests/ExceptionTest.cpp
@@ -32,6 +32,7 @@
 #include <folly/Random.h>
 #include <gtest/gtest.h>
 
+#include "bolt/common/base/BoltException.h"
 #include "bolt/common/base/Exceptions.h"
 using namespace bytedance::bolt;
 
@@ -1027,5 +1028,41 @@ TEST(ExceptionTest, exceptionMacroInlining) {
     BOLT_USER_FAIL(errorStr, "definitely");
   } catch (const std::exception& e) {
     ASSERT_TRUE(folly::StringPiece{e.what()}.startsWith("argument not found"));
+  }
+}
+
+// Tests errorMessage(const char*) path: BOLT_FAIL(nullPtr) as sole argument.
+TEST(ExceptionTest, boltFailWithNullWhatException) {
+  struct NullWhatException : public std::exception {
+    const char* what() const noexcept override {
+      return nullptr;
+    }
+  };
+
+  try {
+    try {
+      throw NullWhatException();
+    } catch (const std::exception& e) {
+      BOLT_FAIL(e.what());
+    }
+    FAIL() << "Expected an exception to be thrown";
+  } catch (const BoltRuntimeError& e) {
+    EXPECT_NE(std::string(e.what()).find("(nullptr)"), std::string::npos)
+        << "Expected '(nullptr)' in message, got: " << e.what();
+  }
+}
+
+// Tests errorMessage(fmt, args...) path: null const char* as a format argument.
+TEST(ExceptionTest, boltFailWithNullPtr) {
+  const char* nullPtr = nullptr;
+
+  try {
+    BOLT_FAIL("error message: {}", nullPtr);
+    FAIL() << "Expected an exception to be thrown";
+  } catch (const BoltRuntimeError& e) {
+    EXPECT_NE(
+        std::string(e.what()).find("error message: (nullptr)"),
+        std::string::npos)
+        << "Expected 'error message: (nullptr)' in message, got: " << e.what();
   }
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #461 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

fmt::vformat throws fmt::format_error("string pointer is null") when given a null const char*. In production, this may happen when a catch block passes e.what() to BOLT_FAIL and the exception's what() returns nullptr. The fmt::format_error escapes instead of the intended BoltRuntimeError, losing exception context and producing a confusing error message.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
