### PR TITLE
[feat][cp] Add Spark CAST(bool as timestamp)

### DIFF
--- a/bolt/expression/CastExpr-inl.h
+++ b/bolt/expression/CastExpr-inl.h
@@ -672,7 +672,8 @@ void CastExpr::applyCastPrimitives(
 #ifndef SPARK_COMPATIABLE
   if constexpr (
       (FromKind == TypeKind::INTEGER || FromKind == TypeKind::BIGINT ||
-       FromKind == TypeKind::REAL || FromKind == TypeKind::DOUBLE ||  FromKind == TypeKind::BOOLEAN) &&
+       FromKind == TypeKind::REAL || FromKind == TypeKind::DOUBLE ||
+       FromKind == TypeKind::BOOLEAN) &&
       ToKind == TypeKind::TIMESTAMP) {
     if (queryConfig.throwExceptionWhenCastIntToTimestamp()) {
       BOLT_FAIL("Cannot cast {} to timestamp", mapTypeKindToName(FromKind));

--- a/bolt/expression/CastExpr-inl.h
+++ b/bolt/expression/CastExpr-inl.h
@@ -672,7 +672,7 @@ void CastExpr::applyCastPrimitives(
 #ifndef SPARK_COMPATIABLE
   if constexpr (
       (FromKind == TypeKind::INTEGER || FromKind == TypeKind::BIGINT ||
-       FromKind == TypeKind::REAL || FromKind == TypeKind::DOUBLE) &&
+       FromKind == TypeKind::REAL || FromKind == TypeKind::DOUBLE ||  FromKind == TypeKind::BOOLEAN) &&
       ToKind == TypeKind::TIMESTAMP) {
     if (queryConfig.throwExceptionWhenCastIntToTimestamp()) {
       BOLT_FAIL("Cannot cast {} to timestamp", mapTypeKindToName(FromKind));

--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -702,12 +702,6 @@ class Converter {
         to.toGMT(*timeZone_, &hasError);
       }
       return hasError ? ConvertStatus::OTHER_FAILURE : ConvertStatus::SUCCESS;
-    } else if constexpr (fromInteger || fromFloat) {
-      if constexpr (fromFloat) {
-        if (FOLLY_UNLIKELY(std::isnan(from) || std::isinf(from))) {
-          return ConvertStatus::OTHER_FAILURE;
-        }
-      }
     } else if constexpr (fromKind == PrimitiveKind::BOOLEAN) {
       if constexpr (isInSpark) {
         // Spark treats boolean as microseconds since epoch when casting to
@@ -716,7 +710,12 @@ class Converter {
         return ConvertStatus::SUCCESS;
       }
       return ConvertStatus::OTHER_FAILURE;
-    }
+    } else if constexpr (fromInteger || fromFloat) {
+      if constexpr (fromFloat) {
+        if (FOLLY_UNLIKELY(std::isnan(from) || std::isinf(from))) {
+          return ConvertStatus::OTHER_FAILURE;
+        }
+      }
       // Spark internally use microsecond precision for timestamp.
       // To avoid overflow, we need to check the range of seconds.
       static constexpr int64_t maxSeconds =

--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -708,6 +708,15 @@ class Converter {
           return ConvertStatus::OTHER_FAILURE;
         }
       }
+    } else if constexpr (fromKind == PrimitiveKind::BOOLEAN) {
+      if constexpr (isInSpark) {
+        // Spark treats boolean as microseconds since epoch when casting to
+        // timestamp: false -> 0us, true -> 1us.
+        to = Timestamp::fromMicrosNoError(from ? 1 : 0);
+        return ConvertStatus::SUCCESS;
+      }
+      return ConvertStatus::OTHER_FAILURE;
+    }
       // Spark internally use microsecond precision for timestamp.
       // To avoid overflow, we need to check the range of seconds.
       static constexpr int64_t maxSeconds =
@@ -1061,12 +1070,15 @@ void registerConverter() {
       PrimitiveKind::BIGINT};
   static constexpr std::array floatType = {
       PrimitiveKind::REAL, PrimitiveKind::DOUBLE};
+  static constexpr std::array booleanType = {PrimitiveKind::BOOLEAN};
   static constexpr std::array timestampType = {PrimitiveKind::TIMESTAMP};
   static constexpr std::array binaryType = {PrimitiveKind::BINARY};
   // integer to timestamp type conversion
   ConverterRegister<integerType, timestampType>::registerConverter();
   // float/double to timestamp type conversion
   ConverterRegister<floatType, timestampType>::registerConverter();
+  // boolean to timestamp type conversion
+  ConverterRegister<booleanType, timestampType>::registerConverter();
   // integer to binary type conversion
   ConverterRegister<integerType, binaryType>::registerConverter();
   // timestamp to integer type conversion

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -429,6 +429,13 @@ TEST_F(SparkCastExprTest, floatToTimestamp) {
           std::nullopt,
           std::nullopt,
           std::nullopt,
+
+TEST_F(SparkCastExprTest, boolToTimestamp) {
+  testCast(
+      makeFlatVector<bool>({true, false}),
+      makeFlatVector<Timestamp>({
+          Timestamp(0, 1000),
+          Timestamp(0, 0),
       }));
 }
 

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -429,6 +429,8 @@ TEST_F(SparkCastExprTest, floatToTimestamp) {
           std::nullopt,
           std::nullopt,
           std::nullopt,
+      }));
+}
 
 TEST_F(SparkCastExprTest, boolToTimestamp) {
   testCast(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Add bool to timestamp cast support for Spark.

Spark's implementation: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L625.

Corresponding PR: https://github.com/facebookincubator/velox/pull/12764

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
