### PR TITLE
ci: reduce test runtime in JIT cmp tests

### DIFF
--- a/bolt/jit/tests/RowEqRowIRTest.cpp
+++ b/bolt/jit/tests/RowEqRowIRTest.cpp
@@ -39,7 +39,7 @@ using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec::test;
 
 static constexpr int32_t kNumVectors = 1;
-static constexpr int32_t kRowsPerVector = 1'000;
+static constexpr int32_t kRowsPerVector = 256;
 
 #define DEBUG 0
 namespace {
@@ -290,8 +290,8 @@ class RowEqRowTest : public OperatorTestBase {
           jitEqual = jitEqual == 0 ? 0 : (jitEqual < 0 ? -1 : 1);
           if (expected != jitEqual) {
             std::stringstream ss;
-            ss << "cmp expected: " << (int)expected
-               << " jitEqual: " << (int)jitEqual
+            ss << "cmp expected: " << static_cast<int>(expected)
+               << " jitEqual: " << static_cast<int>(jitEqual)
                << " row:  " << rowContainer->toString(row)
                << " otherRow: " << rowContainer->toString(otherRow)
                << std::endl;
@@ -302,11 +302,10 @@ class RowEqRowTest : public OperatorTestBase {
         } else {
           bool expected = rowContainer->compareRows(row, otherRow) < 0;
           bool jitEqual = eqFunc(row, otherRow);
-          jitEqual = eqFunc(row, otherRow);
           if (expected != jitEqual) {
             std::stringstream ss;
-            ss << "less expected: " << (int)expected
-               << " jitEqual: " << (int)jitEqual
+            ss << "less expected: " << static_cast<int>(expected)
+               << " jitEqual: " << static_cast<int>(jitEqual)
                << " row:  " << rowContainer->toString(row)
                << " otherRow: " << rowContainer->toString(otherRow)
                << std::endl;
@@ -337,9 +336,11 @@ class RowEqRowTest : public OperatorTestBase {
             rows[i + 1], rowContainer->columnAt(0).offset());
         if (currStr == nextStr) {
           if (currStr.size() == 4) { // equal prefix but different size
-            *((int32_t*)(rows[i] + rowContainer->columnAt(0).offset())) = 2;
+            *(reinterpret_cast<int32_t*>(
+                rows[i] + rowContainer->columnAt(0).offset())) = 2;
           } else if (currStr.size() == 12) { // equal inline but different size
-            *((int32_t*)(rows[i] + rowContainer->columnAt(0).offset())) = 10;
+            *(reinterpret_cast<int32_t*>(
+                rows[i] + rowContainer->columnAt(0).offset())) = 10;
           }
         }
       }

--- a/bolt/jit/tests/RowEqVectorsIRTest.cpp
+++ b/bolt/jit/tests/RowEqVectorsIRTest.cpp
@@ -37,7 +37,7 @@ using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec::test;
 
 static constexpr int32_t kNumVectors = 1;
-static constexpr int32_t kRowsPerVector = 1'000;
+static constexpr int32_t kRowsPerVector = 256;
 
 #define DEBUG 0
 namespace {


### PR DESCRIPTION


### What problem does this PR solve?

Reduce the total test runtime for some of the JIT comparison tests.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

These tests generally take the bulk of the time
during the testing phase in CI. They take a long
time due to performing O(n^2) operations on
randomly-generated vectors. The default vector 
size is 1000, but reducing it to 256 reduces the 
amount of work by a factor of 95% while still
maintaining a large amount of comparisons

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
 
N/A

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)