### PR TITLE
[Feature] Restore safe cast and map-subscript filter pushdown with parser fallback normalization

### DIFF
--- a/bolt/connectors/hive/HiveConnectorUtil.cpp
+++ b/bolt/connectors/hive/HiveConnectorUtil.cpp
@@ -757,6 +757,26 @@ bool isNotExpr(
       exec::FunctionCanonicalName::kNot;
 }
 
+bool containsMapSubscriptExpr(const core::TypedExprPtr& expr) {
+  auto* call = dynamic_cast<const core::CallTypedExpr*>(expr.get());
+  if (call == nullptr) {
+    return false;
+  }
+
+  if ((call->name() == "subscript" || call->name() == "element_at") &&
+      !call->inputs().empty() && call->inputs()[0]->type()->isMap()) {
+    return true;
+  }
+
+  for (const auto& input : call->inputs()) {
+    if (containsMapSubscriptExpr(input)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 core::TypedExprPtr extractFiltersFromRemainingFilter(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator,
@@ -772,6 +792,11 @@ core::TypedExprPtr extractFiltersFromRemainingFilter(
             exec::ExprToSubfieldFilterParser::getInstance()
                 ->leafCallToSubfieldFilter(*call, evaluator, negated)) {
       auto& [subfield, filter] = subfieldAndFilter.value();
+      if (containsMapSubscriptExpr(expr) ||
+          filter->kind() == common::FilterKind::kCast ||
+          filter->kind() == common::FilterKind::kMapSubscript) {
+        return expr;
+      }
       if (auto it = filters.find(subfield); it != filters.end()) {
         oldFilter = it->second.get();
         filter = filter->mergeWith(oldFilter);

--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -219,11 +219,13 @@ HiveDataSource::HiveDataSource(
   if (remainingFilter) {
     bool enableMapSubscriptFilter =
         queryConfig.mapSubscriptFilterPushdownEnabled();
+    bool enableCastFilter = queryConfig.castFilterPushdownEnabled();
     metadataFilter_ = std::make_shared<common::MetadataFilter>(
         *scanSpec_,
         *remainingFilter,
         expressionEvaluator_,
-        enableMapSubscriptFilter);
+        enableMapSubscriptFilter,
+        enableCastFilter);
   }
 
   recalculateRepDefConf(readerOutputType_, queryConfig);

--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -217,15 +217,13 @@ HiveDataSource::HiveDataSource(
       runtimeStats_.get(),
       rowIndexColumns);
   if (remainingFilter) {
-    bool enableMapSubscriptFilter =
-        queryConfig.mapSubscriptFilterPushdownEnabled();
-    bool enableCastFilter = queryConfig.castFilterPushdownEnabled();
     metadataFilter_ = std::make_shared<common::MetadataFilter>(
         *scanSpec_,
         *remainingFilter,
         expressionEvaluator_,
-        enableMapSubscriptFilter,
-        enableCastFilter);
+        common::MetadataFilter::Options{
+            queryConfig.mapSubscriptFilterPushdownEnabled(),
+            queryConfig.castFilterPushdownEnabled()});
   }
 
   recalculateRepDefConf(readerOutputType_, queryConfig);

--- a/bolt/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/bolt/connectors/hive/tests/HiveConnectorTest.cpp
@@ -37,6 +37,7 @@
 #include "bolt/connectors/hive/HiveDataSource.h"
 #include "bolt/core/Expressions.h"
 #include "bolt/expression/ExprToSubfieldFilter.h"
+#include "bolt/expression/tests/TestExprUtils.h"
 namespace bytedance::bolt::connector::hive {
 namespace {
 using namespace bytedance::bolt::common;
@@ -56,18 +57,6 @@ std::vector<Subfield> makeSubfields(const std::vector<std::string>& paths) {
     subfields.emplace_back(path);
   }
   return subfields;
-}
-
-core::TypedExprPtr renameRootCall(
-    const core::TypedExprPtr& expr,
-    const std::string& name) {
-  auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr);
-  BOLT_CHECK_NOT_NULL(call);
-  return std::make_shared<core::CallTypedExpr>(
-      call->type(),
-      std::vector<core::TypedExprPtr>(
-          call->inputs().begin(), call->inputs().end()),
-      name);
 }
 
 class TestNameNormalizingParser : public exec::ExprToSubfieldFilterParser {
@@ -508,7 +497,8 @@ TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {
   ASSERT_EQ(filters.size(), 0);
 
   ensureTestNameNormalizingParserRegistered();
-  expr = renameRootCall(parseExpr("m['a'] > 0", rowType), "greaterthan");
+  expr =
+      exec::test::renameCall(parseExpr("m['a'] > 0", rowType), "greaterthan");
   filters.clear();
   remaining = extractFiltersFromRemainingFilter(expr, &evaluator, filters);
   ASSERT_TRUE(remaining);

--- a/bolt/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/bolt/connectors/hive/tests/HiveConnectorTest.cpp
@@ -35,17 +35,12 @@
 #include "bolt/connectors/hive/HiveConfig.h"
 #include "bolt/connectors/hive/HiveConnectorUtil.h"
 #include "bolt/connectors/hive/HiveDataSource.h"
+#include "bolt/core/Expressions.h"
 #include "bolt/expression/ExprToSubfieldFilter.h"
 namespace bytedance::bolt::connector::hive {
 namespace {
 using namespace bytedance::bolt::common;
 using namespace bytedance::bolt::exec::test;
-
-class HiveConnectorTest : public exec::test::HiveConnectorTestBase {
- protected:
-  std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::memoryManager()->addLeafPool();
-};
 
 void validateNullConstant(const ScanSpec& spec, const Type& type) {
   ASSERT_TRUE(spec.isConstant());
@@ -62,6 +57,49 @@ std::vector<Subfield> makeSubfields(const std::vector<std::string>& paths) {
   }
   return subfields;
 }
+
+core::TypedExprPtr renameRootCall(
+    const core::TypedExprPtr& expr,
+    const std::string& name) {
+  auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr);
+  BOLT_CHECK_NOT_NULL(call);
+  return std::make_shared<core::CallTypedExpr>(
+      call->type(),
+      std::vector<core::TypedExprPtr>(
+          call->inputs().begin(), call->inputs().end()),
+      name);
+}
+
+class TestNameNormalizingParser : public exec::ExprToSubfieldFilterParser {
+ public:
+  core::CallTypedExprPtr normalizeCall(
+      const core::CallTypedExpr& call) override {
+    if (call.name() != "greaterthan") {
+      return nullptr;
+    }
+
+    return std::make_shared<core::CallTypedExpr>(
+        call.type(),
+        std::vector<core::TypedExprPtr>(
+            call.inputs().begin(), call.inputs().end()),
+        "gt");
+  }
+};
+
+void ensureTestNameNormalizingParserRegistered() {
+  static const bool registered = []() {
+    exec::ExprToSubfieldFilterParser::registerParser(
+        std::make_shared<TestNameNormalizingParser>());
+    return true;
+  }();
+  static_cast<void>(registered);
+}
+
+class HiveConnectorTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::memoryManager()->addLeafPool();
+};
 
 folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
 groupSubfields(const std::vector<Subfield>& subfields) {
@@ -423,7 +461,9 @@ TEST_F(HiveConnectorTest, makeScanSpec_filterPartitionKey) {
 TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {
   auto queryCtx = core::QueryCtx::create();
   exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool_.get());
-  auto rowType = ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), DECIMAL(20, 0)});
+  auto rowType =
+      ROW({"c0", "c1", "c2", "m"},
+          {BIGINT(), BIGINT(), DECIMAL(20, 0), MAP(VARCHAR(), BIGINT())});
 
   auto expr = parseExpr("not (c0 > 0 or c1 > 0)", rowType);
   SubfieldFilters filters;
@@ -450,6 +490,29 @@ TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {
   ASSERT_TRUE(remaining);
   ASSERT_EQ(
       remaining->toString(), "not(lt(ROW[\"c2\"],cast 0 as DECIMAL(20, 0)))");
+
+  // Test Cast filter pushdown is skipped from subfield filters and kept in
+  // remaining
+  expr = parseExpr("cast(c0 as INTEGER) > 0", rowType);
+  filters.clear();
+  remaining = extractFiltersFromRemainingFilter(expr, &evaluator, filters);
+  ASSERT_TRUE(remaining);
+  ASSERT_EQ(filters.size(), 0);
+
+  // Test MapSubscript filter pushdown is skipped from subfield filters and kept
+  // in remaining
+  expr = parseExpr("m['a'] > 0", rowType);
+  filters.clear();
+  remaining = extractFiltersFromRemainingFilter(expr, &evaluator, filters);
+  ASSERT_TRUE(remaining);
+  ASSERT_EQ(filters.size(), 0);
+
+  ensureTestNameNormalizingParserRegistered();
+  expr = renameRootCall(parseExpr("m['a'] > 0", rowType), "greaterthan");
+  filters.clear();
+  remaining = extractFiltersFromRemainingFilter(expr, &evaluator, filters);
+  ASSERT_TRUE(remaining);
+  ASSERT_EQ(filters.size(), 0);
 }
 
 } // namespace

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -750,6 +750,9 @@ class QueryConfig {
   static constexpr const char* kMapSubscriptFilterPushdown =
       "map_subscript_filter_pushdown";
 
+  /// Enable filter pushdown for filters with cast operation
+  static constexpr const char* kCastFilterPushdown = "cast_filter_pushdown";
+
   static constexpr const char* kDynamicConcurrencyAdjustmentEnabled =
       "dynamic_concurrency_adjustment_enabled";
 
@@ -1694,7 +1697,13 @@ class QueryConfig {
   /// Returns 'map subscript pushdown enable' flag.
   /// Map subscript filter pushdown is enabled by default.
   bool mapSubscriptFilterPushdownEnabled() const {
-    return get<bool>(kMapSubscriptFilterPushdown, false);
+    return get<bool>(kMapSubscriptFilterPushdown, true);
+  }
+
+  /// Returns 'cast filter pushdown enable' flag.
+  /// Cast filter pushdown is enabled by default.
+  bool castFilterPushdownEnabled() const {
+    return get<bool>(kCastFilterPushdown, true);
   }
 
   int32_t queryMemoryReclaimerPriority() const {

--- a/bolt/dwio/common/MetadataFilter.cpp
+++ b/bolt/dwio/common/MetadataFilter.cpp
@@ -45,8 +45,7 @@ struct MetadataFilter::Node {
       const core::ITypedExpr&,
       core::ExpressionEvaluator*,
       bool negated,
-      bool enableMapSubscriptFilter,
-      bool enableCastFilter);
+      MetadataFilter::Options options);
   virtual ~Node() = default;
   virtual void addToScanSpec(ScanSpec&) const = 0;
   virtual uint64_t* eval(LeafResults&, int size) const = 0;
@@ -174,51 +173,25 @@ std::unique_ptr<MetadataFilter::Node> MetadataFilter::Node::fromExpression(
     const core::ITypedExpr& expr,
     core::ExpressionEvaluator* evaluator,
     bool negated,
-    bool enableMapSubscriptFilter,
-    bool enableCastFilter) {
+    MetadataFilter::Options options) {
   auto* call = asCall(&expr);
   if (!call) {
     return nullptr;
   }
   if (call->name() == "and") {
-    auto lhs = fromExpression(
-        *call->inputs()[0],
-        evaluator,
-        negated,
-        enableMapSubscriptFilter,
-        enableCastFilter);
-    auto rhs = fromExpression(
-        *call->inputs()[1],
-        evaluator,
-        negated,
-        enableMapSubscriptFilter,
-        enableCastFilter);
+    auto lhs = fromExpression(*call->inputs()[0], evaluator, negated, options);
+    auto rhs = fromExpression(*call->inputs()[1], evaluator, negated, options);
     return negated ? OrNode::create(std::move(lhs), std::move(rhs))
                    : AndNode::create(std::move(lhs), std::move(rhs));
   }
   if (call->name() == "or") {
-    auto lhs = fromExpression(
-        *call->inputs()[0],
-        evaluator,
-        negated,
-        enableMapSubscriptFilter,
-        enableCastFilter);
-    auto rhs = fromExpression(
-        *call->inputs()[1],
-        evaluator,
-        negated,
-        enableMapSubscriptFilter,
-        enableCastFilter);
+    auto lhs = fromExpression(*call->inputs()[0], evaluator, negated, options);
+    auto rhs = fromExpression(*call->inputs()[1], evaluator, negated, options);
     return negated ? AndNode::create(std::move(lhs), std::move(rhs))
                    : OrNode::create(std::move(lhs), std::move(rhs));
   }
   if (call->name() == "not") {
-    return fromExpression(
-        *call->inputs()[0],
-        evaluator,
-        !negated,
-        enableMapSubscriptFilter,
-        enableCastFilter);
+    return fromExpression(*call->inputs()[0], evaluator, !negated, options);
   }
   try {
     auto subfieldAndFilter =
@@ -230,10 +203,10 @@ std::unique_ptr<MetadataFilter::Node> MetadataFilter::Node::fromExpression(
 
     auto& [subfield, filter] = subfieldAndFilter.value();
     if (filter->kind() == FilterKind::kMapSubscript &&
-        !enableMapSubscriptFilter) {
+        !options.enableMapSubscriptFilter) {
       return nullptr;
     }
-    if (filter->kind() == FilterKind::kCast && !enableCastFilter) {
+    if (filter->kind() == FilterKind::kCast && !options.enableCastFilter) {
       return nullptr;
     }
     BOLT_CHECK(
@@ -251,15 +224,15 @@ std::unique_ptr<MetadataFilter::Node> MetadataFilter::Node::fromExpression(
 MetadataFilter::MetadataFilter(
     ScanSpec& scanSpec,
     const core::ITypedExpr& expr,
+    core::ExpressionEvaluator* evaluator)
+    : MetadataFilter(scanSpec, expr, evaluator, Options{}) {}
+
+MetadataFilter::MetadataFilter(
+    ScanSpec& scanSpec,
+    const core::ITypedExpr& expr,
     core::ExpressionEvaluator* evaluator,
-    bool enableMapSubscriptFilter,
-    bool enableCastFilter)
-    : root_(Node::fromExpression(
-          expr,
-          evaluator,
-          false,
-          enableMapSubscriptFilter,
-          enableCastFilter)) {
+    Options options)
+    : root_(Node::fromExpression(expr, evaluator, false, options)) {
   if (root_) {
     root_->addToScanSpec(scanSpec);
   }

--- a/bolt/dwio/common/MetadataFilter.cpp
+++ b/bolt/dwio/common/MetadataFilter.cpp
@@ -45,7 +45,8 @@ struct MetadataFilter::Node {
       const core::ITypedExpr&,
       core::ExpressionEvaluator*,
       bool negated,
-      bool enableMapSubscriptFilter);
+      bool enableMapSubscriptFilter,
+      bool enableCastFilter);
   virtual ~Node() = default;
   virtual void addToScanSpec(ScanSpec&) const = 0;
   virtual uint64_t* eval(LeafResults&, int size) const = 0;
@@ -173,30 +174,51 @@ std::unique_ptr<MetadataFilter::Node> MetadataFilter::Node::fromExpression(
     const core::ITypedExpr& expr,
     core::ExpressionEvaluator* evaluator,
     bool negated,
-    bool enableMapSubscriptFilter) {
+    bool enableMapSubscriptFilter,
+    bool enableCastFilter) {
   auto* call = asCall(&expr);
   if (!call) {
     return nullptr;
   }
   if (call->name() == "and") {
     auto lhs = fromExpression(
-        *call->inputs()[0], evaluator, negated, enableMapSubscriptFilter);
+        *call->inputs()[0],
+        evaluator,
+        negated,
+        enableMapSubscriptFilter,
+        enableCastFilter);
     auto rhs = fromExpression(
-        *call->inputs()[1], evaluator, negated, enableMapSubscriptFilter);
+        *call->inputs()[1],
+        evaluator,
+        negated,
+        enableMapSubscriptFilter,
+        enableCastFilter);
     return negated ? OrNode::create(std::move(lhs), std::move(rhs))
                    : AndNode::create(std::move(lhs), std::move(rhs));
   }
   if (call->name() == "or") {
     auto lhs = fromExpression(
-        *call->inputs()[0], evaluator, negated, enableMapSubscriptFilter);
+        *call->inputs()[0],
+        evaluator,
+        negated,
+        enableMapSubscriptFilter,
+        enableCastFilter);
     auto rhs = fromExpression(
-        *call->inputs()[1], evaluator, negated, enableMapSubscriptFilter);
+        *call->inputs()[1],
+        evaluator,
+        negated,
+        enableMapSubscriptFilter,
+        enableCastFilter);
     return negated ? AndNode::create(std::move(lhs), std::move(rhs))
                    : OrNode::create(std::move(lhs), std::move(rhs));
   }
   if (call->name() == "not") {
     return fromExpression(
-        *call->inputs()[0], evaluator, !negated, enableMapSubscriptFilter);
+        *call->inputs()[0],
+        evaluator,
+        !negated,
+        enableMapSubscriptFilter,
+        enableCastFilter);
   }
   try {
     auto subfieldAndFilter =
@@ -209,6 +231,9 @@ std::unique_ptr<MetadataFilter::Node> MetadataFilter::Node::fromExpression(
     auto& [subfield, filter] = subfieldAndFilter.value();
     if (filter->kind() == FilterKind::kMapSubscript &&
         !enableMapSubscriptFilter) {
+      return nullptr;
+    }
+    if (filter->kind() == FilterKind::kCast && !enableCastFilter) {
       return nullptr;
     }
     BOLT_CHECK(
@@ -227,12 +252,14 @@ MetadataFilter::MetadataFilter(
     ScanSpec& scanSpec,
     const core::ITypedExpr& expr,
     core::ExpressionEvaluator* evaluator,
-    bool enableMapSubscriptFilter)
+    bool enableMapSubscriptFilter,
+    bool enableCastFilter)
     : root_(Node::fromExpression(
           expr,
           evaluator,
           false,
-          enableMapSubscriptFilter)) {
+          enableMapSubscriptFilter,
+          enableCastFilter)) {
   if (root_) {
     root_->addToScanSpec(scanSpec);
   }

--- a/bolt/dwio/common/MetadataFilter.h
+++ b/bolt/dwio/common/MetadataFilter.h
@@ -49,7 +49,8 @@ class MetadataFilter {
       ScanSpec&,
       const core::ITypedExpr&,
       core::ExpressionEvaluator*,
-      bool enableMapSubscriptFilter);
+      bool enableMapSubscriptFilter = true,
+      bool enableCastFilter = true);
 
   /// Evaluate the filter results based on logical conjunctions tracked in this
   /// object.  `leafNodeResults` could be reused for intermediate results.  The

--- a/bolt/dwio/common/MetadataFilter.h
+++ b/bolt/dwio/common/MetadataFilter.h
@@ -43,14 +43,23 @@ class MetadataFilter {
  public:
   class LeafNode;
 
+  struct Options {
+    bool enableMapSubscriptFilter{true};
+    bool enableCastFilter{true};
+  };
+
   /// Construct from a ScanSpec and an expression.  The leaf filter nodes
   /// generated will be added to the corresponding position in ScanSpec.
   MetadataFilter(
       ScanSpec&,
       const core::ITypedExpr&,
+      core::ExpressionEvaluator*);
+
+  MetadataFilter(
+      ScanSpec&,
+      const core::ITypedExpr&,
       core::ExpressionEvaluator*,
-      bool enableMapSubscriptFilter = true,
-      bool enableCastFilter = true);
+      Options options);
 
   /// Evaluate the filter results based on logical conjunctions tracked in this
   /// object.  `leafNodeResults` could be reused for intermediate results.  The

--- a/bolt/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/bolt/dwio/common/tests/E2EFilterTestBase.cpp
@@ -456,7 +456,7 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   auto typedExpr = core::Expressions::inferTypes(
       untypedExpr, batches[0]->type(), leafPool_.get());
   auto metadataFilter =
-      std::make_shared<MetadataFilter>(*spec, *typedExpr, evaluator, true);
+      std::make_shared<MetadataFilter>(*spec, *typedExpr, evaluator);
   auto specA = spec->getOrCreateChild("a");
   auto specB = spec->getOrCreateChild("b");
   auto specC = spec->getOrCreateChild(common::Subfield("b.c"));
@@ -605,7 +605,7 @@ void E2EFilterTestBase::testMetadataFilter() {
     auto typedExpr = core::Expressions::inferTypes(
         untypedExpr, batches[0]->type(), leafPool_.get());
     auto metadataFilter =
-        std::make_shared<MetadataFilter>(*spec, *typedExpr, &evaluator, true);
+        std::make_shared<MetadataFilter>(*spec, *typedExpr, &evaluator);
     // Top level metadata filter is null, so leaf node should not be referenced
     // from ScanSpec.
     ASSERT_EQ(spec->childByName("a")->numMetadataFilters(), 0);

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1490,6 +1490,12 @@ class ParquetRowReader::Impl {
       VLOG(1) << "Total row groups: " << rowGroups_.size();
       VLOG(1) << "Total rows: " << rowNumber;
     }
+
+    if (rowGroupIds_.size() < rowGroups_.size()) {
+      LOG(INFO) << "Bolt Parquet Scan: Retained " << rowGroupIds_.size()
+                << " out of " << rowGroups_.size() << " total row groups. "
+                << "Total rows: " << rowNumber;
+    }
   }
 
   int64_t nextRowNumber() {

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1492,9 +1492,9 @@ class ParquetRowReader::Impl {
     }
 
     if (rowGroupIds_.size() < rowGroups_.size()) {
-      LOG(INFO) << "Bolt Parquet Scan: Retained " << rowGroupIds_.size()
-                << " out of " << rowGroups_.size() << " total row groups. "
-                << "Total rows: " << rowNumber;
+      VLOG(1) << "Bolt Parquet Scan: Retained " << rowGroupIds_.size()
+              << " out of " << rowGroups_.size() << " total row groups. "
+              << "Total rows: " << rowNumber;
     }
   }
 

--- a/bolt/expression/ExprToSubfieldFilter.cpp
+++ b/bolt/expression/ExprToSubfieldFilter.cpp
@@ -38,6 +38,11 @@ using namespace bytedance::bolt;
 namespace bytedance::bolt::exec {
 namespace {
 
+inline bool isMapSubscriptFunctionName(std::string_view name) {
+  return name == "subscript" || name == "presto.default.subscript" ||
+      name == "element_at" || name == "presto.default.element_at";
+}
+
 const core::CallTypedExpr* asCall(const core::ITypedExpr* expr) {
   return dynamic_cast<const core::CallTypedExpr*>(expr);
 }
@@ -101,10 +106,7 @@ std::optional<FunctionInfo> FunctionInfo::tryExtractFromExpr(
   }
 
   if (auto callExpr = asCall(expr.get())) {
-    if ((callExpr->name() == "subscript" ||
-         callExpr->name() == "presto.default.subscript" ||
-         callExpr->name() == "element_at" ||
-         callExpr->name() == "presto.default.element_at") &&
+    if (isMapSubscriptFunctionName(callExpr->name()) &&
         filterKeys.find(callExpr->name()) != filterKeys.end()) {
       return FunctionInfo{
           fieldExprOpt->type(), callExpr->type(), callExpr->name(), fieldDepth};
@@ -332,10 +334,7 @@ bool ExprToSubfieldFilterParser::toSubfield(
       // Skip over cast to extract the underlying field
     } else if (
         auto* callExpr = dynamic_cast<const core::CallTypedExpr*>(current)) {
-      if (callExpr->name() == "subscript" ||
-          callExpr->name() == "presto.default.subscript" ||
-          callExpr->name() == "element_at" ||
-          callExpr->name() == "presto.default.element_at") {
+      if (isMapSubscriptFunctionName(callExpr->name())) {
         // Skip over subscript to extract the underlying field
       } else {
         return false;
@@ -719,10 +718,7 @@ bool isSupportedMapSubscriptPushdownKey(const core::TypedExprPtr& fieldSide) {
     return true;
   }
 
-  if (callExpr->name() != "subscript" &&
-      callExpr->name() != "presto.default.subscript" &&
-      callExpr->name() != "element_at" &&
-      callExpr->name() != "presto.default.element_at") {
+  if (!isMapSubscriptFunctionName(callExpr->name())) {
     return true;
   }
 
@@ -768,10 +764,7 @@ combine(
           functionInfo->targetType,
           std::move(filter));
     } else if (
-        (functionInfo->functionName == "subscript" ||
-         functionInfo->functionName == "presto.default.subscript" ||
-         functionInfo->functionName == "element_at" ||
-         functionInfo->functionName == "presto.default.element_at") &&
+        isMapSubscriptFunctionName(functionInfo->functionName) &&
         functionInfo->fieldDepth == 1) {
       // For map subscript expressions, create appropriate filters
       // based on the map value type

--- a/bolt/expression/ExprToSubfieldFilter.cpp
+++ b/bolt/expression/ExprToSubfieldFilter.cpp
@@ -30,10 +30,95 @@
 
 #include "bolt/expression/ExprToSubfieldFilter.h"
 #include "bolt/expression/Expr.h"
+#include "bolt/expression/SingleSubfieldExtractor.h"
+#include "bolt/type/filter/Cast.h"
+#include "bolt/type/filter/MapSubscriptFilter.h"
 
 using namespace bytedance::bolt;
 namespace bytedance::bolt::exec {
 namespace {
+
+const core::CallTypedExpr* asCall(const core::ITypedExpr* expr) {
+  return dynamic_cast<const core::CallTypedExpr*>(expr);
+}
+
+const core::CastTypedExpr* asCast(const core::ITypedExpr* expr) {
+  return dynamic_cast<const core::CastTypedExpr*>(expr);
+}
+
+struct FunctionInfo {
+  TypePtr sourceType;
+  TypePtr targetType;
+  std::string functionName;
+  size_t fieldDepth;
+
+  static std::optional<FunctionInfo> tryExtractFromExpr(
+      const core::TypedExprPtr& expr);
+
+  static inline const std::unordered_set<std::string> filterKeys = {
+      "eq",
+      "neq",
+      "lt",
+      "gt",
+      "lte",
+      "gte",
+      "between",
+      "presto.default.eq",
+      "presto.default.neq",
+      "presto.default.lt",
+      "presto.default.gt",
+      "presto.default.lte",
+      "presto.default.gte",
+      "presto.default.between",
+      "in",
+      "is_null",
+      "cast",
+      "subscript",
+      "presto.default.subscript",
+      "element_at",
+      "presto.default.element_at"};
+};
+
+std::optional<FunctionInfo> FunctionInfo::tryExtractFromExpr(
+    const core::TypedExprPtr& expr) {
+  SingleSubfieldExtractor extractor;
+  auto extractResult = extractor.extract(expr.get());
+  if (!extractResult.has_value()) {
+    return std::nullopt;
+  }
+
+  auto [chainOpt, depth] = extractResult.value();
+  if (chainOpt.empty()) {
+    return std::nullopt;
+  }
+
+  // Notice that SingleSubfieldExtractor in newer codebase might return
+  // std::vector<std::string> as chainOpt. We need to get the actual source
+  // type. We can use fieldTypedExpr for it.
+  auto [fieldExprOpt, fieldDepth] = extractor.fieldTypedExpr(expr.get());
+  if (fieldExprOpt == nullptr) {
+    return std::nullopt;
+  }
+
+  if (auto callExpr = asCall(expr.get())) {
+    if ((callExpr->name() == "subscript" ||
+         callExpr->name() == "presto.default.subscript" ||
+         callExpr->name() == "element_at" ||
+         callExpr->name() == "presto.default.element_at") &&
+        filterKeys.find(callExpr->name()) != filterKeys.end()) {
+      return FunctionInfo{
+          fieldExprOpt->type(), callExpr->type(), callExpr->name(), fieldDepth};
+    } else if (filterKeys.find(callExpr->name()) == filterKeys.end()) {
+      return FunctionInfo{
+          fieldExprOpt->type(), callExpr->type(), callExpr->name(), fieldDepth};
+    }
+  } else if (auto castExpr = asCast(expr.get())) {
+    return FunctionInfo{
+        fieldExprOpt->type(), castExpr->type(), "cast", fieldDepth};
+  }
+  return std::nullopt;
+};
+
 VectorPtr toConstant(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator) {
@@ -87,6 +172,55 @@ toInt64List(const VectorPtr& vector, vector_size_t start, vector_size_t size) {
 
 } // namespace
 
+namespace {
+
+class ChainedExprToSubfieldFilterParser final
+    : public ExprToSubfieldFilterParser {
+ public:
+  explicit ChainedExprToSubfieldFilterParser(
+      std::vector<std::shared_ptr<ExprToSubfieldFilterParser>> parsers)
+      : parsers_(std::move(parsers)) {
+    // Always keep at least the built-in parser.
+    BOLT_CHECK(!parsers_.empty(), "Parser chain must not be empty");
+  }
+
+  std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
+  leafCallToSubfieldFilter(
+      const core::CallTypedExpr& call,
+      core::ExpressionEvaluator* evaluator,
+      bool negated = false) override {
+    if (auto result = parsers_.front()->leafCallToSubfieldFilter(
+            call, evaluator, negated)) {
+      return result;
+    }
+
+    for (auto i = 1; i < parsers_.size(); ++i) {
+      const auto& parser = parsers_[i];
+      if (!parser) {
+        continue;
+      }
+
+      if (auto normalizedCall = parser->normalizeCall(call)) {
+        if (auto result = parsers_.front()->leafCallToSubfieldFilter(
+                *normalizedCall, evaluator, negated)) {
+          return result;
+        }
+      }
+
+      if (auto result =
+              parser->leafCallToSubfieldFilter(call, evaluator, negated)) {
+        return result;
+      }
+    }
+    return std::nullopt;
+  }
+
+ private:
+  const std::vector<std::shared_ptr<ExprToSubfieldFilterParser>> parsers_;
+};
+
+} // namespace
+
 // Analyzes 'expr' to determine if it can be expressed as a subfield filter.
 // Returns a pair of subfield and filter if so. Otherwise, throws.
 //
@@ -136,8 +270,42 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
 }
 
 std::shared_ptr<ExprToSubfieldFilterParser>
-    ExprToSubfieldFilterParser::parser_ =
+    ExprToSubfieldFilterParser::boltParser_ =
         std::make_shared<PrestoExprToSubfieldFilterParser>();
+
+std::vector<std::shared_ptr<ExprToSubfieldFilterParser>>
+    ExprToSubfieldFilterParser::fallbackParsers_ = {};
+
+std::shared_ptr<ExprToSubfieldFilterParser>
+    ExprToSubfieldFilterParser::parser_ = []() {
+      ExprToSubfieldFilterParser::rebuildParserChain();
+      return ExprToSubfieldFilterParser::parser_;
+    }();
+
+// static
+void ExprToSubfieldFilterParser::rebuildParserChain() {
+  std::vector<std::shared_ptr<ExprToSubfieldFilterParser>> chain;
+  // Avoid static initialization order issues across translation units.
+  if (!boltParser_) {
+    boltParser_ = std::make_shared<PrestoExprToSubfieldFilterParser>();
+  }
+  chain.emplace_back(boltParser_);
+  chain.insert(chain.end(), fallbackParsers_.begin(), fallbackParsers_.end());
+  parser_ =
+      std::make_shared<ChainedExprToSubfieldFilterParser>(std::move(chain));
+}
+
+// static
+void ExprToSubfieldFilterParser::registerParser(
+    std::shared_ptr<ExprToSubfieldFilterParser> parser) {
+  BOLT_CHECK_NOT_NULL(parser);
+  // Add as fallback. Bolt built-in parser stays first.
+  fallbackParsers_.emplace_back(std::move(parser));
+  rebuildParserChain();
+}
+
+std::unordered_map<std::string, std::string>
+    ExprToSubfieldFilterParser::aliases_;
 
 // static
 bool ExprToSubfieldFilterParser::toSubfield(
@@ -159,6 +327,19 @@ bool ExprToSubfieldFilterParser::toSubfield(
         return false;
       }
       path.push_back(std::make_unique<common::Subfield::NestedField>(name));
+    } else if (
+        auto* castExpr = dynamic_cast<const core::CastTypedExpr*>(current)) {
+      // Skip over cast to extract the underlying field
+    } else if (
+        auto* callExpr = dynamic_cast<const core::CallTypedExpr*>(current)) {
+      if (callExpr->name() == "subscript" ||
+          callExpr->name() == "presto.default.subscript" ||
+          callExpr->name() == "element_at" ||
+          callExpr->name() == "presto.default.element_at") {
+        // Skip over subscript to extract the underlying field
+      } else {
+        return false;
+      }
     } else if (dynamic_cast<const core::InputTypedExpr*>(current) == nullptr) {
       return false;
     } else {
@@ -168,9 +349,9 @@ bool ExprToSubfieldFilterParser::toSubfield(
     if (current->inputs().empty()) {
       break;
     }
-    if (current->inputs().size() != 1) {
-      return false;
-    }
+    // We only traverse the first input (the child field) for
+    // subscript/element_at calls because the second input is the key, and we
+    // only want the map/array field path.
     current = current->inputs()[0].get();
     if (current == nullptr) {
       return false;
@@ -532,15 +713,146 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeOrFilter(
 }
 
 namespace {
-std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
-combine(common::Subfield& subfield, std::unique_ptr<common::Filter>& filter) {
-  if (filter != nullptr) {
-    return std::make_pair(std::move(subfield), std::move(filter));
+bool isSupportedMapSubscriptPushdownKey(const core::TypedExprPtr& fieldSide) {
+  auto* callExpr = dynamic_cast<const core::CallTypedExpr*>(fieldSide.get());
+  if (callExpr == nullptr || callExpr->inputs().size() != 2) {
+    return true;
   }
 
-  return std::nullopt;
+  if (callExpr->name() != "subscript" &&
+      callExpr->name() != "presto.default.subscript" &&
+      callExpr->name() != "element_at" &&
+      callExpr->name() != "presto.default.element_at") {
+    return true;
+  }
+
+  if (!callExpr->inputs()[0]->type()->isMap()) {
+    return true;
+  }
+
+  auto* constantExpr =
+      dynamic_cast<const core::ConstantTypedExpr*>(callExpr->inputs()[1].get());
+  if (constantExpr == nullptr) {
+    return false;
+  }
+
+  auto keyVariant = constantExpr->value();
+  if (!keyVariant.hasValue()) {
+    return false;
+  }
+
+  return keyVariant.kind() == TypeKind::VARCHAR ||
+      keyVariant.kind() == TypeKind::BIGINT ||
+      keyVariant.kind() == TypeKind::INTEGER;
+}
+
+std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
+combine(
+    const core::TypedExprPtr& fieldSide,
+    common::Subfield& subfield,
+    std::unique_ptr<common::Filter>& filter,
+    core::ExpressionEvaluator* evaluator) {
+  if (!filter) {
+    return std::nullopt;
+  }
+
+  if (!isSupportedMapSubscriptPushdownKey(fieldSide)) {
+    return std::nullopt;
+  }
+
+  if (auto functionInfo = FunctionInfo::tryExtractFromExpr(fieldSide)) {
+    // Cast operator is much faster than ExprSetFilter.
+    if (functionInfo->functionName == "cast" && functionInfo->fieldDepth == 1) {
+      filter = common::createCastFilter(
+          functionInfo->sourceType,
+          functionInfo->targetType,
+          std::move(filter));
+    } else if (
+        (functionInfo->functionName == "subscript" ||
+         functionInfo->functionName == "presto.default.subscript" ||
+         functionInfo->functionName == "element_at" ||
+         functionInfo->functionName == "presto.default.element_at") &&
+        functionInfo->fieldDepth == 1) {
+      // For map subscript expressions, create appropriate filters
+      // based on the map value type
+      if (functionInfo->sourceType->isMap()) {
+        // Extract the key from the subscript expression
+        if (auto* callExpr =
+                dynamic_cast<const core::CallTypedExpr*>(fieldSide.get())) {
+          BOLT_CHECK_EQ(callExpr->inputs().size(), 2);
+          auto keyExpr = callExpr->inputs()[1].get();
+          // Only constant string/integer keys can be converted into metadata
+          // filters. Otherwise, keep the original expression unmodified.
+          auto* constantExpr =
+              dynamic_cast<const core::ConstantTypedExpr*>(keyExpr);
+          if (constantExpr == nullptr) {
+            return std::nullopt;
+          }
+
+          auto keyVariant = constantExpr->value();
+          if (!keyVariant.hasValue()) {
+            return std::nullopt;
+          }
+
+          std::unique_ptr<common::Filter> keyFilter =
+              ExprToSubfieldFilterParser::makeEqualFilter(
+                  callExpr->inputs()[1], evaluator);
+          if (!keyFilter) {
+            return std::nullopt;
+          }
+
+          if (keyVariant.kind() == TypeKind::VARCHAR) {
+            // Use MapSubscriptFilter for map key and value filtering with
+            // string key.
+            filter = common::createMapSubscriptFilter(
+                keyVariant.value<TypeKind::VARCHAR>(),
+                std::move(filter),
+                std::move(keyFilter));
+          } else if (keyVariant.kind() == TypeKind::BIGINT) {
+            // Use MapSubscriptFilter for map key and value filtering with
+            // integer key.
+            filter = common::createMapSubscriptFilter(
+                keyVariant.value<TypeKind::BIGINT>(),
+                std::move(filter),
+                std::move(keyFilter));
+          } else if (keyVariant.kind() == TypeKind::INTEGER) {
+            // Use MapSubscriptFilter for map key and value filtering with
+            // integer key.
+            filter = common::createMapSubscriptFilter(
+                keyVariant.value<TypeKind::INTEGER>(),
+                std::move(filter),
+                std::move(keyFilter));
+          } else {
+            return std::nullopt;
+          }
+        } else {
+          return std::nullopt;
+        }
+
+      } else {
+        // Fallback or unsupported type for subscript
+        return std::nullopt;
+      }
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  return std::make_pair(std::move(subfield), std::move(filter));
 }
 } // namespace
+
+void ExprToSubfieldFilterParser::registerAlias(
+    const std::string& alias,
+    const std::string& canonical) {
+  aliases_[alias] = canonical;
+}
+
+std::string ExprToSubfieldFilterParser::getCanonicalName(
+    const std::string& name) {
+  auto it = aliases_.find(name);
+  return it != aliases_.end() ? it->second : name;
+}
 
 std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
 PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
@@ -554,64 +866,79 @@ PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
   const auto* leftSide = call.inputs()[0].get();
 
   common::Subfield subfield;
-  if (call.name() == "eq") {
+  std::string funcName = getCanonicalName(call.name());
+
+  if (funcName == "eq" || funcName == "presto.default.eq") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = negated ? makeNotEqualFilter(call.inputs()[1], evaluator)
                             : makeEqualFilter(call.inputs()[1], evaluator);
 
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "neq") {
+  } else if (funcName == "neq" || funcName == "presto.default.neq") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = negated ? makeEqualFilter(call.inputs()[1], evaluator)
                             : makeNotEqualFilter(call.inputs()[1], evaluator);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "lte") {
+  } else if (funcName == "lte" || funcName == "presto.default.lte") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = negated
           ? makeGreaterThanFilter(call.inputs()[1], evaluator)
           : makeLessThanOrEqualFilter(call.inputs()[1], evaluator);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "lt") {
+  } else if (funcName == "lt" || funcName == "presto.default.lt") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = negated
           ? makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator)
           : makeLessThanFilter(call.inputs()[1], evaluator);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "gte") {
+  } else if (funcName == "gte" || funcName == "presto.default.gte") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = negated
           ? makeLessThanFilter(call.inputs()[1], evaluator)
           : makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "gt") {
+  } else if (funcName == "gt" || funcName == "presto.default.gt") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = negated
           ? makeLessThanOrEqualFilter(call.inputs()[1], evaluator)
           : makeGreaterThanFilter(call.inputs()[1], evaluator);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "between") {
+  } else if (funcName == "between" || funcName == "presto.default.between") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = makeBetweenFilter(
           call.inputs()[1], call.inputs()[2], evaluator, negated);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "in") {
+  } else if (funcName == "in") {
     if (toSubfield(leftSide, subfield)) {
       auto filter = makeInFilter(call.inputs()[1], evaluator, negated);
-      return combine(subfield, filter);
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
-  } else if (call.name() == "is_null") {
+  } else if (funcName == "is_null") {
     if (toSubfield(leftSide, subfield)) {
+      std::unique_ptr<common::Filter> filter;
       if (negated) {
-        return std::make_pair(std::move(subfield), isNotNull());
+        filter = isNotNull();
+      } else {
+        filter = isNull();
       }
-      return std::make_pair(std::move(subfield), isNull());
+      return combine(call.inputs()[0], subfield, filter, evaluator);
+    }
+  } else if (funcName == "is_not_null") {
+    if (toSubfield(leftSide, subfield)) {
+      std::unique_ptr<common::Filter> filter;
+      if (negated) {
+        filter = isNull();
+      } else {
+        filter = isNotNull();
+      }
+      return combine(call.inputs()[0], subfield, filter, evaluator);
     }
   }
   return std::nullopt;

--- a/bolt/expression/ExprToSubfieldFilter.h
+++ b/bolt/expression/ExprToSubfieldFilter.h
@@ -429,6 +429,16 @@ class ExprToSubfieldFilterParser {
  public:
   virtual ~ExprToSubfieldFilterParser() = default;
 
+  static void registerAlias(
+      const std::string& alias,
+      const std::string& canonical);
+  static std::string getCanonicalName(const std::string& name);
+
+  // Creates an equal subfield filter against the given constant.
+  static std::unique_ptr<common::Filter> makeEqualFilter(
+      const core::TypedExprPtr& valueExpr,
+      core::ExpressionEvaluator* evaluator);
+
   /// Returns a parser provided to an earlier 'registerParser' call. Not thread
   /// safe.
   static const std::shared_ptr<ExprToSubfieldFilterParser>& getInstance() {
@@ -436,12 +446,23 @@ class ExprToSubfieldFilterParser {
     return parser_;
   }
 
-  /// Registers a parser. Silently overwrites previously registered parser if
-  /// any. Not thread safe.
+  /// Registers an additional fallback parser.
+  ///
+  /// The built-in Bolt parser remains the primary parser. This method is for
+  /// platform/vendor specific extensions, and will be consulted only when the
+  /// built-in parser returns std::nullopt.
+  ///
+  /// Not thread safe.
   static void registerParser(
-      std::shared_ptr<ExprToSubfieldFilterParser> parser) {
-    BOLT_CHECK_NOT_NULL(parser);
-    parser_ = std::move(parser);
+      std::shared_ptr<ExprToSubfieldFilterParser> parser);
+
+  /// Gives a fallback parser a chance to rewrite only the outer call into a
+  /// canonical Bolt/Presto form while preserving the original inputs. This is
+  /// useful for dialect-specific operator names, e.g. Spark comparison names,
+  /// where nested expressions should still be interpreted by Bolt's parser.
+  virtual core::CallTypedExprPtr normalizeCall(
+      const core::CallTypedExpr& call) {
+    return nullptr;
   }
 
   /// Analyzes 'call' expression to determine if it can be expressed as a
@@ -454,7 +475,9 @@ class ExprToSubfieldFilterParser {
   leafCallToSubfieldFilter(
       const core::CallTypedExpr& call,
       core::ExpressionEvaluator* evaluator,
-      bool negated = false) = 0;
+      bool negated = false) {
+    return std::nullopt;
+  }
 
   static std::unique_ptr<common::Filter> makeOrFilter(
       std::unique_ptr<common::Filter> a,
@@ -469,11 +492,6 @@ class ExprToSubfieldFilterParser {
 
   // Creates a non-equal subfield filter against the given constant.
   static std::unique_ptr<common::Filter> makeNotEqualFilter(
-      const core::TypedExprPtr& valueExpr,
-      core::ExpressionEvaluator* evaluator);
-
-  // Creates an equal subfield filter against the given constant.
-  static std::unique_ptr<common::Filter> makeEqualFilter(
       const core::TypedExprPtr& valueExpr,
       core::ExpressionEvaluator* evaluator);
 
@@ -512,11 +530,22 @@ class ExprToSubfieldFilterParser {
       bool negated);
 
  private:
-  // Singleton parser instance.
+  static void rebuildParserChain();
+
+  // Built-in parser (Bolt-owned).
+  static std::shared_ptr<ExprToSubfieldFilterParser> boltParser_;
+
+  // Registered fallback parsers (platform/vendor owned).
+  static std::vector<std::shared_ptr<ExprToSubfieldFilterParser>>
+      fallbackParsers_;
+
+  // Singleton parser instance (a chain of boltParser_ + fallbackParsers_).
   static std::shared_ptr<ExprToSubfieldFilterParser> parser_;
+
+  // Alias mapping.
+  static std::unordered_map<std::string, std::string> aliases_;
 };
 
-// Parser for Presto expressions.
 class PrestoExprToSubfieldFilterParser : public ExprToSubfieldFilterParser {
  public:
   std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>

--- a/bolt/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/bolt/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -31,6 +31,7 @@
 #include "bolt/expression/ExprToSubfieldFilter.h"
 #include <gtest/gtest.h>
 #include "bolt/expression/Expr.h"
+#include "bolt/expression/tests/TestExprUtils.h"
 #include "bolt/functions/prestosql/registration/RegistrationFunctions.h"
 #include "bolt/parse/Expressions.h"
 #include "bolt/parse/ExpressionsParser.h"
@@ -49,16 +50,6 @@ void validateSubfield(
     ASSERT_TRUE(subfield.path()[i]);
     ASSERT_EQ(*subfield.path()[i], Subfield::NestedField(expectedPath[i]));
   }
-}
-
-core::CallTypedExprPtr renameCall(
-    const core::CallTypedExprPtr& call,
-    const std::string& name) {
-  return std::make_shared<core::CallTypedExpr>(
-      call->type(),
-      std::vector<core::TypedExprPtr>(
-          call->inputs().begin(), call->inputs().end()),
-      name);
 }
 
 class TestNameNormalizingParser : public ExprToSubfieldFilterParser {
@@ -322,7 +313,7 @@ TEST_F(ExprToSubfieldFilterTest, castIsNullFilter) {
 }
 
 TEST_F(ExprToSubfieldFilterTest, sparkGreaterThanWithMapSubscriptFilter) {
-  auto call = renameCall(
+  auto call = test::renameCall(
       parseCallExpr(
           "element_at(a, 'key') > 42", ROW({{"a", MAP(VARCHAR(), BIGINT())}})),
       "greaterthan");
@@ -334,7 +325,7 @@ TEST_F(ExprToSubfieldFilterTest, sparkGreaterThanWithMapSubscriptFilter) {
 }
 
 TEST_F(ExprToSubfieldFilterTest, sparkLessThanOrEqualWithCastFilter) {
-  auto call = renameCall(
+  auto call = test::renameCall(
       parseCallExpr("cast(a as bigint) <= 42", ROW({{"a", VARCHAR()}})),
       "lessthanorequal");
   auto [subfield, filter] = leafCallToSubfieldFilter(call);

--- a/bolt/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/bolt/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -35,6 +35,7 @@
 #include "bolt/parse/Expressions.h"
 #include "bolt/parse/ExpressionsParser.h"
 #include "bolt/parse/TypeResolver.h"
+#include "bolt/type/filter/FilterBase.h"
 
 using bytedance::bolt::common::Subfield;
 
@@ -50,12 +51,58 @@ void validateSubfield(
   }
 }
 
+core::CallTypedExprPtr renameCall(
+    const core::CallTypedExprPtr& call,
+    const std::string& name) {
+  return std::make_shared<core::CallTypedExpr>(
+      call->type(),
+      std::vector<core::TypedExprPtr>(
+          call->inputs().begin(), call->inputs().end()),
+      name);
+}
+
+class TestNameNormalizingParser : public ExprToSubfieldFilterParser {
+ public:
+  std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
+  leafCallToSubfieldFilter(
+      const core::CallTypedExpr& call,
+      core::ExpressionEvaluator* /*evaluator*/,
+      bool /*negated*/) override {
+    if (call.name() == "greaterthan" || call.name() == "lessthanorequal") {
+      return std::make_pair(
+          common::Subfield("fallback"), std::make_unique<common::IsNull>());
+    }
+    return std::nullopt;
+  }
+
+  core::CallTypedExprPtr normalizeCall(
+      const core::CallTypedExpr& call) override {
+    const auto& name = call.name();
+    std::string canonical;
+    if (name == "greaterthan") {
+      canonical = "gt";
+    } else if (name == "lessthanorequal") {
+      canonical = "lte";
+    } else {
+      return nullptr;
+    }
+
+    return std::make_shared<core::CallTypedExpr>(
+        call.type(),
+        std::vector<core::TypedExprPtr>(
+            call.inputs().begin(), call.inputs().end()),
+        canonical);
+  }
+};
+
 class ExprToSubfieldFilterTest : public testing::Test {
  public:
   static void SetUpTestSuite() {
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    ExprToSubfieldFilterParser::registerParser(
+        std::make_shared<TestNameNormalizingParser>());
   }
 
   core::TypedExprPtr parseExpr(
@@ -240,6 +287,67 @@ TEST_F(ExprToSubfieldFilterTest, nonConstant) {
 
 TEST_F(ExprToSubfieldFilterTest, userError) {
   auto call = parseCallExpr("a = 1 / 0", ROW({{"a", BIGINT()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_FALSE(filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, castFilter) {
+  auto call = parseCallExpr("cast(a as bigint) = 42", ROW({{"a", VARCHAR()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+  ASSERT_EQ(filter->kind(), common::FilterKind::kCast);
+}
+
+TEST_F(ExprToSubfieldFilterTest, mapSubscriptFilter) {
+  auto call = parseCallExpr(
+      "element_at(a, 'key') = 42", ROW({{"a", MAP(VARCHAR(), BIGINT())}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+  ASSERT_EQ(filter->kind(), common::FilterKind::kMapSubscript);
+}
+
+TEST_F(ExprToSubfieldFilterTest, castIsNullFilter) {
+  auto call =
+      parseCallExpr("cast(a as bigint) is null", ROW({{"a", VARCHAR()}}));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+  ASSERT_EQ(filter->kind(), common::FilterKind::kCast);
+}
+
+TEST_F(ExprToSubfieldFilterTest, sparkGreaterThanWithMapSubscriptFilter) {
+  auto call = renameCall(
+      parseCallExpr(
+          "element_at(a, 'key') > 42", ROW({{"a", MAP(VARCHAR(), BIGINT())}})),
+      "greaterthan");
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+  ASSERT_EQ(filter->kind(), common::FilterKind::kMapSubscript);
+}
+
+TEST_F(ExprToSubfieldFilterTest, sparkLessThanOrEqualWithCastFilter) {
+  auto call = renameCall(
+      parseCallExpr("cast(a as bigint) <= 42", ROW({{"a", VARCHAR()}})),
+      "lessthanorequal");
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+  ASSERT_EQ(filter->kind(), common::FilterKind::kCast);
+}
+
+TEST_F(ExprToSubfieldFilterTest, mapSubscriptFilterRequiresConstantKey) {
+  auto call = parseCallExpr(
+      "element_at(a, b) = 42",
+      ROW({{"a", MAP(VARCHAR(), BIGINT())}, {"b", VARCHAR()}}));
   auto [subfield, filter] = leafCallToSubfieldFilter(call);
 
   ASSERT_FALSE(filter);

--- a/bolt/expression/tests/TestExprUtils.h
+++ b/bolt/expression/tests/TestExprUtils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "bolt/core/Expressions.h"
+
+namespace bytedance::bolt::exec::test {
+
+inline core::CallTypedExprPtr renameCall(
+    const core::TypedExprPtr& expr,
+    const std::string& name) {
+  auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr);
+  BOLT_CHECK_NOT_NULL(call);
+  return std::make_shared<core::CallTypedExpr>(
+      call->type(),
+      std::vector<core::TypedExprPtr>(
+          call->inputs().begin(), call->inputs().end()),
+      name);
+}
+
+} // namespace bytedance::bolt::exec::test


### PR DESCRIPTION
### What problem does this PR solve?
This PR restores cast and map-subscript filter pushdown on top of `oss/main` and makes the multi-parser flow safer.

The main change is that Bolt now:
- tries the built-in Bolt parser first,
- lets fallback parsers normalize only the outer call name,
- retries Bolt parsing on that normalized call,
- and only then falls back to full fallback-parser handling.

This keeps nested Bolt-recognized expressions such as `element_at(...)` and `cast(...)` eligible for Bolt-side subfield-filter conversion even when the outer operator comes
from another dialect.

### What changed

#### Expression-to-subfield filter parsing
- Restore cast and map-subscript pushdown in `ExprToSubfieldFilter`.
- Add a generic parser hook to normalize the outer call before retrying Bolt parsing.
- Change parser chaining order to:
  1. Bolt parser
  2. normalized-call retry through Bolt
  3. fallback parser full parse

#### Correctness and safety fixes
- Preserve cast/map-subscript wrappers for `IS NULL` / `IS NOT NULL` pushdown instead of collapsing to the inner field.
- Reject non-constant map keys so expressions like `element_at(a, b) = ...` do not produce invalid metadata filters.
- Avoid pushing unsupported repeated-column map filters into Hive metadata filtering; keep those expressions in the remaining filter instead.

#### Hive / Parquet integration
- Wire restored filters through Hive and Parquet metadata pruning paths.
- Update related metadata filter handling and query config plumbing for cast/map-subscript pushdown.

#### Tests
- Add regression coverage for:
  - wrapped null predicates on cast expressions,
  - non-constant map-subscript keys,
  - fallback normalization for outer dialect-specific operator names while still letting Bolt parse nested map/cast expressions,
  - Hive remaining-filter extraction behavior for map-subscript expressions.

### Why

Without this change, mixed-dialect expressions can lose Bolt-side subfield pushdown opportunities because the fallback parser tries to parse the whole expression itself. That
is especially problematic for cases where only the outer operator name is dialect-specific, but the nested expression is something Bolt already understands well, such as
`element_at(...)` or `cast(...)`.

This PR keeps those nested expressions on the Bolt path while also avoiding unsafe pushdown for unsupported repeated-column filters.

Issue Number: close #479

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
