### PR TITLE
[feat][cp] Use bolt parquet reader in Metadatatest

### DIFF
--- a/bolt/dwio/parquet/arrow/tests/MetadataTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/MetadataTest.cpp
@@ -36,14 +36,24 @@
 
 #include "arrow/util/key_value_metadata.h"
 #include "bolt/dwio/parquet/arrow/FileWriter.h"
-#include "bolt/dwio/parquet/arrow/Schema.h"
-#include "bolt/dwio/parquet/arrow/Statistics.h"
-#include "bolt/dwio/parquet/arrow/ThriftInternal.h"
-#include "bolt/dwio/parquet/arrow/Types.h"
-#include "bolt/dwio/parquet/arrow/tests/FileReader.h"
 #include "bolt/dwio/parquet/arrow/tests/TestUtil.h"
+#include "bolt/dwio/parquet/reader/ParquetReader.h"
+#include "bolt/exec/tests/utils/TempFilePath.h"
+
 namespace bytedance::bolt::parquet::arrow {
 namespace metadata {
+namespace {
+void writeToFile(
+    std::shared_ptr<exec::test::TempFilePath> filePath,
+    std::shared_ptr<arrow::Buffer> buffer) {
+  auto localWriteFile =
+      std::make_unique<LocalWriteFile>(filePath->getPath(), false, false);
+  auto bufferReader = std::make_shared<::arrow::io::BufferReader>(buffer);
+  auto bufferToString = bufferReader->buffer()->ToString();
+  localWriteFile->append(bufferToString);
+  localWriteFile->close();
+}
+} // namespace
 
 // Helper function for generating table metadata
 std::unique_ptr<FileMetaData> GenerateTableMetaData(
@@ -404,21 +414,31 @@ TEST(Metadata, TestAddKeyValueMetadata) {
       file_writer->AddKeyValueMetadata(kv_meta_ignored), ParquetException);
 
   PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
-  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
-  auto file_reader = ParquetFileReader::Open(source);
 
-  ASSERT_NE(nullptr, file_reader->metadata());
-  ASSERT_NE(nullptr, file_reader->metadata()->key_value_metadata());
-  auto read_kv_meta = file_reader->metadata()->key_value_metadata();
-
+  // Write the buffer to a temp file path
+  auto filePath = exec::test::TempFilePath::create();
+  writeToFile(filePath, buffer);
+  memory::MemoryManager::testingSetInstance({});
+  std::shared_ptr<bytedance::bolt::memory::MemoryPool> rootPool =
+      memory::memoryManager()->addRootPool("MetadataTest");
+  std::shared_ptr<bytedance::bolt::memory::MemoryPool> leafPool =
+      rootPool->addLeafChild("MetadataTest");
+  dwio::common::ReaderOptions readerOptions{leafPool.get()};
+  auto input = std::make_unique<dwio::common::BufferedInput>(
+      std::make_shared<LocalReadFile>(filePath->getPath()),
+      readerOptions.getMemoryPool());
+  auto reader = std::make_unique<bytedance::bolt::parquet::ParquetReader>(
+      std::move(input), readerOptions);
+  ASSERT_EQ(3, reader->fileMetaData().keyValueMetadataSize());
   // Verify keys that were added before file writer was closed are present.
   for (int i = 1; i <= 3; ++i) {
     auto index = std::to_string(i);
-    PARQUET_ASSIGN_OR_THROW(auto value, read_kv_meta->Get("test_key_" + index));
+    auto value =
+        reader->fileMetaData().keyValueMetadataValue("test_key_" + index);
     EXPECT_EQ("test_value_" + index, value);
   }
   // Verify keys that were added after file writer was closed are not present.
-  EXPECT_FALSE(read_kv_meta->Contains("test_key_4"));
+  EXPECT_FALSE(reader->fileMetaData().keyValueMetadataContains("test_key_4"));
 }
 
 // TODO: disabled as they require Arrow parquet data dir.
@@ -484,39 +504,50 @@ TEST(Metadata, TestSortingColumns) {
   auto schema = std::static_pointer_cast<schema::GroupNode>(
       schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
 
-  std::vector<SortingColumn> sorting_columns;
+  std::vector<SortingColumn> sortingColumns;
   {
-    SortingColumn sorting_column;
-    sorting_column.column_idx = 0;
-    sorting_column.descending = false;
-    sorting_column.nulls_first = false;
-    sorting_columns.push_back(sorting_column);
+    SortingColumn sortingColumn;
+    sortingColumn.column_idx = 0;
+    sortingColumn.descending = false;
+    sortingColumn.nulls_first = false;
+    sortingColumns.push_back(sortingColumn);
   }
 
   auto sink = CreateOutputStream();
-  auto writer_props = WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->set_sorting_columns(sorting_columns)
-                          ->build();
+  auto writerProps = WriterProperties::Builder()
+                         .disable_dictionary()
+                         ->set_sorting_columns(sortingColumns)
+                         ->build();
 
-  EXPECT_EQ(sorting_columns, writer_props->sorting_columns());
+  EXPECT_EQ(sortingColumns, writerProps->sorting_columns());
 
-  auto file_writer = ParquetFileWriter::Open(sink, schema, writer_props);
+  auto fileWriter = ParquetFileWriter::Open(sink, schema, writerProps);
 
-  auto row_group_writer = file_writer->AppendBufferedRowGroup();
-  row_group_writer->Close();
-  file_writer->Close();
+  auto rowGroupWriter = fileWriter->AppendBufferedRowGroup();
+  rowGroupWriter->Close();
+  fileWriter->Close();
 
   PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
-  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
-  auto file_reader = ParquetFileReader::Open(source);
 
-  ASSERT_NE(nullptr, file_reader->metadata());
-  ASSERT_EQ(1, file_reader->metadata()->num_row_groups());
-  auto row_group_reader = file_reader->RowGroup(0);
-  auto* row_group_read_metadata = row_group_reader->metadata();
-  ASSERT_NE(nullptr, row_group_read_metadata);
-  EXPECT_EQ(sorting_columns, row_group_read_metadata->sorting_columns());
+  // Write the buffer to a temp file path
+  auto filePath = exec::test::TempFilePath::create();
+  writeToFile(filePath, buffer);
+  memory::MemoryManager::testingSetInstance({});
+  std::shared_ptr<bytedance::bolt::memory::MemoryPool> rootPool =
+      memory::memoryManager()->addRootPool("MetadataTest");
+  std::shared_ptr<bytedance::bolt::memory::MemoryPool> leafPool =
+      rootPool->addLeafChild("MetadataTest");
+  dwio::common::ReaderOptions readerOptions{leafPool.get()};
+  auto input = std::make_unique<dwio::common::BufferedInput>(
+      std::make_shared<LocalReadFile>(filePath->getPath()),
+      readerOptions.getMemoryPool());
+  auto reader = std::make_unique<bytedance::bolt::parquet::ParquetReader>(
+      std::move(input), readerOptions);
+  ASSERT_EQ(1, reader->fileMetaData().numRowGroups());
+  auto rowGroup = reader->fileMetaData().rowGroup(0);
+  EXPECT_EQ(sortingColumns[0].column_idx, rowGroup.sortingColumnIdx(0));
+  EXPECT_EQ(sortingColumns[0].descending, rowGroup.sortingColumnDescending(0));
+  EXPECT_EQ(sortingColumns[0].nulls_first, rowGroup.sortingColumnNullsFirst(0));
 }
 
 TEST(ApplicationVersion, Basics) {

--- a/bolt/dwio/parquet/reader/Metadata.cpp
+++ b/bolt/dwio/parquet/reader/Metadata.cpp
@@ -84,6 +84,18 @@ int RowGroupMetaDataPtr::numColumns() const {
   return thriftRowGroupPtr(ptr_)->columns.size();
 }
 
+int32_t RowGroupMetaDataPtr::sortingColumnIdx(int i) const {
+  return thriftRowGroupPtr(ptr_)->sorting_columns[i].column_idx;
+}
+
+bool RowGroupMetaDataPtr::sortingColumnDescending(int i) const {
+  return thriftRowGroupPtr(ptr_)->sorting_columns[i].descending;
+}
+
+bool RowGroupMetaDataPtr::sortingColumnNullsFirst(int i) const {
+  return thriftRowGroupPtr(ptr_)->sorting_columns[i].nulls_first;
+}
+
 int64_t RowGroupMetaDataPtr::numRows() const {
   return thriftRowGroupPtr(ptr_)->num_rows;
 }
@@ -125,6 +137,32 @@ int64_t FileMetaDataPtr::numRows() const {
 
 int FileMetaDataPtr::numRowGroups() const {
   return thriftFileMetaDataPtr(ptr_)->row_groups.size();
+}
+
+int64_t FileMetaDataPtr::keyValueMetadataSize() const {
+  return thriftFileMetaDataPtr(ptr_)->key_value_metadata.size();
+}
+
+bool FileMetaDataPtr::keyValueMetadataContains(
+    const std::string_view key) const {
+  auto thriftKeyValueMeta = thriftFileMetaDataPtr(ptr_)->key_value_metadata;
+  for (const auto& kv : thriftKeyValueMeta) {
+    if (kv.key == key) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string FileMetaDataPtr::keyValueMetadataValue(
+    const std::string_view key) const {
+  int thriftKeyValueMetaSize = keyValueMetadataSize();
+  for (size_t i = 0; i < thriftKeyValueMetaSize; i++) {
+    if (key == thriftFileMetaDataPtr(ptr_)->key_value_metadata[i].key) {
+      return thriftFileMetaDataPtr(ptr_)->key_value_metadata[i].value;
+    }
+  }
+  BOLT_FAIL(fmt::format("Input key {} is not in the key value metadata", key));
 }
 
 } // namespace bytedance::bolt::parquet

--- a/bolt/dwio/parquet/reader/Metadata.h
+++ b/bolt/dwio/parquet/reader/Metadata.h
@@ -70,6 +70,16 @@ class RowGroupMetaDataPtr {
   /// parent's column ordering.
   int numColumns() const;
 
+  /// The sorting column, column index in this row group
+  int32_t sortingColumnIdx(int i) const;
+
+  /// If true, indicates this column is sorted in descending order.
+  bool sortingColumnDescending(int i) const;
+
+  /// If true, nulls will come before non-null values, otherwise, nulls go at
+  /// the end
+  bool sortingColumnNullsFirst(int i) const;
+
   /// Return the ColumnChunkMetaData pointer of the corresponding column index.
   ColumnChunkMetaDataPtr columnChunk(int index) const;
 
@@ -107,6 +117,15 @@ class FileMetaDataPtr {
 
   /// Return the RowGroupMetaData pointer of the corresponding row group index.
   RowGroupMetaDataPtr rowGroup(int index) const;
+
+  /// The key/value metadata size.
+  int64_t keyValueMetadataSize() const;
+
+  /// Returns True if the key/value metadata contains the key input.
+  bool keyValueMetadataContains(const std::string_view key) const;
+
+  /// Returns the value inside the key/value metadata if the key is present.
+  std::string keyValueMetadataValue(const std::string_view key) const;
 
  private:
   const void* ptr_;


### PR DESCRIPTION
Summary:
Change Parquet writer tests to use Velox parquet reader instead of Arrow parquet reader.
Once all the tests are migrated, we can remove the Arrow Parquet reader code.

Velox Pull Request: https://github.com/facebookincubator/velox/pull/11472

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

see Summary

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
