### PR TITLE
fix: Prevent SEGV in paimon with many updates to single PK

### DIFF
--- a/bolt/benchmarks/paimon/PaimonBenchmark.cpp
+++ b/bolt/benchmarks/paimon/PaimonBenchmark.cpp
@@ -27,16 +27,11 @@
 #include <gtest/gtest.h>
 
 #include <bolt/dwio/common/BufferedInput.h>
-#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/memory/Memory.h"
 #include "bolt/dwio/common/Options.h"
-#include "bolt/type/Timestamp.h"
-#include "bolt/vector/tests/utils/VectorTestBase.h"
 #include "folly/Range.h"
 
-#include "bolt/common/base/Fs.h"
 #include "bolt/common/file/FileSystems.h"
-#include "bolt/connectors/hive/HiveConnector.h"
 #include "bolt/connectors/hive/HiveConnectorSplit.h"
 #include "bolt/exec/Task.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
@@ -45,11 +40,8 @@
 #include "bolt/connectors/hive/PaimonConnectorSplit.h"
 #include "bolt/connectors/hive/PaimonConstants.h"
 #include "bolt/connectors/hive/TableHandle.h"
-#include "bolt/connectors/hive/paimon_merge_engines/PaimonRowKind.h"
-#include "bolt/exec/tests/utils/TempDirectoryPath.h"
 
 #include <folly/init/Init.h>
-#include <algorithm>
 
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec;
@@ -65,6 +57,18 @@ DEFINE_string(
 namespace {
 static bool notEmpty(const char* /*flagName*/, const std::string& value) {
   return !value.empty();
+}
+
+std::string benchmarkDataPath(const std::string& subdir) {
+  if (FLAGS_data_path.empty()) {
+    return subdir;
+  }
+
+  if (FLAGS_data_path.back() == '/') {
+    return FLAGS_data_path + subdir;
+  }
+
+  return FLAGS_data_path + "/" + subdir;
 }
 } // namespace
 
@@ -178,10 +182,100 @@ class PaimonBenchmark : public QueryBenchmarkBase {
         core::QueryCtx::create(executor.get()),
         exec::Task::ExecutionMode::kSerial);
 
-    auto filePaths = getFilePaths(FLAGS_data_path);
+    auto filePaths = getFilePaths(benchmarkDataPath("reader"));
 
     std::vector<std::shared_ptr<HiveConnectorSplit>> hiveSplits;
     for (auto filePath : filePaths) {
+      auto hiveSplit = std::make_shared<HiveConnectorSplit>(
+          kHiveConnectorId, filePath, dwio::common::FileFormat::PARQUET);
+      hiveSplits.push_back(hiveSplit);
+    }
+
+    auto connectorSplit =
+        std::make_shared<connector::hive::PaimonConnectorSplit>(
+            kHiveConnectorId, hiveSplits);
+
+    readTask->addSplit(scanNodeId, exec::Split{connectorSplit});
+
+    readTask->noMoreSplits(scanNodeId);
+
+    const auto stats = readTask->taskStats();
+    while (auto result = readTask->next()) {
+    }
+
+    connector::unregisterConnector(kHiveConnectorId);
+    BoltProfilerStop();
+  }
+
+  void runPartialUpdate(std::ostream& out, RunStats& runStats) {
+    BoltProfilerStart("paimon_partial_update.prof");
+
+    auto hiveConnector =
+        connector::getConnectorFactory(connector::kHiveConnectorName)
+            ->newConnector(
+                kHiveConnectorId,
+                std::make_shared<config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>()));
+    connector::registerConnector(hiveConnector);
+
+    filesystems::registerLocalFileSystem();
+
+    std::shared_ptr<folly::Executor> executor(
+        std::make_shared<folly::CPUThreadPoolExecutor>(
+            std::thread::hardware_concurrency()));
+
+    // Schema for partial update: pk_a (primary key), a (double), b (bigint), c
+    // (varchar)
+    auto fileRowType = ROW(
+        {{"pk_a", INTEGER()},
+         {"a", DOUBLE()},
+         {"b", BIGINT()},
+         {"c", VARCHAR()},
+         {"_SEQUENCE_NUMBER", BIGINT()},
+         {"_VALUE_KIND", TINYINT()}});
+    // Project only the data columns (exclude metadata columns)
+    auto rowType = ROW(
+        {{"pk_a", INTEGER()},
+         {"a", DOUBLE()},
+         {"b", BIGINT()},
+         {"c", VARCHAR()}});
+
+    core::PlanNodeId scanNodeId;
+
+    // Use partial-update merge engine with pk_a as primary key
+    std::unordered_map<std::string, std::string> tableParameters{
+        {connector::paimon::kMergeEngine,
+         connector::paimon::kPartialUpdateMergeEngine},
+        {connector::paimon::kPrimaryKey, "a"}};
+
+    auto tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
+        kHiveConnectorId,
+        "hive_table",
+        true,
+        SubfieldFilters{},
+        nullptr,
+        fileRowType,
+        tableParameters);
+
+    auto assignments = getIdentityAssignment(fileRowType);
+
+    auto readPlanFragment = exec::test::PlanBuilder()
+                                .tableScan(rowType, tableHandle, assignments)
+                                .capturePlanNodeId(scanNodeId)
+                                .planFragment();
+
+    // Create the reader task.
+    auto readTask = exec::Task::create(
+        "my_read_task",
+        readPlanFragment,
+        /*destination=*/0,
+        core::QueryCtx::create(executor.get()),
+        exec::Task::ExecutionMode::kSerial);
+
+    auto filePaths = getFilePaths(benchmarkDataPath("partial-update"));
+
+    std::vector<std::shared_ptr<HiveConnectorSplit>> hiveSplits;
+    for (const auto& filePath : filePaths) {
       auto hiveSplit = std::make_shared<HiveConnectorSplit>(
           kHiveConnectorId, filePath, dwio::common::FileFormat::PARQUET);
       hiveSplits.push_back(hiveSplit);
@@ -210,6 +304,12 @@ BENCHMARK(reader) {
   PaimonBenchmark benchmark;
   RunStats runStats;
   benchmark.runMain(std::cout, runStats);
+}
+
+BENCHMARK(partial_update_reader) {
+  PaimonBenchmark benchmark;
+  RunStats runStats;
+  benchmark.runPartialUpdate(std::cout, runStats);
 }
 
 int paimonBenchmarkMain() {

--- a/bolt/benchmarks/paimon/paimon_gen.py
+++ b/bolt/benchmarks/paimon/paimon_gen.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #
 # Copyright (c) ByteDance Ltd. and/or its affiliates
 #
@@ -19,9 +20,15 @@ import numpy as np
 import os
 
 
+def ensure_output_dir(dirname):
+    os.makedirs(dirname, exist_ok=True)
+    return dirname
+
+
 def create_parquet():
+    output_dir = ensure_output_dir("reader")
     num_rows = 400_000_000
-    filename = "a.parquet"
+    filename = os.path.join(output_dir, "a.parquet")
 
     pk_a = np.arange(1, num_rows + 1, dtype=np.int32)
     a = pk_a
@@ -37,7 +44,7 @@ def create_parquet():
     pq.write_table(table, filename, row_group_size=1_000_000, compression="snappy")
     print(f"Created {filename} with {os.path.getsize(filename) / (1024 * 1024):.2f} MB")
 
-    filename = "b.parquet"
+    filename = os.path.join(output_dir, "b.parquet")
 
     pk_a = np.arange(num_rows / 2 + 1, 3 * num_rows / 2 + 1, dtype=np.int32)
     a = pk_a
@@ -57,5 +64,67 @@ def create_parquet():
     print(f"Created {filename} with {os.path.getsize(filename) / (1024 * 1024):.2f} MB")
 
 
+def create_partial_update_parquet():
+    """
+    Generate parquet files for partial update engine benchmark.
+    The partial update engine merges rows with the same primary key by
+    taking the latest non-null value for each column based on sequence number.
+
+    This creates two files with overlapping primary keys where:
+    - File A: pk_a from 1 to num_rows, with values in columns a, b, c
+    - File B: pk_a from num_rows/2+1 to num_rows (overlapping), with different values
+    """
+    output_dir = ensure_output_dir("partial-update")
+    num_rows = 100_000_000
+    filename = os.path.join(output_dir, "a.parquet")
+
+    # File A: rows 1 to num_rows
+    pk_a = np.arange(1, num_rows + 1, dtype=np.int32)
+    a = pk_a.astype(np.float64)  # column a: double
+    b = np.arange(10, num_rows + 10, dtype=np.int64)  # column b: bigint
+    # column c: varchar (string)
+    c = np.array([f"str_{i}" for i in range(1, num_rows + 1)], dtype=object)
+
+    _SEQUENCE_NUMBER1 = np.arange(2, 2 * num_rows + 2, 2, dtype=np.int64)
+    _VALUE_KIND = np.full(num_rows, 1, dtype=np.int8)
+
+    table = pa.Table.from_arrays(
+        [pk_a, a, b, c, _SEQUENCE_NUMBER1, _VALUE_KIND],
+        names=["pk_a", "a", "b", "c", "_SEQUENCE_NUMBER", "_VALUE_KIND"],
+    )
+
+    pq.write_table(table, filename, row_group_size=1_000_000, compression="snappy")
+    print(f"Created {filename} with {os.path.getsize(filename) / (1024 * 1024):.2f} MB")
+
+    # File B: overlapping rows with different values
+    # Overlap range: num_rows/2 + 1 to num_rows
+    overlap_start = num_rows // 2 + 1
+    overlap_end = num_rows
+    num_overlap_rows = overlap_end - overlap_start + 1
+
+    filename = os.path.join(output_dir, "b.parquet")
+
+    pk_a = np.arange(overlap_start, overlap_end + 1, dtype=np.int32)
+    # Different values for overlapping rows - these should be merged
+    a = np.full(num_overlap_rows, 999.99, dtype=np.float64)  # column a: double
+    b = np.arange(1000, 1000 + num_overlap_rows, dtype=np.int64)  # column b: bigint
+    c = np.array(
+        [f"updated_{i}" for i in range(overlap_start, overlap_end + 1)], dtype=object
+    )
+
+    # Higher sequence numbers so these values take precedence
+    _SEQUENCE_NUMBER2 = np.arange(3, 2 * num_overlap_rows + 3, 2, dtype=np.int64)
+    _VALUE_KIND = np.full(num_overlap_rows, 1, dtype=np.int8)
+
+    table = pa.Table.from_arrays(
+        [pk_a, a, b, c, _SEQUENCE_NUMBER2, _VALUE_KIND],
+        names=["pk_a", "a", "b", "c", "_SEQUENCE_NUMBER", "_VALUE_KIND"],
+    )
+
+    pq.write_table(table, filename, row_group_size=1_000_000, compression="snappy")
+    print(f"Created {filename} with {os.path.getsize(filename) / (1024 * 1024):.2f} MB")
+
+
 if __name__ == "__main__":
+    create_partial_update_parquet()
     create_parquet()

--- a/bolt/connectors/hive/PaimonEngine.h
+++ b/bolt/connectors/hive/PaimonEngine.h
@@ -20,13 +20,55 @@
 namespace bytedance::bolt::connector::hive {
 
 struct PaimonEngine {
+  /// Adds a single logical input row into the engine's internal merge state.
+  ///
+  /// Call this after `setResult()` has been called for the current output
+  /// batch. Implementations may update internal state only, append finalized
+  /// rows into `result`, or both, but they must not assume the newly added row
+  /// is immediately safe to emit to the caller.
+  ///
+  /// Returns the current physical size of `result`. Callers should use
+  /// `finalizeCompletedGroups()` to determine how many rows are actually safe
+  /// to expose as output.
   virtual vector_size_t add(PaimonRowIteratorPtr iterator) = 0;
+
+  /// Finalizes any groups that are known to be complete before `nextInput`
+  /// would be consumed.
+  ///
+  /// `nextInput` is the next row that the reader intends to feed into `add()`,
+  /// or `nullptr` when the input stream is exhausted. Engines should use this
+  /// boundary signal to decide whether their current in-flight group can be
+  /// safely materialized into `result` without exposing partially merged state
+  /// across `next()` calls.
+  ///
+  /// Returns the number of rows in `result` that are complete and safe for the
+  /// reader to return to its caller.
+  virtual vector_size_t finalizeCompletedGroups(
+      const PaimonRowIteratorPtr& nextInput) = 0;
+
+  /// Flushes all remaining engine state at end-of-stream.
+  ///
+  /// Call this exactly once after no more input rows remain. This is equivalent
+  /// to forcing a final boundary and must leave the engine with no pending
+  /// groups from the current stream.
+  ///
+  /// Returns the final number of rows that are safe to expose from `result`.
   virtual vector_size_t finish() = 0;
 
+  /// Installs the output row vector for the current reader batch.
+  ///
+  /// The reader must call this before `add()`, `finalizeCompletedGroups()`, or
+  /// `finish()` for a batch. Engines may append finalized rows into this vector
+  /// and may also keep in-progress state that references it, subject to each
+  /// engine's own lifetime rules.
   virtual void setResult(RowVectorPtr result_) {
     result = result_;
   }
 
+  /// Appends the row referenced by `iterator` into `output`.
+  ///
+  /// This helper is intended for engines whose finalized output row is exactly
+  /// the input row selected by merge semantics.
   void append(VectorPtr output, PaimonRowIterator& iterator) {
     VLOG(2) << "Appending:"
             << "-->" << iterator.values->toString(iterator.rowIndex);
@@ -35,6 +77,10 @@ struct PaimonEngine {
     output->copy(iterator.values.get(), targetIndex, iterator.rowIndex, 1);
   }
 
+  /// Removes the last appended row from `output`.
+  ///
+  /// This helper is for engines that model retract-like behavior by undoing the
+  /// most recent append.
   void remove(VectorPtr output, PaimonRowIterator& iterator) {
     output->resize(output->size() - 1);
   }

--- a/bolt/connectors/hive/PaimonSplitReader.cpp
+++ b/bolt/connectors/hive/PaimonSplitReader.cpp
@@ -372,14 +372,22 @@ uint64_t PaimonSplitReader::next(int64_t size, VectorPtr& output) {
   mergeEngine_->setResult(std::dynamic_pointer_cast<RowVector>(output));
 
   auto mergetStartTime = getCurrentTimeMicro();
-  while (!heap.empty()) {
-    auto iterator = heap.top();
+  while (true) {
+    auto iterator = heap.empty() ? nullptr : heap.top();
+    auto rowCnt = mergeEngine_->finalizeCompletedGroups(iterator);
+
+    if (rowCnt >= size || !iterator) {
+      auto mergeTime = (getCurrentTimeMicro() - mergetStartTime) * 1000;
+      ioStats_->incTotalMergeTime(mergeTime);
+      return rowCnt;
+    }
+
     VLOG(2) << "Values:" << iterator->values->toString(iterator->rowIndex)
             << "   Seq:"
             << iterator->sequenceFields->toString(iterator->rowIndex);
     heap.pop();
 
-    int rowCnt = mergeEngine_->add(iterator);
+    mergeEngine_->add(iterator);
 
     if (iterator->next()) {
       heap.push(iterator);
@@ -388,17 +396,7 @@ uint64_t PaimonSplitReader::next(int64_t size, VectorPtr& output) {
       if (nextBatchIterator)
         heap.push(nextBatchIterator);
     }
-
-    if (rowCnt >= size) {
-      return rowCnt;
-    }
   }
-
-  mergeEngine_->finish();
-  auto mergeTime = (getCurrentTimeMicro() - mergetStartTime) * 1000;
-  ioStats_->incTotalMergeTime(mergeTime);
-
-  return output->size();
 }
 
 bool PaimonSplitReader::allPrefetchIssued() const {

--- a/bolt/connectors/hive/paimon_merge_engines/AggregateEngine.cpp
+++ b/bolt/connectors/hive/paimon_merge_engines/AggregateEngine.cpp
@@ -24,11 +24,7 @@ AggregateEngine::AggregateEngine(
 
 vector_size_t AggregateEngine::add(PaimonRowIteratorPtr iterator) {
   if (lastPk_.primaryKeys && !lastPk_.pkEqual(iterator)) {
-    result->resize(result->size() + 1);
-    for (auto i = 0; i < aggregateFunctions_.size(); i++) {
-      auto dest = result->childAt(i);
-      aggregateFunctions_[i]->appendResult(dest);
-    }
+    finalizeCompletedGroups(iterator);
   }
 
   lastPk_ = *iterator;
@@ -41,8 +37,9 @@ vector_size_t AggregateEngine::add(PaimonRowIteratorPtr iterator) {
   return result->size();
 }
 
-vector_size_t AggregateEngine::finish() {
-  if (lastPk_.primaryKeys) {
+vector_size_t AggregateEngine::finalizeCompletedGroups(
+    const PaimonRowIteratorPtr& nextInput) {
+  if (lastPk_.primaryKeys && (!nextInput || !lastPk_.pkEqual(nextInput))) {
     result->resize(result->size() + 1);
     for (auto i = 0; i < aggregateFunctions_.size(); i++) {
       auto dest = result->childAt(i);
@@ -50,7 +47,12 @@ vector_size_t AggregateEngine::finish() {
     }
     lastPk_.primaryKeys = nullptr;
   }
+
   return result->size();
+}
+
+vector_size_t AggregateEngine::finish() {
+  return finalizeCompletedGroups(nullptr);
 }
 
 } // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/paimon_merge_engines/AggregateEngine.h
+++ b/bolt/connectors/hive/paimon_merge_engines/AggregateEngine.h
@@ -30,6 +30,9 @@ class AggregateEngine : public PaimonEngine {
 
   vector_size_t add(PaimonRowIteratorPtr iterator) override;
 
+  vector_size_t finalizeCompletedGroups(
+      const PaimonRowIteratorPtr& nextInput) override;
+
   vector_size_t finish() override;
 
  protected:

--- a/bolt/connectors/hive/paimon_merge_engines/DeduplicateEngine.cpp
+++ b/bolt/connectors/hive/paimon_merge_engines/DeduplicateEngine.cpp
@@ -32,6 +32,10 @@ vector_size_t DeduplicateEngine::add(PaimonRowIteratorPtr iterator) {
   if (ignoreDelete && iterator->isRetract())
     return result->size();
 
+  if (last.primaryKeys && !last.pkEqual(iterator)) {
+    finalizeCompletedGroups(iterator);
+  }
+
   if (last.primaryKeys) {
     VLOG(2) << "Adding Last:"
             << "-->" << last.values->toString(last.rowIndex)
@@ -42,11 +46,6 @@ vector_size_t DeduplicateEngine::add(PaimonRowIteratorPtr iterator) {
           << "  Seq:" << iterator->sequenceFields->toString(iterator->rowIndex);
 
   if (!last.primaryKeys) {
-    last = *iterator;
-  } else if (!last.pkEqual(iterator)) {
-    if (last.isAdd()) {
-      append(result, last);
-    }
     last = *iterator;
   } else if (last.sequenceFields
                  ->compare(
@@ -61,13 +60,20 @@ vector_size_t DeduplicateEngine::add(PaimonRowIteratorPtr iterator) {
   return result->size();
 }
 
-vector_size_t DeduplicateEngine::finish() {
-  if (last.primaryKeys && last.isAdd()) {
-    append(result, last);
+vector_size_t DeduplicateEngine::finalizeCompletedGroups(
+    const PaimonRowIteratorPtr& nextInput) {
+  if (last.primaryKeys && (!nextInput || !last.pkEqual(nextInput))) {
+    if (last.isAdd()) {
+      append(result, last);
+    }
     last.primaryKeys = nullptr;
   }
 
   return result->size();
+}
+
+vector_size_t DeduplicateEngine::finish() {
+  return finalizeCompletedGroups(nullptr);
 }
 
 } // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/paimon_merge_engines/DeduplicateEngine.h
+++ b/bolt/connectors/hive/paimon_merge_engines/DeduplicateEngine.h
@@ -31,6 +31,9 @@ class DeduplicateEngine : public PaimonEngine {
 
   vector_size_t add(PaimonRowIteratorPtr iterator) override;
 
+  vector_size_t finalizeCompletedGroups(
+      const PaimonRowIteratorPtr& nextInput) override;
+
   vector_size_t finish() override;
 };
 

--- a/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.cpp
+++ b/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.cpp
@@ -37,35 +37,36 @@ PartialUpdateEngine::PartialUpdateEngine(
       std::vector<RowVectorPtr>(sequenceGroups_.size(), nullptr);
 }
 
-void PartialUpdateEngine::initPendingResultRow() {
-  if (!pendingResultRow_) {
-    pendingResultRow_ = std::static_pointer_cast<RowVector>(
-        BaseVector::create(result->type(), 1, result->pool()));
-  }
+void PartialUpdateEngine::setResult(RowVectorPtr result_) {
+  PaimonEngine::setResult(result_);
+}
 
-  pendingResultRow_->resize(1);
-  for (int i = 0; i < pendingResultRow_->childrenSize(); i++) {
-    pendingResultRow_->childAt(i)->setNull(0, true);
+void PartialUpdateEngine::startActiveRow() {
+  result->resize(result->size() + 1);
+  activeRowIndex_ = result->size() - 1;
+  hasActiveRow_ = true;
+  for (int i = 0; i < result->childrenSize(); i++) {
+    result->childAt(i)->setNull(activeRowIndex_, true);
   }
 }
 
-void PartialUpdateEngine::flushPendingRow() {
-  if (!lastPk_.primaryKeys || !pendingResultRow_) {
+void PartialUpdateEngine::finalizeActiveRow() {
+  if (!lastPk_.primaryKeys || !hasActiveRow_) {
     return;
   }
 
   for (const auto& [idx, aggr] : aggregations_) {
-    aggr->appendResult(pendingResultRow_->childAt(idx));
+    aggr->appendResult(result->childAt(idx));
   }
-
-  result->resize(result->size() + 1);
-  result->copy(pendingResultRow_.get(), result->size() - 1, 0, 1);
 }
 
 vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
-  if (!lastPk_.primaryKeys || !lastPk_.pkEqual(iterator)) {
-    flushPendingRow();
-    initPendingResultRow();
+  if (lastPk_.primaryKeys && !lastPk_.pkEqual(iterator)) {
+    finalizeCompletedGroups(iterator);
+  }
+
+  if (!lastPk_.primaryKeys) {
+    startActiveRow();
     lastSequenceGroupKeyValues =
         std::vector<RowVectorPtr>(sequenceGroups_.size(), nullptr);
   }
@@ -81,12 +82,12 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
             << std::endl;
   }
 
-  int destIdx = 0;
+  int destIdx = activeRowIndex_;
   for (int i = 0; i < iterator->values->childrenSize(); i++) {
     if (sequenceGroupFields_.find(i) == sequenceGroupFields_.end()) {
       auto src = iterator->values->childAt(i);
       if (!src->isNullAt(iterator->rowIndex)) {
-        auto dest = pendingResultRow_->childAt(i);
+        auto dest = result->childAt(i);
         dest->copy(src.get(), destIdx, iterator->rowIndex, 1);
       }
     }
@@ -100,7 +101,7 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
             key.get(), 0, iterator->rowIndex, CompareFlags()) < 0) {
       for (const auto& idx : iterator->sequenceGroups[i].second) {
         if (aggregations_.find(idx) == aggregations_.end()) {
-          auto dest = pendingResultRow_->childAt(idx);
+          auto dest = result->childAt(idx);
           auto src = iterator->values->childAt(idx);
           dest->copy(src.get(), destIdx, iterator->rowIndex, 1);
         } else {
@@ -123,7 +124,7 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
   lastPk_ = *iterator;
 
   VLOG(2) << "Result:"
-          << "-->" << pendingResultRow_->toString(0);
+          << "-->" << result->toString(activeRowIndex_);
   VLOG(2) << "  Sequence group key:";
   for (int i = 0; i < lastSequenceGroupKeyValues.size(); i++) {
     VLOG(2) << "\t\t\t\t"
@@ -136,11 +137,22 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
   return result->size();
 }
 
-vector_size_t PartialUpdateEngine::finish() {
-  flushPendingRow();
-  lastPk_.primaryKeys = nullptr;
+vector_size_t PartialUpdateEngine::finalizeCompletedGroups(
+    const PaimonRowIteratorPtr& nextInput) {
+  if (lastPk_.primaryKeys && (!nextInput || !lastPk_.pkEqual(nextInput))) {
+    finalizeActiveRow();
+    lastPk_.primaryKeys = nullptr;
+    hasActiveRow_ = false;
+    activeRowIndex_ = 0;
+    lastSequenceGroupKeyValues =
+        std::vector<RowVectorPtr>(sequenceGroups_.size(), nullptr);
+  }
 
-  return result->size();
+  return result->size() - (hasActiveRow_ ? 1 : 0);
+}
+
+vector_size_t PartialUpdateEngine::finish() {
+  return finalizeCompletedGroups(nullptr);
 }
 
 } // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.cpp
+++ b/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.cpp
@@ -37,19 +37,35 @@ PartialUpdateEngine::PartialUpdateEngine(
       std::vector<RowVectorPtr>(sequenceGroups_.size(), nullptr);
 }
 
+void PartialUpdateEngine::initPendingResultRow() {
+  if (!pendingResultRow_) {
+    pendingResultRow_ = std::static_pointer_cast<RowVector>(
+        BaseVector::create(result->type(), 1, result->pool()));
+  }
+
+  pendingResultRow_->resize(1);
+  for (int i = 0; i < pendingResultRow_->childrenSize(); i++) {
+    pendingResultRow_->childAt(i)->setNull(0, true);
+  }
+}
+
+void PartialUpdateEngine::flushPendingRow() {
+  if (!lastPk_.primaryKeys || !pendingResultRow_) {
+    return;
+  }
+
+  for (const auto& [idx, aggr] : aggregations_) {
+    aggr->appendResult(pendingResultRow_->childAt(idx));
+  }
+
+  result->resize(result->size() + 1);
+  result->copy(pendingResultRow_.get(), result->size() - 1, 0, 1);
+}
+
 vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
   if (!lastPk_.primaryKeys || !lastPk_.pkEqual(iterator)) {
-    if (result->size() > 0) {
-      for (const auto& [idx, aggr] : aggregations_) {
-        auto dest = result->childAt(idx);
-        aggr->appendResult(dest);
-      }
-    }
-    result->resize(result->size() + 1);
-    const auto newRowIdx = result->size() - 1;
-    for (int i = 0; i < result->childrenSize(); i++) {
-      result->childAt(i)->setNull(newRowIdx, true);
-    }
+    flushPendingRow();
+    initPendingResultRow();
     lastSequenceGroupKeyValues =
         std::vector<RowVectorPtr>(sequenceGroups_.size(), nullptr);
   }
@@ -65,12 +81,12 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
             << std::endl;
   }
 
-  int destIdx = result->size() - 1;
+  int destIdx = 0;
   for (int i = 0; i < iterator->values->childrenSize(); i++) {
     if (sequenceGroupFields_.find(i) == sequenceGroupFields_.end()) {
       auto src = iterator->values->childAt(i);
       if (!src->isNullAt(iterator->rowIndex)) {
-        auto dest = result->childAt(i);
+        auto dest = pendingResultRow_->childAt(i);
         dest->copy(src.get(), destIdx, iterator->rowIndex, 1);
       }
     }
@@ -84,7 +100,7 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
             key.get(), 0, iterator->rowIndex, CompareFlags()) < 0) {
       for (const auto& idx : iterator->sequenceGroups[i].second) {
         if (aggregations_.find(idx) == aggregations_.end()) {
-          auto dest = result->childAt(idx);
+          auto dest = pendingResultRow_->childAt(idx);
           auto src = iterator->values->childAt(idx);
           dest->copy(src.get(), destIdx, iterator->rowIndex, 1);
         } else {
@@ -107,7 +123,7 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
   lastPk_ = *iterator;
 
   VLOG(2) << "Result:"
-          << "-->" << result->toString(result->size() - 1);
+          << "-->" << pendingResultRow_->toString(0);
   VLOG(2) << "  Sequence group key:";
   for (int i = 0; i < lastSequenceGroupKeyValues.size(); i++) {
     VLOG(2) << "\t\t\t\t"
@@ -121,12 +137,8 @@ vector_size_t PartialUpdateEngine::add(PaimonRowIteratorPtr iterator) {
 }
 
 vector_size_t PartialUpdateEngine::finish() {
-  if (result->size() > 0) {
-    for (const auto& [idx, aggr] : aggregations_) {
-      auto dest = result->childAt(idx);
-      aggr->appendResult(dest);
-    }
-  }
+  flushPendingRow();
+  lastPk_.primaryKeys = nullptr;
 
   return result->size();
 }

--- a/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.h
+++ b/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.h
@@ -38,6 +38,9 @@ class PartialUpdateEngine : public PaimonEngine {
   vector_size_t finish() override;
 
  protected:
+  void initPendingResultRow();
+  void flushPendingRow();
+
   const bool ignoreDelete_;
   const std::
       unordered_map<int, std::shared_ptr<connector::paimon::AggregateFunction>>
@@ -45,6 +48,7 @@ class PartialUpdateEngine : public PaimonEngine {
   const std::vector<std::pair<std::vector<int>, std::vector<int>>>
       sequenceGroups_;
   std::unordered_set<int> sequenceGroupFields_;
+  RowVectorPtr pendingResultRow_;
   PaimonRowIterator lastPk_;
   std::vector<RowVectorPtr> lastSequenceGroupKeyValues;
 };

--- a/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.h
+++ b/bolt/connectors/hive/paimon_merge_engines/PartialUpdateEngine.h
@@ -33,13 +33,18 @@ class PartialUpdateEngine : public PaimonEngine {
           sequenceGroups);
   virtual ~PartialUpdateEngine() = default;
 
+  void setResult(RowVectorPtr result_) override;
+
   vector_size_t add(PaimonRowIteratorPtr iterator) override;
+
+  vector_size_t finalizeCompletedGroups(
+      const PaimonRowIteratorPtr& nextInput) override;
 
   vector_size_t finish() override;
 
  protected:
-  void initPendingResultRow();
-  void flushPendingRow();
+  void finalizeActiveRow();
+  void startActiveRow();
 
   const bool ignoreDelete_;
   const std::
@@ -48,7 +53,8 @@ class PartialUpdateEngine : public PaimonEngine {
   const std::vector<std::pair<std::vector<int>, std::vector<int>>>
       sequenceGroups_;
   std::unordered_set<int> sequenceGroupFields_;
-  RowVectorPtr pendingResultRow_;
+  vector_size_t activeRowIndex_{0};
+  bool hasActiveRow_{false};
   PaimonRowIterator lastPk_;
   std::vector<RowVectorPtr> lastSequenceGroupKeyValues;
 };

--- a/bolt/dwio/paimon/reader/tests/PaimonReaderPartialUpdateTest.cpp
+++ b/bolt/dwio/paimon/reader/tests/PaimonReaderPartialUpdateTest.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <limits>
-#include <map>
 #include <optional>
 #include <string>
 
@@ -24,16 +22,11 @@
 #include <gtest/gtest.h>
 
 #include <bolt/dwio/common/BufferedInput.h>
-#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/memory/Memory.h"
 #include "bolt/dwio/common/Options.h"
-#include "bolt/type/Timestamp.h"
 #include "bolt/vector/tests/utils/VectorTestBase.h"
-#include "folly/Range.h"
 
-#include "bolt/common/base/Fs.h"
 #include "bolt/common/file/FileSystems.h"
-#include "bolt/connectors/hive/HiveConnector.h"
 #include "bolt/connectors/hive/HiveConnectorSplit.h"
 #include "bolt/exec/Task.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
@@ -45,7 +38,6 @@
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
 
 #include <folly/init/Init.h>
-#include <algorithm>
 using namespace bytedance::bolt;
 // using exec::test::HiveConnectorTestBase;
 using namespace bytedance::bolt;
@@ -1333,6 +1325,152 @@ TEST_F(PaimonReaderPartialUpdateTest, uninitializedMemoryTest) {
   }
 
   BOLT_CHECK(nBatch > 0);
+}
+
+TEST_F(
+    PaimonReaderPartialUpdateTest,
+    samePrimaryKeyAcrossOutputBatchesCanCrash) {
+  filesystems::registerLocalFileSystem();
+
+  std::shared_ptr<folly::Executor> executor(
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency()));
+
+  auto tempDir = exec::test::TempDirectoryPath::create();
+
+  /*
+   * Reproducer:
+   * - A large number of updates for a single PK (crosses reader internal
+   *   1024-row batches).
+   * - Sequence-group updates with nullable VARCHAR values to exercise
+   *   copyRanges/copyNulls paths.
+   * - Force tiny output batches so one PK spans many next() calls.
+   */
+  auto rowType = ROW({
+      {"k", BIGINT()},
+      {"sg", BIGINT()},
+      {"v1", VARCHAR()},
+      {"v2", VARCHAR()},
+      {"_SEQUENCE_NUMBER", BIGINT()},
+      {"_VALUE_KIND", TINYINT()},
+  });
+
+  bytedance::bolt::test::VectorMaker maker{leafPool_.get()};
+
+  constexpr int kNumRows = 1200;
+  std::vector<int64_t> kValues(kNumRows, 1);
+  std::vector<int64_t> sgValues;
+  std::vector<int64_t> seqValues;
+  std::vector<std::optional<StringView>> v1Values;
+  std::vector<std::optional<StringView>> v2Values;
+  std::vector<int8_t> rowKinds;
+  sgValues.reserve(kNumRows);
+  seqValues.reserve(kNumRows);
+  v1Values.reserve(kNumRows);
+  v2Values.reserve(kNumRows);
+  rowKinds.reserve(kNumRows);
+
+  for (int i = 0; i < kNumRows; ++i) {
+    sgValues.push_back(i + 1);
+    seqValues.push_back(i + 1);
+    rowKinds.push_back(static_cast<int8_t>(PaimonRowKind::INSERT));
+
+    if (i == kNumRows - 1 || i % 57 == 0) {
+      v1Values.emplace_back("2023-01-04 11:27:58");
+    } else {
+      v1Values.emplace_back(std::nullopt);
+    }
+
+    if (i == kNumRows - 1 || i % 97 == 0) {
+      v2Values.emplace_back("🚀😅🆎😇🌁👾🚯");
+    } else {
+      v2Values.emplace_back(std::nullopt);
+    }
+  }
+
+  createPaimonFile(
+      tempDir->getPath(),
+      executor,
+      {"k"},
+      maker.rowVector(
+          rowType->names(),
+          {maker.flatVector<int64_t>(kValues),
+           maker.flatVector<int64_t>(sgValues),
+           maker.flatVectorNullable<StringView>(v1Values),
+           maker.flatVectorNullable<StringView>(v2Values),
+           maker.flatVector<int64_t>(seqValues),
+           maker.flatVector<int8_t>(rowKinds)}));
+
+  core::PlanNodeId scanNodeId;
+
+  std::unordered_map<std::string, std::string> tableParameters{
+      {connector::paimon::kMergeEngine,
+       connector::paimon::kPartialUpdateMergeEngine},
+      {connector::paimon::kPrimaryKey, "k"},
+      {connector::paimon::kPartialUpdateKeyPrefix + std::string("sg") +
+           connector::paimon::kPartialUpdateSequenceGroup,
+       "v1,v2"}};
+
+  auto tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
+      kHiveConnectorId,
+      "hive_table",
+      true,
+      SubfieldFilters{},
+      nullptr,
+      rowType,
+      tableParameters);
+
+  auto assignments = getIdentityAssignment(rowType);
+
+  auto readPlanFragment = exec::test::PlanBuilder()
+                              .tableScan(rowType, tableHandle, assignments)
+                              .capturePlanNodeId(scanNodeId)
+                              .planFragment();
+
+  auto queryCtx = core::QueryCtx::create(executor.get());
+  queryCtx->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kMaxOutputBatchRows, "1"},
+       {core::QueryConfig::kPreferredOutputBatchRows, "1"}});
+
+  auto readTask = exec::Task::create(
+      "my_read_task",
+      readPlanFragment,
+      /*destination=*/0,
+      queryCtx,
+      exec::Task::ExecutionMode::kSerial);
+
+  auto filePaths = getFilePaths(tempDir->getPath());
+
+  std::vector<std::shared_ptr<hive::HiveConnectorSplit>> hiveSplits;
+  hiveSplits.reserve(filePaths.size());
+  for (const auto& filePath : filePaths) {
+    hiveSplits.push_back(std::make_shared<hive::HiveConnectorSplit>(
+        kHiveConnectorId, filePath, dwio::common::FileFormat::PARQUET));
+  }
+
+  auto connectorSplit = std::make_shared<connector::hive::PaimonConnectorSplit>(
+      kHiveConnectorId, hiveSplits);
+  readTask->addSplit(scanNodeId, exec::Split{connectorSplit});
+  readTask->noMoreSplits(scanNodeId);
+
+  int nBatch = 0;
+  int totalRows = 0;
+  RowVectorPtr lastResult;
+  while (auto result = readTask->next()) {
+    ++nBatch;
+    totalRows += result->size();
+    lastResult = result;
+  }
+
+  BOLT_CHECK(nBatch > 0);
+  EXPECT_EQ(totalRows, 1);
+  ASSERT_TRUE(lastResult != nullptr);
+  EXPECT_EQ(
+      lastResult->childAt(2)->as<SimpleVector<StringView>>()->valueAt(0),
+      "2023-01-04 11:27:58");
+  EXPECT_EQ(
+      lastResult->childAt(3)->as<SimpleVector<StringView>>()->valueAt(0),
+      "🚀😅🆎😇🌁👾🚯");
 }
 
 } // namespace

--- a/bolt/dwio/paimon/reader/tests/PaimonReaderPartialUpdateTest.cpp
+++ b/bolt/dwio/paimon/reader/tests/PaimonReaderPartialUpdateTest.cpp
@@ -1327,9 +1327,7 @@ TEST_F(PaimonReaderPartialUpdateTest, uninitializedMemoryTest) {
   BOLT_CHECK(nBatch > 0);
 }
 
-TEST_F(
-    PaimonReaderPartialUpdateTest,
-    samePrimaryKeyAcrossOutputBatchesCanCrash) {
+TEST_F(PaimonReaderPartialUpdateTest, samePrimaryKeyAcrossOutputBatches) {
   filesystems::registerLocalFileSystem();
 
   std::shared_ptr<folly::Executor> executor(


### PR DESCRIPTION
### What problem does this PR solve?

Fixes a crash when performing a scan with the PartialUpdate engine when a single PK record is updated many times.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Before this fix, the PartialUpdate engine stored the in-progress merged row directly in the `result` variable. If a PK group was not finished when `next(size)` returned, the caller of `next` got a fresh empty `result`, but engine state still assumed the previous in-progress row existed in the output. That could produce invalid destination indexing and malformed copy operations.

`PartialUpdateEngine` now maintains an internal one-row buffer (`pendingResultRow_`) for the currently active PK.

This change flushes only completed PK rows to the output

- On PK change (and at finish()), the engine now:

 - Finalizes aggregate fields into pendingResultRow_.
 - Appends a copy of pendingResultRow_ into result.
 - Resets per-PK sequence-group tracking for the next key.

This ensures result only contains completed rows and is safe to recreate on each `next()` call.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixes SIGSEGV in Paimon PartialUpdate engine when a single PK is updated many times.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)