### PR TITLE
fix: reset stringStats_ on every copy() to prevent stale estimateFlatSize

### DIFF
--- a/bolt/vector/FlatVector-inl.h
+++ b/bolt/vector/FlatVector-inl.h
@@ -217,7 +217,18 @@ void FlatVector<T>::copyValuesAndNulls(
         rows.applyToSelected([&](auto row) {
           auto sourceRow = toSourceRow[row];
           BOLT_DCHECK_GT(source->size(), sourceRow);
-          rawValues_[row] = sourceValues[sourceRow];
+          auto& value = sourceValues[sourceRow];
+          rawValues_[row] = value;
+          if constexpr (std::is_same_v<T, StringView>) {
+            if (kAllSelected) {
+              if (!value.isInline()) {
+                // Only count non-inline strings.
+                stringStatsTotal += value.size();
+              }
+              stringStatsMax =
+                  std::max(stringStatsMax, static_cast<uint64_t>(value.size()));
+            }
+          }
         });
       } else {
         if constexpr (copyAll) {
@@ -366,13 +377,23 @@ void FlatVector<T>::copyValuesAndNulls(
   }
 
   if constexpr (std::is_same_v<T, StringView>) {
+    // Always reset first: the target may be reused across multiple copy()
+    // calls, and stale stats from a previous source must not survive.
+    this->stringStats_.reset();
     if (kAllSelected && stringStatsMax > 0) {
-      // Stats were computed by the non-flat source path. Set them.
+      // Per-element stats were computed above. Apply them.
       this->setStringViewStats(
           StringViewStats{stringStatsTotal, stringStatsMax});
-    } else if (!kAllSelected) {
-      // Partial copy invalidates any previously cached stats.
-      this->stringStats_.reset();
+    } else if (kAllSelected && !toSourceRow && source->isFlatEncoding()) {
+      // Flat-to-flat identity copy (memcpy path) does not iterate elements,
+      // so stringStatsMax is 0. Reuse the source's stats when available.
+      // Only safe for identity copies; remapped copies (toSourceRow != null)
+      // select a subset, so source stats would over-count.
+      const auto& srcStats =
+          source->asUnchecked<FlatVector<StringView>>()->stringStats();
+      if (srcStats.has_value()) {
+        this->setStringViewStats(srcStats.value());
+      }
     }
   }
 }

--- a/bolt/vector/tests/VectorEstimateFlatSizeTest.cpp
+++ b/bolt/vector/tests/VectorEstimateFlatSizeTest.cpp
@@ -536,10 +536,9 @@ TEST_F(VectorEstimateFlatSizeTest, structs) {
 
   EXPECT_EQ(28800, makeDict(row)->retainedSize());
   EXPECT_EQ(2838, makeDict(row)->estimateFlatSize());
-  // Flattening a dict(RowVector) copies each child from the base flat vector,
-  // so StringViewStats is not computed (best-effort). Falls back to
-  // retainedSize-based estimate.
-  EXPECT_EQ(3295, flatten(makeDict(row))->estimateFlatSize());
+  // Flattening a dict(RowVector) copies each child from the base flat vector
+  // via toSourceRow. StringViewStats is computed per-element in this path.
+  EXPECT_EQ(2943, flatten(makeDict(row))->estimateFlatSize());
 
   // Flat struct with dictionary encoded fields. The string child is
   // dict-encoded, so StringViewStats is computed during copy, giving a more
@@ -551,4 +550,79 @@ TEST_F(VectorEstimateFlatSizeTest, structs) {
   EXPECT_EQ(29632, row->retainedSize());
   EXPECT_EQ(2837, row->estimateFlatSize());
   EXPECT_EQ(2943, flatten(row)->estimateFlatSize());
+}
+
+// FlatVector<StringView>::stringStats_ caches string size statistics used by
+// estimateFlatSize(). When a target vector is reused across multiple copy()
+// calls, stringStats_ must reflect the latest copy — not a previous one.
+//
+// This test copies from a dictionary (long strings), then overwrites with a
+// flat source (short inline strings, no toSourceRow). After the second copy,
+// stringStats_ must be cleared because the flat-to-flat identity path does
+// not compute per-element stats.
+TEST_F(VectorEstimateFlatSizeTest, copyFromFlatResetsStaleStringStats) {
+  const vector_size_t kSize = 100;
+
+  auto target =
+      BaseVector::create<FlatVector<StringView>>(VARCHAR(), kSize, pool());
+
+  // First copy: dictionary source with non-inline strings.
+  auto longStringAt = [&](auto row) {
+    return StringView(longStrings_[row % 3]);
+  };
+  auto base = makeFlatVector<StringView>(1'000, longStringAt);
+  auto indices = makeIndices(kSize, [](auto row) { return row * 2; });
+  auto dictSource = wrapInDictionary(indices, kSize, base);
+
+  SelectivityVector allRows(kSize);
+  target->copy(dictSource.get(), allRows, nullptr, true);
+
+  ASSERT_TRUE(target->stringStats().has_value());
+  EXPECT_GT(target->stringStats()->totalBytes, 0);
+
+  // Second copy: flat source with inline strings, no toSourceRow.
+  auto flatSource = makeFlatVector<StringView>(kSize, shortStringAt);
+  target->copy(flatSource.get(), allRows, nullptr, true);
+
+  // stringStats_ must not retain values from the first (dictionary) copy.
+  EXPECT_FALSE(target->stringStats().has_value())
+      << "stringStats_ should be reset after flat-to-flat copy";
+}
+
+// Same scenario as above, but the second copy uses toSourceRow (remapped
+// copy from a flat source). The remapped path computes per-element stats,
+// so stringStats_ should be set to accurate values for the copied rows.
+TEST_F(VectorEstimateFlatSizeTest, remappedCopyFromFlatClearsStaleStats) {
+  const vector_size_t kSize = 100;
+
+  auto target =
+      BaseVector::create<FlatVector<StringView>>(VARCHAR(), kSize, pool());
+
+  // First copy: dictionary source with non-inline strings.
+  auto longStringAt = [&](auto row) {
+    return StringView(longStrings_[row % 3]);
+  };
+  auto base = makeFlatVector<StringView>(1'000, longStringAt);
+  auto indices = makeIndices(kSize, [](auto row) { return row * 2; });
+  auto dictSource = wrapInDictionary(indices, kSize, base);
+
+  SelectivityVector allRows(kSize);
+  target->copy(dictSource.get(), allRows, nullptr, true);
+
+  ASSERT_TRUE(target->stringStats().has_value());
+  EXPECT_GT(target->stringStats()->totalBytes, 0);
+  auto prevEstimate = target->estimateFlatSize();
+
+  // Second copy: flat source with inline strings, via toSourceRow.
+  auto flatSource = makeFlatVector<StringView>(kSize, shortStringAt);
+  std::vector<vector_size_t> toSourceRow(kSize);
+  std::iota(toSourceRow.begin(), toSourceRow.end(), 0);
+
+  target->copy(flatSource.get(), allRows, toSourceRow.data(), true);
+
+  // All copied strings are inline, so totalBytes must be 0.
+  ASSERT_TRUE(target->stringStats().has_value());
+  EXPECT_EQ(target->stringStats()->totalBytes, 0)
+      << "All copied strings are inline; totalBytes should be 0";
+  EXPECT_LT(target->estimateFlatSize(), prevEstimate);
 }


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #406 


### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

In PR #485, we added `stringStats_` to `FlatVector<StringView>::copyValuesAndNulls` to track total string size for accurate `estimateFlatSize()`. However, when the target vector was reused across multiple copy() calls, `stringStats_ `from a previous copy could survive into the next one and inflating `estimateFlatSize()` with stale values.

This happened because the epilogue only set `stringStats_` when per-element stats were computed (`stringStatsMax > 0`), and only reset it on partial copies (`!kAllSelected`). A full copy from a flat source hit neither branch, leaving stale stats intact.

This PR fixes the issue by:
- Always resetting stringStats_ at the start of the epilogue, so stale values never survive.
- Computing per-element stats in the flat+toSourceRow path, which was previously skipped.
- Propagating source stats for flat-to-flat identity copies (memcpy path) where per-element iteration is not performed.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
