### PR TITLE
fix: CompiledModuleSP::userData thread-safe issue

### DIFF
--- a/bolt/jit/CompiledModule.cpp
+++ b/bolt/jit/CompiledModule.cpp
@@ -46,10 +46,10 @@ void CompiledModule::setCodeSize(size_t codeSize) {
 }
 
 void CompiledModule::setUserData(void* data) noexcept {
-  userData_ = data;
+  userData_.store(data, std::memory_order_release);
 }
 void* CompiledModule::getUserData() const noexcept {
-  return userData_;
+  return userData_.load(std::memory_order_acquire);
 }
 
 void CompiledModule::appendCleanCallback(std::function<void()> cleanCallback) {

--- a/bolt/jit/CompiledModule.h
+++ b/bolt/jit/CompiledModule.h
@@ -18,6 +18,7 @@
 
 #ifdef ENABLE_BOLT_JIT
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -52,7 +53,7 @@ struct CompiledModule {
   size_t codeSize_{0};
   std::vector<std::function<void()>> cleanCallbacks_;
 
-  void* userData_{nullptr};
+  std::atomic<void*> userData_{nullptr};
 };
 
 using CompiledModuleSP = std::shared_ptr<CompiledModule>;

--- a/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
+++ b/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
@@ -137,12 +137,11 @@ CompiledModuleSP RowContainerCodeGenerator::codegen() {
           break;
       }
     }
-    if (cacheTypes->size() > 0) {
+    if (cacheTypes->size() > 0 && module->getUserData() == nullptr) {
       module->setUserData(static_cast<void*>(cacheTypes.release()));
       module->appendCleanCallback([mod = module.get()] {
         auto* cacheTypes = static_cast<std::vector<bytedance::bolt::TypePtr>*>(
             mod->getUserData());
-        cacheTypes->clear();
         delete cacheTypes;
         mod->setUserData(nullptr);
       });


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #498

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
