### PR TITLE
[fix][cp] Fix the server crash caused by remote exchange error

### DIFF
--- a/bolt/exec/ExchangeQueue.cpp
+++ b/bolt/exec/ExchangeQueue.cpp
@@ -29,6 +29,10 @@
  */
 
 #include "bolt/exec/ExchangeQueue.h"
+
+#include "bolt/common/testutil/TestValue.h"
+
+using bytedance::bolt::common::testutil::TestValue;
 namespace bytedance::bolt::exec {
 
 SerializedPage::SerializedPage(
@@ -112,6 +116,8 @@ std::vector<std::unique_ptr<SerializedPage>> ExchangeQueue::dequeueLocked(
     bool* atEnd,
     ContinueFuture* future) {
   BOLT_CHECK_NOT_NULL(future);
+  TestValue::adjust(
+      "bytedance::bolt::exec::ExchangeQueue::dequeueLocked", this);
   if (!error_.empty()) {
     *atEnd = true;
     BOLT_FAIL(error_);

--- a/bolt/exec/Merge.cpp
+++ b/bolt/exec/Merge.cpp
@@ -91,6 +91,10 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
 
   maybeStartNextMergeSourceGroup();
 
+  if (sourceMerger_ != nullptr) {
+    sourceMerger_->isBlocked(sourceBlockingFutures_);
+  }
+
   if (sourceBlockingFutures_.empty()) {
     return BlockingReason::kNotBlocked;
   }
@@ -183,12 +187,6 @@ void Merge::setupSpillMerger() {
 }
 
 void Merge::maybeStartNextMergeSourceGroup() {
-  SCOPE_EXIT {
-    if (sourceMerger_ != nullptr) {
-      sourceMerger_->isBlocked(sourceBlockingFutures_);
-    }
-  };
-
   if (sourceMerger_ != nullptr || numStartedSources_ >= sources_.size()) {
     return;
   }

--- a/bolt/exec/tests/MultiFragmentTest.cpp
+++ b/bolt/exec/tests/MultiFragmentTest.cpp
@@ -1113,6 +1113,50 @@ TEST_F(MultiFragmentTest, mergeExchangeOverEmptySources) {
   }
 }
 
+DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeExchangeFailureOnStart) {
+  std::vector<std::shared_ptr<Task>> tasks;
+  std::vector<std::string> leafTaskIds;
+
+  const auto injectErrorMsg{"injectError"};
+  SCOPED_TESTVALUE_SET(
+      "bytedance::bolt::exec::ExchangeQueue::dequeueLocked",
+      std::function<void(ExchangeQueue*)>(
+          ([&](ExchangeQueue* /*unused*/) { BOLT_FAIL(injectErrorMsg); })));
+
+  auto data = makeRowVector(rowType_, 0);
+
+  for (int i = 0; i < 2; ++i) {
+    auto taskId = makeTaskId("leaf-", i);
+    leafTaskIds.push_back(taskId);
+    auto plan =
+        PlanBuilder().values({data}).partitionedOutput({}, 1).planNode();
+
+    auto task = makeTask(taskId, plan, tasks.size());
+    tasks.push_back(task);
+    task->start(4);
+  }
+
+  auto exchangeTaskId = makeTaskId("exchange-", 0);
+  auto plan = PlanBuilder()
+                  .mergeExchange(rowType_, {"c0"})
+                  .singleAggregation({"c0"}, {"count(1)"})
+                  .planNode();
+
+  std::vector<Split> leafTaskSplits;
+  for (auto leafTaskId : leafTaskIds) {
+    leafTaskSplits.emplace_back(remoteSplit(leafTaskId));
+  }
+  BOLT_ASSERT_THROW(
+      test::AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .splits(std::move(leafTaskSplits))
+          .assertResults(""),
+      injectErrorMsg);
+
+  for (auto& task : tasks) {
+    ASSERT_TRUE(waitForTaskCompletion(task.get())) << task->taskId();
+  }
+}
+
 namespace {
 core::PlanNodePtr makeJoinOverExchangePlan(
     const RowTypePtr& exchangeType,


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Corresponding PR: facebookincubator/velox#13905

The remote exchange might run into error so merge operator check if a remote merge source is blocked or not, it might trigger merge source to fetch data from the exchange client which in turn try to dequeue from the exchange source. The dequeue operation might throw if there is already an error. The recent merge spill support moves the merge source is blocked check inside SCOPE_EXIT which converts an throw to a server crash as we can't throw inside a dtor. This changes move the merge source is blocked check out of SCOPE_EXIT and add a unit test to reproduce and verify

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
