### PR TITLE
[misc][cp][DynamicMerge] Remove SCOPE_EXIT from `Merge::getOutputFromSource`

### DIFF
--- a/bolt/exec/Merge.cpp
+++ b/bolt/exec/Merge.cpp
@@ -229,32 +229,31 @@ RowVectorPtr Merge::getOutputFromSpill() {
 }
 
 RowVectorPtr Merge::getOutputFromSource() {
-  BOLT_CHECK_NULL(spillMerger_.get());
+  BOLT_CHECK_NULL(spillMerger_);
   bool atEnd = false;
   output_ = sourceMerger_->getOutput(sourceBlockingFutures_, atEnd);
-  SCOPE_EXIT {
-    if (!atEnd) {
-      return;
-    }
-
-    finishMergeSourceGroup();
-    if (numStartedSources_ < sources_.size()) {
-      return;
-    }
-
-    if (numSpilledRows_ > 0) {
-      setupSpillMerger();
-      return;
-    }
-    finished_ = true;
-  };
-
   if (needSpill()) {
     spill();
-    return nullptr;
+    BOLT_CHECK_NULL(output_);
   }
 
-  BOLT_CHECK_EQ(numSpilledRows_, 0);
+  if (!atEnd) {
+    return std::move(output_);
+  }
+
+  finishMergeSourceGroup();
+  if (numStartedSources_ < sources_.size()) {
+    BOLT_CHECK_NULL(output_);
+    return std::move(output_);
+  }
+
+  if (numSpilledRows_ > 0) {
+    setupSpillMerger();
+    BOLT_CHECK_NULL(output_);
+    return std::move(output_);
+  }
+
+  finished_ = true;
   return std::move(output_);
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Remove SCOPE_EXIT from `Merge::getOutputFromSource`.

Corresponding PR: https://github.com/facebookincubator/velox/pull/13904


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
