### PR TITLE
[fix] json_to_map should return empty map for valid non-object JSON

### DIFF
--- a/bolt/functions/sparksql/JsonToMap.cpp
+++ b/bolt/functions/sparksql/JsonToMap.cpp
@@ -137,7 +137,7 @@ class JsonToMapFunction : public exec::VectorFunction {
           return;
         }
         if (!doc.IsObject()) {
-          // Spark returns empty map for valid non-object JSON
+          // hiveudf returns empty map for valid non-object JSON
           // (null, number, boolean, string, array), not SQL NULL.
           resultWriter.commit();
           return;

--- a/bolt/functions/sparksql/JsonToMap.cpp
+++ b/bolt/functions/sparksql/JsonToMap.cpp
@@ -79,6 +79,12 @@ class JsonToMapFunction : public exec::VectorFunction {
         try {
           simdjson::ondemand::document doc = parser.iterate(padded_data);
           simdjson::ondemand::value val = doc;
+          if (val.type() != simdjson::ondemand::json_type::object) {
+            // hiveudf returns empty map for valid non-object JSON
+            // (null, number, boolean, string, array), not SQL NULL.
+            resultWriter.commit();
+            return;
+          }
           for (auto field : val.get_object()) {
             std::string_view key = field.unescaped_key(true);
             simdjson::ondemand::value value = field.value();
@@ -126,8 +132,14 @@ class JsonToMapFunction : public exec::VectorFunction {
         const std::string_view current = std::string_view(sv.data(), sv.size());
         sonic_json::Document doc;
         doc.Parse(current);
-        if (doc.HasParseError() || !doc.IsObject()) {
+        if (doc.HasParseError()) {
           resultWriter.commitNull();
+          return;
+        }
+        if (!doc.IsObject()) {
+          // Spark returns empty map for valid non-object JSON
+          // (null, number, boolean, string, array), not SQL NULL.
+          resultWriter.commit();
           return;
         }
 

--- a/bolt/functions/sparksql/tests/JsonToMapTest.cpp
+++ b/bolt/functions/sparksql/tests/JsonToMapTest.cpp
@@ -108,6 +108,21 @@ TEST_F(JsonToMapTest, basic) {
   }
 
   {
+    // Valid non-object JSON should return empty map, same as hiveudf.
+    // JSON null
+    testJsonToMap({"null"}, {});
+    // JSON number
+    testJsonToMap({"123"}, {});
+    // JSON boolean
+    testJsonToMap({"true"}, {});
+    testJsonToMap({"false"}, {});
+    // JSON string
+    testJsonToMap({R"("hello")"}, {});
+    // JSON array
+    testJsonToMap({R"([1,2,3])"}, {});
+  }
+
+  {
     // json parse failed, return null
     auto result = evaluateJsonToMap({R"({"a": [1, 223,      23], "a" 1})"});
     auto expectVector =


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #505 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Fix `json_to_map` to return empty map `{}` instead of NULL for valid non-object JSON inputs (null, number, boolean, string, array), aligning with Spark Java behavior
- Both simdjson and sonic parsing paths are updated: valid-but-non-object JSON now commits an empty map instead of calling `commitNull()`
- Add 6 unit test cases covering all non-object JSON types: `null`, `123`, `true`, `false`, `"hello"`, `[1,2,3]`


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
