### PR TITLE
  [feat](flinksql): add element_at with Flink array index semantics

### DIFF
--- a/bolt/functions/flinksql/CMakeLists.txt
+++ b/bolt/functions/flinksql/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bolt_add_library(bolt_functions_flink_impl JsonFunctions.cpp)
+bolt_add_library(bolt_functions_flink_impl JsonFunctions.cpp ElementAt.cpp)
 
 target_link_libraries(
   bolt_functions_flink_impl

--- a/bolt/functions/flinksql/ElementAt.cpp
+++ b/bolt/functions/flinksql/ElementAt.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/lib/SubscriptUtil.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+namespace {
+
+/// element_at(array, index) for Flink SQL semantics:
+///
+/// - index is 1-based.
+/// - If index is a compile-time constant and index < 1, throws an exception.
+/// - If index is a runtime (non-constant) value and index < 1 or out of
+///   bounds, returns NULL silently.
+/// - Negative indices are NOT allowed (unlike Presto/Spark).
+///
+/// Template parameters:
+///   allowNegativeIndices = false             (not needed;
+///   nullOnNonConstantInvalidIndex
+///                                             catches all index < 1 before
+///                                             getIndex)
+///   nullOnNegativeIndices = false            (not used)
+///   allowOutOfBound = true                   (OOB → NULL)
+///   indexStartsAtOne = true                  (1-based)
+///   isElementAt = true
+///   nullOnNonConstantInvalidIndex = true     (constant < 1 → throw;
+///   non-constant < 1 → NULL)
+class FlinkElementAtFunction : public SubscriptImpl<
+                                   /* allowNegativeIndices */ false,
+                                   /* nullOnNegativeIndices */ false,
+                                   /* allowOutOfBound */ true,
+                                   /* indexStartsAtOne */ true,
+                                   /* isElementAt */ true,
+                                   /* nullOnNonConstantInvalidIndex */ true> {
+ public:
+  explicit FlinkElementAtFunction(bool allowCaching)
+      : SubscriptImpl(allowCaching) {}
+};
+
+} // namespace
+
+void registerFlinkElementAtFunction(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name,
+      FlinkElementAtFunction::signatures(),
+      [](const std::string&,
+         const std::vector<exec::VectorFunctionArg>& inputArgs,
+         const bolt::core::QueryConfig& config) {
+        static const auto kSubscriptStateLess =
+            std::make_shared<FlinkElementAtFunction>(false);
+        if (inputArgs[0].type->isArray()) {
+          return kSubscriptStateLess;
+        } else {
+          return std::make_shared<FlinkElementAtFunction>(
+              config.isExpressionEvaluationCacheEnabled());
+        }
+      });
+}
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -20,6 +20,7 @@
 #include "bolt/functions/flinksql/DateTimeFunctions.h"
 #include "bolt/functions/flinksql/Rand.h"
 #include "bolt/functions/flinksql/String.h"
+
 namespace bytedance::bolt::functions {
 // If the function registration order is Presto, Spark, Flink,
 // then these Presto functions may be overwritten by Spark
@@ -81,11 +82,18 @@ static void registerJsonFunctions(const std::string& prefix) {
       json_str_to_array, prefix + "json_str_to_array");
 }
 
+extern void registerFlinkElementAtFunction(const std::string& name);
+
+static void registerArrayFunctions(const std::string& prefix) {
+  registerFlinkElementAtFunction(prefix + "element_at");
+}
+
 void registerFunctions(const std::string& prefix) {
   registerStringFunctions(prefix);
   registerDatetimeFunctions(prefix);
   registerMathFunctions(prefix);
   registerJsonFunctions(prefix);
+  registerArrayFunctions(prefix);
 }
 } // namespace flinksql
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/flinksql/tests/CMakeLists.txt
+++ b/bolt/functions/flinksql/tests/CMakeLists.txt
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 add_executable(
-  bolt_functions_flink_test FlinkSqlDataTimeFunctionsTest.cpp JsonFunctionsTest.cpp RandTest.cpp
-                            StringFunctionsTest.cpp
+  bolt_functions_flink_test ElementAtTest.cpp FlinkSqlDataTimeFunctionsTest.cpp
+                            JsonFunctionsTest.cpp RandTest.cpp StringFunctionsTest.cpp
 )
 
 add_test(

--- a/bolt/functions/flinksql/tests/ElementAtTest.cpp
+++ b/bolt/functions/flinksql/tests/ElementAtTest.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/flinksql/tests/FlinkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::flinksql::test {
+namespace {
+
+class ElementAtTest : public FlinkFunctionBaseTest {};
+
+} // namespace
+
+/// Flink element_at(array, index) semantics:
+///
+/// 1. index is 1-based.
+/// 2. Constant index < 1 (zero or negative) → throws an exception.
+/// 3. Non-constant index < 1 (zero or negative) → returns NULL.
+/// 4. Index out of bounds (constant or non-constant) → returns NULL.
+/// 5. Valid index → returns the corresponding element.
+
+// ── Constant index: valid accesses ──────────────────────────────────────────
+
+TEST_F(ElementAtTest, constantValidIndex) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}});
+  EXPECT_EQ(
+      evaluate<SimpleVector<int64_t>>(
+          "element_at(C0, 1)", makeRowVector({arrayVector}))
+          ->valueAt(0),
+      10);
+  EXPECT_EQ(
+      evaluate<SimpleVector<int64_t>>(
+          "element_at(C0, 3)", makeRowVector({arrayVector}))
+          ->valueAt(0),
+      30);
+}
+
+// ── Constant index: index == 0 → throws ─────────────────────────────────────
+
+TEST_F(ElementAtTest, constantZeroIndexThrows) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}});
+  BOLT_ASSERT_THROW(
+      evaluate<SimpleVector<int64_t>>(
+          "element_at(C0, 0)", makeRowVector({arrayVector})),
+      "SQL array indices start at 1");
+}
+
+// ── Constant index: negative index → throws ──────────────────────────────────
+
+TEST_F(ElementAtTest, constantNegativeIndexThrows) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}});
+  BOLT_ASSERT_THROW(
+      evaluate<SimpleVector<int64_t>>(
+          "element_at(C0, -1)", makeRowVector({arrayVector})),
+      "SQL array indices start at 1");
+}
+
+// ── Constant index: out-of-bounds → returns NULL ─────────────────────────────
+
+TEST_F(ElementAtTest, constantOutOfBoundsReturnsNull) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}});
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "element_at(C0, 99)", makeRowVector({arrayVector}));
+  EXPECT_TRUE(result->isNullAt(0));
+}
+
+// ── Non-constant index: zero → returns NULL ──────────────────────────────────
+
+TEST_F(ElementAtTest, nonConstantZeroIndexReturnsNull) {
+  // Build a flat array column and an index column where index = 0 at runtime.
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}, {40, 50}});
+  auto indexVector = makeFlatVector<int64_t>({0, 0});
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "element_at(C0, C1)", makeRowVector({arrayVector, indexVector}));
+  EXPECT_TRUE(result->isNullAt(0));
+  EXPECT_TRUE(result->isNullAt(1));
+}
+
+// ── Non-constant index: negative → returns NULL ──────────────────────────────
+
+TEST_F(ElementAtTest, nonConstantNegativeIndexReturnsNull) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}, {40, 50}});
+  auto indexVector = makeFlatVector<int64_t>({-1, -2});
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "element_at(C0, C1)", makeRowVector({arrayVector, indexVector}));
+  EXPECT_TRUE(result->isNullAt(0));
+  EXPECT_TRUE(result->isNullAt(1));
+}
+
+// ── Non-constant index: out-of-bounds → returns NULL ─────────────────────────
+
+TEST_F(ElementAtTest, nonConstantOutOfBoundsReturnsNull) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}});
+  auto indexVector = makeFlatVector<int64_t>({99});
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "element_at(C0, C1)", makeRowVector({arrayVector, indexVector}));
+  EXPECT_TRUE(result->isNullAt(0));
+}
+
+// ── Non-constant index: mixed valid / invalid rows ───────────────────────────
+
+TEST_F(ElementAtTest, nonConstantMixedRows) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 20, 30}, {40, 50}, {60}});
+  auto indexVector = makeFlatVector<int64_t>({2, 0, -1});
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "element_at(C0, C1)", makeRowVector({arrayVector, indexVector}));
+  EXPECT_EQ(result->valueAt(0), 20); // valid: 2nd element
+  EXPECT_TRUE(result->isNullAt(1)); // index 0 → null
+  EXPECT_TRUE(result->isNullAt(2)); // index -1 → null
+}
+
+} // namespace bytedance::bolt::functions::flinksql::test

--- a/bolt/functions/lib/SubscriptUtil.h
+++ b/bolt/functions/lib/SubscriptUtil.h
@@ -187,12 +187,16 @@ class MapSubscript {
 /// - allowOutOfBound: if allowed, returns NULL for out of bound accesses; if
 ///   false, throws an exception.
 /// - indexStartsAtOne: whether indices start at zero or one.
+/// - nullOnNonConstantInvalidIndex: when true, any index < 1 (in 1-based mode)
+///   is treated as invalid. For constant indices this triggers an exception;
+///   for non-constant indices it returns NULL silently instead of throwing.
 template <
     bool allowNegativeIndices,
     bool nullOnNegativeIndices,
     bool allowOutOfBound,
     bool indexStartsAtOne,
-    bool isElementAt>
+    bool isElementAt,
+    bool nullOnNonConstantInvalidIndex = false>
 class SubscriptImpl : public exec::Subscript {
  public:
   explicit SubscriptImpl(bool allowCaching)
@@ -330,7 +334,13 @@ class SubscriptImpl : public exec::Subscript {
         const auto adjustedIndex = adjustIndex(
             originalIndex, isZeroSubscriptError, zeroBasedArrayIndex);
         if (isZeroSubscriptError) {
-          context.setBoltExceptionError(row, zeroSubscriptError());
+          if constexpr (nullOnNonConstantInvalidIndex) {
+            // Flink: non-constant invalid index returns NULL silently.
+            nullsBuilder.setNull(row);
+            rawIndices[row] = 0;
+          } else {
+            context.setBoltExceptionError(row, zeroSubscriptError());
+          }
           return;
         }
         const auto elementIndex = getIndex(
@@ -373,9 +383,19 @@ class SubscriptImpl : public exec::Subscript {
 
     // If array indices start at 1.
     if constexpr (indexStartsAtOne) {
-      if (UNLIKELY(index == 0)) {
-        isZeroSubscriptError = true;
-        return 0;
+      if constexpr (nullOnNonConstantInvalidIndex) {
+        // Flink: any index < 1 (including 0 and negative) is invalid.
+        // For constant indices this triggers an exception; for non-constant
+        // indices applyArrayTyped will return NULL instead.
+        if (UNLIKELY(index <= 0)) {
+          isZeroSubscriptError = true;
+          return 0;
+        }
+      } else {
+        if (UNLIKELY(index == 0)) {
+          isZeroSubscriptError = true;
+          return 0;
+        }
       }
 
       // If larger than zero, adjust it.


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

  Implement Flink SQL element_at for arrays and register the function.
  Return null for invalid non-constant indices, keep constant invalid
  indices throwing, and add unit tests for valid, out-of-bounds, zero,
  and negative index cases.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
  Implement Flink SQL element_at for arrays and register the function.
  Return null for invalid non-constant indices, keep constant invalid
  indices throwing, and add unit tests for valid, out-of-bounds, zero,
  and negative index cases.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
