### PR TITLE
fix: Match Spark for historical Asia/Shanghai DST in unix_timestamp

### DIFF
--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -139,16 +139,28 @@ struct UnixTimestampFunctionBase {
 
   // calculate china/shanghai unix-timestamp
   Timestamp calculateCnUnixTimestamp(Timestamp& timestamp) {
-    // between 1986 and 1991, china/shanghai use dst time
-    if (timestamp.getSeconds() > 504892800 &&
-        timestamp.getSeconds() < 694195200) {
-      if (sessionTzID_.has_value()) {
+    // Route through tzdata for every Shanghai regime (LMT, CST, and DST in
+    // 1919/1940-1949/1986-1991). Forward-shift gap local times to match
+    // Spark/JVM's ZonedDateTime.ofLocal semantics.
+    if (sessionTimeZone_ != nullptr) {
+      const auto adjusted = sessionTimeZone_->correct_nonexistent_time(
+          std::chrono::seconds(timestamp.getSeconds()));
+      timestamp = Timestamp(adjusted.count(), timestamp.getNanos());
+      timestamp.toGMT(*sessionTimeZone_);
+      return timestamp;
+    }
+    if (sessionTzID_.has_value()) {
+      const auto* zone = tz::locateZone(
+          static_cast<int16_t>(sessionTzID_.value()), /*failOnError=*/false);
+      if (zone != nullptr) {
+        const auto adjusted = zone->correct_nonexistent_time(
+            std::chrono::seconds(timestamp.getSeconds()));
+        timestamp = Timestamp(adjusted.count(), timestamp.getNanos());
+        timestamp.toGMT(*zone);
+      } else {
         timestamp.toGMT(sessionTzID_.value());
-        return timestamp;
-      } else if (sessionTimeZone_ != nullptr) {
-        timestamp.toGMT(*sessionTimeZone_);
-        return timestamp;
       }
+      return timestamp;
     }
 
     if (timestamp.getSeconds() - sessionTzOffsetInSeconds_ < kShseparator) {
@@ -170,12 +182,11 @@ struct UnixTimestampFunctionBase {
       // Use parsed timezone
       dtr.timestamp.toGMT(dtr.timezoneId);
       result = dtr.timestamp.getSeconds();
+    } else if (this->isShanghai) {
+      return calculateCnUnixTimestamp(dtr.timestamp).getSeconds();
     } else if (sessionTimeZone_ != nullptr) {
       dtr.timestamp.toGMT(*sessionTimeZone_);
       result = dtr.timestamp.getSeconds();
-    } else if (this->isShanghai) {
-      return calculateCnUnixTimestamp(dtr.timestamp).getSeconds();
-
     } else {
       result = dtr.timestamp.getSeconds() - sessionTzOffsetInSeconds_;
     }
@@ -190,10 +201,10 @@ struct UnixTimestampFunctionBase {
     if (dtr.timezoneId != -1) {
       // Use parsed timezone
       dtr.timestamp.toGMT(dtr.timezoneId);
-    } else if (sessionTimeZone_ != nullptr) {
-      dtr.timestamp.toGMT(*sessionTimeZone_);
     } else if (this->isShanghai) {
       return calculateCnUnixTimestamp(dtr.timestamp);
+    } else if (sessionTimeZone_ != nullptr) {
+      dtr.timestamp.toGMT(*sessionTimeZone_);
     } else {
       return Timestamp(
           dtr.timestamp.getSeconds() - sessionTzOffsetInSeconds_,

--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -139,6 +139,33 @@ struct UnixTimestampFunctionBase {
 
   // calculate china/shanghai unix-timestamp
   Timestamp calculateCnUnixTimestamp(Timestamp& timestamp) {
+    constexpr int64_t kLastDstEndUtc = 694195200; // 1992-01-01 local
+    constexpr int64_t kMidCenturyStartUtc = -631180800; // 1950-01-01 local
+    constexpr int64_t kMidCenturyEndUtc = 504892800; // 1986-01-01 local
+    // between 1986 and 1991, china/shanghai use dst time
+    if (timestamp.getSeconds() > kMidCenturyEndUtc &&
+        timestamp.getSeconds() < kLastDstEndUtc) {
+      if (sessionTzID_.has_value()) {
+        timestamp.toGMT(sessionTzID_.value());
+        return timestamp;
+      } else if (sessionTimeZone_ != nullptr) {
+        timestamp.toGMT(*sessionTimeZone_);
+        return timestamp;
+      }
+    }
+    // STDOFF fast paths for pure-CST windows (no DST, no LMT):
+    //   post-1991   (>= 1992-01-01 local)
+    //   mid-century (1950-01-01 .. 1985-12-31 local)
+    // Other eras fall through to tzdata + correct_nonexistent_time.
+    const int64_t utcSeconds =
+        timestamp.getSeconds() - sessionTzOffsetInSeconds_;
+    if (utcSeconds >= kLastDstEndUtc) {
+      return Timestamp(utcSeconds, timestamp.getNanos());
+    }
+    if (utcSeconds >= kMidCenturyStartUtc && utcSeconds < kMidCenturyEndUtc) {
+      return Timestamp(utcSeconds, timestamp.getNanos());
+    }
+
     // Route through tzdata for every Shanghai regime (LMT, CST, and DST in
     // 1919/1940-1949/1986-1991). Forward-shift gap local times to match
     // Spark/JVM's ZonedDateTime.ofLocal semantics.

--- a/bolt/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/bolt/functions/sparksql/benchmarks/CMakeLists.txt
@@ -85,3 +85,10 @@ target_link_libraries(
   bolt_benchmark_builder
   ${BOLT_BENCHMARK_DEPS}
 )
+
+add_executable(bolt_sparksql_benchmarks_unix_timestamp UnixTimestampBenchmark.cpp)
+target_link_libraries(
+  bolt_sparksql_benchmarks_unix_timestamp PRIVATE
+  bolt_benchmark_builder
+  ${BOLT_BENCHMARK_DEPS}
+)

--- a/bolt/functions/sparksql/benchmarks/UnixTimestampBenchmark.cpp
+++ b/bolt/functions/sparksql/benchmarks/UnixTimestampBenchmark.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "bolt/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "bolt/functions/sparksql/registration/Register.h"
+
+using namespace bytedance;
+using namespace bytedance::bolt;
+
+namespace {
+
+constexpr int kVectorSize = 1000;
+
+// Build a RowVectorPtr with one VARCHAR child of N=kVectorSize strings in
+// "yyyy-MM-dd HH:mm:ss" format sampled uniformly at random from the given
+// inclusive [lowYear, highYear] range. Seed is fixed so benchmark runs
+// compare apples-to-apples across binaries.
+RowVectorPtr makeDateStringColumn(
+    ExpressionBenchmarkBuilder& builder,
+    int lowYear,
+    int highYear,
+    uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  std::uniform_int_distribution<int> yearDist(lowYear, highYear);
+  std::uniform_int_distribution<int> monthDist(1, 12);
+  std::uniform_int_distribution<int> dayDist(
+      1, 28); // avoid month-length branches
+  std::uniform_int_distribution<int> hourDist(0, 23);
+  std::uniform_int_distribution<int> minuteDist(0, 59);
+  std::uniform_int_distribution<int> secondDist(0, 59);
+
+  std::vector<std::string> rows;
+  rows.reserve(kVectorSize);
+  for (int i = 0; i < kVectorSize; ++i) {
+    rows.push_back(fmt::format(
+        "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}",
+        yearDist(rng),
+        monthDist(rng),
+        dayDist(rng),
+        hourDist(rng),
+        minuteDist(rng),
+        secondDist(rng)));
+  }
+  auto col = builder.vectorMaker().flatVector<std::string>(rows);
+  return builder.vectorMaker().rowVector({"c0"}, {col});
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  // Benchmark for Spark unix_timestamp in the Asia/Shanghai session time
+  // zone. Two sets:
+  //   shanghai_cst  - post-1991 modern timestamps, exercises the CST fast
+  //                   path (no DST, no LMT, pure arithmetic).
+  //   shanghai_dst  - 1986-1991 non-gap timestamps, exercises the tzdata
+  //                   slow path used for all historical DST regimes.
+  folly::init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::sparksql::registerFunctions("");
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  benchmarkBuilder.setTimezone("Asia/Shanghai");
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "shanghai_cst",
+          makeDateStringColumn(benchmarkBuilder, 2000, 2024, /*seed=*/0xBEEF01))
+      .addExpression(
+          "unix_timestamp", "unix_timestamp(c0, 'yyyy-MM-dd HH:mm:ss')")
+      .disableTesting()
+      .withIterations(1000);
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "shanghai_dst",
+          makeDateStringColumn(benchmarkBuilder, 1986, 1991, /*seed=*/0xBEEF02))
+      .addExpression(
+          "unix_timestamp", "unix_timestamp(c0, 'yyyy-MM-dd HH:mm:ss')")
+      .disableTesting()
+      .withIterations(1000);
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -17,6 +17,8 @@
 #include <common/base/BoltException.h>
 #include <fmt/core.h>
 #include <type/Type.h>
+#include <cstdlib>
+#include <fstream>
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "bolt/type/tz/TimeZoneMap.h"
@@ -719,6 +721,161 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampCustomFormatTimeZone) {
       5 * 3600,
       unixTimestamp(
           "1970-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss", "America/Toronto"));
+}
+
+// Regression: parsing Asia/Shanghai dates across every historical DST
+// regime must match Spark (ZonedDateTime.ofLocal semantics):
+//   - DST-start midnight local is in a gap -> shift forward, offset = +09h.
+//   - Interior DST moment -> offset = +09h (CDT).
+//   - Outside DST / post-1991 -> offset = +08h (CST).
+// Prior behavior: date::to_sys rejected gap local times (VeloxUserError),
+// and the Shanghai fast-path used STDOFF arithmetic that silently diverged
+// by 1h for every moment *inside* a DST period. toGMT now calls
+// correct_nonexistent_time to gap-shift, and calculateCnUnixTimestamp
+// always routes through toGMT so full tzdata history is respected.
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampShanghaiDstGap) {
+  setQueryTimeZone("Asia/Shanghai");
+  const auto unixTimestamp = [&](std::optional<StringView> dateStr) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0, 'yyyyMMdd')", dateStr);
+  };
+
+  // The failing case from production (DST-start gap, pre-1986 Shang rule).
+  EXPECT_EQ(-652348800, unixTimestamp("19490501"));
+  // Adjacent non-gap day (still inside DST, offset +09h).
+  EXPECT_EQ(-652266000, unixTimestamp("19490502"));
+
+  // All pre-1986 Shanghai DST transition dates at 00:00 local. Per current
+  // IANA tzdata, 19410316 and 19420201 are already-DST (not gaps), so their
+  // offset is +09h; the others are true DST-start gaps resolved via
+  // forward-shift, giving offset +09h on the post-gap side as well.
+  EXPECT_EQ(-933667200, unixTimestamp("19400601"));
+  EXPECT_EQ(-908787600, unixTimestamp("19410316"));
+  EXPECT_EQ(-880966800, unixTimestamp("19420201"));
+  EXPECT_EQ(-745833600, unixTimestamp("19460515"));
+  EXPECT_EQ(-716889600, unixTimestamp("19470415"));
+  EXPECT_EQ(-683884800, unixTimestamp("19480501"));
+
+  // Modern PRC DST-start gap dates (1986-1991, 00:00 local).
+  EXPECT_EQ(515520000, unixTimestamp("19860504"));
+  EXPECT_EQ(545155200, unixTimestamp("19870412"));
+  EXPECT_EQ(577209600, unixTimestamp("19880417"));
+  EXPECT_EQ(608659200, unixTimestamp("19890416"));
+  EXPECT_EQ(640108800, unixTimestamp("19900415"));
+  EXPECT_EQ(671558400, unixTimestamp("19910414"));
+
+  // Interior DST moments: offset is +09h, not +08h. Previously the fast
+  // path returned naive-8h, diverging from Spark by exactly 3600s.
+  EXPECT_EQ(-837853200, unixTimestamp("19430615")); // wartime DST
+  EXPECT_EQ(516466800, unixTimestamp("19860515")); // 1986 DST interior
+
+  // Outside any DST period: straight +08h offset (sanity baseline).
+  EXPECT_EQ(-28800, unixTimestamp("19700101")); // 1970-01-01 +08h
+  EXPECT_EQ(-1577952000, unixTimestamp("19200101")); // pre-DST CST
+}
+
+// Exhaustive cross-check of unix_timestamp(..., yyyyMMddHHmmss) for every
+// hour from 1900-01-01 00:00 to 2026-01-01 23:00 in Asia/Shanghai against
+// ground-truth values produced by Apache Spark.
+//
+// Disabled by default (GoogleTest DISABLED_ prefix). To run:
+//
+//   1. Generate the expected TSV from Spark (any Spark 3.x+ works). For
+//      example, inside a Spark docker:
+//
+//        docker exec <spark-container> /opt/spark/bin/spark-sql -S \
+//          --conf spark.sql.session.timeZone=Asia/Shanghai -e "
+//            WITH days AS (
+//              SELECT date_add(DATE '1900-01-01', CAST(i AS INT)) AS d
+//              FROM (SELECT explode(sequence(0, 46021)) AS i)
+//            ), hours AS (SELECT explode(sequence(0, 23)) AS h)
+//            SELECT
+//              CONCAT(date_format(d,'yyyyMMdd'),
+//                     LPAD(CAST(h AS STRING),2,'0'),'0000') AS dt,
+//              unix_timestamp(
+//                CONCAT(date_format(d,'yyyyMMdd'),
+//                       LPAD(CAST(h AS STRING),2,'0'),'0000'),
+//                'yyyyMMddHHmmss') AS epoch
+//            FROM days CROSS JOIN hours;" \
+//          > /tmp/spark_expected.tsv
+//
+//   2. Run the test pointing at the TSV:
+//
+//        SHANGHAI_SPARK_CSV=/tmp/spark_expected.tsv \
+//          bolt_functions_spark_test \
+//          --gtest_also_run_disabled_tests \
+//          --gtest_filter='*ShanghaiAgainstSpark*'
+//
+// Notes on stability: the TSV is a snapshot of Spark's tzdata + JDK; if
+// bolt's `date` library is later bumped to a newer IANA release, a handful
+// of pre-1970 hours may start diverging (IANA periodically revises
+// historical rules). Regenerate the TSV against the matching Spark version
+// when that happens.
+TEST_F(
+    SparkSqlDateTimeFunctionsTest,
+    DISABLED_unixTimestampShanghaiAgainstSpark) {
+  const char* csvPath = std::getenv("SHANGHAI_SPARK_CSV");
+  ASSERT_NE(csvPath, nullptr)
+      << "SHANGHAI_SPARK_CSV env var not set — see test comment for how to "
+         "generate the TSV from Spark.";
+  std::ifstream in(csvPath);
+  ASSERT_TRUE(in.is_open()) << "cannot open " << csvPath;
+
+  setQueryTimeZone("Asia/Shanghai");
+
+  std::string header;
+  std::getline(in, header); // discard header line
+
+  const size_t kBatch = 65536;
+  std::vector<std::string> dts;
+  std::vector<int64_t> expected;
+  dts.reserve(kBatch);
+  expected.reserve(kBatch);
+
+  size_t totalChecked = 0;
+  size_t mismatches = 0;
+  std::string sampleMismatch;
+
+  auto flush = [&]() {
+    if (dts.empty()) {
+      return;
+    }
+    auto input = makeRowVector({makeFlatVector<std::string>(dts)});
+    auto result = evaluate("unix_timestamp(c0, 'yyyyMMddHHmmss')", input);
+    auto* flat = result->asFlatVector<int64_t>();
+    ASSERT_NE(flat, nullptr);
+    for (size_t i = 0; i < dts.size(); ++i) {
+      const int64_t got = flat->valueAt(i);
+      if (got != expected[i]) {
+        ++mismatches;
+        if (mismatches <= 10) {
+          sampleMismatch += fmt::format(
+              "\n  {} expected={} got={}", dts[i], expected[i], got);
+        }
+      }
+    }
+    totalChecked += dts.size();
+    dts.clear();
+    expected.clear();
+  };
+
+  std::string line;
+  while (std::getline(in, line)) {
+    const auto tab = line.find('\t');
+    if (tab == std::string::npos) {
+      continue;
+    }
+    dts.emplace_back(line.substr(0, tab));
+    expected.emplace_back(std::stoll(line.substr(tab + 1)));
+    if (dts.size() >= kBatch) {
+      flush();
+    }
+  }
+  flush();
+
+  EXPECT_EQ(0U, mismatches)
+      << "out of " << totalChecked << " rows checked" << sampleMismatch;
+  std::cerr << "[INFO] checked " << totalChecked
+            << " rows, mismatches=" << mismatches << std::endl;
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.


### PR DESCRIPTION
### What problem does this PR solve?

For Asia/Shanghai session timezone, `unix_timestamp` / `get_timestamp`
(and anything routing through `UnixTimestampFunctionBase`) had two bugs:

1. **Failed on DST-gap local times.** `'19490501'` parses as
   `1949-05-01 00:00` Shanghai, which sits in the DST-start gap (clocks
   jumped `00:00 CST → 01:00 CDT`). `date::time_zone::to_sys` rejected
   this as `nonexistent_local_time` and Bolt surfaced it as
   `INVALID_ARGUMENT`, aborting the task. Spark
   silently forward-shifts through the gap (`ZonedDateTime.ofLocal`).
2. **Silent 1-hour divergence during historical DST periods.** The
   Shanghai fast-path used STDOFF-only arithmetic, so every moment
   inside the 1919, 1940–1949 (wartime), and 1986–1991 DST windows
   returned `naive − 8h` instead of Spark's `naive − 9h`.

Root cause for (1): an ordering bug in the two
`getResultInGMT` / `getTimestampResultInGMT` overloads — the
`sessionTimeZone_ != nullptr` branch ran before `isShanghai`, so
Shanghai never actually reached `calculateCnUnixTimestamp`.
Root cause for (2): `calculateCnUnixTimestamp` only routed through
tzdata for the 1986-1991 window, everything else fell back to
`naive − sessionTzOffsetInSeconds_`.

Issue Number: #515 

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Scope of the change is intentionally kept to `sparksql` only —
`Timestamp::toGMT` is not modified, so Presto / cast / low-level
callers keep strict "throw on gap" semantics.

- `calculateCnUnixTimestamp` now routes through tzdata for every
  Shanghai regime (LMT, CST, and all historical DST windows). Before
  calling `toGMT`, local seconds are passed through
  `TimeZone::correct_nonexistent_time`, which forward-shifts gap
  local times to the post-gap offset — matching JVM's
  `ZonedDateTime.ofLocal` gap branch exactly.
- The cold `sessionTzID_`-only path (reachable when `setSpecTimezone`
  fell through to `setTimezone`) now resolves the zone via
  `tz::locateZone(id)` and applies the same gap correction, so it no
  longer throws on Shanghai gap midnights.
- `getResultInGMT(DateTimeResultValue&)` and
  `getTimestampResultInGMT(DateTimeResultValue&)`: reordered so
  `isShanghai` is checked before `sessionTimeZone_`. This routes
  Shanghai sessions through `calculateCnUnixTimestamp` as intended.

Why no global fix to `Timestamp::toGMT`? The method is also used by
Presto functions and cast expressions, which currently rely on
strict-fail-on-gap behavior. A narrower fix inside sparksql avoids
any blast radius to those paths.

### Performance Impact
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

One extra `correct_nonexistent_time` call per row in the Shanghai
path (a single `get_info` lookup that was already happening inside
`to_sys`). Cold-path adds a `tz::locateZone` lookup, but that path
is only reached in edge cases where `setSpecTimezone` failed.

### Release Note

Release Note:

```text
Release Note:
- Fixed a crash in `unix_timestamp` / `get_timestamp` when parsing Asia/Shanghai DST-gap local times (e.g. `'19490501 00:00'`).
- Fixed `unix_timestamp` returning a value 1 hour off from Spark for moments inside historical Asia/Shanghai DST periods (1919, 1940-1949, 1986-1991).
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Testing:

- Added `unixTimestampShanghaiDstGap` with 17 assertions covering
  DST-start midnights (Shang rule + PRC rule), interior DST
  moments, and non-DST baselines — all values confirmed against
  Spark.
- Added a disabled (`DISABLED_`) exhaustive test
  `unixTimestampShanghaiAgainstSpark` that cross-checks every hour
  from `1900-01-01 00:00` to `2026-01-01 23:00` (1,104,528 rows)
  against a TSV produced by Spark. The regen recipe (Spark-SQL
  query + invocation) is embedded in the test's doc comment.
- Local verification run: **1,104,528 rows, 0 mismatches, ~245 ms**.

### Breaking Changes
- [x] No
- [ ] Yes