### PR TITLE
[fix][cp][DynamicMerge] Make local merge source queue size configurable

### DIFF
--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -128,6 +128,11 @@ class QueryConfig {
   static constexpr const char* kMaxLocalExchangeBufferSize =
       "max_local_exchange_buffer_size";
 
+  /// Maximum number of vectors buffered in each local merge source before
+  /// blocking to wait for consumers.
+  static constexpr const char* kLocalMergeSourceQueueSize =
+      "local_merge_source_queue_size";
+
   /// Maximum size in bytes to accumulate in ExchangeQueue. Enforced
   /// approximately, not strictly.
   static constexpr const char* kMaxExchangeBufferSize =
@@ -912,6 +917,10 @@ class QueryConfig {
   uint64_t maxLocalExchangeBufferSize() const {
     static constexpr uint64_t kDefault = 32UL << 20;
     return get<uint64_t>(kMaxLocalExchangeBufferSize, kDefault);
+  }
+
+  uint32_t localMergeSourceQueueSize() const {
+    return get<uint32_t>(kLocalMergeSourceQueueSize, 2);
   }
 
   uint64_t maxExchangeBufferSize() const {

--- a/bolt/exec/LocalPlanner.cpp
+++ b/bolt/exec/LocalPlanner.cpp
@@ -121,7 +121,10 @@ OperatorSupplier makeOperatorSupplier(
           std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {
     return [localMerge](int32_t operatorId, DriverCtx* ctx) {
       auto mergeSource = ctx->task->addLocalMergeSource(
-          ctx->splitGroupId, localMerge->id(), localMerge->outputType());
+          ctx->splitGroupId,
+          localMerge->id(),
+          localMerge->outputType(),
+          ctx->queryConfig().localMergeSourceQueueSize());
 
       auto consumerCb = [mergeSource](
                             RowVectorPtr input,

--- a/bolt/exec/Merge.cpp
+++ b/bolt/exec/Merge.cpp
@@ -189,6 +189,7 @@ void Merge::setupSpillMerger() {
       std::move(spillReadFilesGroups),
       maxOutputBatchRows_,
       maxOutputBatchBytes_,
+      operatorCtx_->driverCtx()->queryConfig().localMergeSourceQueueSize(),
       &spillConfig_.value(),
       nullptr,
       pool());
@@ -528,13 +529,15 @@ SpillMerger::SpillMerger(
         spillReadFilesGroup,
     vector_size_t maxOutputBatchRows,
     uint64_t maxOutputBatchBytes,
+    int mergeSourceQueueSize,
     const common::SpillConfig* spillConfig,
     const std::shared_ptr<folly::Synchronized<common::SpillStats>>& spillStats,
     bolt::memory::MemoryPool* pool)
     : executor_(spillConfig->executor),
       spillStats_(spillStats),
       pool_(pool->shared_from_this()),
-      sources_(createMergeSources(spillReadFilesGroup.size())),
+      sources_(
+          createMergeSources(spillReadFilesGroup.size(), mergeSourceQueueSize)),
       batchStreams_(createBatchStreams(std::move(spillReadFilesGroup))),
       // TODO: consider to provide a config other than the regular operator
       // batch size to tune the batch size of the spilled source merge output as
@@ -573,11 +576,12 @@ RowVectorPtr SpillMerger::getOutput(
 }
 
 std::vector<std::shared_ptr<MergeSource>> SpillMerger::createMergeSources(
-    size_t numSpillSources) {
+    size_t numSpillSources,
+    int queueSize) {
   std::vector<std::shared_ptr<MergeSource>> sources;
   sources.reserve(numSpillSources);
   for (auto i = 0; i < numSpillSources; ++i) {
-    sources.push_back(MergeSource::createLocalMergeSource());
+    sources.push_back(MergeSource::createLocalMergeSource(queueSize));
   }
   for (const auto& source : sources) {
     source->start();

--- a/bolt/exec/Merge.h
+++ b/bolt/exec/Merge.h
@@ -306,6 +306,7 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
           spillReadFilesGroup,
       vector_size_t maxOutputBatchRows,
       uint64_t maxOutputBatchBytes,
+      int mergeSourceQueueSize,
       const common::SpillConfig* spillConfig,
       const std::shared_ptr<folly::Synchronized<common::SpillStats>>&
           spillStats,
@@ -321,7 +322,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
  private:
   static std::vector<std::shared_ptr<MergeSource>> createMergeSources(
-      size_t numSpillSources);
+      size_t numSpillSources,
+      int queueSize);
 
   static std::vector<std::unique_ptr<BatchStream>> createBatchStreams(
       std::vector<std::vector<std::unique_ptr<SpillReadFile>>>

--- a/bolt/exec/MergeSource.cpp
+++ b/bolt/exec/MergeSource.cpp
@@ -298,11 +298,9 @@ class MergeExchangeSource : public MergeSource {
 };
 } // namespace
 
-std::shared_ptr<MergeSource> MergeSource::createLocalMergeSource() {
-  // Buffer up to 2 vectors from each source before blocking to wait
-  // for consumers.
-  static const int kDefaultQueueSize = 2;
-  return std::make_shared<LocalMergeSource>(kDefaultQueueSize);
+std::shared_ptr<MergeSource> MergeSource::createLocalMergeSource(
+    int queueSize) {
+  return std::make_shared<LocalMergeSource>(queueSize);
 }
 
 std::shared_ptr<MergeSource> MergeSource::createMergeExchangeSource(

--- a/bolt/exec/MergeSource.h
+++ b/bolt/exec/MergeSource.h
@@ -60,7 +60,7 @@ class MergeSource {
   virtual void close() = 0;
 
   // Factory methods to create MergeSources.
-  static std::shared_ptr<MergeSource> createLocalMergeSource();
+  static std::shared_ptr<MergeSource> createLocalMergeSource(int queueSize);
 
   static std::shared_ptr<MergeSource> createMergeExchangeSource(
       MergeExchange* mergeExchange,

--- a/bolt/exec/Task.cpp
+++ b/bolt/exec/Task.cpp
@@ -2600,8 +2600,9 @@ folly::dynamic Task::toJson() const {
 std::shared_ptr<MergeSource> Task::addLocalMergeSource(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId,
-    const RowTypePtr& rowType) {
-  auto source = MergeSource::createLocalMergeSource();
+    const RowTypePtr& rowType,
+    int queueSize) {
+  auto source = MergeSource::createLocalMergeSource(queueSize);
   splitGroupStates_[splitGroupId].localMergeSources[planNodeId].push_back(
       source);
   return source;

--- a/bolt/exec/Task.h
+++ b/bolt/exec/Task.h
@@ -437,7 +437,8 @@ class Task : public std::enable_shared_from_this<Task> {
   std::shared_ptr<MergeSource> addLocalMergeSource(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
-      const RowTypePtr& rowType);
+      const RowTypePtr& rowType,
+      int queueSize);
 
   /// Returns all MergeSource's for the specified splitGroupId and planNodeId.
   const std::vector<std::shared_ptr<MergeSource>>& getLocalMergeSources(

--- a/bolt/exec/tests/MergerTest.cpp
+++ b/bolt/exec/tests/MergerTest.cpp
@@ -165,11 +165,13 @@ class MergerTest : public OperatorTestBase {
         pool());
   }
 
-  static std::vector<std::shared_ptr<MergeSource>> createMergeSources(int num) {
+  static std::vector<std::shared_ptr<MergeSource>> createMergeSources(
+      size_t numSources,
+      size_t queueSize) {
     std::vector<std::shared_ptr<MergeSource>> sources;
-    sources.reserve(num);
-    for (auto i = 0; i < num; ++i) {
-      sources.push_back(MergeSource::createLocalMergeSource());
+    sources.reserve(numSources);
+    for (auto i = 0; i < numSources; ++i) {
+      sources.push_back(MergeSource::createLocalMergeSource(queueSize));
     }
     for (const auto& source : sources) {
       source->start();
@@ -236,13 +238,15 @@ class MergerTest : public OperatorTestBase {
   std::shared_ptr<SpillMerger> createSpillMerger(
       std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
           spillReadFilesGroups,
-      vector_size_t outputBatchRows) const {
+      vector_size_t outputBatchRows,
+      int queueSize) const {
     return std::make_shared<SpillMerger>(
         sortingKeys_,
         inputType_,
         std::move(spillReadFilesGroups),
         outputBatchRows,
         std::numeric_limits<int64_t>::max(),
+        queueSize,
         &spillConfig_,
         spillStats_,
         pool());
@@ -327,37 +331,40 @@ class MergerTest : public OperatorTestBase {
 } // namespace bytedance::bolt::exec::test
 
 TEST_F(MergerTest, sourceMerger) {
-  struct {
+  struct TestSetting {
     size_t maxOutputRows;
     size_t maxOutputBytes;
     size_t numSources;
+    size_t queueSize;
 
     std::string debugString() const {
       return fmt::format(
-          "maxOutputRows:{}, maxOutputBytes:{}, numStreams:{}",
+          "maxOutputRows:{}, maxOutputBytes:{}, numStreams:{}, queueSize:{}",
           maxOutputRows,
           succinctBytes(maxOutputBytes),
-          numSources);
+          numSources,
+          queueSize);
     }
-  } testSettings[] = {
-      {1, 1000'000'000, 1},
-      {1, 1000'000'000, 3},
-      {1, 1000'000'000, 8},
-      {7, 1000'000'000, 1},
-      {7, 1000'000'000, 3},
-      {7, 1000'000'000, 8},
-      {16, 1000'000'000, 1},
-      {16, 1000'000'000, 3},
-      {16, 1000'000'000, 8},
-      {32, 1000'000'000, 3},
-      {1024, 1000'000'000, 8}};
+  };
+  std::vector<TestSetting> testSettings;
+  for (size_t maxOutputRows : {1, 7, 16}) {
+    for (size_t numSources : {1, 3, 8}) {
+      for (size_t queueSize : {1, 2}) {
+        testSettings.push_back(
+            {maxOutputRows, 1'000'000'000, numSources, queueSize});
+      }
+    }
+  }
+  testSettings.push_back({32, 1'000'000'000, 3, 2});
+  testSettings.push_back({1024, 1'000'000'000, 8, 2});
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     std::vector<std::vector<RowVectorPtr>> inputs;
     for (auto i = 1; i <= testData.numSources; ++i) {
       inputs.emplace_back(generateSortedVectors(i, 16));
     }
-    const auto sources = createMergeSources(testData.numSources);
+    const auto sources =
+        createMergeSources(testData.numSources, testData.queueSize);
     const auto sourceMerger = createSourceMerger(
         sources, testData.maxOutputRows, testData.maxOutputBytes);
     createProducers(testData.numSources, inputs, sources);
@@ -373,7 +380,7 @@ TEST_F(MergerTest, sourceMergerWithEmptySources) {
     const auto numVectors = (i % 2 == 0) ? 0 : i;
     inputs.emplace_back(generateSortedVectors(numVectors, 16));
   }
-  const auto sources = createMergeSources(10);
+  const auto sources = createMergeSources(10, 2);
   const auto sourceMerger = createSourceMerger(sources, 32, 1000'000'000);
   createProducers(10, inputs, sources);
   const auto results = getOutputFromSourceMerger(sourceMerger.get());
@@ -382,33 +389,37 @@ TEST_F(MergerTest, sourceMergerWithEmptySources) {
 }
 
 TEST_F(MergerTest, spillMerger) {
-  struct {
+  struct TestSetting {
     size_t maxOutputRows;
     size_t numSources;
+    size_t queueSize;
 
     std::string debugString() const {
       return fmt::format(
-          "maxOutputRows:{}, numStreams:{}", maxOutputRows, numSources);
+          "maxOutputRows:{}, numStreams:{}, queueSize:{}",
+          maxOutputRows,
+          numSources,
+          queueSize);
     }
-  } testSettings[] = {
-      {1, 1},
-      {1, 3},
-      {1, 8},
-      {7, 1},
-      {7, 3},
-      {7, 8},
-      {16, 1},
-      {16, 3},
-      {16, 8},
-      {32, 3},
-      {1024, 8}};
+  };
+  std::vector<TestSetting> testSettings;
+  for (size_t maxOutputRows : {1, 7, 16}) {
+    for (size_t numSources : {1, 3, 8}) {
+      for (size_t queueSize : {1, 2}) {
+        testSettings.push_back({maxOutputRows, numSources, queueSize});
+      }
+    }
+  }
+  testSettings.push_back({32, 3, 2});
+  testSettings.push_back({1024, 8, 2});
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    const auto sources = createMergeSources(testData.numSources);
+    const auto sources =
+        createMergeSources(testData.numSources, testData.queueSize);
     auto [inputs, filesGroup] = generateInputs(testData.numSources, 16);
     ASSERT_EQ(filesGroup.size(), testData.numSources);
-    const auto spillMerger =
-        createSpillMerger(std::move(filesGroup), testData.maxOutputRows);
+    const auto spillMerger = createSpillMerger(
+        std::move(filesGroup), testData.maxOutputRows, testData.queueSize);
     spillMerger->start();
     const auto results = getOutputFromSpillMerger(spillMerger.get());
     const auto expectedResults = makeExpectedResults(inputs, 16);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
Corresponding PR: https://github.com/facebookincubator/velox/pull/14540

Add the new query config `local_merge_source_queue_size` to control how many vectors we buffer in a local merge source.  This can be used to control the memory usage of the pipeline.

This change does not alter any behavior of existing applications, which continue to use the default value (2) same as before.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
