### PR TITLE
[feat][cp][DynamicMerge] Centralize error propagation in SpillMerger

### DIFF
--- a/bolt/exec/Merge.cpp
+++ b/bolt/exec/Merge.cpp
@@ -29,8 +29,9 @@
  */
 
 #include "bolt/exec/Merge.h"
+#include <folly/Traits.h>
+#include <exception>
 #include "bolt/common/testutil/TestValue.h"
-#include "bolt/exec/OperatorUtils.h"
 #include "bolt/exec/Task.h"
 
 using bytedance::bolt::common::testutil::TestValue;
@@ -565,14 +566,22 @@ void SpillMerger::start() {
 
 RowVectorPtr SpillMerger::getOutput(
     std::vector<ContinueFuture>& sourceBlockingFutures,
-    bool& atEnd) const {
+    bool& atEnd) {
   TestValue::adjust(
       "bytedance::bolt::exec::SpillMerger::getOutput", &sourceBlockingFutures);
   sourceMerger_->isBlocked(sourceBlockingFutures);
   if (!sourceBlockingFutures.empty()) {
     return nullptr;
   }
-  return sourceMerger_->getOutput(sourceBlockingFutures, atEnd);
+  // SpillMerger::getOutput waits for all readers to finish, reaches EOF,
+  // and rethrows any captured error. Centralizing error propagation here
+  // helps prevent potential resource leaks.
+  auto output = sourceMerger_->getOutput(sourceBlockingFutures, atEnd);
+
+  if (atEnd) {
+    checkError();
+  }
+  return output;
 }
 
 std::vector<std::shared_ptr<MergeSource>> SpillMerger::createMergeSources(
@@ -619,61 +628,97 @@ std::unique_ptr<SourceMerger> SpillMerger::createSourceMerger(
       type, std::move(streams), maxOutputBatchRows, maxOutputBatchBytes, pool);
 }
 
-// static.
-void SpillMerger::asyncReadFromSpillFileStream(
+void SpillMerger::finishSource(size_t streamIdx) const {
+  ContinueFuture future{ContinueFuture::makeEmpty()};
+  sources_[streamIdx]->enqueue(nullptr, &future);
+  BOLT_CHECK(!future.valid());
+}
+
+void SpillMerger::readFromSpillFileStream(
     const std::weak_ptr<SpillMerger>& mergeHolder,
     size_t streamIdx) {
   TestValue::adjust(
-      "bytedance::bolt::exec::SpillMerger::asyncReadFromSpillFileStream",
+      "bytedance::bolt::exec::SpillMerger::readFromSpillFileStream",
       static_cast<void*>(0));
   const auto merger = mergeHolder.lock();
   if (merger == nullptr) {
     LOG(ERROR) << "SpillMerger is destroyed, abandon reading from batch stream";
     return;
   }
-  merger->readFromSpillFileStream(streamIdx);
-}
+  try {
+    if (hasError()) {
+      finishSource(streamIdx);
+      return;
+    }
 
-void SpillMerger::readFromSpillFileStream(size_t streamIdx) {
-  RowVectorPtr vector;
-  ContinueFuture future{ContinueFuture::makeEmpty()};
-  if (!batchStreams_[streamIdx]->nextBatch(vector)) {
-    BOLT_CHECK_NULL(vector);
-    sources_[streamIdx]->enqueue(nullptr, &future);
-    BOLT_CHECK(!future.valid());
-    return;
-  }
-  const auto blockingReason =
-      sources_[streamIdx]->enqueue(std::move(vector), &future);
-  // TODO: add async error handling.
-  if (blockingReason == BlockingReason::kNotBlocked) {
-    BOLT_CHECK(!future.valid());
-    executor_->add(
-        [mergeHolder = std::weak_ptr(shared_from_this()), streamIdx]() {
-          asyncReadFromSpillFileStream(mergeHolder, streamIdx);
-        });
-  } else {
-    BOLT_CHECK(future.valid());
-    std::move(future)
-        .via(executor_)
-        .thenValue([mergeHolder = std::weak_ptr(shared_from_this()),
-                    streamIdx](folly::Unit) {
-          asyncReadFromSpillFileStream(mergeHolder, streamIdx);
-        })
-        .thenError(
-            folly::tag_t<std::exception>{},
-            [streamIdx](const std::exception& e) {
-              LOG(ERROR) << "Stop the " << streamIdx
-                         << "th batch stream producer on error: " << e.what();
-            });
+    RowVectorPtr vector;
+    if (!batchStreams_[streamIdx]->nextBatch(vector)) {
+      BOLT_CHECK_NULL(vector);
+      finishSource(streamIdx);
+      return;
+    }
+
+    ContinueFuture future{ContinueFuture::makeEmpty()};
+    const auto blockingReason =
+        sources_[streamIdx]->enqueue(std::move(vector), &future);
+    if (blockingReason == BlockingReason::kNotBlocked) {
+      BOLT_CHECK(!future.valid());
+      readFromSpillFileStream(mergeHolder, streamIdx);
+    } else {
+      BOLT_CHECK(future.valid());
+      std::move(future)
+          .via(executor_)
+          .thenValue([this, mergeHolder, streamIdx](auto&&) {
+            readFromSpillFileStream(mergeHolder, streamIdx);
+          })
+          .thenError(
+              folly::tag_t<std::exception>{},
+              [this, mergeHolder, streamIdx](const std::exception& e) {
+                const auto merger = mergeHolder.lock();
+                if (merger != nullptr) {
+                  LOG(ERROR) << "Stop the " << streamIdx
+                             << " th source on error: " << e.what();
+                  setError(std::make_exception_ptr(e));
+                  finishSource(streamIdx);
+                }
+              });
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "The " << streamIdx
+               << " spill stream failed with error: " << e.what();
+    setError(std::current_exception());
+    finishSource(streamIdx);
   }
 }
 
 void SpillMerger::scheduleAsyncSpillFileStreamReads() {
   BOLT_CHECK_EQ(batchStreams_.size(), sources_.size());
   for (auto i = 0; i < batchStreams_.size(); ++i) {
-    executor_->add(
-        [&, streamIdx = i]() { readFromSpillFileStream(streamIdx); });
+    executor_->add([&, streamIdx = i]() {
+      readFromSpillFileStream(std::weak_ptr(shared_from_this()), streamIdx);
+    });
+  }
+}
+
+void SpillMerger::setError(const std::exception_ptr& exception) {
+  std::lock_guard l(mutex_);
+  if (exception_ != nullptr) {
+    return;
+  }
+  exception_ = exception;
+}
+
+bool SpillMerger::hasError() const {
+  std::lock_guard l(mutex_);
+  return exception_ != nullptr;
+}
+
+void SpillMerger::checkError() {
+  if (hasError()) {
+    sourceMerger_.reset();
+    batchStreams_.clear();
+    sources_.clear();
+    std::rethrow_exception(exception_);
   }
 }
 

--- a/bolt/exec/Merge.h
+++ b/bolt/exec/Merge.h
@@ -318,7 +318,7 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
   RowVectorPtr getOutput(
       std::vector<ContinueFuture>& sourceBlockingFutures,
-      bool& atEnd) const;
+      bool& atEnd);
 
  private:
   static std::vector<std::shared_ptr<MergeSource>> createMergeSources(
@@ -336,13 +336,22 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
       uint64_t maxOutputBatchBytes,
       bolt::memory::MemoryPool* pool);
 
-  static void asyncReadFromSpillFileStream(
+  void finishSource(size_t streamIdx) const;
+
+  void readFromSpillFileStream(
       const std::weak_ptr<SpillMerger>& mergeHolder,
       size_t streamIdx);
 
-  void readFromSpillFileStream(size_t streamIdx);
-
   void scheduleAsyncSpillFileStreamReads();
+
+  // Sets 'exception_' when an async reader throws.
+  void setError(const std::exception_ptr& exception);
+
+  // Returns true if any async reader has thrown an exception.
+  bool hasError() const;
+
+  // If any async reader has thrown an exception, rethrows it.
+  void checkError();
 
   folly::Executor* const executor_;
   const std::shared_ptr<folly::Synchronized<common::SpillStats>> spillStats_;
@@ -351,6 +360,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
   std::vector<std::shared_ptr<MergeSource>> sources_;
   std::vector<std::unique_ptr<BatchStream>> batchStreams_;
   std::unique_ptr<SourceMerger> sourceMerger_;
+  mutable std::timed_mutex mutex_;
+  std::exception_ptr exception_ = nullptr;
 };
 
 // LocalMerge merges its source's output into a single stream of

--- a/bolt/exec/Spill.cpp
+++ b/bolt/exec/Spill.cpp
@@ -385,6 +385,8 @@ std::unique_ptr<BatchStream> ConcatFilesSpillBatchStream::create(
 }
 
 bool ConcatFilesSpillBatchStream::nextBatch(RowVectorPtr& batch) {
+  TestValue::adjust(
+      "bytedance::bolt::exec::ConcatFilesSpillBatchStream::nextBatch", nullptr);
   BOLT_CHECK_NULL(batch);
   BOLT_CHECK(!atEnd_);
   for (; fileIndex_ < spillFiles_.size(); ++fileIndex_) {

--- a/bolt/exec/tests/MergeTest.cpp
+++ b/bolt/exec/tests/MergeTest.cpp
@@ -622,6 +622,38 @@ TEST_F(MergeTest, localMergeSpillPartialEmpty) {
   ASSERT_EQ(planStats.spilledRows, 120);
 }
 
+DEBUG_ONLY_TEST_F(MergeTest, localMergeSpillWithException) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 9; ++i) {
+    constexpr vector_size_t batchSize = 137;
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](auto row) { return batchSize * i + row; }, nullEvery(5));
+    auto c1 = makeFlatVector<int64_t>(
+        batchSize, [&](auto row) { return row; }, nullEvery(5));
+    auto c2 = makeFlatVector<double>(
+        batchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
+    auto c3 = makeFlatVector<StringView>(batchSize, [](auto row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+  }
+  createDuckDbTable(vectors);
+
+  for (auto i = 0; i < 11; ++i) {
+    std::atomic_int cnt{0};
+    const auto errorMessage = "ConcatFilesSpillBatchStream::nextBatch fail";
+    SCOPED_TESTVALUE_SET(
+        "bytedance::bolt::exec::ConcatFilesSpillBatchStream::nextBatch",
+        std::function<void(void*)>([&](void* /*unused*/) {
+          if (cnt++ == i) {
+            BOLT_FAIL("ConcatFilesSpillBatchStream::nextBatch fail");
+          }
+        }));
+
+    BOLT_ASSERT_THROW(testSingleKeyWithSpill(vectors, "c0"), errorMessage);
+  }
+}
+
 DEBUG_ONLY_TEST_F(MergeTest, localMergeSmallBatch) {
   std::vector<RowVectorPtr> vectors;
   for (int32_t i = 0; i < 9; ++i) {
@@ -756,7 +788,7 @@ DEBUG_ONLY_TEST_F(MergeTest, localMergeAbort) {
           }));
 
   SCOPED_TESTVALUE_SET(
-      "bytedance::bolt::exec::SpillMerger::asyncReadFromSpillFileStream",
+      "bytedance::bolt::exec::SpillMerger::readFromSpillFileStream",
       std::function<void(void*)>([&](void* /*unused*/) {
         if (cnt++ == 2) {
           blocked = true;

--- a/bolt/exec/tests/MergerTest.cpp
+++ b/bolt/exec/tests/MergerTest.cpp
@@ -28,6 +28,7 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/file/FileSystems.h"
 #include "bolt/exec/Merge.h"
 #include "bolt/exec/MergeSource.h"
@@ -425,4 +426,38 @@ TEST_F(MergerTest, spillMerger) {
     const auto expectedResults = makeExpectedResults(inputs, 16);
     checkResults(expectedResults, results);
   }
+}
+
+DEBUG_ONLY_TEST_F(MergerTest, spillMergerException) {
+  struct TestSetting {
+    size_t maxOutputRows;
+    size_t numSources;
+    size_t queueSize;
+
+    std::string debugString() const {
+      return fmt::format(
+          "maxOutputRows:{}, numStreams:{}, queueSize:{}",
+          maxOutputRows,
+          numSources,
+          queueSize);
+    }
+  };
+
+  std::atomic_int cnt{0};
+  const auto errorMessage = "ConcatFilesSpillBatchStream::nextBatch fail";
+  SCOPED_TESTVALUE_SET(
+      "bytedance::bolt::exec::ConcatFilesSpillBatchStream::nextBatch",
+      std::function<void(void*)>([&](void* /*unused*/) {
+        if (cnt++ == 11) {
+          BOLT_FAIL("ConcatFilesSpillBatchStream::nextBatch fail");
+        }
+      }));
+  const auto numSources = 5;
+  const auto queueSize = 2;
+  const auto sources = createMergeSources(numSources, queueSize);
+  auto [inputs, filesGroup] = generateInputs(numSources, 16);
+  const auto spillMerger =
+      createSpillMerger(std::move(filesGroup), 100, queueSize);
+  spillMerger->start();
+  BOLT_ASSERT_THROW(getOutputFromSpillMerger(spillMerger.get()), errorMessage);
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #191 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Summary:
`SpillMerger::start` dispatches reader threads to fetch data from their respective spill file streams, while `SpillMerger::getOutput` pulls and merges the data. If any reader throws, it sets `SpillMerger::error_` and exits; other readers detect the flag, enqueue `nullptr`, and terminate early. `SpillMerger::getOutput` waits for all readers to finish, reaches EOF, and rethrows the captured error. Centralizing error propagation by rethrowing only on the main thread (`SpillMerger::getOutput`) prevents resource leaks.

Part of https://github.com/facebookincubator/velox/issues/13260

Corresponding PR: https://github.com/facebookincubator/velox/pull/14761

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
