### PR TITLE
[fix] do not throw exception when BoltShuffleReader read from empty stream

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -421,7 +421,12 @@ RowVectorPtr BoltColumnarBatchDeserializer::next() {
     int64_t bytes = 0;
     auto result = BlockPayload::getVectorLayout(in_.get(), type, bytes);
     BOLT_CHECK(result.ok(), "Failed to get vector layout: " + result.message());
-    BOLT_CHECK(bytes != 0, "bytes should not be zero");
+    if (bytes == 0) {
+      // Empty stream: treat as EOS.
+      LOG(INFO) << "BoltColumnarBatchDeserializer: empty input stream, EOS";
+      reachEos_ = true;
+      return nullptr;
+    }
     if (type == static_cast<uint8_t>(RowVectorLayout::kComposite)) {
       vectorLayout_ = RowVectorLayout::kComposite;
       // first byte has been read by checkVectorLayout

--- a/bolt/shuffle/sparksql/tests/ShuffleMiscTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMiscTest.cpp
@@ -14,11 +14,54 @@
  * limitations under the License.
  */
 
+#include <arrow/buffer.h>
+#include <arrow/io/memory.h>
+
+#include "bolt/shuffle/sparksql/BoltArrowMemoryPool.h"
+#include "bolt/shuffle/sparksql/BoltShuffleReader.h"
+#include "bolt/shuffle/sparksql/Utils.h"
 #include "bolt/shuffle/sparksql/tests/ShuffleTestBase.h"
 
 namespace bytedance::bolt::shuffle::sparksql::test {
 
 class ShuffleMiscTest : public ShuffleTestBase {};
+
+// next() should return nullptr on an empty input stream (e.g. an empty
+// Celeborn partition) instead of throwing, across all shuffle modes.
+TEST_F(ShuffleMiscTest, EmptyInputStreamReturnsNullInsteadOfFailing) {
+  // hash partitioning works for all three modes: V1/V2 stay on the columnar
+  // path (isRowBased = false), RowBased takes the row path.
+  const std::vector<std::pair<const char*, ShuffleWriterType>> cases = {
+      {"V1", ShuffleWriterType::V1},
+      {"V2", ShuffleWriterType::V2},
+      {"RowBased", ShuffleWriterType::RowBased},
+  };
+
+  auto rowType = ROW({"c0"}, {INTEGER()});
+  auto schema = boltTypeToArrowSchema(rowType, pool());
+
+  for (const auto& [label, writerType] : cases) {
+    SCOPED_TRACE(label);
+    auto emptyBuf = arrow::Buffer::FromString("");
+    std::shared_ptr<arrow::io::InputStream> emptyStream =
+        std::make_shared<arrow::io::BufferReader>(emptyBuf);
+
+    ShuffleReaderOptions options;
+    options.numPartitions = 1;
+    options.forceShuffleWriterType = static_cast<int32_t>(writerType);
+    options.partitionShortName = "hash";
+    options.shuffleBatchByteSize = 1024 * 1024;
+    options.batchSize = 32;
+
+    auto arrowPool = std::make_shared<BoltArrowMemoryPool>(pool());
+    BoltShuffleReader reader(schema, options, arrowPool.get(), pool());
+
+    auto deserializer = reader.readStream(emptyStream);
+    ASSERT_NE(deserializer, nullptr);
+    EXPECT_EQ(deserializer->next(), nullptr);
+    EXPECT_EQ(deserializer->next(), nullptr);
+  }
+}
 
 // End-to-end test: RoundRobin with Adaptive mode, >=8000 partitions and >=5
 // columns should use V1 consistently on both writer and reader side.


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #526 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Celeborn may generate empty InputStream when there is no data to read for certain mappers. But bolt would throw "bytes should not be zero" when got an empty InputStream. In this PR, we return null instead throw an exception to support this suiation.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
