### PR TITLE
fix lag hang caused by too many string buffers

### DIFF
--- a/bolt/functions/prestosql/window/LeadLag.cpp
+++ b/bolt/functions/prestosql/window/LeadLag.cpp
@@ -459,6 +459,9 @@ class LeadLagFunction : public exec::WindowFunction {
       if (defaultValueRowNumbers.empty()) {
         return;
       }
+      // Drop the previous partition's buffer so `stringBuffers_` doesn't grow
+      // too much
+      defaultValues_->prepareForReuse();
       bool exactSize = (partition_->numRows() == 1) ? true : false;
       partition_->extractColumn(
           defaultValueIndex_.value(),
@@ -503,6 +506,7 @@ class LeadLagFunction : public exec::WindowFunction {
       if (defaultValueRowNumbers.empty()) {
         return;
       }
+      defaultValues_->prepareForReuse();
       bool exactSize = (partition_->numRows() == 1) ? true : false;
       partition_->extractColumn(
           defaultValueIndex_.value(),

--- a/bolt/functions/prestosql/window/tests/LeadLagTest.cpp
+++ b/bolt/functions/prestosql/window/tests/LeadLagTest.cpp
@@ -540,85 +540,20 @@ BOLT_INSTANTIATE_TEST_SUITE_P(LagTest, LeadLagTest, ::testing::Values("lag"));
 
 BOLT_INSTANTIATE_TEST_SUITE_P(LeadTest, LeadLagTest, ::testing::Values("lead"));
 
-// Regression test for an O(N^2) slowdown observed when LAG runs over a query
-// shape like:
-//
-//   lag(varchar_col, 1, default_varchar_col) over (partition by k order by ...)
-//
-// against many small (here single-row) partitions whose VARCHAR values are
-// stored out-of-line -- i.e. each value is longer than 12 bytes, so it does
-// not fit in StringView's inline storage and must point into an external
-// string buffer. Production hit this with timestamp-shaped strings such as
-// '2026-01-01 23:59:59' (19 bytes).
-//
-// Mechanism the fix is guarding against:
-//
-//   1. For each partition, LeadLagFunction::setDefaultValue extracts the
-//      partition's default-value rows into the reusable member vector
-//      `defaultValues_`. extractColumn allocates a string buffer inside
-//      `defaultValues_` to hold those bytes.
-//
-//   2. setDefaultValue then calls `result->copy(defaultValues_, ...)`. For
-//      same-pool VARCHAR copies this routes through
-//      FlatVector::acquireSharedStringBuffers, which makes `result` take a
-//      shared ref to every buffer currently in
-//      `defaultValues_->stringBuffers_`.
-//
-//   3. On the next partition, the buffer in `defaultValues_` is no longer
-//      unique (refcount==2: held by both `defaultValues_` and `result`), so
-//      getBufferWithSpace cannot reuse it. It allocates a new buffer and
-//      appends it to `defaultValues_->stringBuffers_` -- the old buffer is
-//      never removed because it is still referenced by `result`.
-//
-//   4. `defaultValues_->stringBuffers_` therefore grows by one entry per
-//      partition. Each subsequent `result->copy(defaultValues_, ...)` iterates
-//      that whole list inside acquireSharedStringBuffers, giving O(N^2) work
-//      across N partitions.
-//
-// The fix calls `defaultValues_->prepareForReuse()` before each extract, which
-// drops the now-non-unique buffer from `defaultValues_` (the bytes it owns are
-// kept alive via the ref still held by `result`). That keeps
-// `defaultValues_->stringBuffers_` bounded at one entry, returning the per-call
-// acquireSharedStringBuffers walk to O(1).
-//
-// What this test asserts:
-//
-//   The Window operator emits output in batches of `numRowsPerOutput_` rows
-//   (~1024 by default). Within one batch, `result->stringBuffers_` accumulates
-//   the union of all distinct buffers it has acquired from `defaultValues_`.
-//   Because acquireSharedStringBuffers copies *every* entry of
-//   `defaultValues_->stringBuffers_`, in the broken version that union grows
-//   monotonically across batches: batch i's `result` ends up with roughly
-//   i * (rows-per-batch) buffers. We empirically observed on the broken
-//   version: 11264, 21504, 31744, 41984, 50000.
-//
-//   With the fix, `defaultValues_->stringBuffers_` is bounded at 1, so the
-//   only buffers a batch's `result` acquires are the ones produced by the
-//   partitions in that very batch -- bounded by the batch row count
-//   (~1024 in our case).
-//
-//   So `maxBatchBuffers` distinguishes the two cleanly: it scales with kSize
-//   when broken and with rows-per-batch when fixed. The threshold below
-//   (kSize / 10 = 5000) sits comfortably above ~1024 (a few batches' worth of
-//   slack) and far below kSize (50000), so it tolerates batch-sizing changes
-//   while still firing on regressions.
+// Regression test for O(N^2) slowdown in `lag(varchar, k, default_varchar)`
+// over many small partitions: without prepareForReuse(), defaultValues_'s
+// stringBuffers_ grew by one entry per partition, and result->copy walked
+// the whole list each time via acquireSharedStringBuffers.
 TEST_F(LeadLagTest, manySingleRowVarcharPartitions) {
-  // Each row is its own partition, so callApplyForPartitionRows runs kSize
-  // times against the LAG function -- amplifying the per-partition O(N) walk
-  // in the broken version into a clearly visible O(N^2) total.
   constexpr vector_size_t kSize = 50'000;
 
-  // Materialize the value/default strings into long-lived std::strings so the
-  // StringViews we hand to makeFlatVector point at stable memory while
-  // FlatVector::set copies them into its own string buffer. (The
-  // StringView(std::string&&) constructor is deleted precisely to catch the
-  // dangling-temporary mistake, so we cannot use fmt::format directly inline.)
+  // StringView(std::string&&) is deleted, so the strings must outlive the
+  // vectors built from them.
   std::vector<std::string> valueStrings(kSize);
   std::vector<std::string> defaultStrings(kSize);
   for (vector_size_t row = 0; row < kSize; ++row) {
-    // 19 chars -- exceeds StringView's 12-byte inline limit, forcing each
-    // value to live in an external buffer. This is what makes the
-    // acquireSharedStringBuffers path relevant.
+    // >12 chars so values don't fit StringView's inline storage and must
+    // live in an external buffer.
     valueStrings[row] = fmt::format(
         "2026-01-01 {:02d}:{:02d}:{:02d}",
         (row / 3600) % 24,
@@ -631,10 +566,8 @@ TEST_F(LeadLagTest, manySingleRowVarcharPartitions) {
         row % 60);
   }
 
-  // Schema: c0 = unique partition key, c1 = LAG value column,
-  // c2 = LAG per-row default (variable -- routes setDefaultValue through the
-  // `defaultValueIndex_` branch where the `defaultValues_` accumulation bug
-  // lives, not the constant-default branch).
+  // c2 is a per-row default so setDefaultValue takes the defaultValueIndex_
+  // branch (where the bug lives), not the constant-default branch.
   auto data = makeRowVector({
       makeFlatVector<int64_t>(kSize, [](auto row) { return row; }),
       makeFlatVector<StringView>(
@@ -646,16 +579,8 @@ TEST_F(LeadLagTest, manySingleRowVarcharPartitions) {
   auto queryInfo = buildWindowQuery(
       {data}, "lag(c1, 1, c2)", "partition by c0 order by c1 desc", "");
 
-  // We must observe the *raw* per-batch FlatVector that the Window operator
-  // emits. AssertQueryBuilder::copyResults concatenates batches into a fresh
-  // RowVector created in the test's pool; that copy goes through
-  // FlatVector<StringView>::copyRanges' cross-pool path, which writes via
-  // setStringViewValue and re-chunks into the result's own 32 KB buffers --
-  // hiding the per-batch buffer count we want to assert on.
-  //
-  // Driving with TaskCursor + `copyResult=false` skips the queue-side copy
-  // and hands us the operator's own RowVector, so `lagColumn->stringBuffers()`
-  // reports exactly what the Window operator produced.
+  // copyResult=false hands us the operator's raw FlatVector; otherwise the
+  // queue-side copy re-chunks buffers and hides the per-batch count.
   exec::test::CursorParameters params;
   params.planNode = queryInfo.planNode;
   params.copyResult = false;
@@ -667,16 +592,11 @@ TEST_F(LeadLagTest, manySingleRowVarcharPartitions) {
   size_t numBatches = 0;
   while (cursor->moveNext()) {
     auto batch = cursor->current();
-    // Output schema is the input columns followed by one column per window
-    // function. We have a single LAG, so it's the last child.
     auto* lagColumn = batch->childAt(batch->childrenSize() - 1)
                           ->asUnchecked<FlatVector<StringView>>();
     maxBatchBuffers =
         std::max(maxBatchBuffers, lagColumn->stringBuffers().size());
 
-    // Spot-check correctness while we're here: every row sits in its own
-    // size-1 partition with offset=1, so LAG always falls back to the per-row
-    // default (c2 = defaultStrings[row]).
     for (vector_size_t i = 0; i < batch->size(); ++i) {
       ASSERT_FALSE(lagColumn->isNullAt(i));
       ASSERT_EQ(
@@ -690,30 +610,16 @@ TEST_F(LeadLagTest, manySingleRowVarcharPartitions) {
                        .count();
 
   ASSERT_EQ(totalRows, kSize);
-  // Diagnostic line; not part of the assertion, but useful when triaging
-  // future regressions to know whether the slowdown shows up in elapsed
-  // time, in buffer count, or both.
   std::cout << "[manySingleRowVarcharPartitions] rows=" << kSize
             << " batches=" << numBatches
             << " maxBatchBuffers=" << maxBatchBuffers
             << " elapsed=" << elapsedMs << "ms" << std::endl;
 
-  // The actual regression check. See the long comment above for why this
-  // metric distinguishes the broken and fixed code:
-  //
-  //   broken: maxBatchBuffers grows toward kSize (we measured 50000)
-  //   fixed:  maxBatchBuffers stays at ~rows-per-batch (~1024)
-  //
-  // kSize/10 (== 5000) leaves a comfortable margin around the fixed value
-  // while staying well under the broken value, so the test won't go flaky if
-  // the default output batch size shifts modestly.
+  // Broken: maxBatchBuffers ~ kSize (50000). Fixed: ~rows-per-batch (~1024).
   EXPECT_LT(maxBatchBuffers, static_cast<size_t>(kSize / 10))
-      << "lag-column stringBuffers grew across batches (cumulative): "
-      << maxBatchBuffers << " >= " << kSize / 10
-      << ". This indicates defaultValues_->stringBuffers_ is accumulating "
-      << "across partitions -- check that LeadLagFunction::setDefaultValue "
-      << "and setConstantTargetValue still call defaultValues_->prepareForReuse() "
-      << "before extractColumn.";
+      << "defaultValues_->stringBuffers_ is accumulating across partitions; "
+      << "check that setDefaultValue / setConstantTargetValue call "
+      << "defaultValues_->prepareForReuse() before extractColumn.";
 }
 
 // DuckDB has errors in IGNORE NULLS logic for empty

--- a/bolt/functions/prestosql/window/tests/LeadLagTest.cpp
+++ b/bolt/functions/prestosql/window/tests/LeadLagTest.cpp
@@ -31,6 +31,7 @@
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/QueryConfig.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
+#include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/functions/lib/window/tests/WindowTestBase.h"
 #include "bolt/functions/prestosql/window/WindowFunctionsRegistration.h"
 using namespace bytedance::bolt::exec::test;
@@ -538,6 +539,182 @@ TEST_P(LeadLagTest, emptyFrames) {
 BOLT_INSTANTIATE_TEST_SUITE_P(LagTest, LeadLagTest, ::testing::Values("lag"));
 
 BOLT_INSTANTIATE_TEST_SUITE_P(LeadTest, LeadLagTest, ::testing::Values("lead"));
+
+// Regression test for an O(N^2) slowdown observed when LAG runs over a query
+// shape like:
+//
+//   lag(varchar_col, 1, default_varchar_col) over (partition by k order by ...)
+//
+// against many small (here single-row) partitions whose VARCHAR values are
+// stored out-of-line -- i.e. each value is longer than 12 bytes, so it does
+// not fit in StringView's inline storage and must point into an external
+// string buffer. Production hit this with timestamp-shaped strings such as
+// '2026-01-01 23:59:59' (19 bytes).
+//
+// Mechanism the fix is guarding against:
+//
+//   1. For each partition, LeadLagFunction::setDefaultValue extracts the
+//      partition's default-value rows into the reusable member vector
+//      `defaultValues_`. extractColumn allocates a string buffer inside
+//      `defaultValues_` to hold those bytes.
+//
+//   2. setDefaultValue then calls `result->copy(defaultValues_, ...)`. For
+//      same-pool VARCHAR copies this routes through
+//      FlatVector::acquireSharedStringBuffers, which makes `result` take a
+//      shared ref to every buffer currently in
+//      `defaultValues_->stringBuffers_`.
+//
+//   3. On the next partition, the buffer in `defaultValues_` is no longer
+//      unique (refcount==2: held by both `defaultValues_` and `result`), so
+//      getBufferWithSpace cannot reuse it. It allocates a new buffer and
+//      appends it to `defaultValues_->stringBuffers_` -- the old buffer is
+//      never removed because it is still referenced by `result`.
+//
+//   4. `defaultValues_->stringBuffers_` therefore grows by one entry per
+//      partition. Each subsequent `result->copy(defaultValues_, ...)` iterates
+//      that whole list inside acquireSharedStringBuffers, giving O(N^2) work
+//      across N partitions.
+//
+// The fix calls `defaultValues_->prepareForReuse()` before each extract, which
+// drops the now-non-unique buffer from `defaultValues_` (the bytes it owns are
+// kept alive via the ref still held by `result`). That keeps
+// `defaultValues_->stringBuffers_` bounded at one entry, returning the per-call
+// acquireSharedStringBuffers walk to O(1).
+//
+// What this test asserts:
+//
+//   The Window operator emits output in batches of `numRowsPerOutput_` rows
+//   (~1024 by default). Within one batch, `result->stringBuffers_` accumulates
+//   the union of all distinct buffers it has acquired from `defaultValues_`.
+//   Because acquireSharedStringBuffers copies *every* entry of
+//   `defaultValues_->stringBuffers_`, in the broken version that union grows
+//   monotonically across batches: batch i's `result` ends up with roughly
+//   i * (rows-per-batch) buffers. We empirically observed on the broken
+//   version: 11264, 21504, 31744, 41984, 50000.
+//
+//   With the fix, `defaultValues_->stringBuffers_` is bounded at 1, so the
+//   only buffers a batch's `result` acquires are the ones produced by the
+//   partitions in that very batch -- bounded by the batch row count
+//   (~1024 in our case).
+//
+//   So `maxBatchBuffers` distinguishes the two cleanly: it scales with kSize
+//   when broken and with rows-per-batch when fixed. The threshold below
+//   (kSize / 10 = 5000) sits comfortably above ~1024 (a few batches' worth of
+//   slack) and far below kSize (50000), so it tolerates batch-sizing changes
+//   while still firing on regressions.
+TEST_F(LeadLagTest, manySingleRowVarcharPartitions) {
+  // Each row is its own partition, so callApplyForPartitionRows runs kSize
+  // times against the LAG function -- amplifying the per-partition O(N) walk
+  // in the broken version into a clearly visible O(N^2) total.
+  constexpr vector_size_t kSize = 50'000;
+
+  // Materialize the value/default strings into long-lived std::strings so the
+  // StringViews we hand to makeFlatVector point at stable memory while
+  // FlatVector::set copies them into its own string buffer. (The
+  // StringView(std::string&&) constructor is deleted precisely to catch the
+  // dangling-temporary mistake, so we cannot use fmt::format directly inline.)
+  std::vector<std::string> valueStrings(kSize);
+  std::vector<std::string> defaultStrings(kSize);
+  for (vector_size_t row = 0; row < kSize; ++row) {
+    // 19 chars -- exceeds StringView's 12-byte inline limit, forcing each
+    // value to live in an external buffer. This is what makes the
+    // acquireSharedStringBuffers path relevant.
+    valueStrings[row] = fmt::format(
+        "2026-01-01 {:02d}:{:02d}:{:02d}",
+        (row / 3600) % 24,
+        (row / 60) % 60,
+        row % 60);
+    defaultStrings[row] = fmt::format(
+        "2026-12-31 {:02d}:{:02d}:{:02d}",
+        (row / 3600) % 24,
+        (row / 60) % 60,
+        row % 60);
+  }
+
+  // Schema: c0 = unique partition key, c1 = LAG value column,
+  // c2 = LAG per-row default (variable -- routes setDefaultValue through the
+  // `defaultValueIndex_` branch where the `defaultValues_` accumulation bug
+  // lives, not the constant-default branch).
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kSize, [](auto row) { return row; }),
+      makeFlatVector<StringView>(
+          kSize, [&](auto row) { return StringView(valueStrings[row]); }),
+      makeFlatVector<StringView>(
+          kSize, [&](auto row) { return StringView(defaultStrings[row]); }),
+  });
+
+  auto queryInfo = buildWindowQuery(
+      {data}, "lag(c1, 1, c2)", "partition by c0 order by c1 desc", "");
+
+  // We must observe the *raw* per-batch FlatVector that the Window operator
+  // emits. AssertQueryBuilder::copyResults concatenates batches into a fresh
+  // RowVector created in the test's pool; that copy goes through
+  // FlatVector<StringView>::copyRanges' cross-pool path, which writes via
+  // setStringViewValue and re-chunks into the result's own 32 KB buffers --
+  // hiding the per-batch buffer count we want to assert on.
+  //
+  // Driving with TaskCursor + `copyResult=false` skips the queue-side copy
+  // and hands us the operator's own RowVector, so `lagColumn->stringBuffers()`
+  // reports exactly what the Window operator produced.
+  exec::test::CursorParameters params;
+  params.planNode = queryInfo.planNode;
+  params.copyResult = false;
+  auto cursor = exec::test::TaskCursor::create(params);
+
+  auto start = std::chrono::steady_clock::now();
+  size_t totalRows = 0;
+  size_t maxBatchBuffers = 0;
+  size_t numBatches = 0;
+  while (cursor->moveNext()) {
+    auto batch = cursor->current();
+    // Output schema is the input columns followed by one column per window
+    // function. We have a single LAG, so it's the last child.
+    auto* lagColumn = batch->childAt(batch->childrenSize() - 1)
+                          ->asUnchecked<FlatVector<StringView>>();
+    maxBatchBuffers =
+        std::max(maxBatchBuffers, lagColumn->stringBuffers().size());
+
+    // Spot-check correctness while we're here: every row sits in its own
+    // size-1 partition with offset=1, so LAG always falls back to the per-row
+    // default (c2 = defaultStrings[row]).
+    for (vector_size_t i = 0; i < batch->size(); ++i) {
+      ASSERT_FALSE(lagColumn->isNullAt(i));
+      ASSERT_EQ(
+          lagColumn->valueAt(i), StringView(defaultStrings[totalRows + i]));
+    }
+    totalRows += batch->size();
+    ++numBatches;
+  }
+  auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - start)
+                       .count();
+
+  ASSERT_EQ(totalRows, kSize);
+  // Diagnostic line; not part of the assertion, but useful when triaging
+  // future regressions to know whether the slowdown shows up in elapsed
+  // time, in buffer count, or both.
+  std::cout << "[manySingleRowVarcharPartitions] rows=" << kSize
+            << " batches=" << numBatches
+            << " maxBatchBuffers=" << maxBatchBuffers
+            << " elapsed=" << elapsedMs << "ms" << std::endl;
+
+  // The actual regression check. See the long comment above for why this
+  // metric distinguishes the broken and fixed code:
+  //
+  //   broken: maxBatchBuffers grows toward kSize (we measured 50000)
+  //   fixed:  maxBatchBuffers stays at ~rows-per-batch (~1024)
+  //
+  // kSize/10 (== 5000) leaves a comfortable margin around the fixed value
+  // while staying well under the broken value, so the test won't go flaky if
+  // the default output batch size shifts modestly.
+  EXPECT_LT(maxBatchBuffers, static_cast<size_t>(kSize / 10))
+      << "lag-column stringBuffers grew across batches (cumulative): "
+      << maxBatchBuffers << " >= " << kSize / 10
+      << ". This indicates defaultValues_->stringBuffers_ is accumulating "
+      << "across partitions -- check that LeadLagFunction::setDefaultValue "
+      << "and setConstantTargetValue still call defaultValues_->prepareForReuse() "
+      << "before extractColumn.";
+}
 
 // DuckDB has errors in IGNORE NULLS logic for empty
 // frames (tested above). So using non-empty frames.


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #533 

LeadLagFunction keeps a reusable vector member, defaultValues_, used to extract per-partition default-value rows before copying them into the output:

https://github.com/bytedance/bolt/blob/facc036f4b8ce5cea63ddf1b388ef1c598452387/bolt/functions/prestosql/window/LeadLag.cpp#L462-L478

  Step by step, the broken interaction goes:

  1. Partition 1 — extractColumn allocates a string buffer inside defaultValues_->stringBuffers_ and writes the default's bytes into it.
  2. result->copy(defaultValues_, …) for VARCHAR in the same memory pool routes through FlatVector::copyRanges → acquireSharedStringBuffers(defaultValues_), which makes result take a BufferPtr ref to that buffer. The buffer's refcount is now 2 (defaultValues_ + result).
  3. Partition 2 — extractColumn calls getBufferWithSpace, which only reuses the last buffer when buffer->unique() is true. It is now false, so a new buffer is allocated and appended to defaultValues_->stringBuffers_. The old buffer is never removed because defaultValues_ still holds it.
  4. result->copy(defaultValues_, …) calls acquireSharedStringBuffers, which iterates the entire defaultValues_->stringBuffers_ list and adds every entry to result's stringBufferSet_.

  After N partitions, defaultValues_->stringBuffers_ has N entries, every result->copy walks all N → O(N²) total work in the number of partitions.


### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description


  Fix

  Drop defaultValues_'s now-non-unique buffers before each new partition's extract. FlatVector::prepareForReuse does exactly this — its keepAtMostOneStringBuffer helper checks unique(), and a buffer that has been pinned by result is not unique, so it is removed from defaultValues_'s list (the bytes stay alive via result's ref).

New added UT cost reduce from 5211 ms to 158 ms.

Original spark job now finished in 5min 51s compared with 9min 59s in spark vanilla.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
