### PR TITLE
fix: license check bugs

### DIFF
--- a/.github/license_check/check_license.go
+++ b/.github/license_check/check_license.go
@@ -99,5 +99,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	for file := range result.Failure {
+		header.Fix(result.Failure[file], licenseHeaderConfig, &result)
+	}
+
+	if result.HasFailure() {
+		fmt.Printf("[ERROR] the following files don't have a valid license header:\n")
+		for _, f := range result.Failure {
+			fmt.Printf("  %s\n", f)
+		}
+		os.Exit(1)
+	}
+
 	fmt.Printf("[INFO] License check passed successfully\n")
+	os.Exit(0)
 }

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -69,22 +69,21 @@ header:
       distributed under the License is distributed on an "AS IS" BASIS,
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.
       See the License for the specific language governing permissions and
-      limitations under the License\.)|(SPDX-License-Identifier: Apache-2\.0
-      )|(This code is released under the
-      Apache License Version 2.0 http://www.apache.org/licenses/.
+      limitations under the License\.)|(This code is released under the
+      Apache License Version 2.0 http:\/\/www.apache.org\/licenses\/.
 
-      (c) Daniel Lemire, http://lemire.me/en/
+      (c) Daniel Lemire, http:\/\/lemire.me\/en\/
 
       --------------------------------------------------------------------------
-      Copyright (c) ByteDance Ltd. and/or its affiliates.
+      Copyright (c) ByteDance Ltd. and\/or its affiliates.
       SPDX-License-Identifier: Apache-2.0
 
-      This file has been modified by ByteDance Ltd. and/or its affiliates on
+      This file has been modified by ByteDance Ltd. and\/or its affiliates on
       2025-11-11.
 
       Original file was released under the Apache License 2.0,
       with the full license text available at:
-          http://www.apache.org/licenses/LICENSE-2.0
+          http:\/\/www.apache.org\/licenses\/LICENSE-2.0
 
       This modified file is released under the same license.
       --------------------------------------------------------------------------
@@ -115,6 +114,8 @@ header:
     - 'LICENSE'
     - 'MANIFEST.in'
     - 'scripts/conan/patches/**'
+    - '.codespellrc'
+    - 'bolt/substrait/proto/**/*.proto'
 
   comment: on-failure
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
         entry: go run -C .github/license_check check_license.go
         language: golang
         pass_filenames: true
+        require_serial: true
       - id: clang-tidy
         name: Lint C++ files
         description: >-

--- a/bolt/connectors/ConnectorObjectFactory.cpp
+++ b/bolt/connectors/ConnectorObjectFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) International Business Machines Corporation
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bolt/connectors/ConnectorObjectFactory.h
+++ b/bolt/connectors/ConnectorObjectFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) International Business Machines Corporation
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include <shared_mutex>

--- a/bolt/connectors/ConnectorOptions.h
+++ b/bolt/connectors/ConnectorOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) International Business Machines Corporation
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include <initializer_list>

--- a/bolt/connectors/hive/HiveObjectFactory.cpp
+++ b/bolt/connectors/hive/HiveObjectFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) International Business Machines Corporation
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "bolt/connectors/hive/HiveObjectFactory.h"
 
 #include <string>

--- a/bolt/connectors/hive/HiveObjectFactory.h
+++ b/bolt/connectors/hive/HiveObjectFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) International Business Machines Corporation
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "bolt/connectors/ConnectorNames.h"

--- a/bolt/connectors/hive/tests/HiveObjectFactoryTest.cpp
+++ b/bolt/connectors/hive/tests/HiveObjectFactoryTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) International Business Machines Corporation
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <folly/dynamic.h>
 #include <gtest/gtest.h>
 

--- a/bolt/connectors/hive/tests/HiveRowIndexTest.cpp
+++ b/bolt/connectors/hive/tests/HiveRowIndexTest.cpp
@@ -1,6 +1,17 @@
 /*
- * Copyright (c) ByteDance Ltd. and/or its affiliates
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/common/memory/Memory.h"

--- a/bolt/dwio/common/tests/RowIndexScanSpecTest.cpp
+++ b/bolt/dwio/common/tests/RowIndexScanSpecTest.cpp
@@ -1,6 +1,17 @@
 /*
- * Copyright (c) ByteDance Ltd. and/or its affiliates
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/dwio/common/ScanSpec.h"

--- a/bolt/dwio/parquet/reader/VariantColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/VariantColumnReader.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/dwio/parquet/reader/VariantColumnReader.h"

--- a/bolt/dwio/parquet/reader/VariantColumnReader.h
+++ b/bolt/dwio/parquet/reader/VariantColumnReader.h
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/bolt/exec/VariantSerdeDetail.h
+++ b/bolt/exec/VariantSerdeDetail.h
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/bolt/functions/sparksql/VariantEncoding.cpp
+++ b/bolt/functions/sparksql/VariantEncoding.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/functions/sparksql/VariantEncoding.h"

--- a/bolt/functions/sparksql/VariantEncoding.h
+++ b/bolt/functions/sparksql/VariantEncoding.h
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/bolt/functions/sparksql/VariantFunctions.h
+++ b/bolt/functions/sparksql/VariantFunctions.h
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/bolt/functions/sparksql/benchmarks/UnixTimestampBenchmark.cpp
+++ b/bolt/functions/sparksql/benchmarks/UnixTimestampBenchmark.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bolt/functions/sparksql/registration/RegisterVariant.cpp
+++ b/bolt/functions/sparksql/registration/RegisterVariant.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/functions/lib/RegistrationHelpers.h"

--- a/bolt/functions/sparksql/tests/VariantFunctionTest.cpp
+++ b/bolt/functions/sparksql/tests/VariantFunctionTest.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/bolt/type/VariantValue.h
+++ b/bolt/type/VariantValue.h
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/bolt/type/tests/VariantTypeTest.cpp
+++ b/bolt/type/tests/VariantTypeTest.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <gtest/gtest.h>

--- a/bolt/vector/VariantVector.cpp
+++ b/bolt/vector/VariantVector.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/vector/VariantVector.h"

--- a/bolt/vector/VariantVector.h
+++ b/bolt/vector/VariantVector.h
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once

--- a/bolt/vector/tests/VariantVectorTest.cpp
+++ b/bolt/vector/tests/VariantVectorTest.cpp
@@ -1,6 +1,17 @@
 /*
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "bolt/vector/VariantVector.h"


### PR DESCRIPTION
### What problem does this PR solve?

- Disallow SPDX-Identifier header to enforce full license in header
- fix issue in check_license.go which silently passed non-compliant headers
- Automatically apply correct license header to non-compliant files. This is the same as the clang-format check.
- Update pre-commit-config ignore list with files who were vendored into bolt without modifications and retain their Apache 2.0 SPDX header or don't require a header at all

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The license header check was not behaving correctly.
