### PR TITLE
[fix][cp] Use mutex lock to protect cache shutdown

### DIFF
--- a/bolt/common/caching/AsyncDataCache.cpp
+++ b/bolt/common/caching/AsyncDataCache.cpp
@@ -682,6 +682,9 @@ void AsyncDataCache::shutdown() {
   for (auto& shard : shards_) {
     shard->shutdown();
   }
+  if (ssdCache_) {
+    ssdCache_->shutdown();
+  }
 }
 
 void CacheShard::shutdown() {

--- a/bolt/common/caching/SsdCache.cpp
+++ b/bolt/common/caching/SsdCache.cpp
@@ -163,7 +163,7 @@ bool SsdCache::removeFileEntries(
       success &= files_[i]->removeFileEntries(filesToRemove, filesRetained);
     } catch (const std::exception& e) {
       BOLT_SSD_CACHE_LOG(ERROR) << "Error removing file entries from SSD shard "
-                               << files_[i]->shardId() << ": " << e.what();
+                                << files_[i]->shardId() << ": " << e.what();
       success = false;
     }
     --writesInProgress_;

--- a/bolt/common/caching/SsdCache.cpp
+++ b/bolt/common/caching/SsdCache.cpp
@@ -61,7 +61,7 @@ SsdCache::SsdCache(
       "Ssd path '{}' does not start with '/' that points to local file system.",
       filePrefix_);
   filesystems::getFileSystem(filePrefix_, nullptr)
-      ->mkdir(std::filesystem::path(filePrefix).parent_path().string());
+      ->mkdir(std::filesystem::path(filePrefix_).parent_path().string());
 
   files_.reserve(numShards_);
   // Cache size must be a multiple of this so that each shard has the same max
@@ -74,7 +74,8 @@ SsdCache::SsdCache(
         i,
         fileMaxRegions,
         checkpointIntervalBytes / numShards,
-        disableFileCow));
+        disableFileCow,
+        executor_));
   }
 }
 
@@ -84,20 +85,19 @@ SsdFile& SsdCache::file(uint64_t fileId) {
 }
 
 bool SsdCache::startWrite() {
-  if (isShutdown_) {
-    return false;
-  }
-  if (writesInProgress_.fetch_add(numShards_) == 0) {
+  std::lock_guard<std::mutex> l(mutex_);
+  checkNotShutdownLocked();
+  if (writesInProgress_ == 0) {
     // No write was pending, so now all shards are counted as writing.
+    writesInProgress_ += numShards_;
     return true;
   }
-  // There were writes in progress, so compensate for the increment.
-  writesInProgress_.fetch_sub(numShards_);
+  BOLT_CHECK_GE(writesInProgress_, 0);
   return false;
 }
 
 void SsdCache::write(std::vector<CachePin> pins) {
-  BOLT_CHECK_LE(numShards_, writesInProgress_);
+  BOLT_CHECK_EQ(numShards_, writesInProgress_);
 
   BOLT_TEST_ADJUST("bytedance::bolt::cache::SsdCache::write", this);
 
@@ -163,12 +163,11 @@ bool SsdCache::removeFileEntries(
       success &= files_[i]->removeFileEntries(filesToRemove, filesRetained);
     } catch (const std::exception& e) {
       BOLT_SSD_CACHE_LOG(ERROR) << "Error removing file entries from SSD shard "
-                                << files_[i]->shardId() << ": " << e.what();
+                               << files_[i]->shardId() << ": " << e.what();
       success = false;
     }
     --writesInProgress_;
   }
-
   return success;
 }
 
@@ -178,12 +177,6 @@ SsdCacheStats SsdCache::stats() const {
     file->updateStats(stats);
   }
   return stats;
-}
-
-void SsdCache::clear() {
-  for (auto& file : files_) {
-    file->clear();
-  }
 }
 
 std::string SsdCache::toString() const {
@@ -198,20 +191,44 @@ std::string SsdCache::toString() const {
   return out.str();
 }
 
-void SsdCache::testingDeleteFiles() {
-  for (auto& file : files_) {
-    file->deleteFile();
-  }
-}
-
 void SsdCache::shutdown() {
-  isShutdown_ = true;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (shutdown_) {
+      BOLT_SSD_CACHE_LOG(INFO) << "SSD cache has already been shutdown";
+    }
+    shutdown_ = true;
+  }
+
+  BOLT_SSD_CACHE_LOG(INFO) << "SSD cache is shutting down";
   while (writesInProgress_) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
   }
   for (auto& file : files_) {
     file->checkpoint(true);
   }
+  BOLT_SSD_CACHE_LOG(INFO) << "SSD cache has been shutdown";
+}
+
+void SsdCache::testingClear() {
+  for (auto& file : files_) {
+    file->testingClear();
+  }
+}
+
+void SsdCache::testingDeleteFiles() {
+  for (auto& file : files_) {
+    file->testingDeleteFile();
+  }
+}
+
+uint64_t SsdCache::testingTotalLogEvictionFilesSize() {
+  uint64_t size = 0;
+  for (auto& file : files_) {
+    std::filesystem::path p{file->getEvictLogFilePath()};
+    size += std::filesystem::file_size(p);
+  }
+  return size;
 }
 
 } // namespace bytedance::bolt::cache

--- a/bolt/common/caching/SsdCache.h
+++ b/bolt/common/caching/SsdCache.h
@@ -106,10 +106,13 @@ class SsdCache {
   /// Drops all entries. Outstanding pins become invalid but reading them will
   /// mostly succeed since the files will not be rewritten until new content is
   /// stored.
-  void clear();
+  void testingClear();
 
   /// Deletes backing files. Used in testing.
   void testingDeleteFiles();
+
+  /// Returns the total size of eviction log files. Used in testing.
+  uint64_t testingTotalLogEvictionFilesSize();
 
   /// Stops writing to the cache files and waits for pending writes to finish.
   /// If checkpointing is on, makes a checkpoint.
@@ -117,18 +120,29 @@ class SsdCache {
 
   std::string toString() const;
 
+  const std::string& filePrefix() const {
+    return filePrefix_;
+  }
+
  private:
+  void checkNotShutdownLocked() {
+    BOLT_CHECK(
+        !shutdown_, "Unexpected write after SSD cache has been shutdown");
+  }
+
   const std::string filePrefix_;
   const int32_t numShards_;
+
+  // Stats for selecting entries to save from AsyncDataCache.
+  const std::unique_ptr<FileGroupStats> groupStats_;
+  folly::Executor* const executor_;
+  mutable std::mutex mutex_;
+
   std::vector<std::unique_ptr<SsdFile>> files_;
 
   // Count of shards with unfinished writes.
   std::atomic<int32_t> writesInProgress_{0};
-
-  // Stats for selecting entries to save from AsyncDataCache.
-  std::unique_ptr<FileGroupStats> groupStats_;
-  folly::Executor* executor_;
-  std::atomic<bool> isShutdown_{false};
+  bool shutdown_{false};
 };
 
 } // namespace bytedance::bolt::cache

--- a/bolt/common/caching/SsdFile.cpp
+++ b/bolt/common/caching/SsdFile.cpp
@@ -35,6 +35,7 @@
 #include "bolt/common/base/SuccinctPrinter.h"
 #include "bolt/common/caching/FileIds.h"
 #include "bolt/common/caching/SsdCache.h"
+#include "bolt/common/process/TraceContext.h"
 
 #include <fcntl.h>
 #ifdef linux
@@ -51,28 +52,6 @@ DEFINE_bool(ssd_verify_write, false, "Read back data after writing to SSD");
 namespace bytedance::bolt::cache {
 
 namespace {
-// TODO: Remove this function once we migrate all files to velox fs.
-void disableFileCow(int32_t fd) {
-#ifdef linux
-  int attr{0};
-  auto res = ioctl(fd, FS_IOC_GETFLAGS, &attr);
-  BOLT_CHECK_EQ(
-      0,
-      res,
-      "ioctl(FS_IOC_GETFLAGS) failed: {}, {}",
-      res,
-      folly::errnoStr(errno));
-  attr |= FS_NOCOW_FL;
-  res = ioctl(fd, FS_IOC_SETFLAGS, &attr);
-  BOLT_CHECK_EQ(
-      0,
-      res,
-      "ioctl(FS_IOC_SETFLAGS, FS_NOCOW_FL) failed: {}, {}",
-      res,
-      folly::errnoStr(errno));
-#endif // linux
-}
-
 void addEntryToIovecs(AsyncDataCacheEntry& entry, std::vector<iovec>& iovecs) {
   if (entry.tinyData() != nullptr) {
     iovecs.push_back({entry.tinyData(), static_cast<size_t>(entry.size())});
@@ -144,7 +123,6 @@ SsdFile::SsdFile(
   process::TraceContext trace("SsdFile::SsdFile");
   filesystems::FileOptions fileOptions;
   fileOptions.shouldThrowOnFileAlreadyExists = false;
-  fileOptions.bufferWrite = !FLAGS_ssd_odirect;
   writeFile_ = fs_->openFileForWrite(fileName_, fileOptions);
   readFile_ = fs_->openFileForRead(fileName_);
 
@@ -166,7 +144,7 @@ SsdFile::SsdFile(
   }
 
   if (disableFileCow) {
-    disableFileCow();
+    this->disableFileCow();
   }
 }
 
@@ -499,6 +477,7 @@ void SsdFile::updateStats(SsdCacheStats& stats) const {
   stats.bytesRead += stats_.bytesRead;
   stats.entriesCached += entries_.size();
   stats.regionsCached += numRegions_;
+  stats.regionsEvicted += stats_.regionsEvicted;
   for (auto i = 0; i < numRegions_; i++) {
     stats.bytesCached += (regionSizes_[i] - erasedRegionSizes_[i]);
   }
@@ -538,8 +517,8 @@ void SsdFile::testingDeleteFile() {
     fs_->remove(fileName_);
   } catch (const std::exception& e) {
     BOLT_SSD_CACHE_LOG(ERROR) << "Failed to delete cache file " << fileName_
-                             << ", error code: " << errno
-                             << ", error string: " << folly::errnoStr(errno);
+                              << ", error code: " << errno
+                              << ", error string: " << folly::errnoStr(errno);
   }
 }
 
@@ -561,7 +540,7 @@ bool SsdFile::removeFileEntries(
     const FileCacheKey& cacheKey = it->first;
     const SsdRun& ssdRun = it->second;
 
-    if (!cacheKey.fileNum.has_value()) {
+    if (!cacheKey.fileNum.hasValue()) {
       ++it;
       continue;
     }
@@ -759,8 +738,8 @@ void SsdFile::checkpoint(bool force) {
       }
       state.close();
 
-      // Sync checkpoint data file. ofstream does not have a sync method, so open
-      // as fd and sync that.
+      // Sync checkpoint data file. ofstream does not have a sync method, so
+      // open as fd and sync that.
       const auto checkpointFd = checkRc(
           ::open(checkpointPath.c_str(), O_WRONLY),
           "Open of checkpoint file for sync");
@@ -776,14 +755,18 @@ void SsdFile::checkpoint(bool force) {
     } catch (const std::exception& e) {
       try {
         checkpointError(-1, e.what());
-      } catch (const std::exception&) {
+      } catch (const std::exception& nested) {
+        BOLT_SSD_CACHE_LOG(WARNING)
+            << "Ignoring nested checkpoint error: " << nested.what();
       }
       // Ignore nested exception.
     }
   } catch (const std::exception& e) {
     try {
       checkpointError(-1, e.what());
-    } catch (const std::exception&) {
+    } catch (const std::exception& nested) {
+      BOLT_SSD_CACHE_LOG(WARNING)
+          << "Ignoring nested checkpoint error: " << nested.what();
     }
     // Ignore nested exception.
   }
@@ -822,10 +805,12 @@ void SsdFile::initializeCheckpoint() {
     ++stats_.readCheckpointErrors;
     try {
       BOLT_SSD_CACHE_LOG(ERROR) << "Error recovering from checkpoint "
-                               << e.what() << ": Starting without checkpoint";
+                                << e.what() << ": Starting without checkpoint";
       entries_.clear();
       deleteCheckpoint(true);
-    } catch (const std::exception&) {
+    } catch (const std::exception& nested) {
+      BOLT_SSD_CACHE_LOG(WARNING)
+          << "Ignoring nested checkpoint recovery error: " << nested.what();
     }
   }
 }

--- a/bolt/common/caching/SsdFile.cpp
+++ b/bolt/common/caching/SsdFile.cpp
@@ -153,7 +153,7 @@ SsdFile::SsdFile(
   BOLT_CHECK_GE(
       fd_,
       0,
-      "Cannot open or create {}. Error: {}",
+      "Could not open or create {}. Error: {}",
       filename,
       folly::errnoStr(errno));
 
@@ -175,10 +175,10 @@ SsdFile::SsdFile(
   writableRegions_.resize(numRegions_);
   std::iota(writableRegions_.begin(), writableRegions_.end(), 0);
   tracker_.resize(maxRegions_);
-  regionSizes_.resize(maxRegions_);
-  erasedRegionSizes_.resize(maxRegions_);
-  regionPins_.resize(maxRegions_);
-  if (checkpointIntervalBytes_) {
+  regionSizes_.resize(maxRegions_, 0);
+  erasedRegionSizes_.resize(maxRegions_, 0);
+  regionPins_.resize(maxRegions_, 0);
+  if (checkpointEnabled()) {
     initializeCheckpoint();
   }
 }
@@ -353,7 +353,8 @@ bool SsdFile::growOrEvictLocked() {
 
 void SsdFile::clearRegionEntriesLocked(const std::vector<int32_t>& regions) {
   std::unordered_set<int32_t> regionSet{regions.begin(), regions.end()};
-  // Remove all 'entries_' where the dependent points one of 'regionIndices'.
+  // Remove all 'entries_' that reference data in regions described by
+  // 'regionIndices'.
   auto it = entries_.begin();
   while (it != entries_.end()) {
     const auto region = regionIndex(it->second.offset());
@@ -439,8 +440,7 @@ void SsdFile::write(std::vector<CachePin>& pins) {
     storeIndex += numWritten;
   }
 
-  if ((checkpointIntervalBytes_ > 0) &&
-      (bytesAfterCheckpoint_ >= checkpointIntervalBytes_)) {
+  if (checkpointEnabled()) {
     checkpoint();
   }
 }
@@ -460,9 +460,9 @@ void SsdFile::verifyWrite(AsyncDataCacheEntry& entry, SsdRun ssdRun) {
   auto testData = std::make_unique<char[]>(entry.size());
   const auto rc = ::pread(fd_, testData.get(), entry.size(), ssdRun.offset());
   BOLT_CHECK_EQ(rc, entry.size());
-  if (entry.tinyData() != 0) {
+  if (entry.tinyData() != nullptr) {
     if (::memcmp(testData.get(), entry.tinyData(), entry.size()) != 0) {
-      BOLT_FAIL("bad read back");
+      BOLT_FAIL("Bad read back");
     }
   } else {
     const auto& data = entry.data();
@@ -476,8 +476,8 @@ void SsdFile::verifyWrite(AsyncDataCacheEntry& entry, SsdRun ssdRun) {
       if (badIndex != -1) {
         BOLT_FAIL("Bad read back");
       }
-      bytesLeft -= run.numBytes();
-      offset += run.numBytes();
+      bytesLeft -= compareSize;
+      offset += compareSize;
       if (bytesLeft <= 0) {
         break;
       };
@@ -515,7 +515,7 @@ void SsdFile::updateStats(SsdCacheStats& stats) const {
   stats.readCheckpointErrors += stats_.readCheckpointErrors;
 }
 
-void SsdFile::clear() {
+void SsdFile::testingClear() {
   std::lock_guard<std::shared_mutex> l(mutex_);
   entries_.clear();
   std::fill(regionSizes_.begin(), regionSizes_.end(), 0);
@@ -524,7 +524,8 @@ void SsdFile::clear() {
   std::iota(writableRegions_.begin(), writableRegions_.end(), 0);
 }
 
-void SsdFile::deleteFile() {
+void SsdFile::testingDeleteFile() {
+  process::TraceContext trace("SsdFile::testingDeleteFile");
   if (fd_) {
     close(fd_);
     fd_ = 0;
@@ -554,7 +555,7 @@ bool SsdFile::removeFileEntries(
     const FileCacheKey& cacheKey = it->first;
     const SsdRun& ssdRun = it->second;
 
-    if (!cacheKey.fileNum.hasValue()) {
+    if (!cacheKey.fileNum.has_value()) {
       ++it;
       continue;
     }
@@ -603,7 +604,7 @@ bool SsdFile::removeFileEntries(
 }
 
 void SsdFile::logEviction(const std::vector<int32_t>& regions) {
-  if (checkpointIntervalBytes_ > 0) {
+  if (checkpointEnabled()) {
     const int32_t rc = ::write(
         evictLogFd_, regions.data(), regions.size() * sizeof(regions[0]));
     if (rc != regions.size() * sizeof(regions[0])) {
@@ -628,12 +629,12 @@ void SsdFile::deleteCheckpoint(bool keepLog) {
   }
 
   checkpointDeleted_ = true;
-  const auto logPath = fileName_ + kLogExtension;
+  const auto logPath = getEvictLogFilePath();
   int32_t logRc = 0;
   if (!keepLog) {
     logRc = ::unlink(logPath.c_str());
   }
-  const auto checkpointPath = fileName_ + kCheckpointExtension;
+  const auto checkpointPath = getCheckpointFilePath();
   const auto checkpointRc = ::unlink(checkpointPath.c_str());
   if ((logRc != 0) || (checkpointRc != 0)) {
     ++stats_.deleteCheckpointErrors;
@@ -665,7 +666,7 @@ inline const char* asChar(const T* ptr) {
 
 void SsdFile::checkpoint(bool force) {
   std::lock_guard<std::shared_mutex> l(mutex_);
-  if (!force && (bytesAfterCheckpoint_ < checkpointIntervalBytes_)) {
+  if (!needCheckpoint(force)) {
     return;
   }
 
@@ -695,75 +696,83 @@ void SsdFile::checkpoint(bool force) {
     };
 
     std::ofstream state;
-    auto checkpointPath = fileName_ + kCheckpointExtension;
-    state.exceptions(std::ofstream::failbit);
-    state.open(checkpointPath, std::ios_base::out | std::ios_base::trunc);
-    // The checkpoint state file contains:
-    // int32_t The 4 bytes of kCheckpointMagic,
-    // int32_t maxRegions,
-    // int32_t numRegions,
-    // regionScores from the 'tracker_',
-    // {fileId, fileName} pairs,
-    // kMapMarker,
-    // {fileId, offset, SSdRun} triples,
-    // kEndMarker.
-    state.write(kCheckpointMagic, sizeof(int32_t));
-    state.write(asChar(&maxRegions_), sizeof(maxRegions_));
-    state.write(asChar(&numRegions_), sizeof(numRegions_));
+    const auto checkpointPath = getCheckpointFilePath();
+    try {
+      state.exceptions(std::ofstream::failbit);
+      state.open(checkpointPath, std::ios_base::out | std::ios_base::trunc);
+      // The checkpoint state file contains:
+      // int32_t The 4 bytes of kCheckpointMagic,
+      // int32_t maxRegions,
+      // int32_t numRegions,
+      // regionScores from the 'tracker_',
+      // {fileId, fileName} pairs,
+      // kMapMarker,
+      // {fileId, offset, SSdRun} triples,
+      // kEndMarker.
+      state.write(kCheckpointMagic, sizeof(int32_t));
+      state.write(asChar(&maxRegions_), sizeof(maxRegions_));
+      state.write(asChar(&numRegions_), sizeof(numRegions_));
 
-    // Copy the region scores before writing out for tsan.
-    const auto scoresCopy = tracker_.copyScores();
-    state.write(asChar(scoresCopy.data()), maxRegions_ * sizeof(uint64_t));
-    std::unordered_set<uint64_t> fileNums;
-    for (const auto& entry : entries_) {
-      const auto fileNum = entry.first.fileNum.id();
-      if (fileNums.insert(fileNum).second) {
-        state.write(asChar(&fileNum), sizeof(fileNum));
-        const auto name = fileIds().string(fileNum);
-        const int32_t length = name.size();
-        state.write(asChar(&length), sizeof(length));
-        state.write(name.data(), length);
+      // Copy the region scores before writing out for tsan.
+      const auto scoresCopy = tracker_.copyScores();
+      state.write(asChar(scoresCopy.data()), maxRegions_ * sizeof(uint64_t));
+      std::unordered_set<uint64_t> fileNums;
+      for (const auto& entry : entries_) {
+        const auto fileNum = entry.first.fileNum.id();
+        if (fileNums.insert(fileNum).second) {
+          state.write(asChar(&fileNum), sizeof(fileNum));
+          const auto name = fileIds().string(fileNum);
+          const int32_t length = name.size();
+          state.write(asChar(&length), sizeof(length));
+          state.write(name.data(), length);
+        }
       }
+
+      const auto mapMarker = kCheckpointMapMarker;
+      state.write(asChar(&mapMarker), sizeof(mapMarker));
+      for (auto& pair : entries_) {
+        auto id = pair.first.fileNum.id();
+        state.write(asChar(&id), sizeof(id));
+        state.write(asChar(&pair.first.offset), sizeof(pair.first.offset));
+        auto offsetAndSize = pair.second.bits();
+        state.write(asChar(&offsetAndSize), sizeof(offsetAndSize));
+      }
+
+      // NOTE: we need to ensure cache file data sync update completes before
+      // updating checkpoint file.
+      const auto fileSyncRc = fileSync->move();
+      checkRc(*fileSyncRc, "Sync of cache data file");
+
+      const auto endMarker = kCheckpointEndMarker;
+      state.write(asChar(&endMarker), sizeof(endMarker));
+
+      if (state.bad()) {
+        ++stats_.writeCheckpointErrors;
+        checkRc(-1, "Write of checkpoint file");
+      }
+      state.close();
+
+      // Sync checkpoint data file. ofstream does not have a sync method, so open
+      // as fd and sync that.
+      const auto checkpointFd = checkRc(
+          ::open(checkpointPath.c_str(), O_WRONLY),
+          "Open of checkpoint file for sync");
+      BOLT_CHECK_GE(checkpointFd, 0);
+      checkRc(::fsync(checkpointFd), "Sync of checkpoint file");
+      ::close(checkpointFd);
+
+      // NOTE: we shall truncate eviction log after checkpoint file sync
+      // completes so that we never recover from an old checkpoint file without
+      // log evictions. The latter may lead to data consistent issue.
+      checkRc(::ftruncate(evictLogFd_, 0), "Truncate of event log");
+      checkRc(::fsync(evictLogFd_), "Sync of evict log");
+    } catch (const std::exception& e) {
+      try {
+        checkpointError(-1, e.what());
+      } catch (const std::exception&) {
+      }
+      // Ignore nested exception.
     }
-
-    const auto mapMarker = kCheckpointMapMarker;
-    state.write(asChar(&mapMarker), sizeof(mapMarker));
-    for (auto& pair : entries_) {
-      auto id = pair.first.fileNum.id();
-      state.write(asChar(&id), sizeof(id));
-      state.write(asChar(&pair.first.offset), sizeof(pair.first.offset));
-      auto offsetAndSize = pair.second.bits();
-      state.write(asChar(&offsetAndSize), sizeof(offsetAndSize));
-    }
-
-    // NOTE: we need to ensure cache file data sync update completes before
-    // updating checkpoint file.
-    const auto fileSyncRc = fileSync->move();
-    checkRc(*fileSyncRc, "Sync of cache data file");
-
-    const auto endMarker = kCheckpointEndMarker;
-    state.write(asChar(&endMarker), sizeof(endMarker));
-
-    if (state.bad()) {
-      ++stats_.writeCheckpointErrors;
-      checkRc(-1, "Write of checkpoint file");
-    }
-    state.close();
-
-    // Sync checkpoint data file. ofstream does not have a sync method, so open
-    // as fd and sync that.
-    const auto checkpointFd = checkRc(
-        ::open(checkpointPath.c_str(), O_WRONLY),
-        "Open of checkpoint file for sync");
-    BOLT_CHECK_GE(checkpointFd, 0);
-    checkRc(::fsync(checkpointFd), "Sync of checkpoint file");
-    ::close(checkpointFd);
-
-    // NOTE: we shall truncate eviction log after checkpoint file sync
-    // completes so that we never recover from an old checkpoint file without
-    // log evictions. The latter might lead to data consistent issue.
-    checkRc(::ftruncate(evictLogFd_, 0), "Truncate of event log");
-    checkRc(::fsync(evictLogFd_), "Sync of evict log");
   } catch (const std::exception& e) {
     try {
       checkpointError(-1, e.what());
@@ -774,24 +783,24 @@ void SsdFile::checkpoint(bool force) {
 }
 
 void SsdFile::initializeCheckpoint() {
-  if (checkpointIntervalBytes_ == 0) {
+  if (!checkpointEnabled()) {
     return;
   }
   bool hasCheckpoint = true;
-  std::ifstream state(fileName_ + kCheckpointExtension);
+  std::ifstream state(getCheckpointFilePath());
   if (!state.is_open()) {
     hasCheckpoint = false;
     ++stats_.openCheckpointErrors;
     BOLT_SSD_CACHE_LOG(INFO)
         << "Starting shard " << shardId_ << " without checkpoint";
   }
-  const auto logPath = fileName_ + kLogExtension;
+  const auto logPath = getEvictLogFilePath();
   evictLogFd_ = ::open(logPath.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
   if (evictLogFd_ < 0) {
     ++stats_.openLogErrors;
     // Failure to open the log at startup is a process terminating error.
     BOLT_FAIL(
-        "Could not open evict log {}, rc {}: {}",
+        "Could not open evict log {}, rc {} :{}",
         logPath,
         evictLogFd_,
         folly::errnoStr(errno));
@@ -806,7 +815,7 @@ void SsdFile::initializeCheckpoint() {
     ++stats_.readCheckpointErrors;
     try {
       BOLT_SSD_CACHE_LOG(ERROR) << "Error recovering from checkpoint "
-                                << e.what() << ": Starting without checkpoint";
+                               << e.what() << ": Starting without checkpoint";
       entries_.clear();
       deleteCheckpoint(true);
     } catch (const std::exception&) {

--- a/bolt/common/caching/SsdFile.cpp
+++ b/bolt/common/caching/SsdFile.cpp
@@ -51,9 +51,8 @@ DEFINE_bool(ssd_verify_write, false, "Read back data after writing to SSD");
 namespace bytedance::bolt::cache {
 
 namespace {
-// Disable 'copy on write' on the given file. Will throw if failed for any
-// reason, including file system not supporting cow feature.
-void disableCow(int32_t fd) {
+// TODO: Remove this function once we migrate all files to velox fs.
+void disableFileCow(int32_t fd) {
 #ifdef linux
   int attr{0};
   auto res = ioctl(fd, FS_IOC_GETFLAGS, &attr);
@@ -139,37 +138,21 @@ SsdFile::SsdFile(
     : fileName_(filename),
       maxRegions_(maxRegions),
       shardId_(shardId),
+      fs_(filesystems::getFileSystem(fileName_, nullptr)),
       checkpointIntervalBytes_(checkpointIntervalBytes),
       executor_(executor) {
-  int32_t oDirect = 0;
-#ifdef linux
-  oDirect = FLAGS_ssd_odirect ? O_DIRECT : 0;
-#endif // linux
-  fd_ = open(fileName_.c_str(), O_CREAT | O_RDWR | oDirect, S_IRUSR | S_IWUSR);
-  if (FOLLY_UNLIKELY(fd_ < 0)) {
-    ++stats_.openFileErrors;
-  }
-  // TODO: add fault tolerant handling for open file errors.
-  BOLT_CHECK_GE(
-      fd_,
-      0,
-      "Could not open or create {}. Error: {}",
-      filename,
-      folly::errnoStr(errno));
+  process::TraceContext trace("SsdFile::SsdFile");
+  filesystems::FileOptions fileOptions;
+  fileOptions.shouldThrowOnFileAlreadyExists = false;
+  fileOptions.bufferWrite = !FLAGS_ssd_odirect;
+  writeFile_ = fs_->openFileForWrite(fileName_, fileOptions);
+  readFile_ = fs_->openFileForRead(fileName_);
 
-  if (disableFileCow) {
-    disableCow(fd_);
-  }
-
-  readFile_ = std::make_unique<LocalReadFile>(fd_);
-  uint64_t size = lseek(fd_, 0, SEEK_END);
-  numRegions_ = size / kRegionSize;
-  if (numRegions_ > maxRegions_) {
-    numRegions_ = maxRegions_;
-  }
+  const uint64_t size = writeFile_->size();
+  numRegions_ = std::min<int32_t>(size / kRegionSize, maxRegions_);
   fileSize_ = numRegions_ * kRegionSize;
-  if (size % kRegionSize > 0 || size > numRegions_ * kRegionSize) {
-    ftruncate(fd_, fileSize_);
+  if ((size % kRegionSize > 0) || (size > numRegions_ * kRegionSize)) {
+    writeFile_->truncate(fileSize_);
   }
   // The existing regions in the file are writable.
   writableRegions_.resize(numRegions_);
@@ -180,6 +163,10 @@ SsdFile::SsdFile(
   regionPins_.resize(maxRegions_, 0);
   if (checkpointEnabled()) {
     initializeCheckpoint();
+  }
+
+  if (disableFileCow) {
+    disableFileCow();
   }
 }
 
@@ -322,19 +309,22 @@ std::optional<std::pair<uint64_t, int32_t>> SsdFile::getSpace(
 bool SsdFile::growOrEvictLocked() {
   if (numRegions_ < maxRegions_) {
     const auto newSize = (numRegions_ + 1) * kRegionSize;
-    const auto rc = ::ftruncate(fd_, newSize);
-    if (rc >= 0) {
+    try {
+      writeFile_->truncate(newSize);
       fileSize_ = newSize;
       writableRegions_.push_back(numRegions_);
       regionSizes_[numRegions_] = 0;
       erasedRegionSizes_[numRegions_] = 0;
       ++numRegions_;
+      BOLT_SSD_CACHE_LOG(INFO)
+          << "Grow cache file " << fileName_ << " to " << numRegions_
+          << " regions (max: " << maxRegions_ << ")";
       return true;
+    } catch (const std::exception& e) {
+      ++stats_.growFileErrors;
+      BOLT_SSD_CACHE_LOG(ERROR)
+          << "Failed to grow cache file " << fileName_ << " to " << newSize;
     }
-
-    ++stats_.growFileErrors;
-    LOG(ERROR) << "Failed to grow cache file " << fileName_ << " to "
-               << newSize;
   }
 
   auto candidates =
@@ -346,7 +336,8 @@ bool SsdFile::growOrEvictLocked() {
 
   logEviction(candidates);
   clearRegionEntriesLocked(candidates);
-  writableRegions_ = std::move(candidates);
+  stats_.regionsEvicted += candidates.size();
+  writableRegions_ = candidates;
   suspended_ = false;
   return true;
 }
@@ -406,14 +397,7 @@ void SsdFile::write(std::vector<CachePin>& pins) {
     }
     BOLT_CHECK_GE(fileSize_, offset + bytes);
 
-    const auto rc = folly::pwritev(fd_, iovecs.data(), iovecs.size(), offset);
-    if (rc != bytes) {
-      BOLT_SSD_CACHE_LOG(ERROR)
-          << "Failed to write to SSD, file name: " << fileName_
-          << ", fd: " << fd_ << ", size: " << iovecs.size()
-          << ", offset: " << offset << ", error code: " << errno
-          << ", error string: " << folly::errnoStr(errno);
-      ++stats_.writeSsdErrors;
+    if (!write(offset, bytes, iovecs)) {
       // If write fails, we return without adding the pins to the cache. The
       // entries are unchanged.
       return;
@@ -445,6 +429,24 @@ void SsdFile::write(std::vector<CachePin>& pins) {
   }
 }
 
+bool SsdFile::write(
+    int64_t offset,
+    int64_t length,
+    const std::vector<iovec>& iovecs) {
+  try {
+    writeFile_->write(iovecs, offset, length);
+    return true;
+  } catch (const std::exception& e) {
+    BOLT_SSD_CACHE_LOG(ERROR)
+        << "Failed to write to SSD, file name: " << fileName_
+        << ", size: " << iovecs.size() << ", offset: " << offset
+        << ", error code: " << errno
+        << ", error string: " << folly::errnoStr(errno);
+    ++stats_.writeSsdErrors;
+    return false;
+  }
+}
+
 namespace {
 int32_t indexOfFirstMismatch(char* x, char* y, int n) {
   for (auto i = 0; i < n; ++i) {
@@ -457,9 +459,11 @@ int32_t indexOfFirstMismatch(char* x, char* y, int n) {
 } // namespace
 
 void SsdFile::verifyWrite(AsyncDataCacheEntry& entry, SsdRun ssdRun) {
+  process::TraceContext trace("SsdFile::verifyWrite");
   auto testData = std::make_unique<char[]>(entry.size());
-  const auto rc = ::pread(fd_, testData.get(), entry.size(), ssdRun.offset());
-  BOLT_CHECK_EQ(rc, entry.size());
+  const auto rc =
+      readFile_->pread(ssdRun.offset(), entry.size(), testData.get());
+  BOLT_CHECK_EQ(rc.size(), entry.size());
   if (entry.tinyData() != nullptr) {
     if (::memcmp(testData.get(), entry.tinyData(), entry.size()) != 0) {
       BOLT_FAIL("Bad read back");
@@ -526,14 +530,16 @@ void SsdFile::testingClear() {
 
 void SsdFile::testingDeleteFile() {
   process::TraceContext trace("SsdFile::testingDeleteFile");
-  if (fd_) {
-    close(fd_);
-    fd_ = 0;
+  if (writeFile_) {
+    writeFile_->close();
+    writeFile_.reset();
   }
-  auto rc = unlink(fileName_.c_str());
-  if (rc < 0) {
-    BOLT_SSD_CACHE_LOG(ERROR)
-        << "Error deleting cache file " << fileName_ << " rc: " << rc;
+  try {
+    fs_->remove(fileName_);
+  } catch (const std::exception& e) {
+    BOLT_SSD_CACHE_LOG(ERROR) << "Failed to delete cache file " << fileName_
+                             << ", error code: " << errno
+                             << ", error string: " << folly::errnoStr(errno);
   }
 }
 
@@ -682,8 +688,10 @@ void SsdFile::checkpoint(bool force) {
     // We schedule the potentially long fsync of the cache file on another
     // thread of the cache write executor, if available. If there is none, we do
     // the sync on this thread at the end.
-    auto fileSync = std::make_shared<AsyncSource<int>>(
-        [fd = fd_]() { return std::make_unique<int>(::fsync(fd)); });
+    auto fileSync = std::make_shared<AsyncSource<int>>([this]() {
+      writeFile_->flush();
+      return std::make_unique<int>(0);
+    });
     if (executor_ != nullptr) {
       executor_->add([fileSync]() { fileSync->prepare(); });
     }
@@ -740,8 +748,7 @@ void SsdFile::checkpoint(bool force) {
 
       // NOTE: we need to ensure cache file data sync update completes before
       // updating checkpoint file.
-      const auto fileSyncRc = fileSync->move();
-      checkRc(*fileSyncRc, "Sync of cache data file");
+      fileSync->move();
 
       const auto endMarker = kCheckpointEndMarker;
       state.write(asChar(&endMarker), sizeof(endMarker));
@@ -823,10 +830,36 @@ void SsdFile::initializeCheckpoint() {
   }
 }
 
+void SsdFile::disableFileCow() {
+#ifdef linux
+  auto* localWriteFile = dynamic_cast<LocalWriteFile*>(writeFile_.get());
+  BOLT_CHECK(localWriteFile != nullptr, "Expected LocalWriteFile");
+  int attr{0};
+  const auto fd = localWriteFile->fd();
+  const auto res = ioctl(fd, FS_IOC_GETFLAGS, &attr);
+  BOLT_CHECK_EQ(
+      0,
+      res,
+      "ioctl(FS_IOC_GETFLAGS) failed: {}, {}",
+      res,
+      folly::errnoStr(errno));
+  attr |= FS_NOCOW_FL;
+  const auto setRes = ioctl(fd, FS_IOC_SETFLAGS, &attr);
+  BOLT_CHECK_EQ(
+      0,
+      setRes,
+      "ioctl(FS_IOC_SETFLAGS, FS_NOCOW_FL) failed: {}, {}",
+      setRes,
+      folly::errnoStr(errno));
+#endif // linux
+}
+
 bool SsdFile::testingIsCowDisabled() const {
 #ifdef linux
+  auto* localWriteFile = dynamic_cast<LocalWriteFile*>(writeFile_.get());
+  BOLT_CHECK(localWriteFile != nullptr, "Expected LocalWriteFile");
   int attr{0};
-  const auto res = ioctl(fd_, FS_IOC_GETFLAGS, &attr);
+  const auto res = ioctl(localWriteFile->fd(), FS_IOC_GETFLAGS, &attr);
   BOLT_CHECK_EQ(
       0,
       res,

--- a/bolt/common/caching/SsdFile.h
+++ b/bolt/common/caching/SsdFile.h
@@ -33,6 +33,7 @@
 #include "bolt/common/caching/AsyncDataCache.h"
 #include "bolt/common/caching/SsdFileTracker.h"
 #include "bolt/common/file/File.h"
+#include "bolt/common/file/FileSystems.h"
 
 #include <gflags/gflags.h>
 
@@ -336,8 +337,16 @@ class SsdFile {
   // Reads the backing file with ReadFile::preadv().
   void read(uint64_t offset, const std::vector<folly::Range<char*>>& buffers);
 
+  // Writes 'iovecs' to the SSD file at the 'offset'. Returns true if the write
+  // succeeds; otherwise, log the error and return false.
+  bool write(int64_t offset, int64_t length, const std::vector<iovec>& iovecs);
+
   // Verifies that 'entry' has the data at 'run'.
   void verifyWrite(AsyncDataCacheEntry& entry, SsdRun run);
+
+  // Disable 'copy on write'. Will throw if failed for any reason, including
+  // file system not supporting cow feature.
+  void disableFileCow();
 
   // Deletes checkpoint files. If 'keepLog' is true, truncates and syncs the
   // eviction log and leaves this open.
@@ -423,14 +432,17 @@ class SsdFile {
   // Map of file number and offset to location in file.
   folly::F14FastMap<FileCacheKey, SsdRun> entries_;
 
-  // File descriptor. 0 (stdin) means file not open.
-  int32_t fd_{0};
+  // File system.
+  std::shared_ptr<filesystems::FileSystem> fs_;
 
   // Size of the backing file in bytes. Must be multiple of kRegionSize.
   uint64_t fileSize_{0};
 
-  // ReadFile made from 'fd_'.
+  // ReadFile for cache data file.
   std::unique_ptr<ReadFile> readFile_;
+
+  // WriteFile for cache data file.
+  std::unique_ptr<WriteFile> writeFile_;
 
   // Counters.
   SsdCacheStats stats_;

--- a/bolt/common/caching/SsdFile.h
+++ b/bolt/common/caching/SsdFile.h
@@ -202,11 +202,11 @@ class SsdFile {
       const std::string& filename,
       int32_t shardId,
       int32_t maxRegions,
-      int64_t checkpointInternalBytes = 0,
+      int64_t checkpointIntervalBytes = 0,
       bool disableFileCow = false,
       folly::Executor* executor = nullptr);
 
-  // Adds entries of  'pins'  to this file. 'pins' must be in read mode and
+  // Adds entries of  'pins' to this file. 'pins' must be in read mode and
   // those pins that are successfully added to SSD are marked as being on SSD.
   // The file of the entries must be a file that is backed by 'this'.
   void write(std::vector<CachePin>& pins);
@@ -258,12 +258,6 @@ class SsdFile {
   // Adds 'stats_' to 'stats'.
   void updateStats(SsdCacheStats& stats) const;
 
-  // Resets this' to a post-construction empty state. See SsdCache::clear().
-  void clear();
-
-  // Deletes the backing file. Used in testing.
-  void deleteFile();
-
   /// Remove cached entries of files in the fileNum set 'filesToRemove'. If
   /// successful, return true, and 'filesRetained' contains entries that should
   /// not be removed, ex., from pinned regions. Otherwise, return false and
@@ -278,8 +272,32 @@ class SsdFile {
   // written since last checkpoint and silently returns if not.
   void checkpoint(bool force = false);
 
+  /// Returns the SSD file path.
+  const std::string& fileName() const {
+    return fileName_;
+  }
+
+  /// Returns the eviction log file path.
+  std::string getEvictLogFilePath() const {
+    return fileName_ + kLogExtension;
+  }
+
+  /// Deletes the backing file. Used in testing.
+  void testingDeleteFile();
+
+  /// Resets this' to a post-construction empty state. See SsdCache::clear().
+  void testingClear();
+
   /// Returns true if copy on write is disabled for this file. Used in testing.
   bool testingIsCowDisabled() const;
+
+  std::vector<double> testingCopyScores() {
+    return tracker_.copyScores();
+  }
+
+  int32_t testingNumWritableRegions() const {
+    return writableRegions_.size();
+  }
 
  private:
   // 4 first bytes of a checkpoint file. Allows distinguishing between format
@@ -341,9 +359,27 @@ class SsdFile {
   // the files for making new checkpoints.
   void initializeCheckpoint();
 
-  // Synchronously logs that 'regions' are no longer valid in a possibly xisting
+  // Synchronously logs that 'regions' are no longer valid in a possibly existing
   // checkpoint.
   void logEviction(const std::vector<int32_t>& regions);
+
+  // Returns true if checkpoint has been enabled.
+  bool checkpointEnabled() const {
+    return checkpointIntervalBytes_ > 0;
+  }
+
+  // Returns true if checkpoint is needed.
+  bool needCheckpoint(bool force) const {
+    if (!checkpointEnabled()) {
+      return false;
+    }
+    return force || (bytesAfterCheckpoint_ >= checkpointIntervalBytes_);
+  }
+
+  // Returns the checkpoint file path.
+  std::string getCheckpointFilePath() const {
+    return fileName_ + kCheckpointExtension;
+  }
 
   static constexpr const char* kLogExtension = ".log";
   static constexpr const char* kCheckpointExtension = ".cpt";

--- a/bolt/common/caching/SsdFile.h
+++ b/bolt/common/caching/SsdFile.h
@@ -147,6 +147,7 @@ struct SsdCacheStats {
     bytesRead = tsanAtomicValue(other.bytesRead);
     entriesCached = tsanAtomicValue(other.entriesCached);
     regionsCached = tsanAtomicValue(other.regionsCached);
+    regionsEvicted = tsanAtomicValue(other.regionsEvicted);
     bytesCached = tsanAtomicValue(other.bytesCached);
     entriesAgedOut = tsanAtomicValue(other.entriesAgedOut);
     regionsAgedOut = tsanAtomicValue(other.regionsAgedOut);
@@ -169,6 +170,7 @@ struct SsdCacheStats {
   tsan_atomic<uint64_t> bytesRead{0};
   tsan_atomic<uint64_t> entriesCached{0};
   tsan_atomic<uint64_t> regionsCached{0};
+  tsan_atomic<uint64_t> regionsEvicted{0};
   tsan_atomic<uint64_t> bytesCached{0};
   tsan_atomic<uint64_t> entriesAgedOut{0};
   tsan_atomic<uint64_t> regionsAgedOut{0};
@@ -292,7 +294,7 @@ class SsdFile {
   /// Returns true if copy on write is disabled for this file. Used in testing.
   bool testingIsCowDisabled() const;
 
-  std::vector<double> testingCopyScores() {
+  std::vector<uint64_t> testingCopyScores() {
     return tracker_.copyScores();
   }
 
@@ -368,8 +370,8 @@ class SsdFile {
   // the files for making new checkpoints.
   void initializeCheckpoint();
 
-  // Synchronously logs that 'regions' are no longer valid in a possibly existing
-  // checkpoint.
+  // Synchronously logs that 'regions' are no longer valid in a possibly
+  // existing checkpoint.
   void logEviction(const std::vector<int32_t>& regions);
 
   // Returns true if checkpoint has been enabled.

--- a/bolt/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/bolt/common/caching/tests/AsyncDataCacheTest.cpp
@@ -92,19 +92,22 @@ class AsyncDataCacheTest : public testing::Test {
   }
 
   void TearDown() override {
-    if (executor_) {
-      executor_->join();
-    }
     if (cache_) {
-      auto ssdCache = cache_->ssdCache();
+      cache_->shutdown();
+      auto* ssdCache = cache_->ssdCache();
       if (ssdCache) {
         ssdCache->testingDeleteFiles();
       }
-      cache_->shutdown();
+    }
+    if (executor_) {
+      executor_->join();
     }
   }
 
-  void initializeCache(uint64_t maxBytes, int64_t ssdBytes = 0) {
+  void initializeCache(
+      uint64_t maxBytes,
+      int64_t ssdBytes = 0,
+      int64_t checkpointIntervalBytes = 0) {
     if (cache_ != nullptr) {
       cache_->shutdown();
     }
@@ -125,7 +128,8 @@ class AsyncDataCacheTest : public testing::Test {
           ssdBytes,
           4,
           executor(),
-          ssdBytes / 20);
+          checkpointIntervalBytes > 0 ? checkpointIntervalBytes
+                                      : ssdBytes / 20);
     }
 
     memory::MemoryManager::Options options;
@@ -1161,5 +1165,46 @@ DEBUG_ONLY_TEST_F(AsyncDataCacheTest, ttl) {
   EXPECT_EQ(statsTtl.ssdStats->entriesAgedOut, statsT1.ssdStats->entriesCached);
 }
 #endif
+
+TEST_F(AsyncDataCacheTest, shutdown) {
+  constexpr uint64_t kRamBytes = 32 << 20;
+  constexpr uint64_t kSsdBytes = 64UL << 20;
+
+  // Initialize cache with a big checkpointIntervalBytes, giving eviction log
+  // chance to survive.
+  initializeCache(kRamBytes, kSsdBytes, kSsdBytes * 10);
+  ASSERT_EQ(cache_->ssdCache()->stats().openCheckpointErrors, 4);
+
+  // Write large amount of data, making sure eviction is triggered and the log
+  // file is not zero.
+  loadLoop(0, 16 * kSsdBytes);
+  ASSERT_GT(cache_->ssdCache()->stats().regionsEvicted, 0);
+  ASSERT_GT(cache_->ssdCache()->testingTotalLogEvictionFilesSize(), 0);
+
+  // Shutdown cache.
+  const auto bytesWrittenBeforeShutdown =
+      cache_->ssdCache()->stats().bytesWritten;
+  cache_->ssdCache()->shutdown();
+  const auto bytesWrittenAfterShutdown =
+      cache_->ssdCache()->stats().bytesWritten;
+  cache_->ssdCache()->shutdown();
+
+  // No new data has been written after shutdown.
+  ASSERT_EQ(bytesWrittenBeforeShutdown, bytesWrittenAfterShutdown);
+  // Eviction log files have been truncated.
+  ASSERT_EQ(cache_->ssdCache()->testingTotalLogEvictionFilesSize(), 0);
+
+  // New cache write attempt is blocked and triggers exception.
+  VELOX_ASSERT_THROW(
+      cache_->ssdCache()->startWrite(),
+      "Unexpected write after SSD cache has been shutdown");
+
+  // Re-initialize cache.
+  cache_->ssdCache()->testingClear();
+  initializeCache(kRamBytes, kSsdBytes, kSsdBytes * 10);
+  // Checkpoint files are intact and readable.
+  ASSERT_EQ(cache_->ssdCache()->stats().openCheckpointErrors, 0);
+  ASSERT_EQ(cache_->ssdCache()->stats().readCheckpointErrors, 0);
+}
 
 // TODO: add concurrent fuzzer test.

--- a/bolt/common/caching/tests/SsdFileTest.cpp
+++ b/bolt/common/caching/tests/SsdFileTest.cpp
@@ -30,6 +30,7 @@
 
 #include "bolt/common/caching/FileIds.h"
 #include "bolt/common/caching/SsdCache.h"
+#include "bolt/common/file/FileSystems.h"
 #include "bolt/common/memory/Memory.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
 
@@ -56,6 +57,7 @@ class SsdFileTest : public testing::Test {
   static constexpr int64_t kMB = 1 << 20;
 
   static void SetUpTestCase() {
+    filesystems::registerLocalFileSystem();
     memory::MemoryManager::testingSetInstance(
         {memory::MemoryManager::Options{}});
   }

--- a/bolt/common/caching/tests/SsdFileTest.cpp
+++ b/bolt/common/caching/tests/SsdFileTest.cpp
@@ -62,7 +62,7 @@ class SsdFileTest : public testing::Test {
 
   void TearDown() override {
     if (ssdFile_) {
-      ssdFile_->deleteFile();
+      ssdFile_->testingDeleteFile();
     }
     if (cache_) {
       cache_->shutdown();

--- a/bolt/common/file/File.cpp
+++ b/bolt/common/file/File.cpp
@@ -284,7 +284,12 @@ LocalWriteFile::LocalWriteFile(
       }
     }
   }
-  auto* file = fopen(buf.get(), "ab");
+  // Open in read/write binary mode, create if doesn't exist
+  auto* file = fopen(buf.get(), "r+b");
+  if (file == nullptr) {
+    // If file doesn't exist, create it
+    file = fopen(buf.get(), "w+b");
+  }
   BOLT_CHECK_NOT_NULL(
       file,
       "fopen failure in LocalWriteFile constructor, {} {}.",
@@ -343,16 +348,30 @@ void LocalWriteFile::append(std::unique_ptr<folly::IOBuf> data) {
 void LocalWriteFile::truncate(int64_t newSize) {
   checkNotClosed(closed_);
   BOLT_CHECK_GE(newSize, 0, "New size cannot be negative.");
-  auto fd_ = fileno(file_);
-  const auto ret = ::ftruncate(fd_, newSize);
+  auto fd = fileno(file_);
+  const auto ret = ::ftruncate(fd, newSize);
   BOLT_CHECK_EQ(
       ret,
       0,
       "ftruncate failed in LocalWriteFile::truncate: {}.",
       folly::errnoStr(errno));
   // Reposition the file offset to the end of the file for append().
-  ::lseek(fd_, newSize, SEEK_SET);
+  ::lseek(fd, newSize, SEEK_SET);
   size_ = newSize;
+}
+
+void LocalWriteFile::write(
+    const std::vector<iovec>& iovecs,
+    int64_t offset,
+    int64_t length) {
+  checkNotClosed(closed_);
+  auto fd = fileno(file_);
+  const auto ret = folly::pwritev(fd, iovecs.data(), iovecs.size(), offset);
+  BOLT_CHECK_EQ(
+      ret,
+      length,
+      "pwritev failed in LocalWriteFile::write: {}.",
+      folly::errnoStr(errno));
 }
 
 void LocalWriteFile::flush() {
@@ -719,6 +738,22 @@ uint64_t AsyncLocalWriteFile::size() const {
   if (uringEnabled_)
     return offset_;
   return ftell(file_);
+}
+
+void AsyncLocalWriteFile::write(
+    const std::vector<iovec>& iovecs,
+    int64_t offset,
+    int64_t length) {
+  checkNotClosed(closed_);
+  // For async write file, if uring is enabled, we might want to use io_uring,
+  // but for now, let's use pwritev for simplicity.
+  auto fd = fileno(file_);
+  const auto ret = folly::pwritev(fd, iovecs.data(), iovecs.size(), offset);
+  BOLT_CHECK_EQ(
+      ret,
+      length,
+      "pwritev failed in AsyncLocalWriteFile::write: {}.",
+      folly::errnoStr(errno));
 }
 #endif
 } // namespace bytedance::bolt

--- a/bolt/common/file/File.h
+++ b/bolt/common/file/File.h
@@ -363,10 +363,8 @@ class LocalWriteFile final : public WriteFile {
   void append(std::string_view data) final;
   void append(std::unique_ptr<folly::IOBuf> data) final;
   void truncate(int64_t newSize) final;
-  void write(
-      const std::vector<iovec>& iovecs,
-      int64_t offset,
-      int64_t length) final;
+  void write(const std::vector<iovec>& iovecs, int64_t offset, int64_t length)
+      final;
 
   void flush() final;
   void close() final;
@@ -466,10 +464,8 @@ class AsyncLocalWriteFile final : public WriteFile {
 
   void append(std::string_view data) override;
 
-  void write(
-      const std::vector<iovec>& iovecs,
-      int64_t offset,
-      int64_t length) final;
+  void write(const std::vector<iovec>& iovecs, int64_t offset, int64_t length)
+      final;
 
   void flush() final {
     BOLT_UNREACHABLE();

--- a/bolt/common/file/File.h
+++ b/bolt/common/file/File.h
@@ -199,6 +199,14 @@ class WriteFile {
     BOLT_NYI("IOBuf appending is not implemented");
   }
 
+  // Writes data to the file at the specified offset.
+  virtual void write(
+      const std::vector<iovec>& /* iovecs */,
+      int64_t /* offset */,
+      int64_t /* length */) {
+    BOLT_NYI("{} is not implemented", __FUNCTION__);
+  }
+
   /// Truncates file to a new size.
   ///
   /// NOTE: this is only supported on local file system and used by SSD cache
@@ -355,10 +363,18 @@ class LocalWriteFile final : public WriteFile {
   void append(std::string_view data) final;
   void append(std::unique_ptr<folly::IOBuf> data) final;
   void truncate(int64_t newSize) final;
+  void write(
+      const std::vector<iovec>& iovecs,
+      int64_t offset,
+      int64_t length) final;
 
   void flush() final;
   void close() final;
   uint64_t size() const final;
+
+  int fd() const {
+    return fileno(file_);
+  }
 
  private:
   FILE* FOLLY_NONNULL file_;
@@ -449,6 +465,11 @@ class AsyncLocalWriteFile final : public WriteFile {
   void append(std::unique_ptr<folly::IOBuf> data) final;
 
   void append(std::string_view data) override;
+
+  void write(
+      const std::vector<iovec>& iovecs,
+      int64_t offset,
+      int64_t length) final;
 
   void flush() final {
     BOLT_UNREACHABLE();

--- a/bolt/dwio/dwrf/test/CacheInputTest.cpp
+++ b/bolt/dwio/dwrf/test/CacheInputTest.cpp
@@ -691,7 +691,8 @@ TEST_F(CacheTest, readAhead) {
             const void* buffer;
             int32_t size;
             if (!files[i]->next(buffer, size)) {
-              // End of file. Check that a multiple of file size has been read.
+              // End of file. Check that a multiple of file size has been
+              // read.
               EXPECT_EQ(0, totalRead[i] % FileWithReadAhead::kFileSize);
               if (totalRead[i] >= 3 * FileWithReadAhead::kFileSize) {
                 files[i] = nullptr;

--- a/bolt/dwio/dwrf/test/CacheInputTest.cpp
+++ b/bolt/dwio/dwrf/test/CacheInputTest.cpp
@@ -75,13 +75,13 @@ class CacheTest : public testing::Test {
   }
 
   void TearDown() override {
-    executor_->join();
-    auto ssdCache = cache_->ssdCache();
-    if (ssdCache) {
-      ssdCache->testingDeleteFiles();
-    }
     if (cache_) {
       cache_->shutdown();
+    }
+    executor_->join();
+    auto* ssdCache = cache_->ssdCache();
+    if (ssdCache) {
+      ssdCache->testingDeleteFiles();
     }
   }
 


### PR DESCRIPTION
Summary:
Currently, SSD cache use atomics to handle shutdown and writeInProgress counter which are used a lock to prevent concurrent writes to a SSD file. It is better to use mutex to ease the implementation and also prevent any write to SSD file if shutdown has been triggered.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
