### PR TITLE
[fix] Fix NaN ordering in Spark GK percentile_approx

### DIFF
--- a/bolt/connectors/tpch/TpchConnector.cpp
+++ b/bolt/connectors/tpch/TpchConnector.cpp
@@ -115,7 +115,7 @@ TpchDataSource::TpchDataSource(
         handle,
         "ColumnHandle must be an instance of TpchColumnHandle "
         "for '{}' on table '{}'",
-        handle->name(),
+        it->second->name(),
         toTableName(tpchTable_));
 
     auto idx = tpchTableSchema->getChildIdxIfExists(handle->name());

--- a/bolt/exec/StreamingAggregation.h
+++ b/bolt/exec/StreamingAggregation.h
@@ -102,7 +102,7 @@ class StreamingAggregation : public Operator {
 
   // Will hold on accept new input if groups_ size large than
   // groupNumberThreshold_
-  const uint32_t groupNumberThreshold_;
+  const vector_size_t groupNumberThreshold_;
 
   // Used at initialize() and gets reset() afterward.
   std::shared_ptr<const core::AggregationNode> aggregationNode_;

--- a/bolt/functions/lib/GreenwaldKhanna.h
+++ b/bolt/functions/lib/GreenwaldKhanna.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <gfx/timsort.hpp>
+#include <cmath>
+#include <type_traits>
 #include <vector>
 
 #include "bolt/common/memory/MemoryPool.h"
@@ -164,6 +166,9 @@ class GKQuantileSummaries {
     BOLT_CHECK(
         headSampled_.empty(),
         "Cannot operate on an uncompressed summary, call compress() first");
+    if (size == 0) {
+      return;
+    }
     BOLT_CHECK(percentiles, "percentiles must not be null")
     BOLT_CHECK(result, "result must not be null");
 
@@ -264,6 +269,14 @@ class GKQuantileSummaries {
     doCompress(2 * relativeError_ * count_);
   }
 
+  void reset() {
+    sampled_.clear();
+    backupSampled_.clear();
+    headSampled_.clear();
+    count_ = 0;
+    compressed_ = true;
+  }
+
   void merge(const GKQuantileSummaries<T>& other) {
     if (other.count_ == 0) {
       return;
@@ -294,19 +307,55 @@ class GKQuantileSummaries {
     BOLT_CHECK(
         other.headSampled_.empty(),
         "Other buffer needs to be compressed before merge");
-    double mergeThreshold = 2 * relativeError_ * count_;
-    // merge this sampled_ with other.sampled_ and then sort
-    sampled_.reserve(sampled_.size() + other.sampled_.size());
-    sampled_.insert(
-        sampled_.end(), other.sampled_.begin(), other.sampled_.end());
-    gfx::timsort(
-        sampled_.begin(), sampled_.end(), [](const Stats& a, const Stats& b) {
-          return a.value < b.value;
-        });
-    doCompress(mergeThreshold);
+    const auto mergedRelativeError =
+        std::max(relativeError_, other.relativeError_);
+    const auto mergedCount = count_ + other.count_;
+    const auto additionalSelfDelta = static_cast<int64_t>(
+        std::floor(2 * other.relativeError_ * other.count_));
+    const auto additionalOtherDelta =
+        static_cast<int64_t>(std::floor(2 * relativeError_ * count_));
+
+    backupSampled_.clear();
+    backupSampled_.reserve(sampled_.size() + other.sampled_.size());
+
+    size_t selfIdx = 0;
+    size_t otherIdx = 0;
+    while (selfIdx < sampled_.size() && otherIdx < other.sampled_.size()) {
+      const auto& selfSample = sampled_[selfIdx];
+      const auto& otherSample = other.sampled_[otherIdx];
+
+      if (selfSample.value < otherSample.value) {
+        auto nextSample = selfSample;
+        if (otherIdx > 0) {
+          nextSample.delta += additionalSelfDelta;
+        }
+        backupSampled_.emplace_back(nextSample);
+        ++selfIdx;
+      } else {
+        auto nextSample = otherSample;
+        if (selfIdx > 0) {
+          nextSample.delta += additionalOtherDelta;
+        }
+        backupSampled_.emplace_back(nextSample);
+        ++otherIdx;
+      }
+    }
+
+    while (selfIdx < sampled_.size()) {
+      backupSampled_.emplace_back(sampled_[selfIdx]);
+      ++selfIdx;
+    }
+    while (otherIdx < other.sampled_.size()) {
+      backupSampled_.emplace_back(other.sampled_[otherIdx]);
+      ++otherIdx;
+    }
+
+    std::swap(sampled_, backupSampled_);
+    backupSampled_.clear();
+    relativeError_ = mergedRelativeError;
+    count_ = mergedCount;
+    doCompress(2 * mergedRelativeError * mergedCount);
     compressThreshold_ = other.compressThreshold_;
-    relativeError_ = other.relativeError_;
-    count_ += other.count_;
   }
   size_t count() const {
     return count_;
@@ -365,46 +414,77 @@ class GKQuantileSummaries {
   void deserialize(const char* FOLLY_NONNULL data, size_t expectedSize) {
     BOLT_CHECK(data, "can not deserialize data from nullptr.");
     const char* start = data;
-    memcpy(&compressThreshold_, data, sizeof(compressThreshold_));
-    data += sizeof(compressThreshold_);
-    memcpy(&relativeError_, data, sizeof(relativeError_));
-    data += sizeof(relativeError_);
-    memcpy(&count_, data, sizeof(count_));
-    data += sizeof(count_);
+    auto consumedBytes = [&]() { return static_cast<size_t>(data - start); };
+    auto remainingBytes = [&]() {
+      const auto consumed = consumedBytes();
+      BOLT_USER_CHECK_LE(
+          consumed,
+          expectedSize,
+          "Invalid size of deserialized data, expectedSize:{}, consumed:{}",
+          expectedSize,
+          consumed);
+      return expectedSize - consumed;
+    };
+    auto readBytes = [&](void* FOLLY_NONNULL out, size_t bytes) {
+      BOLT_USER_CHECK_LE(
+          bytes,
+          remainingBytes(),
+          "Invalid size of deserialized data, expectedSize:{}, consumed:{}, requested:{}",
+          expectedSize,
+          consumedBytes(),
+          bytes);
+      memcpy(out, data, bytes);
+      data += bytes;
+    };
+
+    sampled_.clear();
+    backupSampled_.clear();
+    headSampled_.clear();
+    compressed_ = false;
+
+    readBytes(&compressThreshold_, sizeof(compressThreshold_));
+    readBytes(&relativeError_, sizeof(relativeError_));
+    readBytes(&count_, sizeof(count_));
     size_t sampledSize = 0;
-    memcpy(&sampledSize, data, sizeof(sampledSize));
-    data += sizeof(sampledSize);
+    readBytes(&sampledSize, sizeof(sampledSize));
     if (sampledSize > 0) {
+      constexpr size_t kSerializedStatsSize =
+          sizeof(T) + sizeof(int64_t) + sizeof(int64_t);
+      BOLT_USER_CHECK_LE(
+          sampledSize,
+          remainingBytes() / kSerializedStatsSize,
+          "Invalid size of deserialized data, sampled size:{}",
+          sampledSize);
       sampled_.resize(sampledSize);
       for (size_t i = 0; i < sampledSize; ++i) {
-        memcpy(&sampled_[i].value, data, sizeof(sampled_[i].value));
-        data += sizeof(sampled_[i].value);
-        memcpy(&sampled_[i].g, data, sizeof(sampled_[i].g));
-        data += sizeof(sampled_[i].g);
-        memcpy(&sampled_[i].delta, data, sizeof(sampled_[i].delta));
-        data += sizeof(sampled_[i].delta);
+        readBytes(&sampled_[i].value, sizeof(sampled_[i].value));
+        readBytes(&sampled_[i].g, sizeof(sampled_[i].g));
+        readBytes(&sampled_[i].delta, sizeof(sampled_[i].delta));
       }
     }
     size_t headSize = 0;
-    memcpy(&headSize, data, sizeof(headSize));
-    data += sizeof(headSize);
+    readBytes(&headSize, sizeof(headSize));
     if (headSize > 0) {
+      BOLT_USER_CHECK_LE(
+          headSize,
+          remainingBytes() / sizeof(T),
+          "Invalid size of deserialized data, head size:{}",
+          headSize);
       headSampled_.resize(headSize);
       for (size_t i = 0; i < headSize; ++i) {
-        memcpy(&headSampled_[i], data, sizeof(headSampled_[i]));
-        data += sizeof(headSampled_[i]);
+        readBytes(&headSampled_[i], sizeof(headSampled_[i]));
       }
       compress();
     }
     compressed_ = true;
-    size_t acrtualSize = data - start;
+    const auto actualSize = consumedBytes();
 
     BOLT_USER_CHECK_EQ(
-        acrtualSize,
-        data - start,
-        "Invalid size of deserialized data, expectedSize:{}, data - start:{}",
+        actualSize,
         expectedSize,
-        acrtualSize);
+        "Invalid size of deserialized data, actual:{}, expected:{}",
+        actualSize,
+        expectedSize);
   }
 
   bool empty() const {
@@ -412,6 +492,21 @@ class GKQuantileSummaries {
   }
 
  private:
+  static bool sparkSortLessThan(T lhs, T rhs) {
+    if constexpr (std::is_floating_point_v<T>) {
+      if (std::isnan(lhs)) {
+        return false;
+      }
+      if (std::isnan(rhs)) {
+        return true;
+      }
+      if (lhs == rhs && lhs == 0) {
+        return std::signbit(lhs) && !std::signbit(rhs);
+      }
+    }
+    return lhs < rhs;
+  }
+
   QueryResult findApproxQuantile(
       size_t index,
       int64_t minRankAtIndex,
@@ -442,7 +537,7 @@ class GKQuantileSummaries {
       return;
     }
     compressed_ = false;
-    gfx::timsort(headSampled_.begin(), headSampled_.end(), std::less<>());
+    gfx::timsort(headSampled_.begin(), headSampled_.end(), sparkSortLessThan);
 
     backupSampled_.clear();
     backupSampled_.reserve(sampled_.size() + headSampled_.size());
@@ -497,7 +592,7 @@ class GKQuantileSummaries {
     // The head contains the current new head, that may be merged with the
     // current element.
     Stats head = sampled_.back();
-    ssize_t i = sampled_.size() - 2;
+    ssize_t i = static_cast<ssize_t>(sampled_.size()) - 2;
 
     // Do not compress the last element
     while (i >= 1) {

--- a/bolt/functions/lib/tests/GKTest.cpp
+++ b/bolt/functions/lib/tests/GKTest.cpp
@@ -15,9 +15,13 @@
  */
 
 #include <gtest/gtest.h>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <optional>
 
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/memory/Memory.h"
 
 #include "bolt/type/Type.h"
@@ -238,6 +242,123 @@ TEST_F(GKTest, randomInput) {
   }
 }
 
+TEST_F(GKTest, doubleNaNSingleSummaryFollowsSparkHeadSort) {
+  const auto nan = std::numeric_limits<double>::quiet_NaN();
+
+  GKQuantileSummaries<double> gk(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  gk.insert(1.0);
+  gk.insert(2.0);
+  gk.insert(nan);
+  gk.compress();
+
+  const auto result = getPercentiles(gk, {0.0, 0.5, 0.9999, 1.0});
+  ASSERT_EQ(result.size(), 4);
+  EXPECT_EQ(result[0], 1.0);
+  EXPECT_EQ(result[1], 2.0);
+  EXPECT_TRUE(std::isnan(result[2]));
+  EXPECT_TRUE(std::isnan(result[3]));
+}
+
+TEST_F(GKTest, doubleSignedZeroSingleSummaryFollowsSparkHeadSort) {
+  GKQuantileSummaries<double> gk(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  gk.insert(0.0);
+  gk.insert(-0.0);
+  gk.compress();
+
+  const auto result = getPercentiles(gk, {0.0, 1.0});
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_TRUE(std::signbit(result[0]));
+  EXPECT_FALSE(std::signbit(result[1]));
+}
+
+TEST_F(GKTest, doubleNaNPartialMergeMatchesSparkCompress) {
+  const auto nan = std::numeric_limits<double>::quiet_NaN();
+
+  GKQuantileSummaries<double> gk(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  gk.insert(1.0);
+  gk.insert(2.0);
+  gk.compress();
+
+  GKQuantileSummaries<double> other(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  other.insert(nan);
+  other.compress();
+  gk.merge(other);
+
+  const auto result = getPercentiles(gk, {0.5, 0.9, 0.99, 0.9999, 1.0});
+  ASSERT_EQ(result.size(), 5);
+  for (const auto value : result) {
+    EXPECT_EQ(value, 2.0);
+  }
+}
+
+TEST_F(GKTest, doublePercentilesWithNaNAreNonDecreasing) {
+  const auto nan = std::numeric_limits<double>::quiet_NaN();
+  const std::vector<double> firstPartial{
+      8814.79, 7960.1,  8492.04, 6837.15, 8429.88, 6034.46, 4464.18, 6628.85,
+      7465.74, 8335.13, 7883.56, 6673.07, 7160.19, 7303.34, 6371.66, 7277.8,
+      4463.77, 8233.78, 8605.39, 8370.71, 6054.61, 4520.48, 5278.29, 6743.67,
+      8697.81, 8828.3,  6975.8,  5624.5,  5544.61, 6099.35, 6562.43, 6507.85,
+      4379.5,  7273.95, 6862.91, 6767.65, 6664.36, 0.0,     5624.5,  7143.87,
+      6277.58, 5624.5,  7123.34, 6662.73, 7083.62, 4863.93, 0.0,     6831.25,
+      6827.66, 6179.52, 6111.47, 6430.53, 644.48,  7262.85, 6425.22, 6804.15,
+      0.0};
+  const std::vector<double> secondPartial{nan, nan, nan, 0.0};
+
+  GKQuantileSummaries<double> gk(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  for (auto value : firstPartial) {
+    gk.insert(value);
+  }
+  gk.compress();
+
+  GKQuantileSummaries<double> other(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  for (auto value : secondPartial) {
+    other.insert(value);
+  }
+  other.compress();
+  gk.merge(other);
+
+  const auto result = getPercentiles(
+      gk,
+      {0.10,
+       0.20,
+       0.30,
+       0.40,
+       0.50,
+       0.60,
+       0.70,
+       0.80,
+       0.90,
+       0.91,
+       0.92,
+       0.93,
+       0.94,
+       0.95,
+       0.96,
+       0.97,
+       0.98,
+       0.99});
+
+  bool seenNaN = false;
+  std::optional<double> previous;
+  for (auto i = 0; i < result.size(); ++i) {
+    if (std::isnan(result[i])) {
+      seenNaN = true;
+      continue;
+    }
+    ASSERT_FALSE(seenNaN) << "finite value after NaN at index: " << i;
+    if (previous.has_value()) {
+      ASSERT_LE(previous.value(), result[i]) << "index: " << i;
+    }
+    previous = result[i];
+  }
+}
+
 TEST_F(GKTest, serializeAndDeserialize) {
   testSerde<double>();
   testSerde<float>();
@@ -247,6 +368,67 @@ TEST_F(GKTest, serializeAndDeserialize) {
   testSerde<int16_t>();
   testSerde<int8_t>();
   testSerde<Timestamp>();
+}
+
+TEST_F(GKTest, deserializeClearsExistingState) {
+  GKQuantileSummaries<double> source(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  std::unique_ptr<char[]> buffer(new char[source.serializedByteSize()]);
+  source.serialize(buffer.get());
+
+  GKQuantileSummaries<double> target(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  target.insert(1.0);
+  target.insert(2.0);
+  target.compress();
+
+  target.deserialize(buffer.get(), source.serializedByteSize());
+  EXPECT_TRUE(target.empty());
+  EXPECT_EQ(target.count(), 0);
+}
+
+TEST_F(GKTest, deserializeRejectsInvalidSize) {
+  GKQuantileSummaries<double> source(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  source.insert(1.0);
+  source.insert(2.0);
+  source.compress();
+  const auto serializedSize = source.serializedByteSize();
+  std::unique_ptr<char[]> buffer(new char[serializedSize]);
+  source.serialize(buffer.get());
+
+  GKQuantileSummaries<double> target(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  BOLT_ASSERT_THROW(
+      target.deserialize(buffer.get(), serializedSize - 1), "Invalid size");
+  BOLT_ASSERT_THROW(
+      target.deserialize(buffer.get(), serializedSize + 1), "Invalid size");
+}
+
+TEST_F(GKTest, resetClearsState) {
+  GKQuantileSummaries<double> gk(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  gk.insert(1.0);
+  gk.insert(2.0);
+  gk.compress();
+
+  gk.reset();
+  EXPECT_TRUE(gk.empty());
+  EXPECT_EQ(gk.count(), 0);
+  EXPECT_TRUE(gk.isCompressed());
+
+  gk.insert(3.0);
+  gk.compress();
+  EXPECT_EQ(gk.query(0.5), 3.0);
+}
+
+TEST_F(GKTest, queryEmptyPercentiles) {
+  GKQuantileSummaries<double> gk(
+      pool_.get(), kEpsilon, kDefaultCompressThreshold, kDefaultHeadSize);
+  gk.insert(1.0);
+  gk.compress();
+
+  EXPECT_TRUE(gk.query(std::vector<double>{}).empty());
 }
 
 TEST_F(GKTest, merge) {

--- a/bolt/functions/sparksql/aggregates/tests/PercentileApproxTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/PercentileApproxTest.cpp
@@ -15,6 +15,9 @@
  */
 
 #include <algorithm>
+#include <cmath>
+#include <limits>
+#include <optional>
 
 #include "bolt/common/base/RandomUtil.h"
 #include "bolt/common/base/tests/GTestUtils.h"
@@ -292,6 +295,54 @@ TEST_F(PercentileApproxTest, partialFull) {
       makeFlatVector<int32_t>(117, [](auto row) { return row < 7 ? 20 : 10; }),
   });
   exec::test::assertQuery(params, {expected});
+}
+
+TEST_F(PercentileApproxTest, percentileArrayWithNaNIsNonDecreasing) {
+  const auto nan = std::numeric_limits<double>::quiet_NaN();
+  const std::vector<double> rawData{
+      8814.79, 7960.1,  8492.04, 6837.15, 8429.88, 6034.46, 4464.18, 6628.85,
+      7465.74, 8335.13, 7883.56, 6673.07, 7160.19, 7303.34, 6371.66, 7277.8,
+      4463.77, 8233.78, 8605.39, 8370.71, 6054.61, 4520.48, 5278.29, 6743.67,
+      8697.81, 8828.3,  6975.8,  5624.5,  5544.61, 6099.35, 6562.43, 6507.85,
+      4379.5,  7273.95, 6862.91, 6767.65, 6664.36, 0.0,     5624.5,  7143.87,
+      6277.58, 5624.5,  7123.34, 6662.73, 7083.62, 4863.93, 0.0,     6831.25,
+      6827.66, 6179.52, 6111.47, 6430.53, 644.48,  7262.85, 6425.22, 6804.15,
+      0.0,     nan,     nan,     nan};
+
+  auto rows = makeRowVector({makeFlatVector<double>(rawData)});
+  auto plan = PlanBuilder()
+                  .values({rows})
+                  .project(
+                      {"c0",
+                       "array_constructor(0.10, 0.20, 0.30, 0.40, 0.50, "
+                       "0.60, 0.70, 0.80, 0.90, 0.91, 0.92, 0.93, "
+                       "0.94, 0.95, 0.96, 0.97, 0.98, 0.99) as pct"})
+                  .singleAggregation({}, {"percentile_approx(c0, pct)"})
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+  ASSERT_EQ(result->size(), 1);
+
+  auto arrayResult = result->childAt(0)->asUnchecked<ArrayVector>();
+  ASSERT_FALSE(arrayResult->isNullAt(0));
+  ASSERT_EQ(arrayResult->sizeAt(0), 18);
+
+  auto elements = arrayResult->elements()->asUnchecked<FlatVector<double>>();
+  const auto offset = arrayResult->offsetAt(0);
+  bool seenNaN = false;
+  std::optional<double> previous;
+  for (vector_size_t i = 0; i < arrayResult->sizeAt(0); ++i) {
+    auto current = elements->valueAt(offset + i);
+    if (std::isnan(current)) {
+      seenNaN = true;
+      continue;
+    }
+    ASSERT_FALSE(seenNaN) << "finite value after NaN at index: " << i;
+    if (previous.has_value()) {
+      ASSERT_LE(previous.value(), current) << "index: " << i;
+    }
+    previous = current;
+  }
 }
 
 TEST_F(PercentileApproxTest, finalAggregateAccuracy) {

--- a/bolt/functions/sparksql/tests/ToJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/ToJsonTest.cpp
@@ -76,7 +76,7 @@ TEST_F(ToJsonTest, basicStruct) {
 
 TEST_F(ToJsonTest, basicArray) {
   auto input = makeNullableArrayVector<int64_t>(
-      {{{1}}, {{2, std::nullopt, 3}}, {{}}, std::nullopt});
+      {{{1}}, {{2, std::nullopt, 3}}, emptyArray, std::nullopt});
   auto expected = makeNullableFlatVector<std::string>(
       {R"([1])", R"([2,null,3])", R"([])", std::nullopt});
   testToJson(input, expected);
@@ -87,7 +87,7 @@ TEST_F(ToJsonTest, basicMap) {
   auto input = makeNullableMapVector<std::string, int64_t>(
       {{{{"a", 1}, {"b", 2}, {"c", 3}}},
        std::nullopt,
-       {{}},
+       emptyArray,
        {{{"a", 1}, {"b", std::nullopt}}}});
   auto expected = makeNullableFlatVector<std::string>(
       {R"({"a":1,"b":2,"c":3})", std::nullopt, R"({})", R"({"a":1,"b":null})"});
@@ -97,7 +97,7 @@ TEST_F(ToJsonTest, basicMap) {
   input = makeNullableMapVector<int64_t, std::string>(
       {{{{1, "a"}, {2, "b"}, {3, "c"}}},
        std::nullopt,
-       {{}},
+       emptyArray,
        {{{1, "a"}, {2, std::nullopt}}}});
   expected = makeNullableFlatVector<std::string>(
       {R"({"1":"a","2":"b","3":"c"})",
@@ -308,7 +308,7 @@ TEST_F(ToJsonTest, nestedMap) {
       {0, 18321, -25567, 2932896, std::nullopt}, DateType::get());
   auto data2 = makeNullableArrayVector<std::string>(
       {{{"a", "b", std::nullopt}},
-       {{}},
+       emptyArray,
        {{"d", "e"}},
        {{"f", std::nullopt, "h"}},
        std::nullopt});


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #539

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

  Align Greenwald-Khanna summary merging with Spark's QuantileSummaries
  behavior so partial percentile_approx aggregation remains monotonic when
  NaN values are present.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
  Align Greenwald-Khanna summary merging with Spark's QuantileSummaries
  behavior so partial percentile_approx aggregation remains monotonic when
  NaN values are present.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
