### PR TITLE
bugfix: fix broken check(numValues <= presetNullsSize_ - presetNullsConsumed_) when reading map

### DIFF
--- a/bolt/dwio/parquet/reader/StructColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/StructColumnReader.cpp
@@ -154,7 +154,8 @@ StructColumnReader::findBestLeaf() {
     auto child = children_[i];
     auto kind = child->fileType().type()->kind();
     // Complex type child repdefs must be read in any case.
-    if (kind == TypeKind::ROW || kind == TypeKind::ARRAY) {
+    if (kind == TypeKind::ROW || kind == TypeKind::ARRAY ||
+        kind == TypeKind::MAP) {
       return child;
     }
     if (!best) {

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1503,6 +1503,68 @@ TEST_F(ParquetReaderTest, skip) {
   EXPECT_EQ(0, rowReader->next(1000, result));
 }
 
+TEST_F(ParquetReaderTest, nestedMapValueNulls) {
+  std::vector<std::map<
+      std::optional<int32_t>,
+      std::optional<std::vector<std::pair<int32_t, std::optional<int32_t>>>>>>
+      maps;
+  maps.reserve(20000);
+  for (auto i = 0; i < 20000; ++i) {
+    if (i % 19 == 0) {
+      maps.push_back({});
+    } else if (i % 17 == 0) {
+      maps.push_back({{i, std::nullopt}});
+    } else if (i % 13 == 0) {
+      maps.push_back(
+          {{i, std::vector<std::pair<int32_t, std::optional<int32_t>>>{}}});
+    } else {
+      maps.push_back(
+          {{i,
+            std::vector<std::pair<int32_t, std::optional<int32_t>>>{
+                {i + 1, i + 2}, {i + 3, std::nullopt}}}});
+    }
+  }
+
+  auto nestedStruct = makeRowVector(
+      {"m", "x"},
+      {createMapOfMapVector(maps),
+       makeFlatVector<int32_t>(
+           20000, [](auto row) { return row; }, nullEvery(23))});
+  auto expected = makeRowVector({"c0"}, {nestedStruct});
+  auto rowType = std::static_pointer_cast<const RowType>(expected->type());
+
+  auto sink = std::make_unique<MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto sinkPtr = sink.get();
+
+  bytedance::bolt::parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  auto writer = std::make_unique<bytedance::bolt::parquet::Writer>(
+      std::move(sink), writerOptions, rowType);
+  writer->write(expected);
+  writer->close();
+
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  std::string data(sinkPtr->data(), sinkPtr->size());
+  auto reader = std::make_unique<ParquetReader>(
+      std::make_unique<dwio::common::BufferedInput>(
+          std::make_shared<InMemoryReadFile>(std::move(data)), *leafPool_),
+      readerOptions);
+
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+  vector_size_t offset = 0;
+  while (auto readRows = rowReader->next(1000, result)) {
+    EXPECT_EQ(readRows, result->size());
+    assertEqualVectorPart(expected, result, offset);
+    offset += readRows;
+  }
+  EXPECT_EQ(offset, expected->size());
+}
+
 TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string filename("varbinary_flba.parquet");
   const std::string sample(getExampleFilePath(filename));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #550 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

findBestLeaf() takes MAP the same as ARRAY and STRUCT when reading rep/def.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
