### PR TITLE
[fix] extract setHdfsOpenFileOptionsFromConfig to all file system

### DIFF
--- a/bolt/common/file/FileSystems.cpp
+++ b/bolt/common/file/FileSystems.cpp
@@ -33,6 +33,7 @@
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <folly/synchronization/CallOnce.h>
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/config/Config.h"
 #include "bolt/common/file/File.h"
 
 #include <cstdio>
@@ -56,6 +57,22 @@ RegisteredFileSystems& registeredFileSystems() {
 }
 
 } // namespace
+
+void copyOpenFileOptionsFromConfig(
+    const config::ConfigBase* config,
+    FileOptions& options,
+    std::string_view prefix) {
+  if (config == nullptr) {
+    return;
+  }
+
+  for (const auto& [key, value] : config->rawConfigsCopy()) {
+    if (key.size() >= prefix.size() &&
+        key.compare(0, prefix.size(), prefix.data(), prefix.size()) == 0) {
+      options.values[key] = value;
+    }
+  }
+}
 
 std::map<std::string, std::string> getConfFromString(
     const std::string& confstr) {

--- a/bolt/common/file/FileSystems.h
+++ b/bolt/common/file/FileSystems.h
@@ -33,10 +33,16 @@
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/common/memory/MemoryPool.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 #include <string_view>
+#include <unordered_map>
+
+#include <folly/Range.h>
 namespace bytedance::bolt {
 namespace config {
 class ConfigBase;
@@ -72,6 +78,13 @@ struct FileOptions {
   /// NOTE: this only applies for write open file.
   bool shouldThrowOnFileAlreadyExists{true};
 };
+
+inline constexpr std::string_view kOpenFileOptionConfigPrefix{"bolt."};
+
+void copyOpenFileOptionsFromConfig(
+    const config::ConfigBase* config,
+    FileOptions& options,
+    std::string_view prefix = kOpenFileOptionConfigPrefix);
 
 /// Defines directory options
 struct DirectoryOptions : FileOptions {

--- a/bolt/common/file/tests/FileTest.cpp
+++ b/bolt/common/file/tests/FileTest.cpp
@@ -30,8 +30,10 @@
 
 #include <fcntl.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <unordered_map>
 
 #include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/common/config/Config.h"
 #include "bolt/common/file/File.h"
 #include "bolt/common/file/FileSystems.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
@@ -42,6 +44,25 @@ using namespace bytedance::bolt;
 using bytedance::bolt::common::Region;
 
 constexpr int kOneMB = 1 << 20;
+
+TEST(FileOptionsTest, copyOpenFileOptionsFromConfig) {
+  auto config = std::make_shared<const config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {"bolt.dfs.replication", "2"},
+          {"bolt.tos.endpoint", "tos-endpoint"},
+          {"spark.hadoop.dfs.replication", "3"}});
+
+  filesystems::FileOptions fileOptions;
+  fileOptions.values["bolt.dfs.replication"] = "1";
+  fileOptions.values["existing.option"] = "existing";
+
+  filesystems::copyOpenFileOptionsFromConfig(config.get(), fileOptions);
+
+  EXPECT_EQ(fileOptions.values.at("bolt.dfs.replication"), "2");
+  EXPECT_EQ(fileOptions.values.at("bolt.tos.endpoint"), "tos-endpoint");
+  EXPECT_EQ(fileOptions.values.at("existing.option"), "existing");
+  EXPECT_EQ(fileOptions.values.count("spark.hadoop.dfs.replication"), 0);
+}
 
 void writeData(WriteFile* writeFile, bool useIOBuf = false) {
   if (useIOBuf) {

--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -34,11 +34,11 @@
 #include "bolt/common/base/Fs.h"
 #include "bolt/common/base/StatsReporter.h"
 #include "bolt/common/base/Uuid.h"
+#include "bolt/common/file/FileSystems.h"
 #include "bolt/common/testutil/TestValue.h"
 #include "bolt/connectors/hive/HiveConfig.h"
 #include "bolt/connectors/hive/HivePartitionFunction.h"
 #include "bolt/connectors/hive/TableHandle.h"
-#include "bolt/connectors/hive/storage_adapters/hdfs/HdfsUtil.h"
 #include "bolt/core/ITypedExpr.h"
 #include "bolt/dwio/common/SortingWriter.h"
 #include "bolt/exec/OperatorUtils.h"
@@ -411,7 +411,7 @@ HiveDataSink::HiveDataSink(
       fileOptions_.values[key] = value.value();
     }
   }
-  filesystems::setHdfsOpenFileOptionsFromConfig(
+  filesystems::copyOpenFileOptionsFromConfig(
       connectorQueryCtx_->sessionProperties(), fileOptions_);
 
   if (!isBucketed()) {

--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -36,13 +36,13 @@
 #include <string>
 #include <unordered_map>
 
+#include "bolt/common/file/FileSystems.h"
 #include "bolt/connectors/hive/HiveConfig.h"
 #include "bolt/connectors/hive/HiveConnectorUtil.h"
 #include "bolt/connectors/hive/IgnoreCorruptFile.h"
 #include "bolt/connectors/hive/PaimonMiscHelpers.h"
 #include "bolt/connectors/hive/PaimonSplitReader.h"
 #include "bolt/connectors/hive/SplitReader.h"
-#include "bolt/connectors/hive/storage_adapters/hdfs/HdfsUtil.h"
 #include "bolt/dwio/common/ReaderFactory.h"
 #include "bolt/dwio/common/exception/Exception.h"
 #include "bolt/expression/FieldReference.h"
@@ -76,7 +76,7 @@ HiveDataSource::HiveDataSource(
       fsSessionConfig_.values[key] = value.value();
     }
   }
-  filesystems::setHdfsOpenFileOptionsFromConfig(
+  filesystems::copyOpenFileOptionsFromConfig(
       connectorQueryCtx_->sessionProperties(), fsSessionConfig_);
   fsSessionConfig_.bufferSize = static_cast<size_t>(hiveConfig_->loadQuantum());
   native_cache_enabled = queryConfig.isNativeCacheEnabled();

--- a/bolt/connectors/hive/storage_adapters/hdfs/HdfsUtil.h
+++ b/bolt/connectors/hive/storage_adapters/hdfs/HdfsUtil.h
@@ -37,7 +37,7 @@
 
 #include <folly/Conv.h>
 
-#include "bolt/common/config/Config.h"
+#include "bolt/common/base/Exceptions.h"
 #include "bolt/common/file/FileSystems.h"
 
 namespace bytedance::bolt::filesystems {
@@ -111,24 +111,6 @@ inline HdfsOpenFileOptions getHdfsOpenFileOptions(const FileOptions& options) {
       replication);
   hdfsOptions.replication = static_cast<short>(replication);
   return hdfsOptions;
-}
-
-inline void setHdfsOpenFileOptionsFromConfig(
-    const config::ConfigBase* config,
-    FileOptions& options) {
-  if (config == nullptr) {
-    return;
-  }
-
-  for (const auto* key :
-       {HdfsOpenFileOptions::kBufferSize,
-        HdfsOpenFileOptions::kReplication,
-        HdfsOpenFileOptions::kBlockSize}) {
-    auto value = config->get<std::string>(key);
-    if (value.hasValue()) {
-      options.values[key] = value.value();
-    }
-  }
 }
 
 } // namespace bytedance::bolt::filesystems

--- a/bolt/connectors/hive/storage_adapters/hdfs/tests/HdfsUtilTest.cpp
+++ b/bolt/connectors/hive/storage_adapters/hdfs/tests/HdfsUtilTest.cpp
@@ -31,8 +31,6 @@
 #include "bolt/connectors/hive/storage_adapters/hdfs/HdfsUtil.h"
 
 #include "bolt/common/base/Exceptions.h"
-#include "bolt/common/file/FileSystems.h"
-
 #include "gtest/gtest.h"
 using namespace bytedance::bolt::filesystems;
 
@@ -91,20 +89,4 @@ TEST(HdfsUtilTest, getHdfsOpenFileOptionsRejectsInvalidValues) {
   EXPECT_THROW(
       getHdfsOpenFileOptions(invalidBufferSize),
       bytedance::bolt::BoltException);
-}
-
-TEST(HdfsUtilTest, setHdfsOpenFileOptionsFromConfig) {
-  auto config = std::make_shared<const bytedance::bolt::config::ConfigBase>(
-      std::unordered_map<std::string, std::string>{
-          {HdfsOpenFileOptions::kBufferSize, "4096"},
-          {HdfsOpenFileOptions::kReplication, "2"},
-          {HdfsOpenFileOptions::kBlockSize, "134217728"}});
-
-  FileOptions fileOptions;
-  setHdfsOpenFileOptionsFromConfig(config.get(), fileOptions);
-
-  EXPECT_EQ(fileOptions.values.at(HdfsOpenFileOptions::kBufferSize), "4096");
-  EXPECT_EQ(fileOptions.values.at(HdfsOpenFileOptions::kReplication), "2");
-  EXPECT_EQ(
-      fileOptions.values.at(HdfsOpenFileOptions::kBlockSize), "134217728");
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->

extract setHdfsOpenFileOptionsFromConfig to all file system

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

extract setHdfsOpenFileOptionsFromConfig to all file system

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- extract setHdfsOpenFileOptionsFromConfig to all file system
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
