### PR TITLE
perf: refactor shuffle check only nulls to reduce cost

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,8 +74,8 @@ repos:
     hooks:
       - id: license-header-check
         name: Check for license headers
-        entry: go run -C .github/license_check check_license.go
-        language: golang
+        entry: bash -c 'GOFLAGS=-buildvcs=false go run -C .github/license_check check_license.go "$@"' --
+        language: system
         pass_filenames: true
         require_serial: true
       - id: clang-tidy

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -851,16 +851,10 @@ arrow::Status BoltShuffleWriter::splitRowVector(
   // now start to split the RowVector
   RETURN_NOT_OK(splitFixedWidthValueBuffer(rv, partitionFixedWidthValueAddrs_));
   RETURN_NOT_OK(splitValidityBuffer<true>(rv));
+  RETURN_NOT_OK(withShuffleCheck(
+      rv, std::string(__FILE__) + ":" + std::to_string(__LINE__)));
   RETURN_NOT_OK(splitBinaryArray(rv));
   RETURN_NOT_OK(splitComplexType(rv));
-
-  RETURN_NOT_OK(withShuffleCheck(
-      rv,
-      std::string(__FILE__) + ":" + std::to_string(__LINE__) + ":after all:",
-      [&](const bytedance::bolt::RowVector& vector, std::string funcLine) {
-        return checkFixedColumnCopyValue(
-            vector, partitionFixedWidthValueAddrs_, std::move(funcLine));
-      }));
 
   // update partition buffer base after split
   for (auto pid = 0; pid < numPartitions_; ++pid) {
@@ -1236,19 +1230,6 @@ arrow::Status BoltShuffleWriter::initColumnTypes(
   }
 
   fixedWidthColumnCount_ = simpleColumnIndices_.size();
-
-  if (options_.shuffleCheckRatio > 0.0) {
-    fixedWidthCheckFunctions_.reserve(fixedWidthColumnCount_);
-    fixedWidthTypeNames_.reserve(fixedWidthColumnCount_);
-    for (size_t col = 0; col < fixedWidthColumnCount_; ++col) {
-      const auto colIdx = simpleColumnIndices_[col];
-      ARROW_ASSIGN_OR_RAISE(
-          auto checkFn,
-          createFixedColumnCheckFunction(arrowColumnTypes_[colIdx]->id()));
-      fixedWidthCheckFunctions_.push_back(checkFn);
-      fixedWidthTypeNames_.push_back(arrowColumnTypes_[colIdx]->ToString());
-    }
-  }
 
   simpleColumnIndices_.insert(
       simpleColumnIndices_.end(),
@@ -2126,12 +2107,6 @@ template arrow::Status BoltShuffleWriter::splitFixedWidthValueBuffer<
     std::vector<std::vector<std::vector<uint8_t*>>>>(
     const bytedance::bolt::RowVector& rv,
     std::vector<std::vector<std::vector<uint8_t*>>>& valueAddrs);
-template arrow::Status BoltShuffleWriter::checkFixedColumnCopyValue<
-    std::vector<std::vector<uint8_t*>>>(
-    const bytedance::bolt::RowVector& rv,
-    std::vector<std::vector<uint8_t*>>& fixedWidthValueAddrs,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition);
 template arrow::Status BoltShuffleWriter::splitValidityBuffer<true>(
     const bytedance::bolt::RowVector& rv);
 template arrow::Status BoltShuffleWriter::splitValidityBuffer<false>(
@@ -2299,198 +2274,50 @@ void BoltShuffleWriter::logShuffleCheckStats(const char* writerType) const {
             << options_.taskAttemptId << " writerType=" << writerType
             << " ratio=" << options_.shuffleCheckRatio
             << " count=" << shuffleCheckCount_
-            << " wallNanos=" << shuffleCheckTimeNanos_
+            << " nulls=" << shuffleCheckNulls_
             << " wallMs=" << (shuffleCheckTimeNanos_ / 1000000.0);
 }
 
-template <typename T>
-void BoltShuffleWriter::checkCopyValue(
-    const uint8_t* srcAddrs,
-    const uint8_t* srcNulls,
-    const std::vector<uint8_t*>& dstAddrs,
-    const std::vector<uint8_t*>& dstNulls,
-    int colId,
-    const std::string& name,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition) {
-  const auto* srcValues = reinterpret_cast<const T*>(srcAddrs);
-  const bool hasSrcNulls = (srcNulls != nullptr);
+arrow::Status BoltShuffleWriter::checkFixedColumnCopyNulls(
+    const bytedance::bolt::RowVector& rv,
+    const std::string& funcLine) {
+  for (auto col = 0; col < simpleColumnIndices_.size(); ++col) {
+    const auto colIdx = simpleColumnIndices_[col];
+    auto& column = rv.childAt(colIdx);
+    auto* srcNulls =
+        column->nulls() == nullptr ? nullptr : column->nulls()->as<uint8_t>();
+    const auto& dstNulls = partitionValidityAddrs_[col];
+    const bool hasSrcNulls = (srcNulls != nullptr);
+    const auto& name = arrowColumnTypes_[colIdx]->ToString();
 
-  for (auto& pid : partitionUsed_) {
-    const uint32_t baseOffset = partition2RowOffsetBase_[pid];
-    const uint32_t endOffset = partition2RowOffsetBase_[pid + 1];
-
-    const uint32_t dstNullBase = partitionBufferBase_[pid];
-    const uint32_t dstValueBase =
-        valueAddrsPointToWritePosition ? 0 : dstNullBase;
-    const auto* dstPidBase = reinterpret_cast<const T*>(dstAddrs[pid]);
-    const auto* dstValues = dstPidBase + dstValueBase;
-
-    const uint8_t* dstNullsPid = dstNulls[pid];
-    const bool hasDstNulls = (dstNullsPid != nullptr);
-
-    // Fast path: no null buffers on either side.
-    if (!hasSrcNulls && !hasDstNulls) {
+    for (auto& pid : partitionUsed_) {
+      const uint32_t baseOffset = partition2RowOffsetBase_[pid];
+      const uint32_t endOffset = partition2RowOffsetBase_[pid + 1];
+      const uint32_t dstNullBase = partitionBufferBase_[pid];
+      const uint8_t* dstNullsPid = dstNulls[pid];
+      const bool hasDstNulls = (dstNullsPid != nullptr);
+      if (!hasSrcNulls && !hasDstNulls) {
+        continue;
+      }
       for (uint32_t offset = baseOffset, pos = 0; offset < endOffset;
            ++offset, ++pos) {
         const uint32_t rowId = rowOffset2RowId_[offset];
-        const auto sValue = srcValues[rowId];
-        const auto dValue = dstValues[pos];
-        if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
-          if (std::isnan(sValue) && std::isnan(dValue)) {
-            continue;
-          }
-        }
+        const bool sNull = !bytedance::bolt::bits::isBitSet(srcNulls, rowId);
+        const bool dNull =
+            !bytedance::bolt::bits::isBitSet(dstNullsPid, dstNullBase + pos);
         BOLT_CHECK(
-            sValue == dValue,
-            "{}:source column value [{}, {}][{}] = {}, null {} is not equal to dest column value {} of partition {}",
+            sNull == dNull,
+            "{}:source column null [{}, {}][{}] = {} is != dest column null {} of partition {}",
             funcLine,
-            colId,
+            colIdx,
             name,
             pos + dstNullBase,
-            sValue,
-            false,
-            dValue,
+            sNull,
+            dNull,
             pid);
+        shuffleCheckNulls_ += sNull;
       }
-      continue;
     }
-
-    for (uint32_t offset = baseOffset, pos = 0; offset < endOffset;
-         ++offset, ++pos) {
-      const uint32_t rowId = rowOffset2RowId_[offset];
-      const bool sNull =
-          hasSrcNulls && !bytedance::bolt::bits::isBitSet(srcNulls, rowId);
-      const bool dNull = hasDstNulls &&
-          !bytedance::bolt::bits::isBitSet(dstNullsPid, dstNullBase + pos);
-
-      BOLT_CHECK(
-          sNull == dNull,
-          "{}:source column null [{}, {}][{}] = {} is not equal to dest column null {} of partition {}",
-          funcLine,
-          colId,
-          name,
-          pos + dstNullBase,
-          sNull,
-          dNull,
-          pid);
-
-      if (sNull) {
-        continue;
-      }
-
-      const auto sValue = srcValues[rowId];
-      const auto dValue = dstValues[pos];
-      if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
-        if (std::isnan(sValue) && std::isnan(dValue)) {
-          continue;
-        }
-      }
-      BOLT_CHECK(
-          sValue == dValue,
-          "{}:source column value [{}, {}][{}] = {}, null {} is not equal to dest column value {} of partition {}",
-          funcLine,
-          colId,
-          name,
-          pos + dstNullBase,
-          sValue,
-          sNull,
-          dValue,
-          pid);
-    }
-  }
-}
-
-template <typename T>
-void BoltShuffleWriter::checkCopyValueTyped(
-    const uint8_t* srcAddrs,
-    const uint8_t* srcNulls,
-    const std::vector<uint8_t*>& dstAddrs,
-    const std::vector<uint8_t*>& dstNulls,
-    int colId,
-    const std::string& name,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition) {
-  checkCopyValue<T>(
-      srcAddrs,
-      srcNulls,
-      dstAddrs,
-      dstNulls,
-      colId,
-      name,
-      funcLine,
-      valueAddrsPointToWritePosition);
-}
-
-arrow::Result<BoltShuffleWriter::FixedColumnCheckFunction>
-BoltShuffleWriter::createFixedColumnCheckFunction(
-    arrow::Type::type typeId) const {
-  switch (typeId) {
-    case arrow::NullType::type_id:
-    case arrow::BooleanType::type_id:
-    case arrow::HalfFloatType::type_id:
-    case arrow::TimestampType::type_id:
-    case arrow::Decimal128Type::type_id:
-      return nullptr;
-    case arrow::Int8Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<int8_t>;
-    case arrow::UInt8Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<uint8_t>;
-    case arrow::Int16Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<int16_t>;
-    case arrow::UInt16Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<uint16_t>;
-    case arrow::Int32Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<int32_t>;
-    case arrow::Date32Type::type_id:
-    case arrow::Time32Type::type_id:
-    case arrow::UInt32Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<uint32_t>;
-    case arrow::FloatType::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<float>;
-    case arrow::Int64Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<int64_t>;
-    case arrow::Date64Type::type_id:
-    case arrow::Time64Type::type_id:
-    case arrow::UInt64Type::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<uint64_t>;
-    case arrow::DoubleType::type_id:
-      return &BoltShuffleWriter::checkCopyValueTyped<double>;
-    default:
-      return arrow::Status::Invalid(
-          "Column type id ",
-          std::to_string(static_cast<int>(typeId)),
-          " is not fixed width");
-  }
-}
-
-template <typename T>
-arrow::Status BoltShuffleWriter::checkFixedColumnCopyValue(
-    const bytedance::bolt::RowVector& rv,
-    T& fixedWidthValueAddrs,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition) {
-  for (auto col = 0; col < fixedWidthColumnCount_; ++col) {
-    const auto colIdx = simpleColumnIndices_[col];
-    auto& column = rv.childAt(colIdx);
-    const uint8_t* srcAddr = (const uint8_t*)column->valuesAsVoid();
-    auto* srcNulls =
-        column->nulls() == nullptr ? nullptr : column->nulls()->as<uint8_t>();
-    const auto& dstAddrs = fixedWidthValueAddrs[col];
-    const auto& dstNulls = partitionValidityAddrs_[col];
-    const auto checkFn = fixedWidthCheckFunctions_[col];
-    if (checkFn == nullptr) {
-      continue;
-    }
-    (this->*checkFn)(
-        srcAddr,
-        srcNulls,
-        dstAddrs,
-        dstNulls,
-        colIdx,
-        fixedWidthTypeNames_[col],
-        funcLine,
-        valueAddrsPointToWritePosition);
   }
   return arrow::Status::OK();
 }

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -327,16 +327,6 @@ class BoltShuffleWriter : public ShuffleWriter {
   }
 
  protected:
-  using FixedColumnCheckFunction = void (BoltShuffleWriter::*)(
-      const uint8_t* srcAddrs,
-      const uint8_t* srcNulls,
-      const std::vector<uint8_t*>& dstAddrs,
-      const std::vector<uint8_t*>& dstNulls,
-      int colId,
-      const std::string& name,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition);
-
   virtual arrow::Status init();
 
   virtual arrow::Status initPartitions();
@@ -377,18 +367,13 @@ class BoltShuffleWriter : public ShuffleWriter {
       const bytedance::bolt::RowVector& rv,
       T& valueAddrs);
 
-  template <typename T>
-  arrow::Status checkFixedColumnCopyValue(
+  arrow::Status checkFixedColumnCopyNulls(
       const bytedance::bolt::RowVector& rv,
-      T& fixedWidthValueAddrs,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition = false);
+      const std::string& funcLine);
 
-  template <typename Fn>
   arrow::Status withShuffleCheck(
       const bytedance::bolt::RowVector& rv,
-      std::string funcLine,
-      Fn&& fn) {
+      std::string funcLine) {
     const auto shuffleCheckRatio =
         std::clamp(options_.shuffleCheckRatio, 0.0, 1.0);
     if (shuffleCheckRatio <= 0.0) {
@@ -401,33 +386,8 @@ class BoltShuffleWriter : public ShuffleWriter {
     }
     ++shuffleCheckCount_;
     bytedance::bolt::NanosecondTimer timer(&shuffleCheckTimeNanos_);
-    return fn(rv, std::move(funcLine));
+    return checkFixedColumnCopyNulls(rv, std::move(funcLine));
   }
-
-  template <typename T>
-  void checkCopyValue(
-      const uint8_t* srcAddrs,
-      const uint8_t* srcNulls,
-      const std::vector<uint8_t*>& dstAddrs,
-      const std::vector<uint8_t*>& dstNulls,
-      int colId,
-      const std::string& name,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition);
-
-  template <typename T>
-  void checkCopyValueTyped(
-      const uint8_t* srcAddrs,
-      const uint8_t* srcNulls,
-      const std::vector<uint8_t*>& dstAddrs,
-      const std::vector<uint8_t*>& dstNulls,
-      int colId,
-      const std::string& name,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition);
-
-  arrow::Result<FixedColumnCheckFunction> createFixedColumnCheckFunction(
-      arrow::Type::type typeId) const;
 
   arrow::Status splitBoolType(
       const uint8_t* srcAddr,
@@ -694,8 +654,6 @@ class BoltShuffleWriter : public ShuffleWriter {
   std::vector<std::vector<uint8_t*>> partitionValidityAddrs_;
   // Used by fixed-width types. Stores raw pointers of partition buffers.
   std::vector<std::vector<uint8_t*>> partitionFixedWidthValueAddrs_;
-  std::vector<FixedColumnCheckFunction> fixedWidthCheckFunctions_;
-  std::vector<std::string> fixedWidthTypeNames_;
   // Used by binary types. Stores raw pointers and metadata of partition
   // buffers.
   std::vector<std::vector<BinaryBuf>> partitionBinaryAddrs_;
@@ -801,6 +759,7 @@ class BoltShuffleWriter : public ShuffleWriter {
   uint64_t stopTime_{0};
   uint64_t shuffleCheckTimeNanos_{0};
   uint64_t shuffleCheckCount_{0};
+  uint64_t shuffleCheckNulls_{0};
   std::mt19937 shuffleCheckRandomEngine_{std::random_device{}()};
   std::bernoulli_distribution shuffleCheckDistribution_;
 

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -396,34 +396,10 @@ arrow::Status BoltShuffleWriterV2::splitRowVector(
   RETURN_NOT_OK(
       splitFixedWidthValueBuffer(rv, partitionFixedWidthValueAddrsVector_));
   RETURN_NOT_OK(splitValidityBuffer<false>(rv));
+  RETURN_NOT_OK(withShuffleCheck(
+      rv, std::string(__FILE__) + ":" + std::to_string(__LINE__)));
   RETURN_NOT_OK(splitBinaryArray(rv));
   RETURN_NOT_OK(splitComplexType(rv));
-  RETURN_NOT_OK(withShuffleCheck(
-      rv,
-      std::string(__FILE__) + ":" + std::to_string(__LINE__),
-      [&](const bytedance::bolt::RowVector& vector, std::string funcLine) {
-        std::vector<std::vector<uint8_t*>> currentFixedWidthValueAddrs(
-            fixedWidthColumnCount_);
-        for (auto col = 0; col < fixedWidthColumnCount_; ++col) {
-          const uint64_t valueWidth = fixedColValueSize_[col];
-          currentFixedWidthValueAddrs[col].resize(numPartitions_, nullptr);
-          for (auto pid = 0; pid < numPartitions_; ++pid) {
-            const auto& buffers =
-                partitionFixedWidthValueAddrsVector_[col][pid];
-            if (!buffers.empty()) {
-              auto* addr = buffers.back();
-              if (valueWidth) {
-                addr +=
-                    static_cast<uint64_t>(partitionBufferBaseInBatches_[pid]) *
-                    valueWidth;
-              }
-              currentFixedWidthValueAddrs[col][pid] = addr;
-            }
-          }
-        }
-        return checkFixedColumnCopyValue(
-            vector, currentFixedWidthValueAddrs, std::move(funcLine), true);
-      }));
 
   for (auto& pid : partitionUsed_) {
     partitionBufferBase_[pid] += partition2RowCount_[pid];


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
