### PR TITLE
[fix] limit skewed hash build spill file rows

### DIFF
--- a/bolt/exec/Spiller.cpp
+++ b/bolt/exec/Spiller.cpp
@@ -813,13 +813,19 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
   BOLT_CHECK(
       type_ != Type::kHashJoinProbe && type_ != Type::kOrderByOutput &&
       type_ != Type::kLocalMergeInput);
-  const bool doPotentialRangePartitionCheck =
-      (supportSkewPartition_ && container_ &&
-       container_->numRows() >
-           std::max(maxSpillRunRows_, kDefaultSpillRunRows));
   uint64_t totalTimeUs{0};
   {
     MicrosecondTimer timer(&totalTimeUs);
+
+    uint64_t maxRowsPerPartition{0};
+    if (supportSkewPartition_) {
+      if (skewedVictim_.has_value() && maxRowsPerFile_ > 0) {
+        maxRowsPerPartition = maxRowsPerFile_;
+      } else if (!isAnySpilled()) {
+        maxRowsPerPartition =
+            bits::divRoundUp(container_->numRows(), state_.maxPartitions());
+      }
+    }
     markAllPartitionsSpilled();
 
     RowContainerIterator rowIter;
@@ -829,9 +835,9 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
 
     bool lastRun{false};
     do {
-      lastRun = fillSpillRuns(&rowIter);
+      lastRun = fillSpillRuns(&rowIter, maxRowsPerPartition);
       runSpill(lastRun);
-      if (doPotentialRangePartitionCheck || skewedVictim_ >= 0) {
+      if (supportSkewPartition_ || skewedVictim_.has_value()) {
         prepareForRangPartitionIfNeeded();
       }
     } while (!lastRun);
@@ -901,8 +907,8 @@ void Spiller::spill(uint32_t partition, const RowVectorPtr& spillVector) {
     state_.appendToPartition(partition, spillVector);
   }
   updateSpillTotalTime(totalTimeUs);
-  if (supportSkewPartition_ && partition == skewedVictim_ &&
-      maxRowsPerFile_ > 0 &&
+  if (supportSkewPartition_ && skewedVictim_.has_value() &&
+      partition == *skewedVictim_ && maxRowsPerFile_ > 0 &&
       state_.rowsInCurrentFile(partition) >= maxRowsPerFile_) {
     state_.finishFile(partition);
   }
@@ -941,7 +947,9 @@ void Spiller::finalizeSpill() {
   finalized_ = true;
 }
 
-bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
+bool Spiller::fillSpillRuns(
+    RowContainerIterator* iterator,
+    const uint64_t maxRowsPerPartition) {
   checkEmptySpillRuns();
   bool lastRun{false};
   uint64_t execTimeUs{0};
@@ -955,6 +963,7 @@ bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
     const bool isSinglePartition = bits_.numPartitions() == 1;
 
     uint64_t totalRows{0};
+    bool maxRowsPerPartitionReached = false;
     for (;;) {
       const auto numRows =
           container_->listRows(iterator, rows.size(), rows.data());
@@ -983,9 +992,20 @@ bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
         spillRuns_[partition].rows.push_back(rows[i]);
         spillRuns_[partition].numBytes += container_->rowSize(rows[i]);
       }
-
       totalRows += numRows;
-      if (maxSpillRunRows_ > 0 && totalRows >= maxSpillRunRows_) {
+      // Stop filling this run once any partition reaches the per-partition row
+      // target, so the skewed partition can be identified before writing an
+      // oversized spill file.
+      if (maxRowsPerPartition > 0 && !maxRowsPerPartitionReached) {
+        for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
+          if (spillRuns_[partition].rows.size() >= maxRowsPerPartition) {
+            maxRowsPerPartitionReached = true;
+            break;
+          }
+        }
+      }
+      if ((maxSpillRunRows_ > 0 && totalRows >= maxSpillRunRows_) ||
+          maxRowsPerPartitionReached) {
         break;
       }
     }
@@ -1109,9 +1129,9 @@ void Spiller::trySplitSkewPartition(SpillPartitionSet& partitionSet) {
 }
 
 void Spiller::prepareForRangPartitionIfNeeded() {
-  if (skewedVictim_ >= 0 && maxRowsPerFile_ >= 0 &&
-      state_.rowsInCurrentFile(skewedVictim_) >= maxRowsPerFile_) {
-    state_.finishFile(skewedVictim_);
+  if (skewedVictim_.has_value() && maxRowsPerFile_ > 0 &&
+      state_.rowsInCurrentFile(*skewedVictim_) >= maxRowsPerFile_) {
+    state_.finishFile(*skewedVictim_);
     return;
   }
   const auto& rowCountVec = state_.spilledRowCount();
@@ -1122,11 +1142,11 @@ void Spiller::prepareForRangPartitionIfNeeded() {
   for (auto i = 0; i < rowCountVec.size(); ++i) {
     auto rowCount = rowCountVec[i];
     if (rowCount > 0) {
-      if (rowCountVec[i] > maxRowCount) {
+      if (rowCount > maxRowCount) {
         maxRowCount = rowCount;
         skewedPartitionNumber = i;
       }
-      minRowCount = std::min(minRowCount, rowCountVec[i]);
+      minRowCount = std::min(minRowCount, rowCount);
     }
   }
   if (minRowCount != 0 &&
@@ -1137,7 +1157,7 @@ void Spiller::prepareForRangPartitionIfNeeded() {
     state_.finishFile(skewedPartitionNumber);
     BOLT_CHECK(state_.numFinishedFiles(skewedPartitionNumber) > 0);
     LOG(INFO) << __FUNCTION__ << ": set maxRowsPerFile_ = " << maxRowsPerFile_
-              << ", skewedVictim_ = " << skewedVictim_;
+              << ", skewedVictim_ = " << *skewedVictim_;
   }
 }
 

--- a/bolt/exec/Spiller.h
+++ b/bolt/exec/Spiller.h
@@ -391,7 +391,9 @@ class Spiller {
   // If 'startRowIter' is not null, we prepare runs starting from the offset
   // pointed by 'startRowIter'.
   // The function returns true if it is the last spill run.
-  bool fillSpillRuns(RowContainerIterator* startRowIter = nullptr);
+  bool fillSpillRuns(
+      RowContainerIterator* startRowIter = nullptr,
+      uint64_t maxRowsPerPartition = 0);
 
   // Prepares spill run of a single partition for the spillable data from the
   // rows.
@@ -463,7 +465,7 @@ class Spiller {
 
   bool supportSkewPartition_{false};
   bool rangePartitioningApplicable_{false};
-  int32_t skewedVictim_{-1};
+  std::optional<uint32_t> skewedVictim_;
   uint32_t maxRowsPerFile_{0};
   int64_t memoryUsedWhenTriggered_{0};
   int32_t skewFileSizeRatioThreshold_ = 10;


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #556 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

 ## Problem

  In HashBuild row-based spill with skew partition support enabled, a skewed partition can still produce oversized spill files. During restore, this can lead to excessive memory pressure and potentially OOM.

  A typical case is:

    skew partition 6, rowCount = 8167
    desired restore granularity ~ 2546 rows per range partition

  However, skew splitting is currently file-granular. If the skewed partition only ends up with 2 spill files, it can only be split into 2 range partitions, even when row-count-based estimation suggests 4. This
  leaves each restored partition too large.

  --------

  ## Root Cause

  In the row-container spill path, fillSpillRuns() keeps accumulating rows into per-partition spillRuns_ until maxSpillRunRows_ (or EOF). For skewed data, one partition may accumulate too many rows in a single
  run.

  runSpill() then writes that run to disk. Although prepareForRangPartitionIfNeeded() can detect skew and flush files, it runs after writing, which is too late to prevent an oversized file from being created.

  Also, HashBuild’s true restore-bound (maxRowsInMemory_) is only set near finishSpill(), i.e., after spill writing has already happened. So it cannot be used as an early file-size limiter during write.

  --------

  ## Solution

  This change introduces an early run-level guard in Spiller::spill(const RowContainerIterator*) for the row-container path, using current average rows per partition:

    maxRowsPerPartition = container_->numRows() / state_.maxPartitions()

  ### Strategy

  1. Enable this only when supportSkewPartition_ is true.
  2. On the first row-container spill, compute maxRowsPerPartition from current container rows and partition count.
  3. In fillSpillRuns(), stop filling the current run once any partition reaches this per-partition row target.
  4. runSpill() writes the bounded run as usual.
  5. Existing prepareForRangPartitionIfNeeded() logic is reused to detect skew victim and flush current file.
  6. After a skew victim is identified, subsequent row-container spill calls continue to enforce the bound using maxRowsPerFile_, preventing later oversized skew files.

  Additionally, skewedVictim_ is migrated from sentinel -1 to std::optional<uint32_t> for clearer semantics.



### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
