### PR TITLE
[fix] fix Spark function json_array_length return type

### DIFF
--- a/bolt/functions/prestosql/SIMDJsonFunctions.h
+++ b/bolt/functions/prestosql/SIMDJsonFunctions.h
@@ -344,12 +344,21 @@ class WrapperJsonArrayLengthFunction {
     useSonic = config.enableSonicJsonArrayLength();
   }
 
-  FOLLY_ALWAYS_INLINE bool call(int64_t& len, const arg_type<Json>& json) {
+  template <typename TResult>
+  FOLLY_ALWAYS_INLINE bool call(TResult& len, const arg_type<Json>& json) {
+    int64_t jsonArrayLength;
     if (useSonic) {
-      return SonicJsonArrayLengthFunction<T>::call(len, json);
+      if (!SonicJsonArrayLengthFunction<T>::call(jsonArrayLength, json)) {
+        return false;
+      }
     } else {
-      return SIMDJsonArrayLengthFunction<T>::call(len, json);
+      if (!SIMDJsonArrayLengthFunction<T>::call(jsonArrayLength, json)) {
+        return false;
+      }
     }
+
+    len = static_cast<TResult>(jsonArrayLength);
+    return true;
   }
 
   bool useSonic = true;

--- a/bolt/functions/sparksql/registration/RegisterJson.cpp
+++ b/bolt/functions/sparksql/registration/RegisterJson.cpp
@@ -36,9 +36,9 @@ void registerJsonFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "json_tuple_with_codegen", jsonTupleSignatures(), makeJsonTuple);
   registerJsonType(); // to register Json type
-  registerFunction<WrapperJsonArrayLengthFunction, int64_t, Json>(
+  registerFunction<WrapperJsonArrayLengthFunction, int32_t, Json>(
       {prefix + "json_array_length"});
-  registerFunction<WrapperJsonArrayLengthFunction, int64_t, Varchar>(
+  registerFunction<WrapperJsonArrayLengthFunction, int32_t, Varchar>(
       {prefix + "json_array_length"});
 
   //   registerFunction<SIMDGetJsonObjectFunction, Varchar, Varchar, Varchar>(

--- a/bolt/functions/sparksql/tests/JsonFunctionTest.cpp
+++ b/bolt/functions/sparksql/tests/JsonFunctionTest.cpp
@@ -131,6 +131,31 @@ TEST_F(JsonFucntionTest, array_test) {
   }
 }
 
+TEST_F(JsonFucntionTest, jsonArrayLength) {
+  auto signatures = getSignatureStrings("json_array_length");
+  ASSERT_EQ(2, signatures.size());
+  ASSERT_EQ(1, signatures.count("(json) -> integer"));
+  ASSERT_EQ(1, signatures.count("(varchar) -> integer"));
+
+  for (auto value : {"true", "false"}) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kEnableSonicJsonArrayLength, value}});
+
+    EXPECT_EQ(
+        std::optional<int32_t>(4),
+        evaluateOnce<int32_t>(
+            "json_array_length(c0)", std::optional<std::string>("[1,2,3,4]")));
+    EXPECT_EQ(
+        std::nullopt,
+        evaluateOnce<int32_t>(
+            "json_array_length(c0)", std::optional<std::string>("{}")));
+    EXPECT_EQ(
+        std::nullopt,
+        evaluateOnce<int32_t>(
+            "json_array_length(c0)", std::optional<std::string>()));
+  }
+}
+
 TEST_F(JsonFucntionTest, CornerCases) {
   // test dom
   for (auto value : {"true", "false"}) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #559

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Spark SQL json_array_length is now registered as returning INTEGER in Bolt SparkSQL registration, matching [Spark/Gluten’s expected type](https://docs.databricks.com/aws/en/sql/language-manual/functions/json_array_length) instead of Bolt PrestoSQL’s BIGINT.
- Made the shared JSON array length wrapper support both return widths, so PrestoSQL can still use BIGINT while SparkSQL uses INTEGER.
- Added Bolt SparkSQL unit coverage.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix Spark-side function json_array_length return type
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
