### PR TITLE
Fix Flink decimal to varchar cast

### DIFF
--- a/bolt/functions/flinksql/CMakeLists.txt
+++ b/bolt/functions/flinksql/CMakeLists.txt
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bolt_add_library(bolt_functions_flink_impl JsonFunctions.cpp ElementAt.cpp)
+bolt_add_library(
+  bolt_functions_flink_impl
+  JsonFunctions.cpp
+  ElementAt.cpp
+  specialforms/FlinkCastExpr.cpp
+)
 
 target_link_libraries(
   bolt_functions_flink_impl

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -15,11 +15,13 @@
  */
 
 #include "bolt/functions/flinksql/registration/Register.h"
+#include "bolt/expression/SpecialFormRegistry.h"
 #include "bolt/expression/VectorFunction.h"
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/flinksql/DateTimeFunctions.h"
 #include "bolt/functions/flinksql/Rand.h"
 #include "bolt/functions/flinksql/String.h"
+#include "bolt/functions/flinksql/specialforms/FlinkCastExpr.h"
 
 namespace bytedance::bolt::functions {
 // If the function registration order is Presto, Spark, Flink,
@@ -88,12 +90,24 @@ static void registerArrayFunctions(const std::string& prefix) {
   registerFlinkElementAtFunction(prefix + "element_at");
 }
 
+namespace {
+
+void registerSpecialFormFunctions(const std::string& prefix) {
+  exec::registerFunctionCallToSpecialForm(
+      "cast", std::make_unique<FlinkCastCallToSpecialForm>());
+  exec::registerFunctionCallToSpecialForm(
+      "try_cast", std::make_unique<FlinkTryCastCallToSpecialForm>());
+}
+
+} // namespace
+
 void registerFunctions(const std::string& prefix) {
   registerStringFunctions(prefix);
   registerDatetimeFunctions(prefix);
   registerMathFunctions(prefix);
   registerJsonFunctions(prefix);
   registerArrayFunctions(prefix);
+  registerSpecialFormFunctions(prefix);
 }
 } // namespace flinksql
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/flinksql/specialforms/FlinkCastExpr.cpp
+++ b/bolt/functions/flinksql/specialforms/FlinkCastExpr.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/specialforms/FlinkCastExpr.h"
+
+#include <array>
+
+#include "bolt/expression/EvalCtx.h"
+#include "bolt/type/DecimalUtil.h"
+#include "bolt/vector/FlatVector.h"
+
+namespace bytedance::bolt::functions::flinksql {
+namespace {
+
+template <typename T>
+void setPlainDecimalString(
+    FlatVector<StringView>* result,
+    vector_size_t row,
+    T value,
+    int32_t scale,
+    int32_t maxSize) {
+  std::array<char, 128> buffer;
+  BOLT_CHECK_LE(
+      maxSize,
+      buffer.size(),
+      "Unexpected decimal to varchar buffer size: {}",
+      maxSize);
+  const auto size =
+      DecimalUtil::convertToString<DecimalUtil::DecimalStringFormat::kPlain>(
+          value, scale, maxSize, buffer.data());
+  result->set(row, StringView(buffer.data(), size));
+}
+
+} // namespace
+
+void FlinkCastExpr::evalSpecialForm(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    VectorPtr& result) {
+  const auto fromType = inputs_[0]->type();
+  if (!(fromType->isDecimal() && type_->isVarchar())) {
+    exec::CastExpr::evalSpecialForm(rows, context, result);
+    return;
+  }
+
+  VectorPtr input;
+  inputs_[0]->eval(rows, context, input);
+
+  exec::LocalSelectivityVector remainingRows(context, rows);
+  context.deselectErrors(*remainingRows);
+
+  exec::LocalDecodedVector decoded(context, *input, *remainingRows);
+  auto* rawNulls = decoded->nulls(remainingRows.get());
+  if (rawNulls) {
+    remainingRows->deselectNulls(
+        rawNulls, remainingRows->begin(), remainingRows->end());
+  }
+
+  VectorPtr localResult;
+  if (!remainingRows->hasSelections()) {
+    localResult =
+        BaseVector::createNullConstant(type_, rows.end(), context.pool());
+  } else {
+    context.ensureWritable(*remainingRows, type_, localResult);
+    auto* flatResult = localResult->asFlatVector<StringView>();
+    BOLT_CHECK_NOT_NULL(flatResult);
+
+    int32_t precision;
+    int32_t scale;
+    if (fromType->isShortDecimal()) {
+      precision = fromType->asShortDecimal().precision();
+      scale = fromType->asShortDecimal().scale();
+      const auto maxSize = DecimalUtil::stringSize(precision, scale);
+      remainingRows->applyToSelected([&](vector_size_t row) {
+        setPlainDecimalString(
+            flatResult, row, decoded->valueAt<int64_t>(row), scale, maxSize);
+      });
+    } else {
+      precision = fromType->asLongDecimal().precision();
+      scale = fromType->asLongDecimal().scale();
+      const auto maxSize = DecimalUtil::stringSize(precision, scale);
+      remainingRows->applyToSelected([&](vector_size_t row) {
+        setPlainDecimalString(
+            flatResult, row, decoded->valueAt<int128_t>(row), scale, maxSize);
+      });
+    }
+  }
+
+  context.moveOrCopyResult(localResult, *remainingRows, result);
+  context.releaseVector(localResult);
+  localResult.reset();
+
+  if (rawNulls || context.errors()) {
+    exec::EvalCtx::addNulls(
+        rows, remainingRows->asRange().bits(), context, type_, result);
+  }
+  context.releaseVector(input);
+}
+
+exec::ExprPtr FlinkCastCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<exec::ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const core::QueryConfig& config) {
+  BOLT_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "CAST statements expect exactly 1 argument, received {}.",
+      compiledChildren.size());
+  return std::make_shared<FlinkCastExpr>(
+      type, std::move(compiledChildren[0]), trackCpuUsage, false);
+}
+
+exec::ExprPtr FlinkTryCastCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<exec::ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const core::QueryConfig& config) {
+  BOLT_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "TRY CAST statements expect exactly 1 argument, received {}.",
+      compiledChildren.size());
+  return std::make_shared<FlinkCastExpr>(
+      type, std::move(compiledChildren[0]), trackCpuUsage, true);
+}
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/specialforms/FlinkCastExpr.h
+++ b/bolt/functions/flinksql/specialforms/FlinkCastExpr.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/expression/CastExpr.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+class FlinkCastExpr : public exec::CastExpr {
+ public:
+  /// @param type The target type of the cast expression.
+  /// @param expr The expression to cast.
+  /// @param trackCpuUsage Whether to track CPU usage.
+  FlinkCastExpr(
+      TypePtr type,
+      exec::ExprPtr&& expr,
+      bool trackCpuUsage,
+      bool nullOnFailure)
+      : exec::CastExpr(type, std::move(expr), trackCpuUsage, nullOnFailure) {}
+
+  void evalSpecialForm(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      VectorPtr& result) override;
+};
+
+class FlinkCastCallToSpecialForm : public exec::CastCallToSpecialForm {
+ public:
+  exec::ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+};
+
+class FlinkTryCastCallToSpecialForm : public exec::TryCastCallToSpecialForm {
+ public:
+  exec::ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+};
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/tests/CMakeLists.txt
+++ b/bolt/functions/flinksql/tests/CMakeLists.txt
@@ -14,8 +14,13 @@
 # limitations under the License.
 
 add_executable(
-  bolt_functions_flink_test ElementAtTest.cpp FlinkSqlDataTimeFunctionsTest.cpp
-                            JsonFunctionsTest.cpp RandTest.cpp StringFunctionsTest.cpp
+  bolt_functions_flink_test
+  ElementAtTest.cpp
+  FlinkCastExprTest.cpp
+  FlinkSqlDataTimeFunctionsTest.cpp
+  JsonFunctionsTest.cpp
+  RandTest.cpp
+  StringFunctionsTest.cpp
 )
 
 add_test(

--- a/bolt/functions/flinksql/tests/FlinkCastExprTest.cpp
+++ b/bolt/functions/flinksql/tests/FlinkCastExprTest.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/registration/Register.h"
+#include "bolt/functions/prestosql/tests/CastBaseTest.h"
+#include "bolt/parse/TypeResolver.h"
+
+namespace bytedance::bolt::functions::flinksql::test {
+
+class FlinkCastExprTest : public functions::test::CastBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    parse::registerTypeResolver();
+    flinksql::registerFunctions("");
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(FlinkCastExprTest, decimalToVarcharPreservesPlainScale) {
+  const auto decimalType = DECIMAL(10, 8);
+
+  testCast<int64_t, StringView>(
+      "varchar",
+      {0, 1, 100000000, -1, std::nullopt},
+      {"0.00000000", "0.00000001", "1.00000000", "-0.00000001", std::nullopt},
+      decimalType,
+      VARCHAR());
+
+  testTryCast<int64_t, StringView>(
+      "varchar",
+      {0, 1, 100000000, -1, std::nullopt},
+      {"0.00000000", "0.00000001", "1.00000000", "-0.00000001", std::nullopt},
+      decimalType,
+      VARCHAR());
+}
+
+TEST_F(FlinkCastExprTest, longDecimalToVarcharPreservesPlainScale) {
+  const auto decimalType = DECIMAL(30, 10);
+
+  testCast<int128_t, StringView>(
+      "varchar",
+      {0, 1, 10000000000LL, -1, std::nullopt},
+      {"0.0000000000",
+       "0.0000000001",
+       "1.0000000000",
+       "-0.0000000001",
+       std::nullopt},
+      decimalType,
+      VARCHAR());
+
+  testTryCast<int128_t, StringView>(
+      "varchar",
+      {0, 1, 10000000000LL, -1, std::nullopt},
+      {"0.0000000000",
+       "0.0000000001",
+       "1.0000000000",
+       "-0.0000000001",
+       std::nullopt},
+      decimalType,
+      VARCHAR());
+}
+
+TEST_F(FlinkCastExprTest, nonDecimalToVarcharUsesDefaultCast) {
+  testCast<int64_t, StringView>(
+      "varchar", {0, 12, -34, std::nullopt}, {"0", "12", "-34", std::nullopt});
+}
+
+} // namespace bytedance::bolt::functions::flinksql::test

--- a/bolt/type/DecimalUtil.h
+++ b/bolt/type/DecimalUtil.h
@@ -133,21 +133,67 @@ class DecimalUtil {
   /// Helper function to calculate max length for decimal to string conversion
   static int32_t stringSize(int32_t precision, int32_t scale);
 
-  /// @brief Convert the unscaled value of a decimal to varchar and write to raw
-  /// string buffer from start position.
-  /// @tparam T The type of input value.
-  /// @param unscaledValue The input unscaled value.
-  /// @param scale The scale of decimal.
-  /// @param maxVarcharSize The estimated max size of a varchar.
-  /// @param startPosition The start position to write from.
-  /// @return write size
+  enum class DecimalStringFormat { kPlain, kSpark };
+
   template <typename T>
-  inline static size_t convertToString(
+  inline static size_t convertToPlainString(
       T unscaledValue,
       int32_t scale,
       int32_t maxVarcharSize,
       char* const startPosition) {
-#ifdef SPARK_COMPATIBLE
+    char* const endPosition = startPosition + maxVarcharSize;
+    char* writePosition = startPosition;
+    if (unscaledValue == 0) {
+      *writePosition++ = '0';
+      if (scale > 0) {
+        *writePosition++ = '.';
+        // Append leading zeros.
+        std::memset(writePosition, '0', scale);
+        writePosition += scale;
+      }
+    } else {
+      if (unscaledValue < 0) {
+        *writePosition++ = '-';
+        unscaledValue = -unscaledValue;
+      }
+      auto [position, errorCode] = std::to_chars(
+          writePosition,
+          endPosition,
+          unscaledValue / (T)DecimalUtil::kPowersOfTen[scale]);
+      BOLT_DCHECK_EQ(
+          errorCode,
+          std::errc(),
+          "Failed to cast decimal to varchar: {}",
+          std::make_error_code(errorCode).message());
+      writePosition = position;
+
+      if (scale > 0) {
+        *writePosition++ = '.';
+        uint128_t fraction =
+            unscaledValue % (T)DecimalUtil::kPowersOfTen[scale];
+        // Append leading zeros.
+        int numLeadingZeros = std::max(scale - countDigits(fraction), 0);
+        std::memset(writePosition, '0', numLeadingZeros);
+        writePosition += numLeadingZeros;
+        // Append remaining fraction digits.
+        auto result = std::to_chars(writePosition, endPosition, fraction);
+        BOLT_DCHECK_EQ(
+            result.ec,
+            std::errc(),
+            "Failed to cast decimal to varchar: {}",
+            std::make_error_code(result.ec).message());
+        writePosition = result.ptr;
+      }
+    }
+    return writePosition - startPosition;
+  }
+
+  template <typename T>
+  inline static size_t convertToSparkString(
+      T unscaledValue,
+      int32_t scale,
+      int32_t maxVarcharSize,
+      char* const startPosition) {
     if (scale == 0) {
       auto [endPosition, errorCode] = std::to_chars(
           startPosition, startPosition + maxVarcharSize, unscaledValue);
@@ -200,53 +246,45 @@ class DecimalUtil {
           std::make_error_code(errorCode).message());
       writePosition = position;
     }
-#else
-    char* writePosition = startPosition;
-    if (unscaledValue == 0) {
-      *writePosition++ = '0';
-      if (scale > 0) {
-        *writePosition++ = '.';
-        // Append leading zeros.
-        std::memset(writePosition, '0', scale);
-        writePosition += scale;
-      }
-    } else {
-      if (unscaledValue < 0) {
-        *writePosition++ = '-';
-        unscaledValue = -unscaledValue;
-      }
-      auto [position, errorCode] = std::to_chars(
-          writePosition,
-          writePosition + maxVarcharSize,
-          unscaledValue / (T)DecimalUtil::kPowersOfTen[scale]);
-      BOLT_DCHECK_EQ(
-          errorCode,
-          std::errc(),
-          "Failed to cast decimal to varchar: {}",
-          std::make_error_code(errorCode).message());
-      writePosition = position;
-
-      if (scale > 0) {
-        *writePosition++ = '.';
-        uint128_t fraction =
-            unscaledValue % (T)DecimalUtil::kPowersOfTen[scale];
-        // Append leading zeros.
-        int numLeadingZeros = std::max(scale - countDigits(fraction), 0);
-        std::memset(writePosition, '0', numLeadingZeros);
-        writePosition += numLeadingZeros;
-        // Append remaining fraction digits.
-        auto result = std::to_chars(
-            writePosition, writePosition + maxVarcharSize, fraction);
-        BOLT_DCHECK_EQ(
-            result.ec,
-            std::errc(),
-            "Failed to cast decimal to varchar: {}",
-            std::make_error_code(result.ec).message());
-        writePosition = result.ptr;
-      }
-    }
-#endif
     return writePosition - startPosition;
+  }
+
+  template <DecimalStringFormat format, typename T>
+  inline static size_t convertToString(
+      T unscaledValue,
+      int32_t scale,
+      int32_t maxVarcharSize,
+      char* const startPosition) {
+    if constexpr (format == DecimalStringFormat::kSpark) {
+      return convertToSparkString(
+          unscaledValue, scale, maxVarcharSize, startPosition);
+    } else {
+      return convertToPlainString(
+          unscaledValue, scale, maxVarcharSize, startPosition);
+    }
+  }
+
+  /// @brief Convert the unscaled value of a decimal to varchar and write to raw
+  /// string buffer from start position.
+  /// @tparam T The type of input value.
+  /// @param unscaledValue The input unscaled value.
+  /// @param scale The scale of decimal.
+  /// @param maxVarcharSize The estimated max size of a varchar.
+  /// @param startPosition The start position to write from.
+  /// @return write size
+  template <typename T>
+  inline static size_t convertToString(
+      T unscaledValue,
+      int32_t scale,
+      int32_t maxVarcharSize,
+      char* const startPosition) {
+#ifdef SPARK_COMPATIBLE
+    return convertToString<DecimalStringFormat::kSpark>(
+        unscaledValue, scale, maxVarcharSize, startPosition);
+#else
+    return convertToString<DecimalStringFormat::kPlain>(
+        unscaledValue, scale, maxVarcharSize, startPosition);
+#endif
   }
 
   template <typename T>


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #560

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Flink keeps the declared decimal scale when casting decimal values to varchar. For example, casting `DECIMAL(10, 8)` zero should produce `0.00000000`, while the current native path produces `0E-8`.

This change adds a Flink-specific cast special form for `decimal -> varchar` and keeps other casts on the default cast path. It also moves the decimal string conversion policy into `DecimalUtil` so callers can explicitly select plain or Spark-style formatting.

A regression test covers `cast` and `try_cast` for `DECIMAL(10, 8)` values including zero, non-zero scaled values, negative values, and nulls.

### Performance Impact
- [x] **No Impact**: This is a correctness fix for Flink decimal-to-varchar cast formatting.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Fixed Flink decimal to varchar cast to preserve decimal scale.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    N/A
    ```
    </details>