### PR TITLE
[Fix] Incorrect dependency regarding release/debug config parsing

### DIFF
--- a/scripts/conan/recipes/paimon-cpp/all/patches/paimon-cpp-conan-deps.patch
+++ b/scripts/conan/recipes/paimon-cpp/all/patches/paimon-cpp-conan-deps.patch
@@ -112,7 +112,7 @@ new file mode 100644
 index 0000000..8462b02
 --- /dev/null
 +++ b/cmake_modules/PaimonConanDeps.cmake
-@@ -0,0 +1,183 @@
+@@ -0,0 +1,184 @@
 +# Copyright 2024-present Alibaba Inc.
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -154,13 +154,14 @@ index 0000000..8462b02
 +
 +    # --- Helper: get the config suffix from the active build type ---
 +    # Conan generates variables like <pkg>_INCLUDE_DIRS_RELEASE or _DEBUG.
-+    # Map CMAKE_BUILD_TYPE to the suffix Conan uses.
-+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
++    # Map CMAKE_BUILD_TYPE to the suffix Conan uses. SetupCxxFlags uppercases it for compatibility, we also compare the uppercase version.
++    string(TOUPPER "${CMAKE_BUILD_TYPE}" _PAIMON_BUILD_TYPE)
++    if(_PAIMON_BUILD_TYPE STREQUAL "DEBUG")
 +        set(_PAIMON_CONAN_CONFIG_SUFFIX "_DEBUG")
-+    elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
++    elseif(_PAIMON_BUILD_TYPE STREQUAL "RELWITHDEBINFO")
 +        # Conan doesn't generate RelWithDebInfo data files; fall back to Release
 +        set(_PAIMON_CONAN_CONFIG_SUFFIX "_RELEASE")
-+    elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
++    elseif(_PAIMON_BUILD_TYPE STREQUAL "MINSIZEREL")
 +        set(_PAIMON_CONAN_CONFIG_SUFFIX "_RELEASE")
 +    else()
 +        # Default to Release (covers empty CMAKE_BUILD_TYPE and unknown types)


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close [#564](https://github.com/bytedance/bolt/issues/564)

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

When building paimon-cpp with Conan dependencies in Debug mode, the CMake configure step reports a Debug build correctly, but the actual build fails because Arrow include directories are not propagated to paimon_objlib .

The failure happens when source files include Arrow headers such as arrow/api.h or arrow/array/array_base.h .

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Update the CMake helper script to uppercase CMAKE_BUILD_TYPE before matching against Conan's expected suffixes, improving compatibility with SetupCxxFlags which uppercases build types. Also bump the file line count from 183 to 184.

Release Note:

```text
Release Note:
- Fixed a parsing error regarding debug build type for paimon.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
