### PR TITLE
WIP: feat(probe-subop): normalized-key probe AArch64 SVE on HashAgg

### DIFF
--- a/bolt/exec/CMakeLists.txt
+++ b/bolt/exec/CMakeLists.txt
@@ -25,6 +25,15 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
+set(BOLT_HASH_AGG_NORMALIZED_KEY_PROBE_SVE "")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*)")
+  list(APPEND BOLT_HASH_AGG_NORMALIZED_KEY_PROBE_SVE
+       HashTableNormalizedKeyProbeSve.cpp)
+else()
+  list(APPEND BOLT_HASH_AGG_NORMALIZED_KEY_PROBE_SVE
+       HashTableNormalizedKeyProbeStubs.cpp)
+endif()
+
 bolt_add_library(
   bolt_exec
   $<$<BOOL:${ENABLE_META_SORT}>:meta/MetaRowSorter.cpp>
@@ -59,6 +68,7 @@ bolt_add_library(
   HashPartitionFunction.cpp
   HashProbe.cpp
   HashTable.cpp
+  ${BOLT_HASH_AGG_NORMALIZED_KEY_PROBE_SVE}
   IndexLookupJoin.cpp
   JoinBridge.cpp
   Limit.cpp
@@ -122,6 +132,12 @@ bolt_add_library(
 )
 
 target_compile_features(bolt_exec PRIVATE cxx_std_20)
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*)")
+  set_source_files_properties(
+    HashTableNormalizedKeyProbeSve.cpp
+    PROPERTIES COMPILE_OPTIONS "-march=armv8-a+sve")
+endif()
 
 set_target_properties(bolt_exec PROPERTIES ENABLE_EXPORTS ON)
 

--- a/bolt/exec/GroupingSet.cpp
+++ b/bolt/exec/GroupingSet.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "bolt/exec/GroupingSet.h"
+#include "bolt/exec/HashTableSveRuntime.h"
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/common/base/SpillConfig.h"
 #include "bolt/common/testutil/TestValue.h"
@@ -399,23 +400,30 @@ std::vector<Accumulator> GroupingSet::accumulators(bool excludeToIntermediate) {
   return accumulators;
 }
 
-void GroupingSet::createHashTable() {
-  bool jitRowEqVectors = queryConfig_.enableJitRowEqVectors();
+std::unique_ptr<BaseHashTable> GroupingSet::createAggregationHashTable() {
+  const bool jitRowEqVectors = queryConfig_.enableJitRowEqVectors();
+  const bool sveNormalizedKeyProbe =
+      boltHashAggSveNormalizedKeyProbeEnabledFromEnv();
   if (ignoreNullKeys_) {
-    table_ = HashTable<true>::createForAggregation(
+    return HashTable<true>::createForAggregation(
         std::move(hashers_),
         accumulators(false),
         &pool_,
         nullptr,
-        jitRowEqVectors);
-  } else {
-    table_ = HashTable<false>::createForAggregation(
-        std::move(hashers_),
-        accumulators(false),
-        &pool_,
-        nullptr,
-        jitRowEqVectors);
+        jitRowEqVectors,
+        sveNormalizedKeyProbe);
   }
+  return HashTable<false>::createForAggregation(
+      std::move(hashers_),
+      accumulators(false),
+      &pool_,
+      nullptr,
+      jitRowEqVectors,
+      sveNormalizedKeyProbe);
+}
+
+void GroupingSet::createHashTable() {
+  table_ = createAggregationHashTable();
 
   RowContainer& rows = *table_->rows();
   initializeAggregates(aggregates_, rows, false);
@@ -449,6 +457,7 @@ void GroupingSet::createHashTable() {
     }
   }
 
+  const bool jitRowEqVectors = queryConfig_.enableJitRowEqVectors();
   lookup_ = std::make_unique<HashLookup>(table_->hashers(), jitRowEqVectors);
   if (!isAdaptive_ && table_->hashMode() != BaseHashTable::HashMode::kHash) {
     table_->forceGenericHashMode();

--- a/bolt/exec/GroupingSet.h
+++ b/bolt/exec/GroupingSet.h
@@ -57,7 +57,7 @@ class GroupingSet {
       tsan_atomic<bool>* nonReclaimableSection,
       OperatorCtx* operatorCtx);
 
-  ~GroupingSet();
+  virtual ~GroupingSet();
 
   // Used by MarkDistinct operator to identify rows with unique values.
   static std::unique_ptr<GroupingSet> createForMarkDistinct(
@@ -274,6 +274,11 @@ class GroupingSet {
   }
 
   void createHashTable();
+
+  /// Builds the aggregation-side hash table. Override to supply a custom
+  /// {@link BaseHashTable} (e.g. when {@code BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE}
+  /// is set, or for plugin-specific table types).
+  virtual std::unique_ptr<BaseHashTable> createAggregationHashTable();
 
   void populateTempVectors(int32_t aggregateIndex, const RowVectorPtr& input);
 

--- a/bolt/exec/HashAggregation.cpp
+++ b/bolt/exec/HashAggregation.cpp
@@ -186,7 +186,7 @@ void HashAggregation::initialize() {
   addRuntimeStat(
       "aggregationOutputCompositeVector",
       RuntimeCounter(supportRowBasedOutput_));
-  groupingSet_ = std::make_unique<GroupingSet>(
+  groupingSet_ = createGroupingSetForHashAggregation(
       inputType,
       std::move(hashers),
       std::move(preGroupedChannels),
@@ -818,5 +818,33 @@ void HashAggregation::updateEstimatedOutputRowSize() {
   } else if (rowSize > estimatedOutputRowSize_.value()) {
     estimatedOutputRowSize_ = rowSize;
   }
+}
+
+std::unique_ptr<GroupingSet> HashAggregation::createGroupingSetForHashAggregation(
+    const RowTypePtr& inputType,
+    std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+    std::vector<column_index_t>&& preGroupedKeys,
+    std::vector<AggregateInfo>&& aggregates,
+    bool ignoreNullKeys,
+    bool isPartial,
+    bool isRawInput,
+    const std::vector<vector_size_t>& globalGroupingSets,
+    const std::optional<column_index_t>& groupIdChannel,
+    const common::SpillConfig* spillConfig,
+    tsan_atomic<bool>* nonReclaimableSection,
+    OperatorCtx* operatorCtx) {
+  return std::make_unique<GroupingSet>(
+      inputType,
+      std::move(hashers),
+      std::move(preGroupedKeys),
+      std::move(aggregates),
+      ignoreNullKeys,
+      isPartial,
+      isRawInput,
+      globalGroupingSets,
+      groupIdChannel,
+      spillConfig,
+      nonReclaimableSection,
+      operatorCtx);
 }
 } // namespace bytedance::bolt::exec

--- a/bolt/exec/HashAggregation.h
+++ b/bolt/exec/HashAggregation.h
@@ -64,6 +64,23 @@ class HashAggregation : public Operator {
 
   void close() override;
 
+ protected:
+  /// Default constructs {@link GroupingSet}. Override together with
+  /// {@link GroupingSet::createAggregationHashTable()} for custom hash tables.
+  virtual std::unique_ptr<GroupingSet> createGroupingSetForHashAggregation(
+      const RowTypePtr& inputType,
+      std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+      std::vector<column_index_t>&& preGroupedKeys,
+      std::vector<AggregateInfo>&& aggregates,
+      bool ignoreNullKeys,
+      bool isPartial,
+      bool isRawInput,
+      const std::vector<vector_size_t>& globalGroupingSets,
+      const std::optional<column_index_t>& groupIdChannel,
+      const common::SpillConfig* spillConfig,
+      tsan_atomic<bool>* nonReclaimableSection,
+      OperatorCtx* operatorCtx);
+
  private:
   void updateRuntimeStats();
 

--- a/bolt/exec/HashTable.cpp
+++ b/bolt/exec/HashTable.cpp
@@ -42,6 +42,8 @@
 #include "bolt/common/process/ProcessBase.h"
 #include "bolt/common/testutil/TestValue.h"
 #include "bolt/exec/HashTable.h"
+
+#include "bolt/exec/HashTableSveRuntime.h"
 #include "bolt/exec/OperatorUtils.h"
 #include "bolt/exec/RowContainer.h"
 #include "bolt/jit/RowContainer/RowContainerCodeGenerator.h"
@@ -77,12 +79,14 @@ HashTable<ignoreNullKeys>::HashTable(
     memory::MemoryPool* pool,
     const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
     bool enableJit,
+    bool sveNormalizedKeyProbeEnabled,
     bool hybridMode)
     : BaseHashTable(std::move(hashers)),
       minTableSizeForParallelJoinBuild_(minTableSizeForParallelJoinBuild),
       isJoinBuild_(isJoinBuild),
       joinBuildNoDuplicates_(!allowDuplicates),
       hashMode_(mode),
+      sveNormalizedKeyProbeRequested_(sveNormalizedKeyProbeEnabled),
       enableJit_(enableJit) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
@@ -148,6 +152,7 @@ HashTable<ignoreNullKeys>::HashTable(
     memory::MemoryPool* pool,
     const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
     bool enableJitRowEqVectors,
+    bool sveNormalizedKeyProbeEnabled,
     bool hybridMode)
     : HashTable<ignoreNullKeys>(
           std::move(hashers),
@@ -161,6 +166,7 @@ HashTable<ignoreNullKeys>::HashTable(
           pool,
           stringArena,
           enableJitRowEqVectors,
+          sveNormalizedKeyProbeEnabled,
           hybridMode) {}
 
 int32_t ProbeState::row() const {
@@ -358,6 +364,14 @@ void HashTable<ignoreNullKeys>::storeRowPointer(
     reinterpret_cast<char**>(table_)[index] = row;
     return;
   }
+  if (hashMode_ == HashMode::kNormalizedKey &&
+      normalizedKeyMode_ == NormalizedKeyMode::kScalar && !isJoinBuild_) {
+    auto* table = reinterpret_cast<NormalizedKeySlot*>(table_);
+    table[index].key =
+        reinterpret_cast<normalized_key_t*>(row)[-1]; // NOLINT
+    table[index].value = row;
+    return;
+  }
   const int64_t offset = bucketOffset(index);
   auto* bucket = bucketAt(offset);
   const auto slotIndex = index & (sizeof(TagVector) - 1);
@@ -370,16 +384,17 @@ char* HashTable<ignoreNullKeys>::insertEntry(
     HashLookup& lookup,
     uint64_t index,
     vector_size_t row) {
+  if (hashMode_ == HashMode::kNormalizedKey &&
+      normalizedKeyMode_ == NormalizedKeyMode::kSve) {
+    return insertEntryforSVE(lookup, index, row);
+  }
   char* group = rows_->newRow();
   lookup.hits[row] = group; // NOLINT
   storeKeys(lookup, row);
-  storeRowPointer(index, lookup.hashes[row], group);
   if (hashMode_ == HashMode::kNormalizedKey) {
-    // We store the unique digest of key values (normalized key) in
-    // the word below the row. Space was reserved in the allocation
-    // unless we have given up on normalized keys.
     RowContainer::normalizedKey(group) = lookup.normalizedKeys[row]; // NOLINT
   }
+  storeRowPointer(index, lookup.hashes[row], group);
   ++numDistinct_;
   lookup.newGroups.push_back(row);
   return group;
@@ -630,7 +645,51 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
 }
 
 template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::groupNormalizedKeyProbeScalar(
+    HashLookup& lookup) {
+  BOLT_DCHECK(!lookup.hashes.empty());
+  BOLT_DCHECK(!lookup.hits.empty());
+
+  int32_t numProbes = lookup.rows.size();
+  const vector_size_t* rows = lookup.rows.data();
+  auto hashes = lookup.hashes.data();
+  auto groups = lookup.hits.data();
+
+  auto* table = reinterpret_cast<NormalizedKeySlot*>(table_);
+  for (int32_t i = 0; i < numProbes; ++i) {
+    auto row = rows[i];
+    uint64_t index = hashes[row] & (capacity_ - 1);
+    uint64_t start = index;
+    while (true) {
+      char* group = table[index].value;
+      if (UNLIKELY(!table[index].value)) {
+        group = insertEntry(lookup, index, row);
+        groups[row] = group;
+        break;
+      }
+      if (table[index].key == lookup.normalizedKeys[row]) {
+        groups[row] = group;
+        break;
+      }
+      index = (index + 1) & (capacity_ - 1);
+      if (index == start) {
+        BOLT_FAIL(
+            "Have looped through all the buckets in table: {}", toString());
+      }
+    }
+  }
+}
+
+template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::groupNormalizedKeyProbe(HashLookup& lookup) {
+  if (normalizedKeyMode_ == NormalizedKeyMode::kScalar) {
+    groupNormalizedKeyProbeScalar(lookup);
+    return;
+  }
+  if (normalizedKeyMode_ == NormalizedKeyMode::kSve) {
+    groupNormalizedKeyProbeSVE(lookup);
+    return;
+  }
   ProbeState state1;
   ProbeState state2;
   ProbeState state3;
@@ -839,21 +898,28 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
   BOLT_CHECK(bits::isPowerOfTwo(size), "Size is not a power of two: {}", size);
   BOLT_CHECK_GT(size, 0);
   capacity_ = size;
-  const uint64_t byteSize = capacity_ * tableSlotSize();
+  size_t slotSize;
+  if (hashMode_ == HashMode::kNormalizedKey &&
+      normalizedKeyMode_ == NormalizedKeyMode::kScalar && !isJoinBuild_) {
+    slotSize = 16;
+  } else if (
+      hashMode_ == HashMode::kNormalizedKey &&
+      normalizedKeyMode_ == NormalizedKeyMode::kSve && !isJoinBuild_) {
+    slotSize = 17;
+  } else {
+    slotSize = tableSlotSize();
+  }
+  const uint64_t byteSize = capacity_ * slotSize;
   BOLT_CHECK_EQ(byteSize % kBucketSize, 0);
   numTombstones_ = 0;
   sizeMask_ = byteSize - 1;
   numBuckets_ = byteSize / kBucketSize;
   sizeBits_ = __builtin_popcountll(sizeMask_);
   bucketOffsetMask_ = sizeMask_ & ~(kBucketSize - 1);
-  // The total size is 8 bytes per slot, in groups of 16 slots with 16 bytes of
-  // tags and 16 * 6 bytes of pointers and a padding of 16 bytes to round up the
-  // cache line.
-  const auto numPages =
-      memory::AllocationTraits::numPages(size * tableSlotSize());
+  const auto numPages = memory::AllocationTraits::numPages(size * slotSize);
   rows_->pool()->allocateContiguous(numPages, tableAllocation_);
   table_ = tableAllocation_.data<char*>();
-  memset(table_, 0, capacity_ * sizeof(char*));
+  memset(table_, 0, capacity_ * slotSize);
 }
 
 template <bool ignoreNullKeys>
@@ -868,8 +934,16 @@ void HashTable<ignoreNullKeys>::clear() {
     }
   }
   if (table_) {
-    // All modes have 8 bytes per slot.
-    memset(table_, 0, capacity_ * sizeof(char*));
+    if (hashMode_ == HashMode::kNormalizedKey &&
+        normalizedKeyMode_ == NormalizedKeyMode::kScalar && !isJoinBuild_) {
+      memset(table_, 0, capacity_ * 16);
+    } else if (
+        hashMode_ == HashMode::kNormalizedKey &&
+        normalizedKeyMode_ == NormalizedKeyMode::kSve && !isJoinBuild_) {
+      memset(table_, 0, capacity_ * 17);
+    } else {
+      memset(table_, 0, capacity_ * sizeof(char*));
+    }
   }
   numDistinct_ = 0;
   numTombstones_ = 0;
@@ -1214,6 +1288,10 @@ void HashTable<ignoreNullKeys>::insertForGroupBy(
       BOLT_CHECK_NULL(table_[index]);
       table_[index] = groups[i];
     }
+  } else if (
+      hashMode_ == HashMode::kNormalizedKey &&
+      normalizedKeyMode_ == NormalizedKeyMode::kSve) {
+    insertForGroupBySve(groups, hashes, numGroups);
   } else {
     constexpr int32_t kPrefetchDistance = 10;
     for (int32_t i = 0; i < numGroups; ++i) {
@@ -1449,10 +1527,55 @@ void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
     checkSize(numNew, true);
   } else if (mode == HashMode::kNormalizedKey) {
     hashMode_ = HashMode::kNormalizedKey;
+    updateNormalizedKeyModeForAggregation();
     capacity_ = 0;
     // Makes tables of the right size and rehashes.
     checkSize(numNew, true);
   }
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::updateNormalizedKeyModeForAggregation() {
+  if (isJoinBuild_ || !sveNormalizedKeyProbeRequested_) {
+    normalizedKeyMode_ = NormalizedKeyMode::kNativeBolt;
+    return;
+  }
+  if (linuxAarch64RuntimeHasSve()) {
+    normalizedKeyMode_ = NormalizedKeyMode::kSve;
+  } else {
+    normalizedKeyMode_ = NormalizedKeyMode::kScalar;
+  }
+}
+
+template <bool ignoreNullKeys>
+uint64_t* HashTable<ignoreNullKeys>::getKeyPtr() {
+  return reinterpret_cast<uint64_t*>(table_);
+}
+
+template <bool ignoreNullKeys>
+char** HashTable<ignoreNullKeys>::getValuePtr() {
+  return reinterpret_cast<char**>(table_ + capacity_);
+}
+
+template <bool ignoreNullKeys>
+uint8_t* HashTable<ignoreNullKeys>::getTagPtr() {
+  return reinterpret_cast<uint8_t*>(table_ + 2 * capacity_);
+}
+
+template <bool ignoreNullKeys>
+char* HashTable<ignoreNullKeys>::insertEntryforSVE(
+    HashLookup& lookup,
+    uint64_t index,
+    vector_size_t row) {
+  char* group = rows_->newRow();
+  lookup.hits[row] = group; // NOLINT
+  storeKeys(lookup, row);
+  if (hashMode_ == HashMode::kNormalizedKey) {
+    RowContainer::normalizedKey(group) = lookup.normalizedKeys[row]; // NOLINT
+  }
+  ++numDistinct_;
+  lookup.newGroups.push_back(row);
+  return group;
 }
 
 template <bool ignoreNullKeys>

--- a/bolt/exec/HashTable.h
+++ b/bolt/exec/HashTable.h
@@ -159,6 +159,15 @@ class BaseHashTable {
   /// Specifies the hash mode of a table.
   enum class HashMode { kHash, kArray, kNormalizedKey };
 
+  /// Layout for normalized-key group-by probe (aggregation only).
+  enum class NormalizedKeyMode { kNativeBolt, kScalar, kSve };
+
+  /// 16-byte slot for {@link NormalizedKeyMode::kScalar}: key + row pointer.
+  struct NormalizedKeySlot {
+    uint64_t key;
+    char* value;
+  };
+
   static constexpr int8_t kNoSpillInputStartPartitionBit = -1;
 
   /// Returns the string of the given 'mode'.
@@ -551,6 +560,7 @@ class HashTable : public BaseHashTable {
       memory::MemoryPool* pool,
       const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
       bool enableJitRowEqVectors,
+      bool sveNormalizedKeyProbeEnabled = false,
       bool hybridMode = false);
 
   HashTable(
@@ -565,6 +575,7 @@ class HashTable : public BaseHashTable {
       memory::MemoryPool* pool,
       const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
       bool enableJitRowEqVectors,
+      bool sveNormalizedKeyProbeEnabled = false,
       bool hybridMode = false);
 
   ~HashTable() override = default;
@@ -574,7 +585,8 @@ class HashTable : public BaseHashTable {
       const std::vector<Accumulator>& accumulators,
       memory::MemoryPool* pool,
       const std::shared_ptr<bolt::HashStringAllocator>& stringArena,
-      bool jitRowEqVectors) {
+      bool jitRowEqVectors,
+      bool sveNormalizedKeyProbeEnabled = false) {
     return std::make_unique<HashTable>(
         std::move(hashers),
         accumulators,
@@ -585,7 +597,8 @@ class HashTable : public BaseHashTable {
         0, // minTableSizeForParallelJoinBuild
         pool,
         stringArena,
-        jitRowEqVectors);
+        jitRowEqVectors,
+        sveNormalizedKeyProbeEnabled);
   }
 
   static std::unique_ptr<HashTable> createForJoin(
@@ -610,6 +623,7 @@ class HashTable : public BaseHashTable {
         pool,
         nullptr,
         jitRowEqVectors,
+        false, // sveNormalizedKeyProbeEnabled
         hybridMode);
   }
 
@@ -976,6 +990,11 @@ class HashTable : public BaseHashTable {
 
   char* insertEntry(HashLookup& lookup, uint64_t index, vector_size_t row);
 
+  char* insertEntryforSVE(
+      HashLookup& lookup,
+      uint64_t index,
+      vector_size_t row);
+
   bool compareKeys(const char* group, HashLookup& lookup, vector_size_t row);
 
   bool compareKeys(const char* group, const char* inserted);
@@ -985,6 +1004,20 @@ class HashTable : public BaseHashTable {
 
   // Shortcut path for group by with normalized keys.
   void groupNormalizedKeyProbe(HashLookup& lookup);
+
+  void groupNormalizedKeyProbeScalar(HashLookup& lookup);
+
+  void groupNormalizedKeyProbeSVE(HashLookup& lookup);
+
+  void insertForGroupBySve(char** groups, uint64_t* hashes, int32_t numGroups);
+
+  uint64_t* getKeyPtr();
+
+  char** getValuePtr();
+
+  uint8_t* getTagPtr();
+
+  void updateNormalizedKeyModeForAggregation();
 
   // Array probe with SIMD.
   void arrayJoinProbe(HashLookup& lookup);
@@ -1126,6 +1159,8 @@ class HashTable : public BaseHashTable {
   // Counts the number of rehash() calls.
   int64_t numRehashes_{0};
   HashMode hashMode_ = HashMode::kArray;
+  NormalizedKeyMode normalizedKeyMode_ = NormalizedKeyMode::kNativeBolt;
+  bool sveNormalizedKeyProbeRequested_{false};
   // Owns the memory of multiple build side hash join tables that are
   // combined into a single probe hash table.
   std::vector<std::unique_ptr<HashTable<ignoreNullKeys>>> otherTables_;

--- a/bolt/exec/HashTableNormalizedKeyProbeStubs.cpp
+++ b/bolt/exec/HashTableNormalizedKeyProbeStubs.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/exec/HashTable.h"
+
+namespace bytedance::bolt::exec {
+
+// Linked on non-aarch64 so HashTable.cpp can reference SVE symbols. Runtime
+// uses kScalar/kNativeBolt only; these paths are not taken in normal operation.
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::groupNormalizedKeyProbeSVE(HashLookup& lookup) {
+  groupNormalizedKeyProbeScalar(lookup);
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::insertForGroupBySve(
+    char** /*groups*/,
+    uint64_t* /*hashes*/,
+    int32_t /*numGroups*/) {
+  BOLT_FAIL(
+      "SVE normalized-key insertForGroupBy requires aarch64 with SVE support");
+}
+
+template void HashTable<true>::groupNormalizedKeyProbeSVE(HashLookup&);
+template void HashTable<false>::groupNormalizedKeyProbeSVE(HashLookup&);
+template void HashTable<true>::insertForGroupBySve(char**, uint64_t*, int32_t);
+template void HashTable<false>::insertForGroupBySve(char**, uint64_t*, int32_t);
+
+} // namespace bytedance::bolt::exec

--- a/bolt/exec/HashTableNormalizedKeyProbeSve.cpp
+++ b/bolt/exec/HashTableNormalizedKeyProbeSve.cpp
@@ -1,0 +1,588 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Licensed under the Apache License, Version 2.0
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm_sve.h>
+
+#include "bolt/exec/HashTable.h"
+
+namespace bytedance::bolt::exec {
+namespace {
+
+inline __attribute__((always_inline)) svbool_t
+get_uniq_mask2(svbool_t pg, const svuint64_t val) {
+  svuint64_t s1 = svext_u64(val, val, 1);
+  svbool_t mask2 = svcmpeq(svwhilelt_b64(0, 3), val, s1);
+
+  svuint64_t s2 = svext_u64(val, val, 2);
+  svbool_t mask3 = svcmpeq(svwhilelt_b64(0, 2), val, s2);
+  svbool_t mask12 = svorr_b_z(pg, mask2, mask3);
+
+  svuint64_t s3 = svext_u64(val, val, 3);
+  svbool_t mask4 = svcmpeq(svwhilelt_b64(0, 1), val, s3);
+
+  svbool_t mask = svorr_b_z(pg, mask4, mask12);
+  mask = svnot_b_z(pg, mask);
+
+  return mask;
+}
+
+} // namespace
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::groupNormalizedKeyProbeSVE(HashLookup& lookup) {
+  constexpr int32_t kVectorWidth = 4;
+  constexpr int32_t kTagShiftBits = 38;
+  constexpr uint64_t kTagMask = 0x80;
+  constexpr int32_t kProbeStep = 32;
+  constexpr int32_t kBitsPerByte = 8;
+  constexpr int32_t kInvalidIndex = INT_MAX;
+  constexpr int32_t kPrefetchDistance = 8;
+
+  int32_t numProbes = lookup.rows.size();
+  const int32_t* rows = lookup.rows.data();
+  auto hashes = lookup.hashes.data();
+  auto groups = lookup.hits.data();
+  auto normalizedKeys = lookup.normalizedKeys.data();
+
+  bool all = false;
+  if (lookup.rows.size() - 1 == lookup.rows[numProbes - 1]) {
+    all = true;
+  }
+
+  // Core vector build loop for this group
+  // svuint64_t keyVec = svdup_n_u64(0);
+  svuint64_t valVec = svdup_n_u64(0);
+  // svuint64_t tabKey = svdup_n_u64(0);
+
+  svuint64_t currIndex = svdup_n_u64(0);
+  // svuint64_t indexVec = svindex_u64(0, 1);
+  svint64_t rowId = svdup_n_s64(0);
+  svbool_t indexMask = svptrue_b64();
+  svbool_t emptyMask = svptrue_b64();
+  // svuint8_t zeroMask = svdup_n_u8(0);
+
+
+  int32_t i = 0;
+  svbool_t predicateMask = svptrue_b64();
+  while (i + kVectorWidth < numProbes) {
+    if (i + kVectorWidth + kPrefetchDistance < numProbes) {
+      for (int32_t p = 0; p < kVectorWidth; ++p) {
+        int32_t prefetchRow = i + kVectorWidth + kPrefetchDistance + p;
+        uint64_t prefetchIdx = hashes[prefetchRow] & (capacity_ - 1);
+        // Prefetch tag/value/key for upcoming slots
+        svprfb(svptrue_b8(), getTagPtr() + prefetchIdx, SV_PLDL1STRM);
+        svprfd(svptrue_b64(), getValuePtr() + prefetchIdx, SV_PLDL1STRM);
+        svprfd(svptrue_b64(), getKeyPtr() + prefetchIdx, SV_PLDL1STRM);
+      }
+    }
+
+    // load normalized keys and curr_index
+    if (all) {
+      currIndex = svld1(predicateMask, hashes + i);
+    } else {
+      rowId = svld1sw_s64(predicateMask, rows + i);
+      svint64_t rowOffset = svlsl_n_s64_z(predicateMask, rowId, 3);
+      currIndex = svld1_gather_offset(
+          predicateMask, hashes, svreinterpret_u64(rowOffset));
+    }
+
+    // calc tag
+    svuint64_t currTagTmp =
+        svlsr_n_u64_x(predicateMask, currIndex, kTagShiftBits);
+    svuint64_t currTag = svorr_n_u64_z(
+        predicateMask,
+        currTagTmp,
+        kTagMask);
+
+    // Mask to slot index in table
+    currIndex = svand_n_u64_z(predicateMask, currIndex, capacity_ - 1);
+    svuint64_t htOffset = svlsl_n_u64_z(predicateMask, currIndex, 3);
+    valVec = svld1_gather_u64offset_u64(
+        predicateMask,
+        reinterpret_cast<uint64_t*>(getValuePtr()),
+        htOffset);
+
+    emptyMask = svcmpeq_n_u64(predicateMask, valVec, 0);
+    if (svptest_any(predicateMask, emptyMask)) {
+      indexMask = get_uniq_mask2(
+          emptyMask,
+          currIndex); // Deduplicate slot indices for empty lanes
+    } else {
+      indexMask = emptyMask;
+    }
+
+    svbool_t toWriteMask = svand_z(predicateMask, indexMask, emptyMask);
+
+    // Per-lane table indices
+    uint64_t htIndices[kVectorWidth] = {0, 0, 0, 0};
+    svst1(svptrue_b64(), htIndices, currIndex);
+
+    uint64_t tags[kVectorWidth] = {0, 0, 0, 0};
+    svst1(svptrue_b64(), tags, currTag);
+
+    uint32_t flag = 0;
+    __asm__("str %1, [%0]"
+                         :
+                         : "r"(&flag), "Upl"(toWriteMask)
+                         : "memory");
+    uint32_t flag1 = flag;
+    while (flag1) {
+      int32_t offset = __builtin_ctz(flag1);
+      int32_t idx = offset / kBitsPerByte;
+      uint64_t htIdx = htIndices[idx];
+
+      getKeyPtr()[htIdx] = normalizedKeys[i + idx];
+      getValuePtr()[htIdx] =
+          insertEntryforSVE(lookup, htIdx, i + idx);
+      groups[i + idx] = getValuePtr()[htIdx];
+      getTagPtr()[htIdx] = tags[idx];
+
+      flag1 &= (flag1 - 1);
+    }
+
+
+    uint32_t conflictFlag = ~flag & 0x01010101;
+
+    // Conflict lanes: linear probe
+    while (conflictFlag) {
+      int32_t offset = __builtin_ctz(conflictFlag);
+      int32_t idx = offset / kBitsPerByte;
+      int32_t rowIdx = i + idx;
+
+      bool processSuccess = false;
+      int64_t htStartIdx = htIndices[idx];
+
+
+      
+      while (!processSuccess) {
+        // Scan tags from htStartIdx (wrap at capacity)
+        svbool_t tagPredicate = svwhilelt_b8(htStartIdx, capacity_);
+        svuint8_t htTag =
+            svld1_u8(tagPredicate, getTagPtr() + htStartIdx);
+
+        svuint8_t conflictTag =
+            svdup_lane(svreinterpret_u8_u64(currTag), offset);
+
+        svbool_t matchZero = svcmpeq_n_u8(tagPredicate, htTag, 0);
+        svbool_t conflictMatch = svcmpeq_u8(tagPredicate, htTag, conflictTag);
+        uint32_t zeroMask = 0;
+        uint32_t conflictMask = 0;
+        __asm__("str %1, [%0]"
+                             :
+                             : "r"(&zeroMask), "Upl"(matchZero)
+                             : "memory");
+        __asm__("str %1, [%0]"
+                             :
+                             : "r"(&conflictMask), "Upl"(conflictMatch)
+                             : "memory");
+        int32_t zeroBefore = kInvalidIndex;
+        int32_t htZeroIdx = kInvalidIndex;
+        if (zeroMask) {
+          zeroBefore = __builtin_ctz(zeroMask);
+          htZeroIdx = htStartIdx + zeroBefore;
+        }
+        
+
+        uint64_t currNormalizedKey = normalizedKeys[rowIdx];
+        while (conflictMask) {
+          int32_t conflictIdx = __builtin_ctz(conflictMask);
+          //
+          if (conflictIdx > zeroBefore) {
+            // insert new
+            getKeyPtr()[htZeroIdx] = currNormalizedKey;
+            getValuePtr()[htZeroIdx] =
+                insertEntryforSVE(lookup, htZeroIdx, rowIdx);
+            groups[rowIdx] = getValuePtr()[htZeroIdx];
+            getTagPtr()[htZeroIdx] = tags[idx];
+            
+            processSuccess = true;
+            break;
+          } else {
+            // compare normalize key
+            int32_t htIdx =
+                htStartIdx + conflictIdx;
+            if (currNormalizedKey == getKeyPtr()[htIdx]) {
+              groups[rowIdx] = getValuePtr()[htIdx];
+              
+              processSuccess = true;
+              break;
+            }
+          }
+          conflictMask = conflictMask & (conflictMask - 1);
+        }
+        if (zeroMask && !processSuccess) {
+          getKeyPtr()[htZeroIdx] = currNormalizedKey;
+          getValuePtr()[htZeroIdx] =
+              insertEntryforSVE(lookup, htZeroIdx, rowIdx);
+          groups[rowIdx] = getValuePtr()[htZeroIdx];
+          getTagPtr()[htZeroIdx] = tags[idx];
+          processSuccess = true;
+        }
+
+        htStartIdx =
+            capacity_ - htStartIdx > kProbeStep ? htStartIdx + kProbeStep : 0;
+      }
+      conflictFlag &= (conflictFlag - 1);
+    }
+    i += kVectorWidth;
+  }
+    predicateMask = svwhilelt_b64(i, numProbes);
+    // load normalized keys and curr_index
+    if (all) {
+      currIndex = svld1(predicateMask, hashes + i);
+    } else {
+      rowId = svld1sw_s64(predicateMask, rows + i);
+      svint64_t rowOffset = svlsl_n_s64_z(predicateMask, rowId, 3);
+      currIndex = svld1_gather_offset(
+          predicateMask, hashes, svreinterpret_u64(rowOffset));
+    }
+
+    // calc tag
+    svuint64_t currTagTmp =
+        svlsr_n_u64_x(predicateMask, currIndex, kTagShiftBits);
+    svuint64_t currTag = svorr_n_u64_z(
+        predicateMask,
+        currTagTmp,
+        kTagMask);
+
+    // Mask to slot index in table
+    currIndex = svand_n_u64_z(predicateMask, currIndex, capacity_ - 1);
+    svuint64_t htOffset = svlsl_n_u64_z(predicateMask, currIndex, 3);
+    valVec = svld1_gather_u64offset_u64(
+        predicateMask,
+        reinterpret_cast<uint64_t*>(getValuePtr()),
+        htOffset);
+
+    emptyMask = svcmpeq_n_u64(predicateMask, valVec, 0);
+    if (svptest_any(predicateMask, emptyMask)) {
+      indexMask = get_uniq_mask2(
+          emptyMask,
+          currIndex); // Deduplicate slot indices for empty lanes
+    } else {
+      indexMask = emptyMask;
+    }
+
+    svbool_t toWriteMask = svand_z(predicateMask, indexMask, emptyMask);
+
+    // Per-lane table indices
+    uint64_t htIndices[kVectorWidth] = {0, 0, 0, 0};
+    svst1(svptrue_b64(), htIndices, currIndex);
+
+    uint64_t tags[kVectorWidth] = {0, 0, 0, 0};
+    svst1(svptrue_b64(), tags, currTag);
+
+    uint32_t flag = 0;
+    __asm__("str %1, [%0]"
+                         :
+                         : "r"(&flag), "Upl"(toWriteMask)
+                         : "memory");
+    uint32_t flag1 = flag;
+    while (flag1) {
+      int32_t offset = __builtin_ctz(flag1);
+      int32_t idx = offset / kBitsPerByte;
+      uint64_t htIdx = htIndices[idx];
+
+      getKeyPtr()[htIdx] = normalizedKeys[i + idx];
+      getValuePtr()[htIdx] =
+          insertEntryforSVE(lookup, htIdx, i + idx);
+      groups[i + idx] = getValuePtr()[htIdx];
+      getTagPtr()[htIdx] = tags[idx];
+
+      flag1 &= (flag1 - 1);
+    }
+
+
+
+  svbool_t conflictIndex = svnot_b_z(predicateMask, toWriteMask);
+  uint32_t conflictFlag = 0;
+  __asm__ __volatile__("str %1, [%0]" : : "r"(&conflictFlag), "Upl"(conflictIndex): "memory");
+    // Conflict lanes: linear probe
+    while (conflictFlag) {
+      int32_t offset = __builtin_ctz(conflictFlag);
+      int32_t idx = offset / kBitsPerByte;
+      int32_t rowIdx = i + idx;
+
+      bool processSuccess = false;
+      int64_t htStartIdx = htIndices[idx];
+
+
+      
+      while (!processSuccess) {
+        // Scan tags from htStartIdx (wrap at capacity)
+        svbool_t tagPredicate = svwhilelt_b8(htStartIdx, capacity_);
+        svuint8_t htTag =
+            svld1_u8(tagPredicate, getTagPtr() + htStartIdx);
+
+        svuint8_t conflictTag =
+            svdup_lane(svreinterpret_u8_u64(currTag), offset);
+
+        svbool_t matchZero = svcmpeq_n_u8(tagPredicate, htTag, 0);
+        svbool_t conflictMatch = svcmpeq_u8(tagPredicate, htTag, conflictTag);
+        uint32_t zeroMask = 0;
+        uint32_t conflictMask = 0;
+        __asm__("str %1, [%0]"
+                             :
+                             : "r"(&zeroMask), "Upl"(matchZero)
+                             : "memory");
+        __asm__("str %1, [%0]"
+                             :
+                             : "r"(&conflictMask), "Upl"(conflictMatch)
+                             : "memory");
+        int32_t zeroBefore = kInvalidIndex;
+        int32_t htZeroIdx = kInvalidIndex;
+        if (zeroMask) {
+          zeroBefore = __builtin_ctz(zeroMask);
+          htZeroIdx = htStartIdx + zeroBefore;
+        }
+        
+
+        uint64_t currNormalizedKey = normalizedKeys[rowIdx];
+        while (conflictMask) {
+          int32_t conflictIdx = __builtin_ctz(conflictMask);
+          //
+          if (conflictIdx > zeroBefore) {
+            // insert new
+            getKeyPtr()[htZeroIdx] = currNormalizedKey;
+            getValuePtr()[htZeroIdx] =
+                insertEntryforSVE(lookup, htZeroIdx, rowIdx);
+            groups[rowIdx] = getValuePtr()[htZeroIdx];
+            getTagPtr()[htZeroIdx] = tags[idx];
+            
+            processSuccess = true;
+            break;
+          } else {
+            // compare normalize key
+            int32_t htIdx =
+                htStartIdx + conflictIdx;
+            if (currNormalizedKey == getKeyPtr()[htIdx]) {
+              groups[rowIdx] = getValuePtr()[htIdx];
+              
+              processSuccess = true;
+              break;
+            }
+          }
+          conflictMask = conflictMask & (conflictMask - 1);
+        }
+        if (zeroMask && !processSuccess) {
+          getKeyPtr()[htZeroIdx] = currNormalizedKey;
+          getValuePtr()[htZeroIdx] =
+              insertEntryforSVE(lookup, htZeroIdx, rowIdx);
+          groups[rowIdx] = getValuePtr()[htZeroIdx];
+          getTagPtr()[htZeroIdx] = tags[idx];
+          processSuccess = true;
+        }
+
+        htStartIdx =
+            capacity_ - htStartIdx > kProbeStep ? htStartIdx + kProbeStep : 0;
+      }
+      conflictFlag &= (conflictFlag - 1);
+    }
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::insertForGroupBySve(
+    char** groups,
+    uint64_t* hashes,
+    int32_t numGroups) {
+  constexpr int32_t kVectorWidth = 4;
+  constexpr int32_t kTagShiftBits = 38;
+  constexpr uint64_t kTagMask = 0x80;
+  constexpr int32_t kProbeStep = 32;
+  constexpr int32_t kBitsPerByte = 8;
+  constexpr int32_t kInvalidIndex = INT_MAX;
+  constexpr int32_t kPrefetchDistance = 8;
+
+  int32_t numProbes = numGroups;
+  svuint64_t valVec = svdup_n_u64(0);
+  svuint64_t currIndex = svdup_n_u64(0);
+  svbool_t indexMask = svptrue_b64();
+  svbool_t emptyMask = svptrue_b64();
+
+  int32_t i = 0;
+  svbool_t predicateMask = svptrue_b64();
+  while (i + kVectorWidth < numProbes) {
+    if (i + kVectorWidth + kPrefetchDistance < numProbes) {
+      for (int32_t p = 0; p < kVectorWidth; ++p) {
+        int32_t prefetchRow = i + kVectorWidth + kPrefetchDistance + p;
+        uint64_t prefetchIdx = hashes[prefetchRow] & (capacity_ - 1);
+        svprfb(svptrue_b8(), getTagPtr() + prefetchIdx, SV_PLDL1STRM);
+        svprfd(svptrue_b64(), getValuePtr() + prefetchIdx, SV_PLDL1STRM);
+        svprfd(svptrue_b64(), getKeyPtr() + prefetchIdx, SV_PLDL1STRM);
+      }
+    }
+
+    currIndex = svld1(predicateMask, hashes + i);
+
+    svuint64_t currTagTmp =
+        svlsr_n_u64_x(predicateMask, currIndex, kTagShiftBits);
+    svuint64_t currTag =
+        svorr_n_u64_z(predicateMask, currTagTmp, kTagMask);
+
+    currIndex = svand_n_u64_z(predicateMask, currIndex, capacity_ - 1);
+    svuint64_t htOffset = svlsl_n_u64_z(predicateMask, currIndex, 3);
+    valVec = svld1_gather_u64offset_u64(
+        predicateMask,
+        reinterpret_cast<uint64_t*>(getValuePtr()),
+        htOffset);
+
+    emptyMask = svcmpeq_n_u64(predicateMask, valVec, 0);
+    if (svptest_any(predicateMask, emptyMask)) {
+      indexMask = get_uniq_mask2(emptyMask, currIndex);
+    } else {
+      indexMask = emptyMask;
+    }
+
+    svbool_t toWriteMask = svand_z(predicateMask, indexMask, emptyMask);
+
+    uint64_t htIndices[kVectorWidth] = {0, 0, 0, 0};
+    svst1(svptrue_b64(), htIndices, currIndex);
+
+    uint64_t tags[kVectorWidth] = {0, 0, 0, 0};
+    svst1(svptrue_b64(), tags, currTag);
+
+    uint32_t flag = 0;
+    __asm__("str %1, [%0]" : : "r"(&flag), "Upl"(toWriteMask) : "memory");
+    uint32_t flag1 = flag;
+    while (flag1) {
+      int32_t offset = __builtin_ctz(flag1);
+      int32_t idx = offset / kBitsPerByte;
+      uint64_t htIdx = htIndices[idx];
+
+      getKeyPtr()[htIdx] = reinterpret_cast<uint64_t*>(groups[i + idx])[-1];
+      getValuePtr()[htIdx] = groups[i + idx];
+      getTagPtr()[htIdx] = tags[idx];
+
+      flag1 &= (flag1 - 1);
+    }
+
+    uint32_t conflictFlag = ~flag & 0x01010101;
+    while (conflictFlag) {
+      int32_t offset = __builtin_ctz(conflictFlag);
+      int32_t idx = offset / kBitsPerByte;
+      int32_t rowIdx = i + idx;
+      int64_t htStartIdx = htIndices[idx];
+
+      while (true) {
+        svbool_t tagPredicate = svwhilelt_b8(htStartIdx, capacity_);
+        svuint8_t htTag = svld1_u8(tagPredicate, getTagPtr() + htStartIdx);
+        svbool_t matchZero = svcmpeq_n_u8(tagPredicate, htTag, 0);
+
+        uint32_t zeroMask = 0;
+        __asm__("str %1, [%0]"
+                :
+                : "r"(&zeroMask), "Upl"(matchZero)
+                : "memory");
+
+        if (zeroMask) {
+          int32_t zeroBefore = __builtin_ctz(zeroMask);
+          int32_t htZeroIdx = htStartIdx + zeroBefore;
+
+          getKeyPtr()[htZeroIdx] =
+              reinterpret_cast<uint64_t*>(groups[rowIdx])[-1];
+          getValuePtr()[htZeroIdx] = groups[rowIdx];
+          getTagPtr()[htZeroIdx] = tags[idx];
+          break;
+        }
+
+        htStartIdx = capacity_ - htStartIdx > kProbeStep ? htStartIdx + kProbeStep
+                                                         : 0;
+      }
+      conflictFlag &= (conflictFlag - 1);
+    }
+    i += kVectorWidth;
+  }
+
+  predicateMask = svwhilelt_b64(i, numProbes);
+  currIndex = svld1(predicateMask, hashes + i);
+
+  svuint64_t currTagTmp =
+      svlsr_n_u64_x(predicateMask, currIndex, kTagShiftBits);
+  svuint64_t currTag = svorr_n_u64_z(predicateMask, currTagTmp, kTagMask);
+
+  currIndex = svand_n_u64_z(predicateMask, currIndex, capacity_ - 1);
+  svuint64_t htOffset = svlsl_n_u64_z(predicateMask, currIndex, 3);
+  valVec = svld1_gather_u64offset_u64(
+      predicateMask,
+      reinterpret_cast<uint64_t*>(getValuePtr()),
+      htOffset);
+
+  emptyMask = svcmpeq_n_u64(predicateMask, valVec, 0);
+  if (svptest_any(predicateMask, emptyMask)) {
+    indexMask = get_uniq_mask2(emptyMask, currIndex);
+  } else {
+    indexMask = emptyMask;
+  }
+
+  svbool_t toWriteMask = svand_z(predicateMask, indexMask, emptyMask);
+
+  uint64_t htIndices[kVectorWidth] = {0, 0, 0, 0};
+  svst1(svptrue_b64(), htIndices, currIndex);
+
+  uint64_t tags[kVectorWidth] = {0, 0, 0, 0};
+  svst1(svptrue_b64(), tags, currTag);
+
+  uint32_t flag = 0;
+  __asm__("str %1, [%0]" : : "r"(&flag), "Upl"(toWriteMask) : "memory");
+  uint32_t flag1 = flag;
+  while (flag1) {
+    int32_t offset = __builtin_ctz(flag1);
+    int32_t idx = offset / kBitsPerByte;
+    uint64_t htIdx = htIndices[idx];
+
+    getKeyPtr()[htIdx] = reinterpret_cast<uint64_t*>(groups[i + idx])[-1];
+    getValuePtr()[htIdx] = groups[i + idx];
+    getTagPtr()[htIdx] = tags[idx];
+
+    flag1 &= (flag1 - 1);
+  }
+
+  svbool_t conflictIndex = svnot_b_z(predicateMask, toWriteMask);
+  uint32_t conflictFlag = 0;
+  __asm__ __volatile__(
+      "str %1, [%0]" : : "r"(&conflictFlag), "Upl"(conflictIndex) : "memory");
+  while (conflictFlag) {
+    int32_t offset = __builtin_ctz(conflictFlag);
+    int32_t idx = offset / kBitsPerByte;
+    int32_t rowIdx = i + idx;
+    int64_t htStartIdx = htIndices[idx];
+
+    while (true) {
+      svbool_t tagPredicate = svwhilelt_b8(htStartIdx, capacity_);
+      svuint8_t htTag = svld1_u8(tagPredicate, getTagPtr() + htStartIdx);
+      svbool_t matchZero = svcmpeq_n_u8(tagPredicate, htTag, 0);
+
+      uint32_t zeroMask = 0;
+      __asm__("str %1, [%0]"
+              :
+              : "r"(&zeroMask), "Upl"(matchZero)
+              : "memory");
+
+      if (zeroMask) {
+        int32_t zeroBefore = __builtin_ctz(zeroMask);
+        int32_t htZeroIdx = htStartIdx + zeroBefore;
+
+        getKeyPtr()[htZeroIdx] =
+            reinterpret_cast<uint64_t*>(groups[rowIdx])[-1];
+        getValuePtr()[htZeroIdx] = groups[rowIdx];
+        getTagPtr()[htZeroIdx] = tags[idx];
+        break;
+      }
+
+      htStartIdx = capacity_ - htStartIdx > kProbeStep ? htStartIdx + kProbeStep
+                                                       : 0;
+    }
+    conflictFlag &= (conflictFlag - 1);
+  }
+}
+
+template void HashTable<true>::groupNormalizedKeyProbeSVE(HashLookup&);
+template void HashTable<false>::groupNormalizedKeyProbeSVE(HashLookup&);
+template void HashTable<true>::insertForGroupBySve(char**, uint64_t*, int32_t);
+template void HashTable<false>::insertForGroupBySve(char**, uint64_t*, int32_t);
+
+} // namespace bytedance::bolt::exec

--- a/bolt/exec/HashTableSveRuntime.h
+++ b/bolt/exec/HashTableSveRuntime.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cctype>
+#include <cstdlib>
+
+#if defined(__aarch64__) && defined(__linux__)
+#include <sys/auxv.h>
+#endif
+
+namespace bytedance::bolt::exec {
+
+/// Opt-in via BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE. Unset or empty → off.
+/// Enable with 1 / true / yes / on (ASCII, case-insensitive for words).
+/// Disable explicitly with 0 / false / no / off. Unknown values → off.
+inline bool boltHashAggSveNormalizedKeyProbeEnabledFromEnv() {
+  const char* v = std::getenv("BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE");
+  if (v == nullptr || *v == '\0') {
+    return false;
+  }
+  if (v[0] == '1' && v[1] == '\0') {
+    return true;
+  }
+  if (v[0] == '0' && v[1] == '\0') {
+    return false;
+  }
+  auto eqNoCase = [](const char* a, const char* b) {
+    while (*a && *b) {
+      if (std::tolower(static_cast<unsigned char>(*a)) !=
+          std::tolower(static_cast<unsigned char>(*b))) {
+        return false;
+      }
+      ++a;
+      ++b;
+    }
+    return *a == *b;
+  };
+  if (eqNoCase(v, "true") || eqNoCase(v, "yes") || eqNoCase(v, "on")) {
+    return true;
+  }
+  if (eqNoCase(v, "false") || eqNoCase(v, "no") || eqNoCase(v, "off")) {
+    return false;
+  }
+  return false;
+}
+
+inline bool linuxAarch64RuntimeHasSve() {
+#if defined(__aarch64__) && defined(__linux__)
+#ifndef HWCAP_SVE
+  constexpr unsigned long kBoltHwcapSve = 1UL << 22;
+#else
+  constexpr unsigned long kBoltHwcapSve = HWCAP_SVE;
+#endif
+  return (getauxval(AT_HWCAP) & kBoltHwcapSve) != 0;
+#else
+  return false;
+#endif
+}
+
+} // namespace bytedance::bolt::exec

--- a/bolt/exec/tests/HashTableTest.cpp
+++ b/bolt/exec/tests/HashTableTest.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "bolt/exec/HashTable.h"
+#include "bolt/exec/HashTableSveRuntime.h"
 #include "bolt/common/base/SelectivityInfo.h"
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
@@ -42,6 +43,9 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <memory>
+#ifndef _WIN32
+#include <cstdlib>
+#endif
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec;
 using namespace bytedance::bolt::test;
@@ -80,6 +84,14 @@ class HashTableTestHelper {
 
   void setHashMode(BaseHashTable::HashMode mode, int32_t numNew) {
     table_->setHashMode(mode, numNew);
+  }
+
+  void setNormalizedKeyMode(BaseHashTable::NormalizedKeyMode mode) {
+    table_->normalizedKeyMode_ = mode;
+  }
+
+  void setSveNormalizedKeyProbeRequested(bool requested) {
+    table_->sveNormalizedKeyProbeRequested_ = requested;
   }
 
  private:
@@ -1187,6 +1199,69 @@ TEST_P(HashTableTest, toStringMultipleKeys) {
 
   ASSERT_NO_THROW(table->toString());
 }
+
+TEST(HashTableTest, boltHashAggSveNormalizedKeyProbeEnv) {
+#ifndef _WIN32
+  const char* const kEnv = "BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE";
+  unsetenv(kEnv);
+  EXPECT_FALSE(boltHashAggSveNormalizedKeyProbeEnabledFromEnv());
+  ASSERT_EQ(setenv(kEnv, "1", 1), 0);
+  EXPECT_TRUE(boltHashAggSveNormalizedKeyProbeEnabledFromEnv());
+  ASSERT_EQ(setenv(kEnv, "0", 1), 0);
+  EXPECT_FALSE(boltHashAggSveNormalizedKeyProbeEnabledFromEnv());
+  unsetenv(kEnv);
+#else
+  GTEST_SKIP() << "setenv/unsetenv not used on Windows";
+#endif
+}
+
+#if defined(__aarch64__) && defined(__linux__)
+TEST_P(HashTableTest, normalizedKeySveMatchesScalar) {
+  auto type = ROW({"k1"}, {BIGINT()});
+  const int32_t numRows = 512;
+  keySpacing_ = 7;
+
+  auto makeTable = [&](BaseHashTable::NormalizedKeyMode mode) {
+    std::vector<std::unique_ptr<VectorHasher>> keyHashers;
+    keyHashers.emplace_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+    auto table = HashTable<false>::createForAggregation(
+        std::move(keyHashers),
+        std::vector<Accumulator>{},
+        pool(),
+        nullptr,
+        GetParam().jitRowEqVectors,
+        true);
+    auto helper = HashTableTestHelper<false>::create(table.get());
+    helper.setSveNormalizedKeyProbeRequested(true);
+    helper.setHashMode(BaseHashTable::HashMode::kNormalizedKey, numRows);
+    helper.setNormalizedKeyMode(mode);
+    return table;
+  };
+
+  auto runProbe = [&](HashTable<false>& table) {
+    std::vector<RowVectorPtr> batches;
+    makeRows(numRows, 1, 0, type, batches);
+    auto lookup = std::make_unique<HashLookup>(
+        table.hashers(), GetParam().jitRowEqVectors);
+    insertGroups(*batches.back(), *lookup, table);
+    return lookup->hits;
+  };
+
+  auto scalarTable = makeTable(BaseHashTable::NormalizedKeyMode::kScalar);
+  const auto scalarHits = runProbe(*scalarTable);
+
+  if (!linuxAarch64RuntimeHasSve()) {
+    GTEST_SKIP() << "No SVE at runtime";
+  }
+  auto sveTable = makeTable(BaseHashTable::NormalizedKeyMode::kSve);
+  const auto sveHits = runProbe(*sveTable);
+
+  ASSERT_EQ(scalarHits.size(), sveHits.size());
+  for (vector_size_t i = 0; i < scalarHits.size(); ++i) {
+    ASSERT_EQ(scalarHits[i], sveHits[i]) << "at row " << i;
+  }
+}
+#endif
 
 TEST(HashTableTest, tableInsertPartitionInfo) {
   std::vector<char*> overflows;


### PR DESCRIPTION
### What problem does this PR solve?

HashAgg with **normalized-key** hash tables can spend significant time in `groupNormalizedKeyProbe` on AArch64. This PR adds an **opt-in** SVE vectorized probe/insert path (17-byte slot layout + tag region), wired through the aggregation hash-table factory, with **scalar parity** tests and **non-aarch64 link stubs**. Join hash tables (`createForJoin` / `joinProbe`) are unchanged and stay on native Bolt.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

**What**

- Add **SVE normalized-key probe** for HashAgg: `groupNormalizedKeyProbeSVE`, `insertForGroupBySve`, 17B slot+tag table layout; scalar path uses `BaseHashTable::NormalizedKeySlot` (16B key+pointer, in `HashTable.h`).
- Split **SVE TU** `HashTableNormalizedKeyProbeSve.cpp` (aarch64, `-march=armv8-a+sve`); **stubs** `HashTableNormalizedKeyProbeStubs.cpp` on other platforms for link safety.
- **`HashTableSveRuntime.h`**: `boltHashAggSveNormalizedKeyProbeEnabledFromEnv()` + `linuxAarch64RuntimeHasSve()` (`AT_HWCAP` / `HWCAP_SVE`).
- **Extension hooks** (default stock behavior): `HashAggregation::createGroupingSetForHashAggregation`, `GroupingSet::createAggregationHashTable` — override point for custom `BaseHashTable` / env-driven table type without copying `HashAggregation`.
- **`NormalizedKeyMode`**: `kNativeBolt` (default) / `kScalar` (16B slots) / `kSve` (17B+tag); Join build forces `kNativeBolt` via `createForJoin(..., sve=false)` and `isJoinBuild_`.

**Env opt-in (`BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE`)**

| Env value | Aggregation hash table |
| --- | --- |
| unset, empty, or unknown | **off** → `kNativeBolt` (same as upstream default) |
| `1` | enable SVE path when Linux aarch64 + runtime SVE |
| `true`, `yes`, or `on` (ASCII, case-insensitive) | same as `1` |
| `0` | off |
| `false`, `no`, or `off` (ASCII, case-insensitive) | same as `0` |

Executor example (Gluten / Spark): `spark.executorEnv.BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE=1`.

**Registration / runtime chain (HashAgg only)**

`createForAggregation` does **not** call `updateNormalizedKeyModeForAggregation()` directly; it only sets `sveNormalizedKeyProbeRequested_` in the ctor. Mode is chosen later when the table switches to `HashMode::kNormalizedKey` via `setHashMode` (from `checkSize` / analyze).

```text
GroupingSet::createAggregationHashTable()  [override hook]
  └─ sveFlag = boltHashAggSveNormalizedKeyProbeEnabledFromEnv()
        └─ HashTable::createForAggregation(..., sveFlag)
              └─ ctor: sveNormalizedKeyProbeRequested_ = sveFlag
                  (normalizedKeyMode_ stays kNativeBolt until setHashMode)

addInput → checkSize / analyze → setHashMode(kNormalizedKey)   [when applicable]
  └─ updateNormalizedKeyModeForAggregation()
        ├─ isJoinBuild_ || !sveNormalizedKeyProbeRequested_ → kNativeBolt
        ├─ linuxAarch64RuntimeHasSve() → kSve
        └─ else → kScalar

groupProbe (hashMode_ == kNormalizedKey)
  └─ groupNormalizedKeyProbe()
        ├─ kScalar  → groupNormalizedKeyProbeScalar
        ├─ kSve     → groupNormalizedKeyProbeSVE  (SVE TU)
        └─ kNativeBolt → ProbeState / fullProbe (existing)
```

**Join (out of scope for SVE)**

```text
HashTable::createForJoin(..., sveNormalizedKeyProbeEnabled=false, isJoinBuild=true)
  → normalizedKeyMode_ = kNativeBolt always
joinProbe → joinNormalizedKeyProbe   (never groupNormalizedKeyProbeSVE)
```

<details>
<summary>Flowchart — HashAgg probe mode (mermaid — click to expand)</summary>

```mermaid
flowchart TD
  A[groupProbe + kNormalizedKey] --> B[groupNormalizedKeyProbe]
  B --> C{normalizedKeyMode_}
  C -->|kScalar| D[groupNormalizedKeyProbeScalar]
  C -->|kSve| E[groupNormalizedKeyProbeSVE]
  C -->|kNativeBolt| F[ProbeState / fullProbe]
  G[createForJoin / joinProbe] --> H[kNativeBolt + joinNormalizedKeyProbe]
```

</details>

<details>
<summary>File roles (HashTable + GroupingSet) (mermaid — click to expand)</summary>

```mermaid
flowchart TB
  subgraph hooks["Extension hooks"]
    HA["HashAggregation.h/cpp\ncreateGroupingSetForHashAggregation"]
    GS["GroupingSet.h/cpp\ncreateAggregationHashTable"]
  end

  subgraph hashtable["HashTable"]
    HT["HashTable.cpp / .h\ndispatch, allocateTables, insert"]
    RT["HashTableSveRuntime.h\nenv + HWCAP_SVE"]
    SVE["HashTableNormalizedKeyProbeSve.cpp\nSVE probe + insertForGroupBySve"]
    STUB["HashTableNormalizedKeyProbeStubs.cpp\nnon-aarch64"]
  end

  GS -->|env| RT
  GS --> HT
  HA --> GS
  HT --> SVE
  HT --> STUB
  classDef prNew fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#000
  classDef prModified fill:#fff3cd,stroke:#ffc107,stroke-width:2px,color:#000
  class SVE,STUB,RT prNew
  class HT,HA,GS prModified
```

Legend: **green** = new; **yellow** = modified.

</details>

| Step | File / symbol | Role |
| --- | --- | --- |
| 0 | `GroupingSet::createAggregationHashTable` | Reads env; calls `createForAggregation(..., sveFlag)`. Override for plugin/custom table. |
| 1 | `HashTableSveRuntime.h` | Env parser; `linuxAarch64RuntimeHasSve()` on Linux aarch64. |
| 2 | `HashTable` ctor | Stores `sveNormalizedKeyProbeRequested_` from `createForAggregation(..., sveFlag)`. |
| 2b | `setHashMode(kNormalizedKey)` → `updateNormalizedKeyModeForAggregation` | Sets `kSve` / `kScalar` / `kNativeBolt`; Join build → always `kNativeBolt`. |
| 3 | `allocateTables` / `clear` / `insertForGroupBy` | 16B vs 17B+tag vs F14 layout; SVE insert via `insertForGroupBySve` when `kSve`. |
| 4 | `groupNormalizedKeyProbe` | Dispatches scalar / SVE / native probe. |
| 5 | `HashTableNormalizedKeyProbeSve.cpp` | SVE intrinsics; **not** linked on non-aarch64. |
| 6 | `HashTableNormalizedKeyProbeStubs.cpp` | Non-aarch64: SVE probe → scalar fallback; insert → `BOLT_FAIL` if called. |
| 7 | `createForJoin` | Always `sveNormalizedKeyProbeEnabled=false`; `joinProbe` unchanged. |

**Tests**

- `HashTableTest.boltHashAggSveNormalizedKeyProbeEnv` — env parser (`setenv` / unset / `0` / `1`)
- `HashTableTest.normalizedKeySveMatchesScalar` — `#if __aarch64__ && __linux__`: helper sets `kSve` vs `kScalar`, compares probe `hits`; `GTEST_SKIP` if no runtime SVE

```bash
make unittest_release TEST=bbolt_exec_test \
  TEST_ARGS='--gtest_filter=HashTableTest.boltHashAggSveNormalizedKeyProbeEnv:HashTableTest.normalizedKeySveMatchesScalar*'
```

### Performance Impact

- [ ] **No Impact**
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**

### Release Note

Please describe the changes in this PR

Release Note:

```text
Release Note:
- HashAgg normalized-key probe: optional AArch64 SVE path (17B slot + tag layout).
- Opt-in: set BOLT_HASH_AGG_SVE_NORMALIZED_KEY_PROBE=1 (or true/yes/on) on executors; default off (native Bolt).
- Join hash tables (createForJoin / joinProbe) unchanged.
- Extension hooks on HashAggregation / GroupingSet for custom aggregation hash tables.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
