### PR TITLE
refactor: clear the shuffle check code

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -869,8 +869,8 @@ arrow::Status BoltShuffleWriter::splitRowVector(
           for (auto pid = 0; pid < numPartitions_; ++pid) {
             auto* addr = partitionFixedWidthValueAddrs_[col][pid];
             if (addr != nullptr && valueWidth > 0) {
-              addr += static_cast<uint64_t>(partitionBufferBase_[pid]) *
-                  valueWidth;
+              addr +=
+                  static_cast<uint64_t>(partitionBufferBase_[pid]) * valueWidth;
             }
             currentFixedWidthValueAddrs[col][pid] = addr;
           }

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -856,10 +856,27 @@ arrow::Status BoltShuffleWriter::splitRowVector(
 
   RETURN_NOT_OK(withShuffleCheck(
       rv,
-      std::string(__FILE__) + ":" + std::to_string(__LINE__) + ":after all:",
+      std::string(__FILE__) + ":" + std::to_string(__LINE__),
       [&](const bytedance::bolt::RowVector& vector, std::string funcLine) {
+        // Pre-compute addresses pointing to current write position so that
+        // checkFixedColumnCopyValue does not need to consider the
+        // partitionBufferBase_ offset.
+        std::vector<std::vector<uint8_t*>> currentFixedWidthValueAddrs(
+            fixedWidthColumnCount_);
+        for (auto col = 0; col < fixedWidthColumnCount_; ++col) {
+          const uint64_t valueWidth = fixedColValueSize_[col];
+          currentFixedWidthValueAddrs[col].resize(numPartitions_, nullptr);
+          for (auto pid = 0; pid < numPartitions_; ++pid) {
+            auto* addr = partitionFixedWidthValueAddrs_[col][pid];
+            if (addr != nullptr && valueWidth > 0) {
+              addr += static_cast<uint64_t>(partitionBufferBase_[pid]) *
+                  valueWidth;
+            }
+            currentFixedWidthValueAddrs[col][pid] = addr;
+          }
+        }
         return checkFixedColumnCopyValue(
-            vector, partitionFixedWidthValueAddrs_, std::move(funcLine));
+            vector, currentFixedWidthValueAddrs, std::move(funcLine));
       }));
 
   // update partition buffer base after split
@@ -1236,6 +1253,19 @@ arrow::Status BoltShuffleWriter::initColumnTypes(
   }
 
   fixedWidthColumnCount_ = simpleColumnIndices_.size();
+
+  // Pre-compute the byte width of each fixed-width column's single value.
+  // Boolean is bit-packed and stored separately, so its width is recorded as 0.
+  fixedColValueSize_.reserve(fixedWidthColumnCount_);
+  for (size_t col = 0; col < fixedWidthColumnCount_; ++col) {
+    const auto colIdx = simpleColumnIndices_[col];
+    if (arrowColumnTypes_[colIdx]->id() == arrow::BooleanType::type_id) {
+      fixedColValueSize_.push_back(0);
+    } else {
+      fixedColValueSize_.push_back(
+          static_cast<uint16_t>(valueBufferSizeForFixedWidthArray(col, 1)));
+    }
+  }
 
   if (options_.shuffleCheckRatio > 0.0) {
     fixedWidthCheckFunctions_.reserve(fixedWidthColumnCount_);
@@ -2126,12 +2156,6 @@ template arrow::Status BoltShuffleWriter::splitFixedWidthValueBuffer<
     std::vector<std::vector<std::vector<uint8_t*>>>>(
     const bytedance::bolt::RowVector& rv,
     std::vector<std::vector<std::vector<uint8_t*>>>& valueAddrs);
-template arrow::Status BoltShuffleWriter::checkFixedColumnCopyValue<
-    std::vector<std::vector<uint8_t*>>>(
-    const bytedance::bolt::RowVector& rv,
-    std::vector<std::vector<uint8_t*>>& fixedWidthValueAddrs,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition);
 template arrow::Status BoltShuffleWriter::splitValidityBuffer<true>(
     const bytedance::bolt::RowVector& rv);
 template arrow::Status BoltShuffleWriter::splitValidityBuffer<false>(
@@ -2311,8 +2335,7 @@ void BoltShuffleWriter::checkCopyValue(
     const std::vector<uint8_t*>& dstNulls,
     int colId,
     const std::string& name,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition) {
+    const std::string& funcLine) {
   const auto* srcValues = reinterpret_cast<const T*>(srcAddrs);
   const bool hasSrcNulls = (srcNulls != nullptr);
 
@@ -2320,11 +2343,11 @@ void BoltShuffleWriter::checkCopyValue(
     const uint32_t baseOffset = partition2RowOffsetBase_[pid];
     const uint32_t endOffset = partition2RowOffsetBase_[pid + 1];
 
+    // dstAddrs[pid] is pre-adjusted by callers to point to the current write
+    // position, so no extra value-base offset is needed here. The validity
+    // buffer is still indexed from the partition buffer base.
     const uint32_t dstNullBase = partitionBufferBase_[pid];
-    const uint32_t dstValueBase =
-        valueAddrsPointToWritePosition ? 0 : dstNullBase;
-    const auto* dstPidBase = reinterpret_cast<const T*>(dstAddrs[pid]);
-    const auto* dstValues = dstPidBase + dstValueBase;
+    const auto* dstValues = reinterpret_cast<const T*>(dstAddrs[pid]);
 
     const uint8_t* dstNullsPid = dstNulls[pid];
     const bool hasDstNulls = (dstNullsPid != nullptr);
@@ -2409,17 +2432,9 @@ void BoltShuffleWriter::checkCopyValueTyped(
     const std::vector<uint8_t*>& dstNulls,
     int colId,
     const std::string& name,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition) {
+    const std::string& funcLine) {
   checkCopyValue<T>(
-      srcAddrs,
-      srcNulls,
-      dstAddrs,
-      dstNulls,
-      colId,
-      name,
-      funcLine,
-      valueAddrsPointToWritePosition);
+      srcAddrs, srcNulls, dstAddrs, dstNulls, colId, name, funcLine);
 }
 
 arrow::Result<BoltShuffleWriter::FixedColumnCheckFunction>
@@ -2464,12 +2479,10 @@ BoltShuffleWriter::createFixedColumnCheckFunction(
   }
 }
 
-template <typename T>
 arrow::Status BoltShuffleWriter::checkFixedColumnCopyValue(
     const bytedance::bolt::RowVector& rv,
-    T& fixedWidthValueAddrs,
-    const std::string& funcLine,
-    bool valueAddrsPointToWritePosition) {
+    const std::vector<std::vector<uint8_t*>>& fixedWidthValueAddrs,
+    const std::string& funcLine) {
   for (auto col = 0; col < fixedWidthColumnCount_; ++col) {
     const auto colIdx = simpleColumnIndices_[col];
     auto& column = rv.childAt(colIdx);
@@ -2489,8 +2502,7 @@ arrow::Status BoltShuffleWriter::checkFixedColumnCopyValue(
         dstNulls,
         colIdx,
         fixedWidthTypeNames_[col],
-        funcLine,
-        valueAddrsPointToWritePosition);
+        funcLine);
   }
   return arrow::Status::OK();
 }

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -334,8 +334,7 @@ class BoltShuffleWriter : public ShuffleWriter {
       const std::vector<uint8_t*>& dstNulls,
       int colId,
       const std::string& name,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition);
+      const std::string& funcLine);
 
   virtual arrow::Status init();
 
@@ -377,12 +376,10 @@ class BoltShuffleWriter : public ShuffleWriter {
       const bytedance::bolt::RowVector& rv,
       T& valueAddrs);
 
-  template <typename T>
   arrow::Status checkFixedColumnCopyValue(
       const bytedance::bolt::RowVector& rv,
-      T& fixedWidthValueAddrs,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition = false);
+      const std::vector<std::vector<uint8_t*>>& fixedWidthValueAddrs,
+      const std::string& funcLine);
 
   template <typename Fn>
   arrow::Status withShuffleCheck(
@@ -412,8 +409,7 @@ class BoltShuffleWriter : public ShuffleWriter {
       const std::vector<uint8_t*>& dstNulls,
       int colId,
       const std::string& name,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition);
+      const std::string& funcLine);
 
   template <typename T>
   void checkCopyValueTyped(
@@ -423,8 +419,7 @@ class BoltShuffleWriter : public ShuffleWriter {
       const std::vector<uint8_t*>& dstNulls,
       int colId,
       const std::string& name,
-      const std::string& funcLine,
-      bool valueAddrsPointToWritePosition);
+      const std::string& funcLine);
 
   arrow::Result<FixedColumnCheckFunction> createFixedColumnCheckFunction(
       arrow::Type::type typeId) const;
@@ -694,6 +689,8 @@ class BoltShuffleWriter : public ShuffleWriter {
   std::vector<std::vector<uint8_t*>> partitionValidityAddrs_;
   // Used by fixed-width types. Stores raw pointers of partition buffers.
   std::vector<std::vector<uint8_t*>> partitionFixedWidthValueAddrs_;
+  // Byte width of each fixed-width column's single value. 0 for boolean.
+  std::vector<uint16_t> fixedColValueSize_;
   std::vector<FixedColumnCheckFunction> fixedWidthCheckFunctions_;
   std::vector<std::string> fixedWidthTypeNames_;
   // Used by binary types. Stores raw pointers and metadata of partition

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -422,7 +422,7 @@ arrow::Status BoltShuffleWriterV2::splitRowVector(
           }
         }
         return checkFixedColumnCopyValue(
-            vector, currentFixedWidthValueAddrs, std::move(funcLine), true);
+            vector, currentFixedWidthValueAddrs, std::move(funcLine));
       }));
 
   for (auto& pid : partitionUsed_) {
@@ -444,18 +444,14 @@ arrow::Status BoltShuffleWriterV2::initFixedColumnSize(
       bytedance::bolt::bits::roundUp(rv.childrenSize(), 8) / 8;
   needAlignmentBitmap_.resize(bitmapBytes, 0);
 
+  // fixedColValueSize_ has been populated by the base class in
+  // initColumnTypes.
   for (size_t i = 0; i < fixedWidthColumnCount_; ++i) {
-    switch (arrowColumnTypes_[simpleColumnIndices_[i]]->id()) {
-      case arrow::BooleanType::type_id: {
-        ++numberBooleanColumns;
-        fixedColValueSize_.push_back(0);
-      } break;
-      default: {
-        fixedColValueSize_.push_back(valueBufferSizeForFixedWidthArray(i, 1));
-        if (fixedColValueSize_.back() > 8) {
-          bytedance::bolt::bits::setBit(needAlignmentBitmap_.data(), i);
-        }
-      } break;
+    if (arrowColumnTypes_[simpleColumnIndices_[i]]->id() ==
+        arrow::BooleanType::type_id) {
+      ++numberBooleanColumns;
+    } else if (fixedColValueSize_[i] > 8) {
+      bytedance::bolt::bits::setBit(needAlignmentBitmap_.data(), i);
     }
   }
 

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.h
@@ -341,7 +341,6 @@ class BoltShuffleWriterV2 final : public BoltShuffleWriter {
   std::vector<std::vector<std::unique_ptr<arrow::ResizableBuffer>>>
       partitionBooleanValueBuffers_;
   std::map<uint32_t, bool> fullBatch_;
-  std::vector<uint16_t> fixedColValueSize_;
   std::vector<uint8_t> needAlignmentBitmap_;
   std::vector<uint32_t> partitionBytesPerBatch_;
   std::vector<bool> isValidityBufferRowVectorMode_;


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

align the shuffle code of shuffleWriterV1 and shuffleWriterV2.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
