### PR TITLE
[fix] Fix makeFlatVector initializer-list overload

### DIFF
--- a/bolt/vector/tests/VectorTest.cpp
+++ b/bolt/vector/tests/VectorTest.cpp
@@ -1061,6 +1061,13 @@ TEST_F(VectorTest, createOpaque) {
   EXPECT_EQ(NonPOD::alive, 0);
 }
 
+TEST_F(VectorTest, makeFlatVectorSingleElementInitializerList) {
+  auto vector = makeFlatVector<int64_t>({0});
+
+  ASSERT_EQ(vector->size(), 1);
+  EXPECT_EQ(vector->valueAt(0), 0);
+}
+
 TEST_F(VectorTest, getOrCreateEmpty) {
   auto empty = BaseVector::getOrCreateEmpty(nullptr, VARCHAR(), pool());
   EXPECT_NE(empty, nullptr);

--- a/bolt/vector/tests/utils/VectorTestBase.h
+++ b/bolt/vector/tests/utils/VectorTestBase.h
@@ -33,6 +33,7 @@
 #include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 
+#include <initializer_list>
 #include "bolt/vector/FlatVector.h"
 #include "bolt/vector/tests/utils/VectorMaker.h"
 
@@ -216,6 +217,13 @@ class VectorTestBase {
   template <typename T>
   FlatVectorPtr<EvalType<T>> makeFlatVector(
       const std::vector<T>& data,
+      const TypePtr& type = CppToType<T>::create()) {
+    return vectorMaker_.flatVector<T>(data, type);
+  }
+
+  template <typename T>
+  FlatVectorPtr<EvalType<T>> makeFlatVector(
+      std::initializer_list<T> data,
       const TypePtr& type = CppToType<T>::create()) {
     return vectorMaker_.flatVector<T>(data, type);
   }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #569

Fixes a flaky Release failure in ElementAtTest.nonConstantOutOfBoundsReturnsNull.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

makeFlatVector<int64_t>({0}) could bind to the size_t overload and create an empty vector. That made wrapInConstant read row 0 out of bounds in the Flink element_at test.

Add an initializer_list overload and cover the single-element case.

### Performance Impact

- [x] No Impact: test helper fix only.

### Release Note

```text
Release Note:
- Fixed a flaky Flink element_at test caused by the makeFlatVector initializer-list overload.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)