### PR TITLE
[fix] Throw on schema mismatch in ReaderBase::convertType

### DIFF
--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -72,7 +72,7 @@ namespace {
 
 // Schema-mismatch checks for ReaderBase::convertType.
 constexpr const char* kTypeMappingErrorFmtStr =
-    "Parquet column cannot be converted. Column: [{}], Expected: {}";
+    "Schema mismatch, Column: [{}], From Kind: {}, To Kind: {}";
 
 // Checks whether 'type' is an integer type at least as wide as
 // 'minTypeKind'. Used to gate integer widening:
@@ -1001,11 +1001,13 @@ TypePtr ReaderBase::convertType(
         const bool unannotatedArrayMatch = !strictMatch && isRepeated &&
             requestedType->isArray() &&
             isCompatibleFunc(requestedType->asArray().elementType());
-        BOLT_USER_CHECK(
-            strictMatch || unannotatedArrayMatch,
-            kTypeMappingErrorFmtStr,
-            schemaElement.name,
-            requestedType->toString());
+        if (!(strictMatch || unannotatedArrayMatch)) {
+          BOLT_SCHEMA_MISMATCH_ERROR(fmt::format(
+              kTypeMappingErrorFmtStr,
+              schemaElement.name,
+              schemaElement.type,
+              mapTypeKindToName(requestedType->kind())));
+        }
         if (unannotatedArrayMatch) {
           LOG_FIRST_N(INFO, 8)
               << "Reading unannotated array (legacy Parquet 1.0): column '"

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -69,6 +69,59 @@ namespace {
   }
   return algo;
 }
+
+// Schema-mismatch checks for ReaderBase::convertType.
+constexpr const char* kTypeMappingErrorFmtStr =
+    "Parquet column cannot be converted. Column: [{}], Expected: {}";
+
+// Checks whether 'type' is an integer type at least as wide as
+// 'minTypeKind'. Used to gate integer widening:
+//   minTypeKind=TINYINT  accepts TINYINT/SMALLINT/INTEGER/BIGINT (INT_8 leaf)
+//   minTypeKind=SMALLINT accepts SMALLINT/INTEGER/BIGINT          (INT_16 leaf)
+//   minTypeKind=INTEGER  accepts INTEGER/BIGINT                   (INT_32 leaf)
+//   minTypeKind=BIGINT   accepts BIGINT only                      (INT_64 leaf)
+bool isIntCompatible(
+    const bytedance::bolt::TypePtr& type,
+    bytedance::bolt::TypeKind minTypeKind) {
+  using TK = bytedance::bolt::TypeKind;
+  static_assert(
+      static_cast<int>(TK::TINYINT) < static_cast<int>(TK::SMALLINT) &&
+      static_cast<int>(TK::SMALLINT) < static_cast<int>(TK::INTEGER) &&
+      static_cast<int>(TK::INTEGER) < static_cast<int>(TK::BIGINT));
+  const auto kind = type->kind();
+  switch (kind) {
+    case TK::TINYINT:
+    case TK::SMALLINT:
+    case TK::INTEGER:
+    case TK::BIGINT:
+      return static_cast<int>(kind) >= static_cast<int>(minTypeKind);
+    default:
+      return false;
+  }
+}
+
+// Predicates for the cross-family implicit cast that the column reader
+// layer performs at read time (Spark/Hive STRING<->INT compatibility):
+//   - StringColumnReader::makeCastExpr handles VARCHAR/VARBINARY file ->
+//     int family requested type
+//   - IntegerColumnReader::makeCastExpr handles int family file ->
+//     VARCHAR/VARBINARY requested type
+// Both makeCastExpr paths compile unconditionally so convertType keeps
+// these schema pairs uniform across build flavours. Non-Spark builds
+// still get the strict check at ParquetColumnReader.cpp:95 via
+// matchType() for the VARCHAR-file -> INT-requested direction, which
+// fires after convertType and throws with its existing error message.
+bool acceptsVarcharFileForReaderCast(const bytedance::bolt::TypePtr& t) {
+  using TK = bytedance::bolt::TypeKind;
+  const auto k = t->kind();
+  return k == TK::TINYINT || k == TK::SMALLINT || k == TK::INTEGER ||
+      k == TK::BIGINT;
+}
+bool acceptsIntFileForReaderCast(const bytedance::bolt::TypePtr& t) {
+  return t->kind() == bytedance::bolt::TypeKind::VARCHAR ||
+      t->kind() == bytedance::bolt::TypeKind::VARBINARY;
+}
+
 } // namespace
 
 /// Metadata and options for reading Parquet.
@@ -925,6 +978,42 @@ TypePtr ReaderBase::convertType(
           schemaElement.__isset.type_length,
       "FIXED_LEN_BYTE_ARRAY requires length to be set");
 
+  // Whether this leaf is a Parquet "repeated" field (unannotated array).
+  // Allows requestedType=ARRAY<element> to be satisfied by checking against
+  // the element type — see isCompatible() in the anonymous namespace.
+  const bool isRepeated = schemaElement.__isset.repetition_type &&
+      schemaElement.repetition_type == thrift::FieldRepetitionType::REPEATED;
+
+  // Common helper: emits a user-error matching Spark's
+  // SchemaColumnConvertNotSupportedException semantics when the requested
+  // type can't be satisfied by this Parquet leaf. No-op when there is no
+  // requested type (caller is only inferring the file's declared schema).
+  auto checkRequested =
+      [&](const std::function<bool(const TypePtr&)>& isCompatibleFunc) {
+        if (requestedType == nullptr) {
+          return;
+        }
+        const bool strictMatch = isCompatibleFunc(requestedType);
+        // Legacy Parquet 1.0 unannotated array: a repeated field that
+        // isn't wrapped in a LIST group. If requestedType is ARRAY and
+        // the leaf is REPEATED, fall back to checking the array's
+        // element type.
+        const bool unannotatedArrayMatch = !strictMatch && isRepeated &&
+            requestedType->isArray() &&
+            isCompatibleFunc(requestedType->asArray().elementType());
+        BOLT_USER_CHECK(
+            strictMatch || unannotatedArrayMatch,
+            kTypeMappingErrorFmtStr,
+            schemaElement.name,
+            requestedType->toString());
+        if (unannotatedArrayMatch) {
+          LOG_FIRST_N(INFO, 8)
+              << "Reading unannotated array (legacy Parquet 1.0): column '"
+              << schemaElement.name << "', requested type "
+              << requestedType->toString();
+        }
+      };
+
   if (schemaElement.__isset.converted_type) {
     switch (schemaElement.converted_type) {
       case thrift::ConvertedType::INT_8:
@@ -932,6 +1021,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "INT8 converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::TINYINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return TINYINT();
 
       case thrift::ConvertedType::INT_16:
@@ -939,6 +1032,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "INT16 converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::SMALLINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return SMALLINT();
 
       case thrift::ConvertedType::INT_32:
@@ -946,6 +1043,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "INT32 converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::INTEGER) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return INTEGER();
 
       case thrift::ConvertedType::INT_64:
@@ -953,6 +1054,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "INT64 converted type can only be set for value of thrift::Type::INT64");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::BIGINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return BIGINT();
 
       case thrift::ConvertedType::UINT_8:
@@ -960,6 +1065,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_8 converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::TINYINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return TINYINT();
 
       case thrift::ConvertedType::UINT_16:
@@ -967,6 +1076,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_16 converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::SMALLINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return SMALLINT();
 
       case thrift::ConvertedType::UINT_32:
@@ -974,6 +1087,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_32 converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::INTEGER) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return INTEGER();
 
       case thrift::ConvertedType::UINT_64:
@@ -981,6 +1098,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "UINT_64 converted type can only be set for value of thrift::Type::INT64");
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::BIGINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return BIGINT();
 
       case thrift::ConvertedType::DATE:
@@ -988,6 +1109,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "DATE converted type can only be set for value of thrift::Type::INT32");
+        checkRequested([](const TypePtr& t) { return t->isDate(); });
         return DATE();
 
       case thrift::ConvertedType::TIMESTAMP_MICROS:
@@ -996,12 +1118,26 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "TIMESTAMP_MICROS or TIMESTAMP_MILLIS converted type can only be set for value of thrift::Type::INT64");
+        checkRequested(
+            [](const TypePtr& t) { return t->kind() == TypeKind::TIMESTAMP; });
         return TIMESTAMP();
 
       case thrift::ConvertedType::DECIMAL: {
         BOLT_CHECK(
             schemaElement.__isset.precision && schemaElement.__isset.scale,
             "DECIMAL requires a length and scale specifier!");
+        // Decimal widening: scale must not shrink and precision must grow
+        // at least as fast as scale
+        const auto filePrecision = schemaElement.precision;
+        const auto fileScale = schemaElement.scale;
+        checkRequested([&](const TypePtr& t) {
+          if (!t->isDecimal()) {
+            return false;
+          }
+          auto [precision, scale] = getDecimalPrecisionScale(*t);
+          return scale >= fileScale &&
+              (precision - filePrecision) >= (scale - fileScale);
+        });
         return DECIMAL(schemaElement.precision, schemaElement.scale);
       }
 
@@ -1010,6 +1146,10 @@ TypePtr ReaderBase::convertType(
         switch (schemaElement.type) {
           case thrift::Type::BYTE_ARRAY:
           case thrift::Type::FIXED_LEN_BYTE_ARRAY:
+            checkRequested([](const TypePtr& t) {
+              return t->kind() == TypeKind::VARCHAR ||
+                  acceptsVarcharFileForReaderCast(t);
+            });
             return VARCHAR();
           default:
             BOLT_FAIL(
@@ -1021,6 +1161,10 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::BYTE_ARRAY,
             "ENUM converted type can only be set for value of thrift::Type::BYTE_ARRAY");
+        checkRequested([](const TypePtr& t) {
+          return t->kind() == TypeKind::VARCHAR ||
+              acceptsVarcharFileForReaderCast(t);
+        });
         return VARCHAR();
       }
       case thrift::ConvertedType::MAP:
@@ -1038,13 +1182,22 @@ TypePtr ReaderBase::convertType(
   } else {
     switch (schemaElement.type) {
       case thrift::Type::type::BOOLEAN:
+        checkRequested(
+            [](const TypePtr& t) { return t->kind() == TypeKind::BOOLEAN; });
         return BOOLEAN();
       case thrift::Type::type::INT32:
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::INTEGER) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return INTEGER();
       case thrift::Type::type::INT64:
         // For Int64 Timestamp in nano precision
         if (schemaElement.__isset.logicalType &&
             schemaElement.logicalType.__isset.TIMESTAMP) {
+          checkRequested([](const TypePtr& t) {
+            return t->kind() == TypeKind::TIMESTAMP;
+          });
           return TIMESTAMP();
         }
         if (schemaElement.__isset.converted_type &&
@@ -1052,17 +1205,36 @@ TypePtr ReaderBase::convertType(
                  thrift::ConvertedType::TIMESTAMP_MILLIS ||
              schemaElement.converted_type ==
                  thrift::ConvertedType::TIMESTAMP_MICROS)) {
+          checkRequested([](const TypePtr& t) {
+            return t->kind() == TypeKind::TIMESTAMP;
+          });
           return TIMESTAMP();
         }
+        checkRequested([](const TypePtr& t) {
+          return isIntCompatible(t, TypeKind::BIGINT) ||
+              acceptsIntFileForReaderCast(t);
+        });
         return BIGINT();
       case thrift::Type::type::INT96:
+        checkRequested(
+            [](const TypePtr& t) { return t->kind() == TypeKind::TIMESTAMP; });
         return TIMESTAMP(); // INT96 only maps to a timestamp
       case thrift::Type::type::FLOAT:
+        checkRequested([](const TypePtr& t) {
+          return t->kind() == TypeKind::REAL || t->kind() == TypeKind::DOUBLE;
+        });
         return REAL();
       case thrift::Type::type::DOUBLE:
+        checkRequested(
+            [](const TypePtr& t) { return t->kind() == TypeKind::DOUBLE; });
         return DOUBLE();
       case thrift::Type::type::BYTE_ARRAY:
       case thrift::Type::type::FIXED_LEN_BYTE_ARRAY:
+        checkRequested([](const TypePtr& t) {
+          return t->kind() == TypeKind::VARCHAR ||
+              t->kind() == TypeKind::VARBINARY ||
+              acceptsVarcharFileForReaderCast(t);
+        });
         if (requestedType && requestedType->isVarchar()) {
           return VARCHAR();
         } else {

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -33,7 +33,6 @@
 #include <type/Type.h>
 #include <cstdlib>
 #include <filesystem>
-#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/QueryCtx.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 #include "bolt/dwio/parquet/writer/Writer.h"

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -33,6 +33,7 @@
 #include <type/Type.h>
 #include <cstdlib>
 #include <filesystem>
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/QueryCtx.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 #include "bolt/dwio/parquet/writer/Writer.h"

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1301,6 +1301,257 @@ TEST_F(ParquetTableScanTest, deltaByteArray) {
   assertSelect({"a"}, "SELECT a from expected");
 }
 
+// Plan-level matrix coverage for the strict convertType policy.
+//
+// Each case writes a 3-row parquet file using `fileType`, then runs a
+// TableScan plan declaring `declaredType` (propagated to HiveConnector
+// via dataColumns, which becomes ReaderOptions::fileSchema). We assert:
+//   - shouldThrow=true: AssertQueryBuilder.copyResults raises an error
+//     whose message contains Case::errMsg (defaults to the BoltUserError
+//     from convertType; non-Spark builds also see matchType rejections).
+//   - shouldThrow=false: copyResults returns 3 rows of declaredType
+//     and (when `expectedValues` is supplied) the values match.
+TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
+  struct Case {
+    const char* name;
+    TypePtr fileType;
+    TypePtr declaredType;
+    bool shouldThrow;
+    // Substring to match against the thrown error. Defaults to the
+    // BoltUserError raised by ReaderBase::convertType. Override when a
+    // case is rejected by a later layer with a different message
+    // (e.g. ParquetColumnReader::matchType in non-Spark builds).
+    const char* errMsg = "Parquet column cannot be converted";
+  };
+
+  // clang-format off
+  const std::vector<Case> cases = {
+    // ---- Reject: structural mismatch (the original SIGSEGV bug) ----
+    {"array_declared_vs_varchar_file", VARCHAR(),       ARRAY(VARCHAR()),   true},
+    {"array_declared_vs_bigint_file",  BIGINT(),        ARRAY(BIGINT()),    true},
+
+    // ---- Reject: integer narrowing ----
+    {"bigint_to_integer",              BIGINT(),        INTEGER(),          true},
+    {"integer_to_smallint",            INTEGER(),       SMALLINT(),         true},
+    {"integer_to_tinyint",             INTEGER(),       TINYINT(),          true},
+
+    // ---- Reject: cross-family with no column-reader auto-cast ----
+    {"integer_to_double",              INTEGER(),       DOUBLE(),           true},
+    {"bigint_to_double",               BIGINT(),        DOUBLE(),           true},
+    {"integer_to_real",                INTEGER(),       REAL(),             true},
+
+    // ---- Reject: float narrowing ----
+    {"double_to_real",                 DOUBLE(),        REAL(),             true},
+
+    // ---- Reject: BOOLEAN cross-family ----
+    {"boolean_to_integer",             BOOLEAN(),       INTEGER(),          true},
+    {"boolean_to_varchar",             BOOLEAN(),       VARCHAR(),          true},
+
+    // ---- Reject: DECIMAL widening violations ----
+    {"decimal_scale_shrink",           DECIMAL(10, 2),  DECIMAL(10, 0),     true},
+    {"decimal_scale_grew_prec_same",   DECIMAL(10, 2),  DECIMAL(10, 5),     true},
+    {"decimal_both_shrink",            DECIMAL(38, 18), DECIMAL(10, 2),     true},
+
+    // ---- Reject: DECIMAL cross-family ----
+    {"decimal_to_bigint",              DECIMAL(10, 2),  BIGINT(),           true},
+    {"decimal_to_varchar",             DECIMAL(10, 2),  VARCHAR(),          true},
+
+    // ---- Accept: identity ----
+    {"bigint_to_bigint",   BIGINT(),  BIGINT(),   false},
+    {"varchar_to_varchar", VARCHAR(), VARCHAR(),  false},
+    {"double_to_double",   DOUBLE(),  DOUBLE(),   false},
+    {"boolean_to_boolean", BOOLEAN(), BOOLEAN(),  false},
+
+    // ---- Accept: integer widening within int family ----
+    {"tinyint_to_smallint", TINYINT(), SMALLINT(), false},
+    {"tinyint_to_integer",  TINYINT(), INTEGER(),  false},
+    {"tinyint_to_bigint",   TINYINT(), BIGINT(),   false},
+    {"smallint_to_integer", SMALLINT(),INTEGER(),  false},
+    {"smallint_to_bigint",  SMALLINT(),BIGINT(),   false},
+    {"integer_to_bigint",   INTEGER(), BIGINT(),   false},
+
+    // ---- Accept: float widening (REAL -> DOUBLE, lossless) ----
+    {"real_to_double",      REAL(),    DOUBLE(),   false},
+
+    // ---- Accept: DECIMAL widening ----
+    {"decimal_identity",              DECIMAL(10, 2),  DECIMAL(10, 2),     false},
+    {"decimal_widen_precision_only",  DECIMAL(10, 2),  DECIMAL(15, 2),     false},
+    {"decimal_widen_both",            DECIMAL(10, 2),  DECIMAL(20, 5),     false},
+    {"decimal_widen_to_long_decimal", DECIMAL(10, 2),  DECIMAL(28, 5),     false},
+
+    // ---- Accept: column-reader auto-cast int family -> VARCHAR ----
+    //  (IntegerColumnReader::makeCastExpr; the cast path compiles in
+    //  both build flavours and matchType() lets INT fileType fall
+    //  through to its default branch, so this works in non-Spark too.)
+    {"tinyint_to_varchar", TINYINT(), VARCHAR(), false},
+    {"smallint_to_varchar",SMALLINT(),VARCHAR(), false},
+    {"integer_to_varchar", INTEGER(), VARCHAR(), false},
+    {"bigint_to_varchar",  BIGINT(),  VARCHAR(), false},
+
+    // ---- Column-reader auto-cast VARCHAR -> int family ----
+    //  StringColumnReader::makeCastExpr handles the cast in both build
+    //  flavours; convertType accepts the pair. In non-Spark builds an
+    //  extra matchType() check at ParquetColumnReader.cpp:95 then
+    //  rejects VARCHAR-file -> INT-requested with its own message, so
+    //  the case expectation flips per flavour.
+#ifdef SPARK_COMPATIBLE
+    {"varchar_to_tinyint", VARCHAR(), TINYINT(), false},
+    {"varchar_to_smallint",VARCHAR(), SMALLINT(),false},
+    {"varchar_to_integer", VARCHAR(), INTEGER(), false},
+    {"varchar_to_bigint",  VARCHAR(), BIGINT(),  false},
+#else
+    {"varchar_to_bigint",  VARCHAR(), BIGINT(),  true, "file schema type"},
+#endif
+  };
+  // clang-format on
+
+  // 3-row sample data builder. DECIMAL is INT64-backed and gets the
+  // type override; the rest use their native C++ types.
+  auto makeSampleData = [&](const TypePtr& fileType) -> RowVectorPtr {
+    if (fileType->isDecimal()) {
+      return makeRowVector(
+          {"c0"}, {makeFlatVector<int64_t>({100, 200, 300}, fileType)});
+    }
+    switch (fileType->kind()) {
+      case TypeKind::TINYINT:
+        return makeRowVector({"c0"}, {makeFlatVector<int8_t>({1, 2, 3})});
+      case TypeKind::SMALLINT:
+        return makeRowVector({"c0"}, {makeFlatVector<int16_t>({1, 2, 3})});
+      case TypeKind::INTEGER:
+        return makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+      case TypeKind::BIGINT:
+        return makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3})});
+      case TypeKind::REAL:
+        return makeRowVector(
+            {"c0"}, {makeFlatVector<float>({1.0f, 2.0f, 3.0f})});
+      case TypeKind::DOUBLE:
+        return makeRowVector({"c0"}, {makeFlatVector<double>({1.0, 2.0, 3.0})});
+      case TypeKind::BOOLEAN:
+        return makeRowVector(
+            {"c0"}, {makeFlatVector<bool>({true, false, true})});
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+        return makeRowVector(
+            {"c0"}, {makeFlatVector<StringView>({"100", "200", "300"})});
+      default:
+        BOLT_FAIL("unsupported test fileType: {}", fileType->toString());
+    }
+  };
+
+  for (const auto& c : cases) {
+    SCOPED_TRACE(c.name);
+
+    auto data = makeSampleData(c.fileType);
+    auto file = exec::test::TempFilePath::create();
+    WriterOptions writerOptions;
+    writeToParquetFile(file->getPath(), {data}, writerOptions);
+
+    auto declaredRowType = ROW({"c0"}, {c.declaredType});
+    auto plan = PlanBuilder(pool())
+                    .tableScan(declaredRowType, {}, "", declaredRowType)
+                    .planNode();
+
+    if (c.shouldThrow) {
+      BOLT_ASSERT_THROW(
+          AssertQueryBuilder(plan)
+              .split(makeSplit(file->getPath()))
+              .copyResults(pool()),
+          c.errMsg);
+    } else {
+      auto result = AssertQueryBuilder(plan)
+                        .split(makeSplit(file->getPath()))
+                        .copyResults(pool());
+      ASSERT_NE(result, nullptr);
+      EXPECT_EQ(result->size(), 3) << "expected 3 rows, got " << result->size();
+      EXPECT_TRUE(result->type()->equivalent(*declaredRowType))
+          << "expected " << declaredRowType->toString() << ", got "
+          << result->type()->toString();
+    }
+  }
+}
+
+// Targeted value-validation companion for the matrix above. The cases
+// here exercise the data path (not just convertType), so we explicitly
+// check the column-reader-level cast and the integer-widening path
+// produce the right values.
+TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
+  // 1. INT widening: file INT32 [1,2,3] read as BIGINT -> [1,2,3].
+  {
+    auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {BIGINT()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  // 2. Float widening: REAL [1.5, 2.5, 3.5] read as DOUBLE.
+  {
+    auto data =
+        makeRowVector({"c0"}, {makeFlatVector<float>({1.5f, 2.5f, 3.5f})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {DOUBLE()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<double>({1.5, 2.5, 3.5})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+#ifdef SPARK_COMPATIBLE
+  // 3. Auto-cast VARCHAR -> BIGINT: ["100","200","300"] -> [100,200,300].
+  //    Skipped in non-Spark builds because matchType() at
+  //    ParquetColumnReader.cpp:95 rejects VARCHAR-file -> INT-requested
+  //    before the column-reader cast can run.
+  {
+    auto data = makeRowVector(
+        {"c0"}, {makeFlatVector<StringView>({"100", "200", "300"})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {BIGINT()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<int64_t>({100, 200, 300})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+#endif
+
+  // 4. Auto-cast INTEGER -> VARCHAR: [1,2,3] -> ["1","2","3"].
+  //    Works in both build flavours: matchType() lets INT fileType fall
+  //    through, and IntegerColumnReader::makeCastExpr handles the cast.
+  {
+    auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {VARCHAR()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<StringView>({"1", "2", "3"})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   // todo: use folly::Init init after upgrade folly lib

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1318,10 +1318,13 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     TypePtr declaredType;
     bool shouldThrow;
     // Substring to match against the thrown error. Defaults to the
-    // BoltUserError raised by ReaderBase::convertType. Override when a
-    // case is rejected by a later layer with a different message
-    // (e.g. ParquetColumnReader::matchType in non-Spark builds).
-    const char* errMsg = "Parquet column cannot be converted";
+    // BoltUserError raised by ReaderBase::convertType via
+    // BOLT_SCHEMA_MISMATCH_ERROR (same error code as DWRF/ORC, same
+    // "Schema mismatch, ..., From Kind: X, To Kind: Y" layout).
+    // Override when a case is rejected by a later layer with a
+    // different message (e.g. ParquetColumnReader::matchType in
+    // non-Spark builds).
+    const char* errMsg = "Schema mismatch";
   };
 
   // clang-format off


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #575 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

When the table-declared column type doesn't match the Parquet file's physical/converted leaf type, `ReaderBase::convertType` used to silently return the file's leaf type. Downstream operators then reinterpreted the resulting vector under the wrong logical type and crashed. This PR adds a strict `BOLT_USER_CHECK` in every branch of `convertType`, throwing a clean `BoltUserError` at file-open time, before any column reader is built to avoid crash.

Also, since integer and varchar type data is implicitly cast during `IntegerColumnReader` and `StringColumnReader`, the newly added check also accepts mismatches between these types.

 #### Upstream references

  Adapted from these Velox PRs:

  - [facebookincubator/velox#12350](https://github.com/facebookincubator/velox/pull/12350) — main fix introducing `isCompatible` + per-branch `VELOX_CHECK` in `convertType`
  - [facebookincubator/velox#13864](https://github.com/facebookincubator/velox/pull/13864) — unannotated array exemption (`isRepeated && requestedType->isArray()`)

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix coredump when schema not match
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
