### PR TITLE
fix: sanitize null char* to prevent fmt exception

### DIFF
--- a/bolt/common/base/Exceptions.h
+++ b/bolt/common/base/Exceptions.h
@@ -158,6 +158,10 @@ inline const char* errorMessage(const char* s) {
   return s ? s : "(nullptr)";
 }
 
+inline const char* errorMessage(char* s) {
+  return s ? s : "(nullptr)";
+}
+
 inline std::string errorMessage(const std::string& str) {
   return str;
 }
@@ -170,6 +174,10 @@ decltype(auto) sanitizeArg(const T& arg) {
 // Replaces null const char* with "(nullptr)" so fmt::vformat won't throw
 // "string pointer is null" when argument is nullptr.
 inline const char* sanitizeArg(const char* arg) {
+  return arg ? arg : "(nullptr)";
+}
+
+inline const char* sanitizeArg(char* arg) {
   return arg ? arg : "(nullptr)";
 }
 

--- a/bolt/common/base/tests/ExceptionTest.cpp
+++ b/bolt/common/base/tests/ExceptionTest.cpp
@@ -1066,3 +1066,26 @@ TEST(ExceptionTest, boltFailWithNullPtr) {
         << "Expected 'error message: (nullptr)' in message, got: " << e.what();
   }
 }
+
+// test char* without const
+TEST(ExceptionTest, boltFailWithNullCharPtr) {
+  char* nullPtr = nullptr;
+
+  try {
+    BOLT_FAIL(nullPtr);
+    FAIL() << "Expected an exception to be thrown";
+  } catch (const BoltRuntimeError& e) {
+    EXPECT_NE(std::string(e.what()).find("(nullptr)"), std::string::npos)
+        << "Expected '(nullptr)' in message, got: " << e.what();
+  }
+
+  try {
+    BOLT_FAIL("error message: {}", nullPtr);
+    FAIL() << "Expected an exception to be thrown";
+  } catch (const BoltRuntimeError& e) {
+    EXPECT_NE(
+        std::string(e.what()).find("error message: (nullptr)"),
+        std::string::npos)
+        << "Expected 'error message: (nullptr)' in message, got: " << e.what();
+  }
+}


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #461 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

In PR #467, we added a sanitize wrapper to exception message arguments to avoid passing `nullptr` to fmt. However, we only added support for `const char*`, and in certain situations the argument may be `char*`, which still triggers `string pointer is null`. We fix that in this PR.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix string pointer is null exception
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
