### PR TITLE
fix format of timestamp string in to_json function

### DIFF
--- a/bolt/functions/prestosql/tests/ToJsonTest.cpp
+++ b/bolt/functions/prestosql/tests/ToJsonTest.cpp
@@ -644,7 +644,7 @@ TEST_F(ToJsonTest, fromSpark) {
     auto rowChild = makeNullableFlatVector<Timestamp>({Timestamp(1, 1)});
     auto rowVector = makeRowVector({rowChild});
     auto expectedVector = makeNullableFlatVector<StringView>(
-        {R"({"c0":"1970-01-01T00:00:01.000+00:00"})"}, VARCHAR());
+        {R"({"c0":"1970-01-01T00:00:01.000Z"})"}, VARCHAR());
     toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
 
     setQueryTimeZone("Asia/Shanghai");

--- a/bolt/functions/prestosql/types/JsonType.cpp
+++ b/bolt/functions/prestosql/types/JsonType.cpp
@@ -200,7 +200,7 @@ void generateJsonTyped(
             false,
             timePolicy,
             true,
-            std::nullopt);
+            "Z");
         result.append(buffer, size);
         result.append("\"");
       } else if constexpr (std::is_same_v<T, VariantValue>) {


### PR DESCRIPTION
### What problem does this PR solve?
In #572 we added Timestamp support for the Spark to_json function. However the timezone part of the formatted string was emitted as a numeric offset (e.g. +00:00) even when the effective timezone is UTC. Spark's to_json formats UTC as the literal Z suffix (ISO-8601 Xxx pattern), so the output of Bolt's to_json does not match Spark's behavior for timestamps in UTC.

Example (current behavior, UTC):
Issue Number: close #571 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

When formatting a Timestamp value in generateJsonTyped (JsonType.cpp), we call the Joda-style datetime formatter with pattern yyyy-MM-dd'T'HH:mm:ss.SSSZZ. The last argument of formatter->format(...) is the zero-offset text: when the effective offset is 0, the formatter will emit this literal string instead of +00:00. Previously we passed std::nullopt, so the formatter fell back to the numeric +00:00 representation, which differs from Spark's default to_json output.

This PR passes "Z" as the zero-offset text so that:

UTC timestamps are serialized as ...Z (matching Spark).
Non-UTC offsets are unchanged (e.g. Asia/Shanghai still produces +08:00).
The corresponding unit test in ToJsonTest.cpp (fromSpark) is updated to expect Z for the UTC case. The existing +08:00 assertion for Asia/Shanghai is left untouched and continues to pass, confirming non-UTC offsets are unaffected.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
