### PR TITLE
fix: use correct tbb lib name in debug mode

### DIFF
--- a/scripts/conan/recipes/paimon-cpp/all/conanfile.py
+++ b/scripts/conan/recipes/paimon-cpp/all/conanfile.py
@@ -200,7 +200,9 @@ class PaimonCppConan(ConanFile):
 
         # TBB is built from source via ExternalProject (ThirdpartyToolchain)
         tbb_comp = self.cpp_info.components["tbb"]
-        tbb_comp.libs = ["tbb"]
+        tbb_comp.libs = [
+            "tbb_debug" if str(self.settings.build_type) == "Debug" else "tbb"
+        ]
         tbb_comp.set_property("cmake_target_name", "Paimon::tbb")
 
         # Internal static libraries (no headers to export — included via paimon's include/)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #581 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

tbb uses the name "tbb_debug" when built in debug mode, so just need to change the name used in the recipe.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

N/A

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
