### PR TITLE
fix: support narrow to TINYINT/SMALLINT for with physical_type INT32 to compatible with legacy parquet

### DIFF
--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -74,32 +74,6 @@ namespace {
 constexpr const char* kTypeMappingErrorFmtStr =
     "Schema mismatch, Column: [{}], From Kind: {}, To Kind: {}";
 
-// Checks whether 'type' is an integer type at least as wide as
-// 'minTypeKind'. Used to gate integer widening:
-//   minTypeKind=TINYINT  accepts TINYINT/SMALLINT/INTEGER/BIGINT (INT_8 leaf)
-//   minTypeKind=SMALLINT accepts SMALLINT/INTEGER/BIGINT          (INT_16 leaf)
-//   minTypeKind=INTEGER  accepts INTEGER/BIGINT                   (INT_32 leaf)
-//   minTypeKind=BIGINT   accepts BIGINT only                      (INT_64 leaf)
-bool isIntCompatible(
-    const bytedance::bolt::TypePtr& type,
-    bytedance::bolt::TypeKind minTypeKind) {
-  using TK = bytedance::bolt::TypeKind;
-  static_assert(
-      static_cast<int>(TK::TINYINT) < static_cast<int>(TK::SMALLINT) &&
-      static_cast<int>(TK::SMALLINT) < static_cast<int>(TK::INTEGER) &&
-      static_cast<int>(TK::INTEGER) < static_cast<int>(TK::BIGINT));
-  const auto kind = type->kind();
-  switch (kind) {
-    case TK::TINYINT:
-    case TK::SMALLINT:
-    case TK::INTEGER:
-    case TK::BIGINT:
-      return static_cast<int>(kind) >= static_cast<int>(minTypeKind);
-    default:
-      return false;
-  }
-}
-
 // Predicates for the cross-family implicit cast that the column reader
 // layer performs at read time (Spark/Hive STRING<->INT compatibility):
 //   - StringColumnReader::makeCastExpr handles VARCHAR/VARBINARY file ->
@@ -111,6 +85,11 @@ bool isIntCompatible(
 // still get the strict check at ParquetColumnReader.cpp:95 via
 // matchType() for the VARCHAR-file -> INT-requested direction, which
 // fires after convertType and throws with its existing error message.
+// Cross-family implicit cast for VARCHAR/VARBINARY file columns:
+// StringColumnReader::makeCastExpr handles VARCHAR/VARBINARY file -> int
+// family requested type. Non-Spark builds also get a strict check at
+// ParquetColumnReader.cpp:95 via matchType() that fires after convertType
+// and throws with its own error message for that case.
 bool acceptsVarcharFileForReaderCast(const bytedance::bolt::TypePtr& t) {
   using TK = bytedance::bolt::TypeKind;
   const auto k = t->kind();
@@ -120,6 +99,30 @@ bool acceptsVarcharFileForReaderCast(const bytedance::bolt::TypePtr& t) {
 bool acceptsIntFileForReaderCast(const bytedance::bolt::TypePtr& t) {
   return t->kind() == bytedance::bolt::TypeKind::VARCHAR ||
       t->kind() == bytedance::bolt::TypeKind::VARBINARY;
+}
+
+// Compatibility predicate for Parquet INT32-physical source columns
+// (INT_8 / INT_16 / INT_32 / UINT_* annotated, plus unannotated INT32).
+// Accepts:
+//   - Any int-family target. Narrowing (file INT32 -> requested ByteType /
+//     ShortType) is silently truncated at read time, matching Spark's
+//     vectorized reader. Covers HIVE-14294 where Hive 1.x writes
+//     TINYINT/SMALLINT as unannotated INT32 (SPARK-16632).
+//   - VARCHAR / VARBINARY target via IntegerColumnReader::makeCastExpr,
+//     which performs the int-to-string cast at read time.
+bool isInt32Compatible(const bytedance::bolt::TypePtr& type) {
+  using TK = bytedance::bolt::TypeKind;
+  const auto k = type->kind();
+  return k == TK::TINYINT || k == TK::SMALLINT || k == TK::INTEGER ||
+      k == TK::BIGINT || acceptsIntFileForReaderCast(type);
+}
+
+// Compatibility predicate for Parquet INT64-physical source columns.
+// Accepts BIGINT only (no integer narrowing), plus VARCHAR / VARBINARY
+// via IntegerColumnReader::makeCastExpr.
+bool isInt64Compatible(const bytedance::bolt::TypePtr& type) {
+  using TK = bytedance::bolt::TypeKind;
+  return type->kind() == TK::BIGINT || acceptsIntFileForReaderCast(type);
 }
 
 } // namespace
@@ -1023,10 +1026,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "INT8 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::TINYINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return TINYINT();
 
       case thrift::ConvertedType::INT_16:
@@ -1034,10 +1034,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "INT16 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::SMALLINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return SMALLINT();
 
       case thrift::ConvertedType::INT_32:
@@ -1045,10 +1042,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "INT32 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::INTEGER) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return INTEGER();
 
       case thrift::ConvertedType::INT_64:
@@ -1056,10 +1050,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "INT64 converted type can only be set for value of thrift::Type::INT64");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::BIGINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt64Compatible(t); });
         return BIGINT();
 
       case thrift::ConvertedType::UINT_8:
@@ -1067,10 +1058,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_8 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::TINYINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return TINYINT();
 
       case thrift::ConvertedType::UINT_16:
@@ -1078,10 +1066,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_16 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::SMALLINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return SMALLINT();
 
       case thrift::ConvertedType::UINT_32:
@@ -1089,10 +1074,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_32 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::INTEGER) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return INTEGER();
 
       case thrift::ConvertedType::UINT_64:
@@ -1100,10 +1082,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "UINT_64 converted type can only be set for value of thrift::Type::INT64");
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::BIGINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt64Compatible(t); });
         return BIGINT();
 
       case thrift::ConvertedType::DATE:
@@ -1188,10 +1167,7 @@ TypePtr ReaderBase::convertType(
             [](const TypePtr& t) { return t->kind() == TypeKind::BOOLEAN; });
         return BOOLEAN();
       case thrift::Type::type::INT32:
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::INTEGER) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return INTEGER();
       case thrift::Type::type::INT64:
         // For Int64 Timestamp in nano precision
@@ -1212,10 +1188,7 @@ TypePtr ReaderBase::convertType(
           });
           return TIMESTAMP();
         }
-        checkRequested([](const TypePtr& t) {
-          return isIntCompatible(t, TypeKind::BIGINT) ||
-              acceptsIntFileForReaderCast(t);
-        });
+        checkRequested([](const TypePtr& t) { return isInt64Compatible(t); });
         return BIGINT();
       case thrift::Type::type::INT96:
         checkRequested(

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1333,10 +1333,21 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     {"array_declared_vs_varchar_file", VARCHAR(),       ARRAY(VARCHAR()),   true},
     {"array_declared_vs_bigint_file",  BIGINT(),        ARRAY(BIGINT()),    true},
 
-    // ---- Reject: integer narrowing ----
+    // ---- Reject: INT64 narrowing (both flavours; Spark INT64 reader
+    //               also rejects Byte/Short/Integer requests). ----
     {"bigint_to_integer",              BIGINT(),        INTEGER(),          true},
-    {"integer_to_smallint",            INTEGER(),       SMALLINT(),         true},
-    {"integer_to_tinyint",             INTEGER(),       TINYINT(),          true},
+    {"bigint_to_smallint",             BIGINT(),        SMALLINT(),         true},
+    {"bigint_to_tinyint",              BIGINT(),        TINYINT(),          true},
+
+    // ---- Accept: INT32 narrowing. File INT32 -> requested Byte/Short
+    //      is silently truncated at read time by IntegerColumnReader,
+    //      matching Spark's vectorized reader (ByteUpdater/ShortUpdater)
+    //      and covering HIVE-14294 / SPARK-16632 where Hive 1.x writes
+    //      TINYINT/SMALLINT as unannotated INT32. See the
+    //      integer-narrowing block in convertTypePolicyValueChecks
+    //      for end-to-end values. ----
+    {"integer_to_smallint",            INTEGER(),       SMALLINT(),         false},
+    {"integer_to_tinyint",             INTEGER(),       TINYINT(),          false},
 
     // ---- Reject: cross-family with no column-reader auto-cast ----
     {"integer_to_double",              INTEGER(),       DOUBLE(),           true},
@@ -1534,6 +1545,41 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
     EXPECT_TRUE(assertEqualResults({expected}, {result}));
   }
 #endif
+
+  // 3a/3b. INT32 narrowing: file INT32 read back as TINYINT and SMALLINT.
+  //        Models HIVE-14294 / SPARK-16632 where Hive 1.x writes TINYINT/
+  //        SMALLINT as unannotated INT32. The matching matrix cases only
+  //        assert no-throw; these check the data path actually narrows
+  //        correctly instead of returning garbage. IntegerColumnReader
+  //        does the silent truncation, matching Spark / Trino / parquet-mr.
+  {
+    auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    {
+      auto declared = ROW({"c0"}, {TINYINT()});
+      auto plan =
+          PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+      auto result = AssertQueryBuilder(plan)
+                        .split(makeSplit(file->getPath()))
+                        .copyResults(pool());
+      auto expected =
+          makeRowVector({"c0"}, {makeFlatVector<int8_t>({1, 2, 3})});
+      EXPECT_TRUE(assertEqualResults({expected}, {result}));
+    }
+    {
+      auto declared = ROW({"c0"}, {SMALLINT()});
+      auto plan =
+          PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+      auto result = AssertQueryBuilder(plan)
+                        .split(makeSplit(file->getPath()))
+                        .copyResults(pool());
+      auto expected =
+          makeRowVector({"c0"}, {makeFlatVector<int16_t>({1, 2, 3})});
+      EXPECT_TRUE(assertEqualResults({expected}, {result}));
+    }
+  }
 
   // 4. Auto-cast INTEGER -> VARCHAR: [1,2,3] -> ["1","2","3"].
   //    Works in both build flavours: matchType() lets INT fileType fall


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #587 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
In the legacy Hive implementation, INT8/INT16 values were stored in Parquet with an INT32 physical type and no converted type. However, in PR #576, we added a strict check between the requested type and the physical type, which causes an exception when reading these legacy Parquet files.
```
############ Column(is_exclude) ############
name: is_exclude
path: is_exclude
max_definition_level: 1
max_repetition_level: 0
physical_type: INT32
logical_type: None
converted_type (legacy): NONE
compression: ZSTD (space_saved: -20%)
```
https://issues.apache.org/jira/browse/HIVE-14294

### Spark implementation
In spark `ParquetVectorUpdaterFactory.java`, parquet's INT32 type could narrow to Byte/Short no matter it has annotation or not. But parquet's INT64 only accept Long and does not support narrow.
https://github.com/apache/spark/blob/421b8001107d73f0ea3c9c1313ee878124c37142/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java#L99-L102

So in Bolt, we match Spark's behavior by allowing narrowing for INT32 while keeping a strict check for INT64. We also apply this in non-Spark mode to improve compatibility with legacy Parquet INT32 files and existing workloads.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Support INT32 narrowing in legacy parquet file
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
