### PR TITLE
[fix] tighten HashBuild probe admission under memory pressure

### DIFF
--- a/bolt/common/base/NumberParsing.h
+++ b/bolt/common/base/NumberParsing.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cctype>
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <system_error>
+
+namespace bytedance::bolt {
+
+inline std::optional<int64_t> parseInt64(std::string_view text) {
+  int64_t number = 0;
+  const auto* begin = text.data();
+  const auto* end = text.data() + text.size();
+  const auto [ptr, ec] = std::from_chars(begin, end, number);
+  if (ec != std::errc() || ptr != end) {
+    return std::nullopt;
+  }
+  return number;
+}
+
+inline std::optional<int64_t> extractNumberAfterPrefix(
+    std::string_view text,
+    std::string_view prefix) {
+  const auto prefixPos = text.find(prefix);
+  if (prefixPos == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto numStart = prefixPos + prefix.size();
+  auto numEnd = numStart;
+  while (numEnd < text.size() &&
+         std::isdigit(static_cast<unsigned char>(text[numEnd]))) {
+    ++numEnd;
+  }
+  if (numEnd == numStart) {
+    return std::nullopt;
+  }
+
+  return parseInt64(text.substr(numStart, numEnd - numStart));
+}
+
+inline std::optional<int64_t> extractNumberBetween(
+    std::string_view text,
+    std::string_view prefix,
+    std::string_view suffix) {
+  const auto prefixPos = text.find(prefix);
+  if (prefixPos == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto numStart = prefixPos + prefix.size();
+  const auto numEnd = text.find(suffix, numStart);
+  if (numEnd == std::string_view::npos || numEnd == numStart) {
+    return std::nullopt;
+  }
+
+  return parseInt64(text.substr(numStart, numEnd - numStart));
+}
+
+} // namespace bytedance::bolt

--- a/bolt/common/base/tests/CMakeLists.txt
+++ b/bolt/common/base/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   FsTest.cpp
   RangeTest.cpp
   RuntimeMetricsTest.cpp
+  NumberParsingTest.cpp
   ScopedLockTest.cpp
   SemaphoreTest.cpp
   SimdUtilTest.cpp

--- a/bolt/common/base/tests/NumberParsingTest.cpp
+++ b/bolt/common/base/tests/NumberParsingTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/common/base/NumberParsing.h"
+
+#include <gtest/gtest.h>
+
+namespace bytedance::bolt::test {
+namespace {
+
+TEST(NumberParsingTest, extractNumberAfterPrefix) {
+  EXPECT_EQ(extractNumberAfterPrefix("query_ATTEMPT_4", "ATTEMPT_"), 4);
+  EXPECT_EQ(extractNumberAfterPrefix("ATTEMPT_9_suffix", "ATTEMPT_"), 9);
+  EXPECT_EQ(extractNumberAfterPrefix("ATTEMPT_123", "ATTEMPT_"), 123);
+
+  EXPECT_EQ(extractNumberAfterPrefix("query", "ATTEMPT_"), std::nullopt);
+  EXPECT_EQ(extractNumberAfterPrefix("ATTEMPT_", "ATTEMPT_"), std::nullopt);
+  EXPECT_EQ(extractNumberAfterPrefix("ATTEMPT_abc", "ATTEMPT_"), std::nullopt);
+}
+
+TEST(NumberParsingTest, extractNumberBetween) {
+  EXPECT_EQ(
+      extractNumberBetween("query_0_TID_123_ATTEMPT_4", "_TID_", "_ATTEMPT_"),
+      123);
+
+  EXPECT_EQ(
+      extractNumberBetween("query_0_ATTEMPT_4", "_TID_", "_ATTEMPT_"),
+      std::nullopt);
+  EXPECT_EQ(
+      extractNumberBetween("query_0_TID__ATTEMPT_4", "_TID_", "_ATTEMPT_"),
+      std::nullopt);
+  EXPECT_EQ(
+      extractNumberBetween("query_0_TID_abc_ATTEMPT_4", "_TID_", "_ATTEMPT_"),
+      std::nullopt);
+}
+
+} // namespace
+} // namespace bytedance::bolt::test

--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
@@ -33,6 +33,11 @@ ExecutionMemoryPoolPtr ExecutionMemoryPool::instance() {
   return instance_;
 }
 
+std::string ExecutionMemoryPool::debugString() {
+  return inited() ? instance()->toString()
+                  : "ExecutionMemoryPool(not initialized)";
+}
+
 // Call ExecutionMemoryPool::init does not mean that BoltMemoryManager is
 // enabled, but enabling BoltMemoryManager definitely means that
 // ExecutionMemoryPool::init has been executed.
@@ -106,6 +111,52 @@ int64_t ExecutionMemoryPool::getMemoryUsageForTask(int64_t taskAttemptId) {
   return (ans == memoryForTask_.end()) ? 0L : ans->second;
 }
 
+ExecutionMemoryPool::ScopedDisableDynamicMemoryQuotaManager
+ExecutionMemoryPool::scopedDisableDynamicMemoryQuotaManagerForTask(
+    int64_t taskAttemptId) {
+  auto self = shared_from_this();
+  disableDynamicMemoryQuotaManagerForTask(taskAttemptId);
+  return folly::makeGuard(
+      std::function<void()>([self = std::move(self), taskAttemptId]() {
+        self->enableDynamicMemoryQuotaManagerForTask(taskAttemptId);
+      }));
+}
+
+std::optional<ExecutionMemoryPool::ScopedDisableDynamicMemoryQuotaManager>
+ExecutionMemoryPool::maybeScopedDisableDynamicMemoryQuotaManagerForTask(
+    const std::optional<int64_t>& taskAttemptId) {
+  if (!taskAttemptId.has_value() || !inited()) {
+    return std::nullopt;
+  }
+  return instance()->scopedDisableDynamicMemoryQuotaManagerForTask(
+      *taskAttemptId);
+}
+
+void ExecutionMemoryPool::disableDynamicMemoryQuotaManagerForTask(
+    int64_t taskAttemptId) {
+  MemoryMutexGuard guard(lock_);
+  ++dynamicMemoryQuotaManagerDisableCounts_[taskAttemptId];
+}
+
+void ExecutionMemoryPool::enableDynamicMemoryQuotaManagerForTask(
+    int64_t taskAttemptId) {
+  MemoryMutexGuard guard(lock_);
+  auto it = dynamicMemoryQuotaManagerDisableCounts_.find(taskAttemptId);
+  if (it == dynamicMemoryQuotaManagerDisableCounts_.end()) {
+    LOG(WARNING)
+        << "TID " << taskAttemptId
+        << " is not disabled by dynamic memory quota manager, cannot be enabled";
+    return;
+  }
+  BOLT_CHECK(
+      it->second > 0,
+      "Expect dynamic memory quota disable count is greater than 0 for task {}",
+      taskAttemptId);
+  if (--it->second == 0) {
+    dynamicMemoryQuotaManagerDisableCounts_.erase(it);
+  }
+}
+
 int64_t ExecutionMemoryPool::acquireMemory(
     int64_t numBytes,
     int64_t taskAttemptId) {
@@ -127,10 +178,12 @@ int64_t ExecutionMemoryPool::acquireMemory(
     int64_t maxPoolSize = internalPoolSize();
     int64_t maxMemoryPerTask = maxPoolSize / numActiveTasks;
     int64_t minMemoryPerTask = internalPoolSize() / (2 * numActiveTasks);
+    int64_t configureMaxMemoryPerTask = poolSize_.value_or(0) / numActiveTasks;
+    int64_t freeMemory = internalMemoryFree();
 
     int64_t maxToGrant =
         std::min(numBytes, std::max<int64_t>(0L, maxMemoryPerTask - curMem));
-    int64_t toGrant = std::min(maxToGrant, internalMemoryFree());
+    int64_t toGrant = std::min(maxToGrant, freeMemory);
 
     if (toGrant < numBytes && curMem + toGrant < minMemoryPerTask) {
       LOG(INFO) << "TID " << taskAttemptId
@@ -171,8 +224,23 @@ int64_t ExecutionMemoryPool::acquireMemory(
         return 0;
       }
     } else {
-      bool enable = option_.enable && !thisRunHasBorrowed;
-      if (enable) {
+      bool disabledByTask =
+          dynamicMemoryQuotaManagerDisableCounts_.find(taskAttemptId) !=
+          dynamicMemoryQuotaManagerDisableCounts_.end();
+      if (disabledByTask) {
+        maxToGrant = std::min(
+            numBytes,
+            std::max<int64_t>(0L, configureMaxMemoryPerTask - curMem));
+        toGrant = std::min(maxToGrant, freeMemory);
+        LOG(INFO) << "TID " << taskAttemptId
+                  << " dynamic memory quota manager is disabled by task"
+                  << ", configureMaxMemoryPerTask="
+                  << succinctBytes(configureMaxMemoryPerTask)
+                  << ", maxToGrant=" << succinctBytes(maxToGrant)
+                  << ", toGrant=" << succinctBytes(toGrant)
+                  << ", freeMemory=" << succinctBytes(freeMemory)
+                  << ", curMem=" << succinctBytes(curMem);
+      } else if (option_.enable && !thisRunHasBorrowed) {
         bool notEnough = toGrant < numBytes;
         bool reachThreshold = poolExtendSize_.has_value() &&
             memIncreaseSize_ >= option_.sampleSize;
@@ -183,6 +251,18 @@ int64_t ExecutionMemoryPool::acquireMemory(
           });
 
           if (triggerDynamicMemoryQuotaManager(notEnough, reachThreshold)) {
+            auto& watermark = borrowFromRssWatermarkBytes_[taskAttemptId];
+            auto newWatermark = std::min(configureMaxMemoryPerTask, curMem);
+            if (newWatermark > watermark) {
+              LOG(INFO) << "TID " << taskAttemptId
+                        << " borrow from RSS watermark updated to "
+                        << succinctBytes(newWatermark) << " from "
+                        << succinctBytes(watermark)
+                        << ", configureMaxMemoryPerTask="
+                        << succinctBytes(configureMaxMemoryPerTask)
+                        << ", curMem=" << succinctBytes(curMem);
+              watermark = newWatermark;
+            }
             continue;
           }
         }
@@ -219,6 +299,7 @@ int64_t ExecutionMemoryPool::releaseMemory(
     memoryForTask_[taskAttemptId] -= memoryToFree;
     if (memoryForTask_[taskAttemptId] == 0) {
       memoryForTask_.erase(taskAttemptId);
+      borrowFromRssWatermarkBytes_.erase(taskAttemptId);
     }
   }
   cv_.notify_all();
@@ -315,6 +396,16 @@ std::optional<int64_t> ExecutionMemoryPool::getMinimumFreeMemoryForTask(
   }
   auto usage = instance()->getMemoryUsageForTask(taskAttemptId);
   return std::max<int64_t>(0L, available - usage);
+}
+
+uint64_t ExecutionMemoryPool::borrowFromRssWatermarkBytes(
+    int64_t taskAttemptId) {
+  if (!inited()) {
+    return 0;
+  }
+  MemoryMutexGuard guard(instance()->lock_);
+  const auto it = instance()->borrowFromRssWatermarkBytes_.find(taskAttemptId);
+  return it == instance()->borrowFromRssWatermarkBytes_.end() ? 0 : it->second;
 }
 
 std::ostream& operator<<(std::ostream& os, const ExecutionMemoryPool& pool) {

--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.h
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.h
@@ -167,8 +167,7 @@ class ExecutionMemoryPool final
   const DynamicMemoryQuotaManagerOption option_;
   int64_t memIncreaseSize_{0};
   std::optional<int64_t> poolExtendSize_;
-  std::unordered_map<int64_t, uint32_t>
-      dynamicMemoryQuotaManagerDisableCounts_;
+  std::unordered_map<int64_t, uint32_t> dynamicMemoryQuotaManagerDisableCounts_;
   std::unordered_map<int64_t, int64_t> borrowFromRssWatermarkBytes_;
   DynamicMemoryQuotaManagerStatistics statistics_;
 };

--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.h
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.h
@@ -18,12 +18,15 @@
 
 #include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
 #include <vector>
+
+#include <folly/ScopeGuard.h>
 
 #include "bolt/common/memory/sparksql/DynamicMemoryQuotaManager.h"
 namespace bytedance::bolt::memory::sparksql {
@@ -38,6 +41,9 @@ using ExecutionMemoryPoolWeakPtr = std::weak_ptr<ExecutionMemoryPool>;
 class ExecutionMemoryPool final
     : public std::enable_shared_from_this<ExecutionMemoryPool> {
  public:
+  using ScopedDisableDynamicMemoryQuotaManager =
+      decltype(folly::makeGuard(std::function<void()>{}));
+
   explicit ExecutionMemoryPool(
       int32_t maxTaskNumber = 1,
       const DynamicMemoryQuotaManagerOption& option = {});
@@ -79,6 +85,13 @@ class ExecutionMemoryPool final
 
   int64_t getOveragedMemoryForTask(int64_t taskAttemptId);
 
+  ScopedDisableDynamicMemoryQuotaManager
+  scopedDisableDynamicMemoryQuotaManagerForTask(int64_t taskAttemptId);
+
+  static std::optional<ScopedDisableDynamicMemoryQuotaManager>
+  maybeScopedDisableDynamicMemoryQuotaManagerForTask(
+      const std::optional<int64_t>& taskAttemptId);
+
   friend std::ostream& operator<<(
       std::ostream& os,
       const ExecutionMemoryPool& pool);
@@ -88,6 +101,8 @@ class ExecutionMemoryPool final
       const ExecutionMemoryPool* pool);
 
   std::string toString() const;
+
+  static std::string debugString();
 
   static void init(
       bool enable,
@@ -120,10 +135,16 @@ class ExecutionMemoryPool final
     return inited() ? instance()->poolExtendSize_.has_value() : false;
   }
 
+  static uint64_t borrowFromRssWatermarkBytes(int64_t taskAttemptId);
+
   // For testing only, reset pool size to test new cases with new pool size
   static void testingResetPoolSize(int64_t newSize);
 
  private:
+  void disableDynamicMemoryQuotaManagerForTask(int64_t taskAttemptId);
+
+  void enableDynamicMemoryQuotaManagerForTask(int64_t taskAttemptId);
+
   int64_t internalMemoryUsed() const;
 
   int64_t internalPoolSize() const;
@@ -146,6 +167,9 @@ class ExecutionMemoryPool final
   const DynamicMemoryQuotaManagerOption option_;
   int64_t memIncreaseSize_{0};
   std::optional<int64_t> poolExtendSize_;
+  std::unordered_map<int64_t, uint32_t>
+      dynamicMemoryQuotaManagerDisableCounts_;
+  std::unordered_map<int64_t, int64_t> borrowFromRssWatermarkBytes_;
   DynamicMemoryQuotaManagerStatistics statistics_;
 };
 

--- a/bolt/common/memory/sparksql/tests/MemoryConsumerTest.cpp
+++ b/bolt/common/memory/sparksql/tests/MemoryConsumerTest.cpp
@@ -94,6 +94,14 @@ TEST_F(MemoryConsumerTest, basic) {
   BOLT_CHECK(memoryPool->memoryUsed() == 0, "Expect free all memory");
 }
 
+TEST_F(MemoryConsumerTest, debugStringDoesNotRequireGlobalInitialization) {
+  EXPECT_FALSE(ExecutionMemoryPool::inited());
+  EXPECT_NO_THROW({
+    const auto detail = ExecutionMemoryPool::debugString();
+    EXPECT_FALSE(detail.empty());
+  });
+}
+
 TEST_F(MemoryConsumerTest, multiTask) {
   const int runs = 10;
   for (int run = 0; run < runs; ++run) {
@@ -320,6 +328,104 @@ TEST_F(MemoryConsumerTest, multiConsumer) {
         consumeMem[i]);
     consumers[i]->freeMemory(consumeMem[i]);
   }
+}
+
+TEST_F(MemoryConsumerTest, scopedDisableDynamicMemoryQuotaManagerForTask) {
+  DynamicMemoryQuotaManagerOption option;
+  option.enable = true;
+  option.quotaTriggerRatio = 0.0;
+  option.rssMinRatio = 0.0;
+  option.rssMaxRatio = 0.0;
+  option.extendMinRatio = 2.0;
+  option.extendMaxRatio = 2.0;
+  option.extendScaleRatio = 1.0;
+  option.sampleRatio = 1.0;
+  option.sampleSize = 1;
+  option.changeThresholdRatio = 0.0;
+  option.logPrintFreq = 0.0;
+
+  constexpr int64_t kTaskAttemptId = 7;
+  auto memoryPool = std::make_shared<ExecutionMemoryPool>(1, option);
+  memoryPool->setPoolSize(100);
+
+  EXPECT_EQ(memoryPool->acquireMemory(100, kTaskAttemptId), 100);
+
+  {
+    auto scopedDisable =
+        memoryPool->scopedDisableDynamicMemoryQuotaManagerForTask(
+            kTaskAttemptId);
+    EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 0);
+  }
+
+  EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 1);
+}
+
+TEST_F(
+    MemoryConsumerTest,
+    scopedDisableDynamicMemoryQuotaManagerForTaskSupportsNesting) {
+  DynamicMemoryQuotaManagerOption option;
+  option.enable = true;
+  option.quotaTriggerRatio = 0.0;
+  option.rssMinRatio = 0.0;
+  option.rssMaxRatio = 0.0;
+  option.extendMinRatio = 2.0;
+  option.extendMaxRatio = 2.0;
+  option.extendScaleRatio = 1.0;
+  option.sampleRatio = 1.0;
+  option.sampleSize = 1;
+  option.changeThresholdRatio = 0.0;
+  option.logPrintFreq = 0.0;
+
+  constexpr int64_t kTaskAttemptId = 7;
+  auto memoryPool = std::make_shared<ExecutionMemoryPool>(1, option);
+  memoryPool->setPoolSize(100);
+
+  EXPECT_EQ(memoryPool->acquireMemory(100, kTaskAttemptId), 100);
+
+  auto outerScopedDisable =
+      memoryPool->scopedDisableDynamicMemoryQuotaManagerForTask(kTaskAttemptId);
+  {
+    auto innerScopedDisable =
+        memoryPool->scopedDisableDynamicMemoryQuotaManagerForTask(
+            kTaskAttemptId);
+    EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 0);
+  }
+
+  EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 0);
+}
+
+TEST_F(
+    MemoryConsumerTest,
+    scopedDisableDynamicMemoryQuotaManagerForTaskSurvivesReleaseAllMemory) {
+  DynamicMemoryQuotaManagerOption option;
+  option.enable = true;
+  option.quotaTriggerRatio = 0.0;
+  option.rssMinRatio = 0.0;
+  option.rssMaxRatio = 0.0;
+  option.extendMinRatio = 2.0;
+  option.extendMaxRatio = 2.0;
+  option.extendScaleRatio = 1.0;
+  option.sampleRatio = 1.0;
+  option.sampleSize = 1;
+  option.changeThresholdRatio = 0.0;
+  option.logPrintFreq = 0.0;
+
+  constexpr int64_t kTaskAttemptId = 7;
+  auto memoryPool = std::make_shared<ExecutionMemoryPool>(1, option);
+  memoryPool->setPoolSize(100);
+
+  EXPECT_EQ(memoryPool->acquireMemory(100, kTaskAttemptId), 100);
+
+  {
+    auto scopedDisable =
+        memoryPool->scopedDisableDynamicMemoryQuotaManagerForTask(
+            kTaskAttemptId);
+    EXPECT_EQ(memoryPool->releaseMemory(100, kTaskAttemptId), 100);
+
+    EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 0);
+  }
+
+  EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 1);
 }
 
 } // namespace bytedance::bolt::memory::sparksql

--- a/bolt/connectors/hive/IgnoreCorruptFile.h
+++ b/bolt/connectors/hive/IgnoreCorruptFile.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/NumberParsing.h"
 #include "bolt/connectors/hive/storage_adapters/hdfs/StorageException.h"
 
 class IgnoreCorruptFileHelper {
@@ -113,25 +114,8 @@ class IgnoreCorruptFileHelper {
               << fmt::format("{}", fmt::join(exceptionKeyWords, ", "));
   }
   static int64_t extractAttemptNumber(const std::string& taskId) {
-    const std::string prefix = "ATTEMPT_";
-    size_t prefix_pos = taskId.find(prefix);
-    if (prefix_pos == std::string::npos) {
-      return -1;
-    }
-    size_t num_start = prefix_pos + prefix.length();
-    size_t num_end = num_start;
-    while (num_end < taskId.length() && std::isdigit(taskId[num_end])) {
-      num_end++;
-    }
-    if (num_end == num_start) {
-      return -1;
-    }
-    try {
-      return std::stoi(taskId.substr(num_start, num_end - num_start));
-    } catch (...) {
-      return -1;
-    }
-    return -1;
+    return bytedance::bolt::extractNumberAfterPrefix(taskId, "ATTEMPT_")
+        .value_or(-1);
   }
   inline static bool hasInitialized_{false};
   inline static int64_t taskMaxFailures_{0};

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -445,6 +445,16 @@ class QueryConfig {
   static constexpr const char* kHashBuildProbeAdmissionUnderMemoryPressure =
       "hash_build_probe_admission_under_memory_pressure_enabled";
 
+  /// The multiple of preferred output batch size used to reserve enough memory
+  /// for output.
+  static constexpr const char* kOutputBatchMemoryReservationMultiple =
+      "output_batch_memory_reservation_multiple";
+
+  /// The ratio used to decide whether current memory usage is close enough to
+  /// the memory pressure watermark.
+  static constexpr const char* kMemoryPressureWatermarkRatio =
+      "memory_pressure_watermark_ratio";
+
   /// The minimum number of table rows that can trigger the parallel hash join
   /// table build.
   static constexpr const char* kMinTableRowsForParallelJoinBuild =
@@ -1426,6 +1436,14 @@ class QueryConfig {
 
   bool hashBuildProbeAdmissionUnderMemoryPressureEnabled() const {
     return get<bool>(kHashBuildProbeAdmissionUnderMemoryPressure, true);
+  }
+
+  uint64_t outputBatchMemoryReservationMultiple() const {
+    return get<uint64_t>(kOutputBatchMemoryReservationMultiple, 8);
+  }
+
+  double memoryPressureWatermarkRatio() const {
+    return get<double>(kMemoryPressureWatermarkRatio, 0.7);
   }
 
   uint32_t minTableRowsForParallelJoinBuild() const {

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -440,6 +440,11 @@ class QueryConfig {
   static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
       "hash_probe_finish_early_on_empty_build";
 
+  /// If true, reserve extra hash build memory for probe admission when the task
+  /// is under memory pressure.
+  static constexpr const char* kHashBuildProbeAdmissionUnderMemoryPressure =
+      "hash_build_probe_admission_under_memory_pressure_enabled";
+
   /// The minimum number of table rows that can trigger the parallel hash join
   /// table build.
   static constexpr const char* kMinTableRowsForParallelJoinBuild =
@@ -1417,6 +1422,10 @@ class QueryConfig {
 
   bool hashProbeFinishEarlyOnEmptyBuild() const {
     return get<bool>(kHashProbeFinishEarlyOnEmptyBuild, true);
+  }
+
+  bool hashBuildProbeAdmissionUnderMemoryPressureEnabled() const {
+    return get<bool>(kHashBuildProbeAdmissionUnderMemoryPressure, true);
   }
 
   uint32_t minTableRowsForParallelJoinBuild() const {

--- a/bolt/core/tests/QueryConfigTest.cpp
+++ b/bolt/core/tests/QueryConfigTest.cpp
@@ -59,6 +59,18 @@ TEST_F(QueryConfigTest, setConfig) {
   ASSERT_TRUE(config.isLegacyCast());
 }
 
+TEST_F(QueryConfigTest, hashBuildProbeAdmissionUnderMemoryPressureConfig) {
+  auto queryCtx = QueryCtx::create(nullptr, QueryConfig{{}});
+  ASSERT_TRUE(queryCtx->queryConfig()
+                  .hashBuildProbeAdmissionUnderMemoryPressureEnabled());
+
+  std::unordered_map<std::string, std::string> configData(
+      {{QueryConfig::kHashBuildProbeAdmissionUnderMemoryPressure, "false"}});
+  queryCtx = QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+  ASSERT_FALSE(queryCtx->queryConfig()
+                   .hashBuildProbeAdmissionUnderMemoryPressureEnabled());
+}
+
 TEST_F(QueryConfigTest, taskWriterCountConfig) {
   struct {
     std::optional<int> numWriterCounter;

--- a/bolt/exec/CMakeLists.txt
+++ b/bolt/exec/CMakeLists.txt
@@ -67,6 +67,7 @@ bolt_add_library(
   LocalShuffle.cpp
   MarkDistinct.cpp
   MemoryReclaimer.cpp
+  MemoryPressureUtils.cpp
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp

--- a/bolt/exec/Driver.cpp
+++ b/bolt/exec/Driver.cpp
@@ -787,8 +787,13 @@ StopReason Driver::runInternal(
                     nextOp,
                     curOperatorId_ + 1,
                     kOpMethodNoMoreInput);
+                auto* nextOpPool = nextOp->pool();
                 LOG_SPARK(INFO)
-                    << "Operator " << nextOp->name() << " no more input.";
+                    << "Operator " << nextOp->name() << " no more input. "
+                    << nextOpPool->name() << "["
+                    << succinctBytes(nextOpPool->currentBytes()) << ", "
+                    << succinctBytes(nextOpPool->reservedBytes()) << ", "
+                    << succinctBytes(nextOpPool->capacity()) << "]";
                 break;
               }
             }

--- a/bolt/exec/HashBuild.cpp
+++ b/bolt/exec/HashBuild.cpp
@@ -1250,6 +1250,9 @@ bool HashBuild::finishHashBuild() {
 uint64_t HashBuild::probeAdmissionExtraReservationBytes(
     uint64_t numRows) const {
   const bool notReadyForProbeAdmission =
+      !operatorCtx_->driverCtx()
+           ->queryConfig()
+           .hashBuildProbeAdmissionUnderMemoryPressureEnabled() ||
       !spillEnabled() || isInputFromSpill() || numRows == 0;
   const bool spillUnavailable = spiller_ == nullptr ||
       spiller_->isAllSpilled() || exceededMaxSpillLevelLimit_;

--- a/bolt/exec/HashBuild.cpp
+++ b/bolt/exec/HashBuild.cpp
@@ -49,8 +49,6 @@
 using bytedance::bolt::common::testutil::TestValue;
 namespace bytedance::bolt::exec {
 namespace {
-constexpr uint64_t kProbeAdmissionOutputBatchMultiple = 8;
-
 // Map HashBuild 'state' to the corresponding driver blocking reason.
 BlockingReason fromStateToBlockingReason(HashBuild::State state) {
   switch (state) {
@@ -1278,13 +1276,18 @@ uint64_t HashBuild::probeAdmissionExtraReservationBytes(
             << succinctBytes(pressureWatermarkBytes) << ", details "
             << task->memoryPressureDetails();
   if (pressureWatermarkBytes != 0 &&
-      currentBytes > pressureWatermarkBytes * 0.7) {
+      currentBytes > pressureWatermarkBytes *
+              operatorCtx_->driverCtx()
+                  ->queryConfig()
+                  .memoryPressureWatermarkRatio()) {
     return pressureWatermarkBytes;
   }
 
   const uint64_t probeReservationLimit =
       operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes() *
-      kProbeAdmissionOutputBatchMultiple;
+      operatorCtx_->driverCtx()
+          ->queryConfig()
+          .outputBatchMemoryReservationMultiple();
   return std::min<uint64_t>(currentBytes / 2, probeReservationLimit);
 }
 

--- a/bolt/exec/HashBuild.cpp
+++ b/bolt/exec/HashBuild.cpp
@@ -32,6 +32,7 @@
 #include <boost/sort/pdqsort/pdqsort.hpp>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
 #include "bolt/common/base/Counters.h"
 #include "bolt/common/base/Exceptions.h"
@@ -48,6 +49,8 @@
 using bytedance::bolt::common::testutil::TestValue;
 namespace bytedance::bolt::exec {
 namespace {
+constexpr uint64_t kProbeAdmissionOutputBatchMultiple = 8;
+
 // Map HashBuild 'state' to the corresponding driver blocking reason.
 BlockingReason fromStateToBlockingReason(HashBuild::State state) {
   switch (state) {
@@ -1105,7 +1108,9 @@ bool HashBuild::finishHashBuild() {
     otherBuilds.push_back(build);
   }
 
-  ensureTableFits(numRows);
+  const uint64_t probeReservationBytes =
+      probeAdmissionExtraReservationBytes(numRows);
+  ensureTableFits(numRows, probeReservationBytes);
 
   std::vector<std::unique_ptr<BaseHashTable>> otherTables;
   otherTables.reserve(peers.size());
@@ -1228,7 +1233,6 @@ bool HashBuild::finishHashBuild() {
       }
     }
   }
-
   if (joinBridge_->setHashTable(
           std::move(table_),
           std::move(spillPartitions),
@@ -1241,6 +1245,44 @@ bool HashBuild::finishHashBuild() {
   // table build.
   pool()->release();
   return true;
+}
+
+uint64_t HashBuild::probeAdmissionExtraReservationBytes(
+    uint64_t numRows) const {
+  const bool notReadyForProbeAdmission =
+      !spillEnabled() || isInputFromSpill() || numRows == 0;
+  const bool spillUnavailable = spiller_ == nullptr ||
+      spiller_->isAllSpilled() || exceededMaxSpillLevelLimit_;
+  if (notReadyForProbeAdmission || spillUnavailable) {
+    return 0;
+  }
+
+  const auto currentBytes = pool()->currentBytes();
+  const auto* task = operatorCtx_->task().get();
+  const auto pressure = task->memoryPressureSnapshot();
+  const auto pressureWatermarkBytes = pressure.admissionWatermarkBytes();
+  // Reclaim records a task-level pressure watermark. Borrow-from-RSS records
+  // the current task's execution memory usage at the point dynamic memory
+  // management is triggered. Taking the minimum non-zero watermark makes the
+  // earliest pressure signal drive a stronger pre-probe admission reservation
+  // while the build side can still spill.
+  LOG(INFO) << name() << " probeAdmissionExtraReservationBytes: currentBytes="
+            << succinctBytes(currentBytes) << ", reclaimWatermarkBytes="
+            << succinctBytes(pressure.reclaimWatermarkBytes)
+            << ", borrowFromRssWatermarkBytes="
+            << succinctBytes(pressure.borrowFromRssWatermarkBytes)
+            << ", pressureWatermarkBytes="
+            << succinctBytes(pressureWatermarkBytes) << ", details "
+            << task->memoryPressureDetails();
+  if (pressureWatermarkBytes != 0 &&
+      currentBytes > pressureWatermarkBytes * 0.7) {
+    return pressureWatermarkBytes;
+  }
+
+  const uint64_t probeReservationLimit =
+      operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes() *
+      kProbeAdmissionOutputBatchMultiple;
+  return std::min<uint64_t>(currentBytes / 2, probeReservationLimit);
 }
 
 void HashBuild::recordSpillStats() {
@@ -1270,7 +1312,9 @@ void HashBuild::recordSpillStats(Spiller* spiller) {
   }
 }
 
-void HashBuild::ensureTableFits(uint64_t numRows) {
+void HashBuild::ensureTableFits(
+    uint64_t numRows,
+    uint64_t extraReservationBytes) {
   // NOTE: we don't need memory reservation if all the partitions have been
   // spilled as nothing need to be built.
   if (!spillEnabled() || spiller_ == nullptr || spiller_->isAllSpilled() ||
@@ -1280,11 +1324,29 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
 
   // NOTE: reserve a bit more memory to consider the extra memory used for
   // parallel table build operation.
-  const uint64_t bytesToReserve = table_->estimateHashTableSize(numRows) * 1.1;
+  const uint64_t tableBytesToReserve =
+      table_->estimateHashTableSize(numRows) * 1.1;
+  const uint64_t bytesToReserve = tableBytesToReserve + extraReservationBytes;
+
   {
     Operator::ReclaimableSectionGuard guard(this);
     BOLT_TEST_ADJUST("bytedance::bolt::exec::HashBuild::ensureTableFits", this);
+    const auto scopedDisableMemoryExpansion =
+        operatorCtx_->task()->maybeScopedDisableMemoryExpansion();
+    LOG(INFO) << name() << " ensureTableFits: try to reserve "
+              << succinctBytes(bytesToReserve) << " for hash table, "
+              << "tableReservation=" << succinctBytes(tableBytesToReserve)
+              << ", probeExtraReservation="
+              << succinctBytes(extraReservationBytes) << ", " << pool()->name()
+              << "[" << succinctBytes(pool()->currentBytes()) << ", "
+              << succinctBytes(pool()->reservedBytes()) << ", "
+              << succinctBytes(pool()->capacity()) << "]"
+              << ", memoryPressure="
+              << operatorCtx_->task()->memoryPressureDetails();
     if (pool()->maybeReserve(bytesToReserve)) {
+      if (spiller_->isAllSpilled()) {
+        pool()->release();
+      }
       return;
     }
   }
@@ -1293,7 +1355,10 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
                << succinctBytes(bytesToReserve) << " for memory pool "
                << pool()->name()
                << ", usage: " << succinctBytes(pool()->currentBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", tableReservation=" << succinctBytes(tableBytesToReserve)
+               << ", probeExtraReservation="
+               << succinctBytes(extraReservationBytes);
 }
 
 void HashBuild::postHashBuildProcess() {

--- a/bolt/exec/HashBuild.h
+++ b/bolt/exec/HashBuild.h
@@ -147,6 +147,15 @@ class HashBuild final : public Operator {
   // barrier for the next round of hash table build operation if it needs.
   bool finishHashBuild();
 
+  // Invoked before the final merged join table is built to estimate the extra
+  // reservation needed to admit the table into probe. Normally this returns an
+  // incremental reservation derived from the current HashBuild memory
+  // footprint and the preferred output batch budget. If the current HashBuild
+  // footprint has already exceeded the task pressure watermark, it returns that
+  // watermark directly to make ensureTableFits() apply stronger admission
+  // pressure before publishing the table to probe.
+  uint64_t probeAdmissionExtraReservationBytes(uint64_t numRows) const;
+
   // [Morsel-driven] same as HashProbe::skipProbeOnEmptyBuild
   bool skipProbeOnEmptyBuild() const {
     return isInnerJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
@@ -210,9 +219,11 @@ class HashBuild final : public Operator {
   bool ensureInputFits(RowVectorPtr& input, SpilledRows spilledRows);
 
   // Invoked to ensure there is sufficient memory to build the join table with
-  // the specified 'numRows' if spilling is enabled. The function throws to fail
-  // the query if the memory reservation fails.
-  void ensureTableFits(uint64_t numRows);
+  // the specified 'numRows' if spilling is enabled. 'extraReservationBytes'
+  // captures any additional pre-probe headroom requirement. If the merged join
+  // table cannot satisfy the reservation or the pre-probe admission threshold,
+  // the function triggers an inline build spill before probe starts.
+  void ensureTableFits(uint64_t numRows, uint64_t extraReservationBytes);
 
   // Invoked to reserve memory for 'input' if disk spilling is enabled. The
   // function returns true on success, otherwise false.

--- a/bolt/exec/MemoryPressureUtils.cpp
+++ b/bolt/exec/MemoryPressureUtils.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/exec/MemoryPressureUtils.h"
+
+#include "bolt/common/memory/sparksql/ExecutionMemoryPool.h"
+
+#include <exception>
+
+namespace bytedance::bolt::exec::memorypressure {
+
+std::optional<int64_t> extractSparkTaskAttemptId(std::string_view taskId) {
+  constexpr std::string_view kTaskAttemptIdPrefix = "_TID_";
+  constexpr std::string_view kTaskAttemptIdSuffix = "_ATTEMPT_";
+
+  const auto begin = taskId.find(kTaskAttemptIdPrefix);
+  if (begin == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto idBegin = begin + kTaskAttemptIdPrefix.size();
+  const auto idEnd = taskId.find(kTaskAttemptIdSuffix, idBegin);
+  if (idEnd == std::string_view::npos || idEnd == idBegin) {
+    return std::nullopt;
+  }
+
+  try {
+    return std::stoll(std::string(taskId.substr(idBegin, idEnd - idBegin)));
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+MemoryPressureSnapshot snapshot(
+    uint64_t reclaimWatermarkBytes,
+    const std::optional<int64_t>& sparkTaskAttemptId) {
+  uint64_t borrowFromRssWatermarkBytes = 0;
+  if (sparkTaskAttemptId.has_value()) {
+    borrowFromRssWatermarkBytes =
+        memory::sparksql::ExecutionMemoryPool::borrowFromRssWatermarkBytes(
+            *sparkTaskAttemptId);
+  }
+  return MemoryPressureSnapshot{
+      reclaimWatermarkBytes, borrowFromRssWatermarkBytes};
+}
+
+std::optional<ScopedMemoryExpansionGuard> maybeScopedDisableMemoryExpansion(
+    const std::optional<int64_t>& sparkTaskAttemptId) {
+  auto guard = memory::sparksql::ExecutionMemoryPool::
+      maybeScopedDisableDynamicMemoryQuotaManagerForTask(sparkTaskAttemptId);
+  if (!guard.has_value()) {
+    return std::nullopt;
+  }
+  return ScopedMemoryExpansionGuard(std::move(*guard));
+}
+
+std::string details() {
+  return memory::sparksql::ExecutionMemoryPool::debugString();
+}
+
+} // namespace bytedance::bolt::exec::memorypressure

--- a/bolt/exec/MemoryPressureUtils.cpp
+++ b/bolt/exec/MemoryPressureUtils.cpp
@@ -16,32 +16,16 @@
 
 #include "bolt/exec/MemoryPressureUtils.h"
 
+#include "bolt/common/base/NumberParsing.h"
 #include "bolt/common/memory/sparksql/ExecutionMemoryPool.h"
-
-#include <exception>
 
 namespace bytedance::bolt::exec::memorypressure {
 
 std::optional<int64_t> extractSparkTaskAttemptId(std::string_view taskId) {
   constexpr std::string_view kTaskAttemptIdPrefix = "_TID_";
   constexpr std::string_view kTaskAttemptIdSuffix = "_ATTEMPT_";
-
-  const auto begin = taskId.find(kTaskAttemptIdPrefix);
-  if (begin == std::string_view::npos) {
-    return std::nullopt;
-  }
-
-  const auto idBegin = begin + kTaskAttemptIdPrefix.size();
-  const auto idEnd = taskId.find(kTaskAttemptIdSuffix, idBegin);
-  if (idEnd == std::string_view::npos || idEnd == idBegin) {
-    return std::nullopt;
-  }
-
-  try {
-    return std::stoll(std::string(taskId.substr(idBegin, idEnd - idBegin)));
-  } catch (const std::exception&) {
-    return std::nullopt;
-  }
+  return extractNumberBetween(
+      taskId, kTaskAttemptIdPrefix, kTaskAttemptIdSuffix);
 }
 
 MemoryPressureSnapshot snapshot(

--- a/bolt/exec/MemoryPressureUtils.h
+++ b/bolt/exec/MemoryPressureUtils.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace bytedance::bolt::exec::memorypressure {
+
+class ScopedMemoryExpansionGuard {
+ public:
+  template <typename Guard>
+  explicit ScopedMemoryExpansionGuard(Guard&& guard)
+      : guard_(std::make_unique<GuardModel<std::decay_t<Guard>>>(
+            std::forward<Guard>(guard))) {}
+
+  ScopedMemoryExpansionGuard(ScopedMemoryExpansionGuard&&) noexcept = default;
+
+  ScopedMemoryExpansionGuard& operator=(ScopedMemoryExpansionGuard&&) noexcept =
+      default;
+
+  ScopedMemoryExpansionGuard(const ScopedMemoryExpansionGuard&) = delete;
+  ScopedMemoryExpansionGuard& operator=(const ScopedMemoryExpansionGuard&) =
+      delete;
+
+  ~ScopedMemoryExpansionGuard() = default;
+
+ private:
+  struct GuardConcept {
+    virtual ~GuardConcept() = default;
+  };
+
+  template <typename Guard>
+  struct GuardModel final : GuardConcept {
+    explicit GuardModel(Guard&& guard) : guard_(std::move(guard)) {}
+
+    Guard guard_;
+  };
+
+  std::unique_ptr<GuardConcept> guard_;
+};
+
+struct MemoryPressureSnapshot {
+  uint64_t reclaimWatermarkBytes{0};
+  uint64_t borrowFromRssWatermarkBytes{0};
+
+  uint64_t admissionWatermarkBytes() const {
+    if (reclaimWatermarkBytes == 0) {
+      return borrowFromRssWatermarkBytes;
+    }
+    if (borrowFromRssWatermarkBytes == 0) {
+      return reclaimWatermarkBytes;
+    }
+    return std::min(reclaimWatermarkBytes, borrowFromRssWatermarkBytes);
+  }
+};
+
+std::optional<int64_t> extractSparkTaskAttemptId(std::string_view taskId);
+
+MemoryPressureSnapshot snapshot(
+    uint64_t reclaimWatermarkBytes,
+    const std::optional<int64_t>& sparkTaskAttemptId);
+
+std::optional<ScopedMemoryExpansionGuard> maybeScopedDisableMemoryExpansion(
+    const std::optional<int64_t>& sparkTaskAttemptId);
+
+std::string details();
+
+} // namespace bytedance::bolt::exec::memorypressure

--- a/bolt/exec/Operator.cpp
+++ b/bolt/exec/Operator.cpp
@@ -292,12 +292,13 @@ int32_t OperatorCtx::getConcurrency() const {
 
 std::string OperatorCtx::toString() const {
   return fmt::format(
-      "{}#{}[taskId={}, pipelineId={}, driverId={}]",
+      "{}#{}[task={}, pipe={}, driver={}, op={}]",
       operatorType(),
-      operatorId(),
+      planNodeId(),
       taskId(),
       driverCtx_->pipelineId,
-      driverCtx_->driverId);
+      driverCtx_->driverId,
+      operatorId());
 }
 
 void OperatorCtx::traverseOpToGetRowCount(

--- a/bolt/exec/Task.cpp
+++ b/bolt/exec/Task.cpp
@@ -28,7 +28,6 @@
  * --------------------------------------------------------------------------
  */
 
-#include <string>
 #include <thread>
 
 #include "bolt/common/base/Counters.h"
@@ -312,6 +311,7 @@ Task::Task(
     std::function<void(std::exception_ptr)> onError)
     : uuid_{makeUuid()},
       taskId_(taskId),
+      sparkTaskAttemptId_(memorypressure::extractSparkTaskAttemptId(taskId)),
       destination_(destination),
       mode_(mode),
       memoryArbitrationPriority_(memoryArbitrationPriority),
@@ -328,6 +328,20 @@ Task::Task(
   VLOG(1) << "Task initialize: " << taskId_ << ", plan: "
           << folly::json::serialize(planFragment_.planNode->serialize(), opts);
   maybeInitTrace();
+}
+
+Task::MemoryPressureSnapshot Task::memoryPressureSnapshot() const {
+  return memorypressure::snapshot(
+      memoryPressureWatermarkBytes(), sparkTaskAttemptId_);
+}
+
+std::optional<Task::ScopedMemoryExpansionGuard>
+Task::maybeScopedDisableMemoryExpansion() const {
+  return memorypressure::maybeScopedDisableMemoryExpansion(sparkTaskAttemptId_);
+}
+
+std::string Task::memoryPressureDetails() const {
+  return memorypressure::details();
 }
 
 Task::~Task() {
@@ -3226,6 +3240,8 @@ uint64_t Task::MemoryReclaimer::reclaimTask(
   if (task->isCancelled()) {
     return 0;
   }
+
+  task->recordMemoryPressureWatermarkBytes(task->pool()->currentBytes());
 
   uint64_t reclaimedBytes{0};
   reclaimedBytes = memory::MemoryReclaimer::reclaim(

--- a/bolt/exec/Task.h
+++ b/bolt/exec/Task.h
@@ -29,11 +29,17 @@
  */
 
 #pragma once
+
+#include <atomic>
+#include <memory>
+#include <optional>
+
 #include "bolt/core/PlanFragment.h"
 #include "bolt/core/QueryCtx.h"
 #include "bolt/exec/Driver.h"
 #include "bolt/exec/ExecutorTaskScheduler.h"
 #include "bolt/exec/LocalPartition.h"
+#include "bolt/exec/MemoryPressureUtils.h"
 #include "bolt/exec/MemoryReclaimer.h"
 #include "bolt/exec/MergeSource.h"
 #include "bolt/exec/PushBasedEvent.h"
@@ -50,6 +56,9 @@ class HashJoinBridge;
 class NestedLoopJoinBridge;
 class Task : public std::enable_shared_from_this<Task> {
  public:
+  using ScopedMemoryExpansionGuard = memorypressure::ScopedMemoryExpansionGuard;
+  using MemoryPressureSnapshot = memorypressure::MemoryPressureSnapshot;
+
   /// Threading mode the task is executed.
   enum class ExecutionMode {
     /// Mode that executes the query serially (single-threaded) on the calling
@@ -301,6 +310,46 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Returns Task Stats by copy as other threads might be updating the
   /// structure.
   TaskStats taskStats() const;
+
+  std::optional<int64_t> sparkTaskAttemptId() const {
+    return sparkTaskAttemptId_;
+  }
+
+  void recordMemoryPressureWatermarkBytes(uint64_t bytes) {
+    if (bytes == 0) {
+      return;
+    }
+    auto current =
+        memoryPressureWatermarkBytes_.load(std::memory_order_relaxed);
+    while (current < bytes) {
+      if (memoryPressureWatermarkBytes_.compare_exchange_weak(
+              current, bytes, std::memory_order_relaxed)) {
+        LOG(INFO) << "Task " << taskId_
+                  << " memory pressure watermark updated to " << bytes
+                  << " bytes";
+        return;
+      }
+    }
+  }
+
+  void recordMemoryReclaimWatermarkBytes(uint64_t bytes) {
+    recordMemoryPressureWatermarkBytes(bytes);
+  }
+
+  MemoryPressureSnapshot memoryPressureSnapshot() const;
+
+  std::optional<ScopedMemoryExpansionGuard> maybeScopedDisableMemoryExpansion()
+      const;
+
+  std::string memoryPressureDetails() const;
+
+  uint64_t memoryPressureWatermarkBytes() const {
+    return memoryPressureWatermarkBytes_.load(std::memory_order_relaxed);
+  }
+
+  uint64_t memoryReclaimWatermarkBytes() const {
+    return memoryPressureWatermarkBytes();
+  }
 
   /// Information about an operator call that helps debugging stuck calls.
   struct OpCallInfo {
@@ -1106,6 +1155,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // Application specific task ID specified at construction time. May not be
   // unique or universally unique.
   const std::string taskId_;
+  const std::optional<int64_t> sparkTaskAttemptId_;
   const int destination_;
 
   // The execution mode of the task. It is enforced that a task can only be
@@ -1115,6 +1165,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // In a multi-task system, it is used to make cross task decisions by memory
   // arbitration to determine which task to reclaim first.
   const int32_t memoryArbitrationPriority_{0};
+
+  std::atomic<uint64_t> memoryPressureWatermarkBytes_{0};
 
   std::shared_ptr<core::QueryCtx> queryCtx_;
 

--- a/bolt/exec/tests/HashJoinTest.cpp
+++ b/bolt/exec/tests/HashJoinTest.cpp
@@ -1140,6 +1140,50 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbeWithSpillMemoryThreshold) {
       .run();
 }
 
+TEST_P(MultiThreadedHashJoinTest, emptyProbeWithReclaimWatermark) {
+  if (numDrivers_ != 1) {
+    GTEST_SKIP() << "Covers single-driver finishHashBuild admission path only";
+  }
+
+  std::atomic<bool> injectOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "bytedance::bolt::exec::HashBuild::finishHashBuild",
+      std::function<void(HashBuild*)>([&](HashBuild* buildOp) {
+        if (!injectOnce.exchange(false)) {
+          return;
+        }
+        auto task = buildOp->testingOperatorCtx()->task();
+        task->recordMemoryPressureWatermarkBytes(1);
+      }));
+
+  auto spillDirectory = exec::test::TempDirectoryPath::create();
+  auto queryPool = memory::memoryManager()->addRootPool(
+      "", 8 << 20, memory::MemoryReclaimer::create());
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .keyTypes({BIGINT()})
+      .probeVectors(0, 5)
+      .buildVectors(1500, 5)
+      .queryPool(std::move(queryPool))
+      .spillDirectory(spillDirectory->path)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        const auto statsPair = taskSpilledStats(*task);
+        ASSERT_GT(statsPair.first.spilledRows, 0);
+        ASSERT_GT(statsPair.first.spilledBytes, 0);
+        ASSERT_GT(statsPair.first.spilledPartitions, 0);
+        ASSERT_GT(statsPair.first.spilledFiles, 0);
+        ASSERT_EQ(statsPair.second.spilledRows, 0);
+        ASSERT_EQ(statsPair.second.spilledBytes, 0);
+        ASSERT_GT(statsPair.second.spilledPartitions, 0);
+        ASSERT_EQ(statsPair.second.spilledFiles, 0);
+      })
+      .run();
+}
+
 DEBUG_ONLY_TEST_P(
     MultiThreadedHashJoinTest,
     raceBetweenTaskTerminationAndThesholdTriggeredSpill) {

--- a/bolt/exec/tests/TaskTest.cpp
+++ b/bolt/exec/tests/TaskTest.cpp
@@ -528,6 +528,52 @@ class TaskTest : public HiveConnectorTestBase {
   }
 };
 
+TEST_F(TaskTest, sparkTaskAttemptId) {
+  auto plan = PlanBuilder()
+                  .values({makeRowVector(ROW({"c0"}, {BIGINT()}), 1)})
+                  .planFragment();
+  auto task = Task::create(
+      "query_0_TID_123_ATTEMPT_4",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+
+  EXPECT_EQ(task->sparkTaskAttemptId(), 123);
+
+  plan = PlanBuilder()
+             .values({makeRowVector(ROW({"c0"}, {BIGINT()}), 1)})
+             .planFragment();
+  task = Task::create(
+      "test_cursor_1",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+
+  EXPECT_EQ(task->sparkTaskAttemptId(), std::nullopt);
+}
+
+TEST_F(TaskTest, memoryPressureSnapshot) {
+  auto plan = PlanBuilder()
+                  .values({makeRowVector(ROW({"c0"}, {BIGINT()}), 1)})
+                  .planFragment();
+  auto task = Task::create(
+      "query_0_TID_123_ATTEMPT_4",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+
+  task->recordMemoryPressureWatermarkBytes(100);
+  task->recordMemoryPressureWatermarkBytes(50);
+
+  const auto snapshot = task->memoryPressureSnapshot();
+  EXPECT_EQ(snapshot.reclaimWatermarkBytes, 100);
+  EXPECT_EQ(snapshot.borrowFromRssWatermarkBytes, 0);
+  EXPECT_EQ(snapshot.admissionWatermarkBytes(), 100);
+}
+
 TEST_F(TaskTest, wrongPlanNodeForSplit) {
   auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
       "test",


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #577 

Reserve additional probe-side admission budget before publishing HashBuild tables when task-level memory pressure is observed, so the build side can still spill before probe starts.

Move memory pressure helpers into MemoryPressureUtils to keep HashBuild away from SparkSQL ExecutionMemoryPool internals, and make ExecutionMemoryPool::debugString() take the pool lock before formatting shared state.


### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

#### Background

When `HashBuild` finishes building the hash table and is about to publish it to the probe side, the existing admission logic may only reserve memory for the build-side hash table itself. If the executor is already under memory pressure, the probe side may still need additional memory for output batches and join processing after the table is published. At that point, the build side has fewer opportunities to reduce memory usage via spill, which increases the risk of OOM during probe.

#### Changes
##### Reserve additional probe admission budget in HashBuild under memory pressure
Before publishing the built hash table, `HashBuild` now computes an extra reservation based on task-level memory pressure signals. This allows the build side to trigger spill earlier, before the probe side starts consuming the table.
The new logic considers:
    - task memory reclaim watermark
    - SparkSQL `ExecutionMemoryPool` borrow-from-RSS watermark
    - current hash table memory usage
    - whether build-side spill is still available
If a memory pressure watermark exists and current build memory exceeds the threshold, `HashBuild` applies a stronger admission reservation so that it can spill before the probe phase starts.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
