### PR TITLE
[fix] support hash table spill before hash probe

### DIFF
--- a/bolt/exec/HashBuild.cpp
+++ b/bolt/exec/HashBuild.cpp
@@ -378,7 +378,7 @@ void HashBuild::setupSpiller(
         HashBitRange(startBit, startBit + spillConfig.joinRepartitionBits);
   }
 
-  bool firstLevelSpill = (hashBits.begin() == spillConfig.startPartitionBit);
+  const bool useRangePartition = canUseRangePartition(hashBits);
   spiller_ = std::make_unique<Spiller>(
       Spiller::Type::kHashJoinBuild,
       table_->rows(),
@@ -386,9 +386,7 @@ void HashBuild::setupSpiller(
       std::move(hashBits),
       &spillConfig,
       spillConfig.maxFileSize,
-      (firstLevelSpill && supportSkewPartition() &&
-       joinBridge_->numBuilders() == 1 &&
-       operatorCtx_->task()->numDrivers(operatorCtx_->driverCtx()) == 1));
+      useRangePartition);
   spiller_->setSpillConfig(&spillConfig);
   spiller_->setSkewThreshold(
       skewFileSizeRatioThreshold_, skewRowCountRatioThreshold_);
@@ -1229,18 +1227,97 @@ bool HashBuild::finishHashBuild() {
     }
   }
 
+  auto tableSpillFunc =
+      spillPartitions.empty() ? createTableSpillFunc() : nullptr;
+  // Release the unused reservation before publishing the built table to probe.
+  // This drops the temporary reservation while keeping the actual hash table
+  // memory as used reservation.
+  pool()->release();
+
   if (joinBridge_->setHashTable(
           std::move(table_),
           std::move(spillPartitions),
           joinHasNullKeys_,
-          &offsetTojoinBits_)) {
+          &offsetTojoinBits_,
+          std::move(tableSpillFunc))) {
     intermediateStateCleared_ = true;
     spillGroup_->restart();
   }
-  // Release the unused memory reservation since we have finished the merged
-  // table build.
-  pool()->release();
   return true;
+}
+
+HashJoinBridge::HashJoinTableSpillFunc HashBuild::createTableSpillFunc() {
+  if (!spillEnabled() || isInputFromSpill() || spiller_ == nullptr ||
+      exceededMaxSpillLevelLimit_) {
+    VLOG(1) << name()
+            << " createTableSpillFunc disabled: spillEnabled=" << spillEnabled()
+            << ", isInputFromSpill=" << isInputFromSpill()
+            << ", hasSpiller=" << (spiller_ != nullptr)
+            << ", exceededMaxSpillLevelLimit=" << exceededMaxSpillLevelLimit_;
+    return nullptr;
+  }
+
+  auto tableSpillConfig = std::make_shared<common::SpillConfig>(*spillConfig());
+  auto tableSpillSpiller = std::make_shared<Spiller>(
+      Spiller::Type::kHashJoinBuild,
+      table_->rows(),
+      tableType_,
+      spiller_->hashBits(),
+      tableSpillConfig.get(),
+      tableSpillConfig->maxFileSize,
+      canUseRangePartition(spiller_->hashBits()));
+  tableSpillSpiller->setSpillConfig(tableSpillConfig.get());
+  tableSpillSpiller->setSkewThreshold(
+      skewFileSizeRatioThreshold_, skewRowCountRatioThreshold_);
+  if (hybridJoin_ && table_->hybridData()) {
+    tableSpillSpiller->setHybridMode(true, table_->hybridData());
+  }
+  auto operatorName = name();
+  tableSpillStats_ =
+      std::make_shared<folly::Synchronized<common::SpillStats>>();
+  auto tableSpillStats = tableSpillStats_;
+
+  return [tableSpillConfig, tableSpillSpiller, tableSpillStats, operatorName](
+             std::shared_ptr<BaseHashTable> table) {
+    SpillPartitionSet spillPartitions;
+    tableSpillSpiller->spill();
+    tableSpillSpiller->finishSpill(spillPartitions);
+    auto iter = spillPartitions.begin();
+    while (iter != spillPartitions.end()) {
+      if (iter->second->numFiles() > 0) {
+        ++iter;
+      } else {
+        iter = spillPartitions.erase(iter);
+      }
+    }
+    const auto spillStats = tableSpillSpiller->stats();
+    BOLT_CHECK_EQ(spillStats.spillSortTimeUs, 0);
+    *tableSpillStats->wlock() += spillStats;
+    LOG(INFO) << operatorName << " bridge table spill callback: finish, "
+              << "spilledPartitions=" << spillPartitions.size()
+              << ", spilledBytes=" << succinctBytes(spillStats.spilledBytes)
+              << ", spilledFiles=" << spillStats.spilledFiles
+              << ", spillTotalTimeUs=" << spillStats.spillTotalTimeUs;
+    return spillPartitions;
+  };
+}
+
+OperatorStats HashBuild::stats(bool clear) {
+  auto stats = Operator::stats(clear);
+  if (tableSpillStats_ != nullptr) {
+    auto lockedTableSpillStats = tableSpillStats_->wlock();
+    stats.addSpillStats(*lockedTableSpillStats);
+    if (clear) {
+      lockedTableSpillStats->reset();
+    }
+  }
+  return stats;
+}
+
+bool HashBuild::canUseRangePartition(const HashBitRange& hashBits) const {
+  return hashBits.begin() == spillConfig()->startPartitionBit &&
+      supportSkewPartition() && joinBridge_->numBuilders() == 1 &&
+      operatorCtx_->task()->numDrivers(operatorCtx_->driverCtx()) == 1;
 }
 
 void HashBuild::recordSpillStats() {

--- a/bolt/exec/HashBuild.h
+++ b/bolt/exec/HashBuild.h
@@ -106,6 +106,9 @@ class HashBuild final : public Operator {
 
   bool isFinished() override;
 
+  using Operator::stats;
+  OperatorStats stats(bool clear) override;
+
   void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
       override;
 
@@ -147,6 +150,10 @@ class HashBuild final : public Operator {
   // barrier for the next round of hash table build operation if it needs.
   bool finishHashBuild();
 
+  // Creates a spill callback for the finished build table held by the join
+  // bridge before probe starts.
+  HashJoinBridge::HashJoinTableSpillFunc createTableSpillFunc();
+
   // [Morsel-driven] same as HashProbe::skipProbeOnEmptyBuild
   bool skipProbeOnEmptyBuild() const {
     return isInnerJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
@@ -173,6 +180,8 @@ class HashBuild final : public Operator {
   void recordSpillStats();
   void recordSpillStats(Spiller* spiller);
   void recordSpillReadStats();
+
+  bool canUseRangePartition(const HashBitRange& hashBits) const;
 
   // Indicates if the input is read from spill data or not.
   bool isInputFromSpill() const;
@@ -448,6 +457,8 @@ class HashBuild final : public Operator {
   bool isDREnabled_{false};
   int32_t maxHashTableBucketCount_{std::numeric_limits<int32_t>::max()};
   std::shared_ptr<RowFormatInfo> rowFormatInfo_{nullptr};
+
+  std::shared_ptr<folly::Synchronized<common::SpillStats>> tableSpillStats_;
 
   // For hybrid join
   bool hybridJoin_{false};

--- a/bolt/exec/HashJoinBridge.cpp
+++ b/bolt/exec/HashJoinBridge.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "bolt/exec/HashJoinBridge.h"
+#include "bolt/common/base/SuccinctPrinter.h"
 namespace bytedance::bolt::exec {
 void HashJoinBridge::start() {
   std::lock_guard<std::mutex> l(mutex_);
@@ -56,12 +57,13 @@ bool HashJoinBridge::setHashTable(
     std::unique_ptr<BaseHashTable> table,
     SpillPartitionSet spillPartitionSet,
     bool hasNullKeys,
-    SpillOffsetToBitsSet offsetToJoinBits) {
+    SpillOffsetToBitsSet offsetToJoinBits,
+    HashJoinTableSpillFunc tableSpillFunc) {
   BOLT_CHECK_NOT_NULL(table, "setHashTable called with null table");
 
   auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
 
-  bool hasSpillData;
+  bool mayHaveSpillData;
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -88,13 +90,16 @@ bool HashJoinBridge::setHashTable(
         std::move(spillPartitionIdSet),
         hasNullKeys,
         offsetToJoinBits);
+    probeStarted_ = false;
+    tableSpillFunc_ = std::move(tableSpillFunc);
     restoringSpillPartitionId_.reset();
 
-    hasSpillData = !spillPartitionSets_.empty();
+    mayHaveSpillData =
+        !spillPartitionSets_.empty() || tableSpillFunc_ != nullptr;
     promises = std::move(promises_);
   }
   notify(std::move(promises));
-  return hasSpillData;
+  return mayHaveSpillData;
 }
 
 void HashJoinBridge::setAntiJoinHasNullKeys() {
@@ -107,6 +112,8 @@ void HashJoinBridge::setAntiJoinHasNullKeys() {
     BOLT_CHECK(restoringSpillShards_.empty());
 
     buildResult_ = HashBuildResult{};
+    probeStarted_ = false;
+    tableSpillFunc_ = nullptr;
     restoringSpillPartitionId_.reset();
     spillPartitions.swap(spillPartitionSets_);
     promises = std::move(promises_);
@@ -116,20 +123,34 @@ void HashJoinBridge::setAntiJoinHasNullKeys() {
 
 std::optional<HashJoinBridge::HashBuildResult> HashJoinBridge::tableOrFuture(
     ContinueFuture* future) {
-  std::lock_guard<std::mutex> l(mutex_);
-  BOLT_CHECK(started_);
-  BOLT_CHECK(!cancelled_, "Getting hash table after join is aborted");
-  BOLT_CHECK(
-      !buildResult_.has_value() ||
-      (!restoringSpillPartitionId_.has_value() &&
-       restoringSpillShards_.empty()));
+  std::optional<HashBuildResult> result;
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    BOLT_CHECK(started_);
+    BOLT_CHECK(!cancelled_, "Getting hash table after join is aborted");
+    BOLT_CHECK(
+        !buildResult_.has_value() ||
+        (!restoringSpillPartitionId_.has_value() &&
+         restoringSpillShards_.empty()));
 
-  if (buildResult_.has_value()) {
-    return buildResult_.value();
+    if (buildResult_.has_value() && !tableSpillInProgress_) {
+      if (tableSpillFunc_ != nullptr) {
+        tableSpillFunc_ = nullptr;
+        if (spillPartitionSets_.empty()) {
+          promises = std::move(promises_);
+        }
+      }
+      probeStarted_ = true;
+      result = buildResult_.value();
+    } else {
+      promises_.emplace_back("HashJoinBridge::tableOrFuture");
+      *future = promises_.back().getSemiFuture();
+      return std::nullopt;
+    }
   }
-  promises_.emplace_back("HashJoinBridge::tableOrFuture");
-  *future = promises_.back().getSemiFuture();
-  return std::nullopt;
+  notify(std::move(promises));
+  return result;
 }
 
 bool HashJoinBridge::probeFinished() {
@@ -148,6 +169,7 @@ bool HashJoinBridge::probeFinished() {
     // not needed anymore. We'll wait for the HashBuild operator to build a new
     // table from the next spill partition now.
     buildResult_.reset();
+    tableSpillFunc_ = nullptr;
 
     if (!spillPartitionSets_.empty()) {
       hasSpillInput = true;
@@ -158,7 +180,7 @@ bool HashJoinBridge::probeFinished() {
       spillPartitionSets_.erase(spillPartitionSets_.begin());
       promises = std::move(promises_);
     } else {
-      BOLT_CHECK(promises_.empty());
+      promises = std::move(promises_);
     }
   }
   notify(std::move(promises));
@@ -175,6 +197,12 @@ std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
 
   if (!restoringSpillPartitionId_.has_value()) {
     if (spillPartitionSets_.empty()) {
+      if (tableSpillInProgress_ ||
+          (buildResult_.has_value() && tableSpillFunc_ != nullptr)) {
+        promises_.emplace_back("HashJoinBridge::spillInputOrFuture");
+        *future = promises_.back().getSemiFuture();
+        return std::nullopt;
+      }
       return HashJoinBridge::SpillInput{};
     } else {
       promises_.emplace_back("HashJoinBridge::spillInputOrFuture");
@@ -186,6 +214,98 @@ std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
   auto spillShard = std::move(restoringSpillShards_.back());
   restoringSpillShards_.pop_back();
   return SpillInput(std::move(spillShard));
+}
+
+uint64_t HashJoinBridge::reclaim(
+    uint64_t targetBytes,
+    memory::MemoryReclaimer::Stats& /*stats*/) {
+  int64_t reclaimedBytes{0};
+  std::shared_ptr<BaseHashTable> table;
+  HashJoinTableSpillFunc tableSpillFunc;
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (probeStarted_ || tableSpillInProgress_ || !buildResult_.has_value() ||
+        buildResult_->table == nullptr || !spillPartitionSets_.empty() ||
+        tableSpillFunc_ == nullptr) {
+      return 0;
+    }
+
+    table = buildResult_->table;
+    tableSpillFunc = std::move(tableSpillFunc_);
+    tableSpillFunc_ = nullptr;
+    tableSpillInProgress_ = true;
+    LOG(INFO) << "HashJoinBridge::reclaim: start table spill, targetBytes="
+              << succinctBytes(targetBytes)
+              << ", tableRows=" << table->rows()->numRows()
+              << ", tableDistinct=" << table->numDistinct()
+              << ", tableCurrentBytes="
+              << succinctBytes(table->rows()->pool()->currentBytes())
+              << ", tableReservedBytes="
+              << succinctBytes(table->rows()->pool()->reservedBytes());
+  }
+
+  SpillPartitionSet spillPartitionSet;
+  SpillPartitionIdSet spillPartitionIdSet;
+  try {
+    {
+      memory::ScopedReclaimedBytesRecorder recorder(
+          table->rows()->pool(), &reclaimedBytes);
+      spillPartitionSet = tableSpillFunc(table);
+      spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
+      if (!spillPartitionSet.empty()) {
+        table->clear();
+        table->rows()->pool()->release();
+      }
+      LOG(INFO) << "HashJoinBridge::reclaim: finish table spill, "
+                << "spilledPartitions=" << spillPartitionSet.size()
+                << ", reclaimedBytes=" << succinctBytes(reclaimedBytes)
+                << ", tableCurrentBytes="
+                << succinctBytes(table->rows()->pool()->currentBytes())
+                << ", tableReservedBytes="
+                << succinctBytes(table->rows()->pool()->reservedBytes());
+    }
+  } catch (...) {
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      BOLT_CHECK(tableSpillInProgress_);
+      tableSpillInProgress_ = false;
+      promises = std::move(promises_);
+    }
+    LOG(ERROR) << "HashJoinBridge::reclaim: table spill failed";
+    notify(std::move(promises));
+    throw;
+  }
+
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    BOLT_CHECK(tableSpillInProgress_);
+    tableSpillInProgress_ = false;
+
+    if (spillPartitionSet.empty()) {
+      promises = std::move(promises_);
+    } else {
+      BOLT_CHECK(buildResult_.has_value());
+      BOLT_CHECK_NOT_NULL(buildResult_->table);
+
+      BOLT_CHECK(spillPartitionSets_.empty());
+      for (auto& partitionEntry : spillPartitionSet) {
+        const auto id = partitionEntry.first;
+        BOLT_CHECK_EQ(spillPartitionSets_.count(id), 0);
+        spillPartitionSets_.emplace(id, std::move(partitionEntry.second));
+      }
+
+      buildResult_->spillPartitionIds = std::move(spillPartitionIdSet);
+      LOG(INFO) << "HashJoinBridge::reclaim: table spill published to probe, "
+                << "spillPartitionIds="
+                << buildResult_->spillPartitionIds.size()
+                << ", pendingSpillPartitions=" << spillPartitionSets_.size();
+
+      promises = std::move(promises_);
+    }
+  }
+  notify(std::move(promises));
+  return reclaimedBytes;
 }
 
 bool isLeftNullAwareJoinWithFilter(
@@ -221,6 +341,12 @@ uint64_t HashJoinMemoryReclaimer::reclaim(
     reclaimedBytes = child->reclaim(targetBytes, maxWaitMs, stats);
     return false;
   });
+  if (reclaimedBytes == 0 || reclaimedBytes < targetBytes) {
+    if (auto joinBridge = joinBridge_.lock()) {
+      reclaimedBytes += memory::MemoryReclaimer::run(
+          [&]() { return joinBridge->reclaim(targetBytes, stats); }, stats);
+    }
+  }
   return reclaimedBytes;
 }
 

--- a/bolt/exec/HashJoinBridge.h
+++ b/bolt/exec/HashJoinBridge.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "bolt/exec/HashTable.h"
 #include "bolt/exec/JoinBridge.h"
 #include "bolt/exec/MemoryReclaimer.h"
@@ -45,6 +47,9 @@ class HashJoinBridge : public JoinBridge {
   HashJoinBridge(bool isMorselDriven = false) : JoinBridge(isMorselDriven){};
   void start() override;
 
+  using HashJoinTableSpillFunc =
+      std::function<SpillPartitionSet(std::shared_ptr<BaseHashTable>)>;
+
   /// Invoked by HashBuild operator ctor to add to this bridge by incrementing
   /// 'numBuilders_'. The latter is used to split the spill partition data among
   /// HashBuild operators to parallelize the restoring operation.
@@ -58,7 +63,8 @@ class HashJoinBridge : public JoinBridge {
       std::unique_ptr<BaseHashTable> table,
       SpillPartitionSet spillPartitionSet,
       bool hasNullKeys,
-      SpillOffsetToBitsSet offsetToJoinBits = nullptr);
+      SpillOffsetToBitsSet offsetToJoinBits = nullptr,
+      HashJoinTableSpillFunc tableSpillFunc = nullptr);
 
   void setAntiJoinHasNullKeys();
 
@@ -124,6 +130,8 @@ class HashJoinBridge : public JoinBridge {
   std::optional<SpillInput> spillInputOrFuture(
       ContinueFuture* FOLLY_NONNULL future);
 
+  uint64_t reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats);
+
   uint32_t numBuilders() const {
     return numBuilders_;
   }
@@ -138,6 +146,12 @@ class HashJoinBridge : public JoinBridge {
   uint32_t numBuilders_{0};
 
   std::optional<HashBuildResult> buildResult_;
+
+  bool probeStarted_{false};
+
+  bool tableSpillInProgress_{false};
+
+  HashJoinTableSpillFunc tableSpillFunc_;
 
   // restoringSpillPartitionXxx member variables are populated by the
   // bridge itself. When probe side finished processing, the bridge picks the
@@ -172,6 +186,13 @@ bool canDropDuplicates(
 
 class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  public:
+  static std::unique_ptr<memory::MemoryReclaimer> create(
+      std::shared_ptr<HashJoinBridge> joinBridge,
+      int32_t priority = 0) {
+    return std::unique_ptr<memory::MemoryReclaimer>(
+        new HashJoinMemoryReclaimer(std::move(joinBridge), priority));
+  }
+
   static std::unique_ptr<memory::MemoryReclaimer> create(int32_t priority = 0) {
     return std::unique_ptr<memory::MemoryReclaimer>(
         new HashJoinMemoryReclaimer(priority));
@@ -185,6 +206,13 @@ class HashJoinMemoryReclaimer final : public MemoryReclaimer {
 
  private:
   HashJoinMemoryReclaimer(int32_t priority) : MemoryReclaimer(priority) {}
+
+  HashJoinMemoryReclaimer(
+      std::shared_ptr<HashJoinBridge> joinBridge,
+      int32_t priority)
+      : MemoryReclaimer(priority), joinBridge_(std::move(joinBridge)) {}
+
+  std::weak_ptr<HashJoinBridge> joinBridge_;
 };
 
 /// Returns true if 'pool' is a hash build operator's memory pool. The check is

--- a/bolt/exec/Operator.cpp
+++ b/bolt/exec/Operator.cpp
@@ -563,16 +563,28 @@ void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
 void Operator::recordSpillStats(const common::SpillStats& spillStats) {
   BOLT_CHECK(noMoreInput_);
   auto lockedStats = stats_.wlock();
-  lockedStats->spilledInputBytes += spillStats.spilledInputBytes;
-  lockedStats->spilledBytes += spillStats.spilledBytes;
-  lockedStats->spilledRows += spillStats.spilledRows;
-  lockedStats->spilledPartitions += spillStats.spilledPartitions;
-  lockedStats->spilledFiles += spillStats.spilledFiles;
-  lockedStats->spillTotalTime +=
+  lockedStats->addSpillStats(spillStats);
+
+  if (spillStats.spillRuns != 0) {
+    common::updateGlobalSpillRunStats(spillStats.spillRuns);
+  }
+  if (spillStats.spillMaxLevelExceededCount != 0) {
+    common::updateGlobalMaxSpillLevelExceededCount(
+        spillStats.spillMaxLevelExceededCount);
+  }
+}
+
+void OperatorStats::addSpillStats(const common::SpillStats& spillStats) {
+  spilledInputBytes += spillStats.spilledInputBytes;
+  spilledBytes += spillStats.spilledBytes;
+  spilledRows += spillStats.spilledRows;
+  spilledPartitions += spillStats.spilledPartitions;
+  spilledFiles += spillStats.spilledFiles;
+  spillTotalTime +=
       spillStats.spillTotalTimeUs * Timestamp::kNanosecondsInMicrosecond;
 
   if (spillStats.spillFillTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillFillTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -581,7 +593,7 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillSortTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillSortTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -590,7 +602,7 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillConvertTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillConvertTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -599,7 +611,7 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillTotalTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillTotalTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -608,7 +620,7 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillSerializationTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillSerializationTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -617,7 +629,7 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillFlushTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillFlushTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -626,12 +638,12 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillWrites != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         Operator::kSpillWrites,
         RuntimeCounter{static_cast<int64_t>(spillStats.spillWrites)});
   }
   if (spillStats.spillWriteTimeUs != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillWriteTime",
         RuntimeCounter{
             static_cast<int64_t>(
@@ -640,19 +652,16 @@ void Operator::recordSpillStats(const common::SpillStats& spillStats) {
             RuntimeCounter::Unit::kNanos});
   }
   if (spillStats.spillRuns != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "spillRuns",
         RuntimeCounter{static_cast<int64_t>(spillStats.spillRuns)});
-    common::updateGlobalSpillRunStats(spillStats.spillRuns);
   }
 
   if (spillStats.spillMaxLevelExceededCount != 0) {
-    lockedStats->addRuntimeStat(
+    addRuntimeStat(
         "exceededMaxSpillLevel",
         RuntimeCounter{
             static_cast<int64_t>(spillStats.spillMaxLevelExceededCount)});
-    common::updateGlobalMaxSpillLevelExceededCount(
-        spillStats.spillMaxLevelExceededCount);
   }
 }
 

--- a/bolt/exec/OperatorStats.h
+++ b/bolt/exec/OperatorStats.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "bolt/common/base/SpillStats.h"
 #include "bolt/common/memory/MemoryPool.h"
 #include "bolt/common/time/CpuWallTimer.h"
 #include "bolt/expression/ExprStats.h"
@@ -266,6 +267,7 @@ struct OperatorStats {
 
   void addRuntimeStat(const std::string& name, const RuntimeCounter& value);
   void setRuntimeStat(const std::string& name, const RuntimeCounter& value);
+  void addSpillStats(const common::SpillStats& spillStats);
   void add(const OperatorStats& other);
   void clear();
   folly::dynamic serialize() const {

--- a/bolt/exec/Task.cpp
+++ b/bolt/exec/Task.cpp
@@ -544,20 +544,24 @@ memory::MemoryPool* Task::getOrAddJoinNodePool(
     return nodePools_[nodeId];
   }
   childPools_.push_back(pool_->addAggregateChild(
-      fmt::format("node.{}", nodeId), createNodeReclaimer(true)));
+      fmt::format("node.{}", nodeId),
+      createNodeReclaimer(true, planNodeId, splitGroupId)));
   auto* nodePool = childPools_.back().get();
   nodePools_[nodeId] = nodePool;
   return nodePool;
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createNodeReclaimer(
-    bool isHashJoinNode) const {
+    bool isHashJoinNode,
+    const core::PlanNodeId& planNodeId,
+    uint32_t splitGroupId) {
   if (pool()->reclaimer() == nullptr) {
     return nullptr;
   }
   // Sets memory reclaimer for the parent node memory pool on the first child
   // operator construction which has set memory reclaimer.
-  return isHashJoinNode ? HashJoinMemoryReclaimer::create()
+  return isHashJoinNode ? HashJoinMemoryReclaimer::create(
+                              getHashJoinBridgeLocked(splitGroupId, planNodeId))
                         : exec::MemoryReclaimer::create();
 }
 

--- a/bolt/exec/Task.h
+++ b/bolt/exec/Task.h
@@ -810,7 +810,9 @@ class Task : public std::enable_shared_from_this<Task> {
   // customized instance for hash join plan node, otherwise creates a default
   // memory reclaimer.
   std::unique_ptr<memory::MemoryReclaimer> createNodeReclaimer(
-      bool isHashJoinNode) const;
+      bool isHashJoinNode,
+      const core::PlanNodeId& planNodeId = "",
+      uint32_t splitGroupId = kUngroupedGroupId);
 
   // Creates a memory reclaimer instance for an exchange client if the task
   // memory pool has set memory reclaimer. We don't support to reclaim memory

--- a/bolt/exec/tests/HashJoinBridgeTest.cpp
+++ b/bolt/exec/tests/HashJoinBridgeTest.cpp
@@ -157,6 +157,17 @@ class HashJoinBridgeTest : public testing::Test,
     return partitionSet;
   }
 
+  SpillPartitionSet makeSingleFakeSpillPartitionSet(
+      uint8_t partitionBitOffset) {
+    SpillPartitionSet partitionSet;
+    const SpillPartitionId id(partitionBitOffset, 0);
+    partitionSet.emplace(
+        id,
+        std::make_unique<SpillPartition>(
+            id, makeFakeSpillFiles(numSpillFilesPerPartition_)));
+    return partitionSet;
+  }
+
   int32_t getSpillLevel(uint8_t partitionBitOffset) {
     return (partitionBitOffset - startPartitionBitOffset_) / numPartitionBits_;
   }
@@ -382,6 +393,268 @@ TEST_P(HashJoinBridgeTest, withSpill) {
       }
     }
   }
+}
+
+TEST_P(HashJoinBridgeTest, reclaimReadyTableBeforeProbeStarts) {
+  auto joinBridge = createJoinBridge();
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    joinBridge->addBuilder();
+  }
+  joinBridge->start();
+
+  bool spillCallbackCalled = false;
+  auto spilledPartitions =
+      makeSingleFakeSpillPartitionSet(startPartitionBitOffset_);
+  const auto spilledPartitionIds = toSpillPartitionIdSet(spilledPartitions);
+  ASSERT_TRUE(joinBridge->setHashTable(
+      createFakeHashTable(),
+      {},
+      false,
+      nullptr,
+      [&](std::shared_ptr<BaseHashTable> table) {
+        EXPECT_NE(table, nullptr);
+        spillCallbackCalled = true;
+        return std::move(spilledPartitions);
+      }));
+
+  auto buildFutures = createEmptyFutures(numBuilders_);
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    ASSERT_FALSE(joinBridge->spillInputOrFuture(&buildFutures[i]).has_value());
+    ASSERT_TRUE(buildFutures[i].valid());
+  }
+
+  memory::MemoryReclaimer::Stats stats;
+  ASSERT_EQ(joinBridge->reclaim(0, stats), 0);
+  ASSERT_TRUE(spillCallbackCalled);
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    buildFutures[i].wait();
+    ASSERT_FALSE(joinBridge->spillInputOrFuture(&buildFutures[i]).has_value());
+    ASSERT_TRUE(buildFutures[i].valid());
+  }
+
+  auto probeFutures = createEmptyFutures(numProbers_);
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+    ASSERT_TRUE(tableOr.has_value());
+    ASSERT_NE(tableOr->table, nullptr);
+    ASSERT_FALSE(tableOr->restoredPartitionId.has_value());
+    ASSERT_EQ(tableOr->spillPartitionIds, spilledPartitionIds);
+  }
+
+  ASSERT_TRUE(joinBridge->probeFinished());
+  std::optional<SpillPartitionId> restoredPartitionId;
+  int32_t numSpilledFiles = 0;
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    buildFutures[i].wait();
+    auto inputOr = joinBridge->spillInputOrFuture(&buildFutures[i]);
+    ASSERT_TRUE(inputOr.has_value());
+    ASSERT_NE(inputOr->spillPartition, nullptr);
+    restoredPartitionId = inputOr->spillPartition->id();
+    ASSERT_TRUE(spilledPartitionIds.contains(restoredPartitionId.value()));
+    numSpilledFiles += inputOr->spillPartition->numFiles();
+  }
+  ASSERT_EQ(numSpilledFiles, numSpillFilesPerPartition_);
+
+  ASSERT_FALSE(joinBridge->setHashTable(createFakeHashTable(), {}, false));
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+    ASSERT_TRUE(tableOr.has_value());
+    ASSERT_NE(tableOr->table, nullptr);
+    ASSERT_EQ(tableOr->restoredPartitionId, restoredPartitionId);
+  }
+}
+
+TEST_P(HashJoinBridgeTest, reclaimReadyTableDisabledAfterProbeStarts) {
+  auto joinBridge = createJoinBridge();
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    joinBridge->addBuilder();
+  }
+  joinBridge->start();
+
+  bool spillCallbackCalled = false;
+  ASSERT_TRUE(joinBridge->setHashTable(
+      createFakeHashTable(),
+      {},
+      false,
+      nullptr,
+      [&](std::shared_ptr<BaseHashTable> /*table*/) {
+        spillCallbackCalled = true;
+        return makeFakeSpillPartitionSet(startPartitionBitOffset_);
+      }));
+
+  auto buildFutures = createEmptyFutures(numBuilders_);
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    ASSERT_FALSE(joinBridge->spillInputOrFuture(&buildFutures[i]).has_value());
+    ASSERT_TRUE(buildFutures[i].valid());
+  }
+
+  auto probeFutures = createEmptyFutures(numProbers_);
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+    ASSERT_TRUE(tableOr.has_value());
+    ASSERT_NE(tableOr->table, nullptr);
+  }
+
+  memory::MemoryReclaimer::Stats stats;
+  ASSERT_EQ(joinBridge->reclaim(0, stats), 0);
+  ASSERT_FALSE(spillCallbackCalled);
+
+  ASSERT_FALSE(joinBridge->probeFinished());
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    buildFutures[i].wait();
+    auto inputOr = joinBridge->spillInputOrFuture(&buildFutures[i]);
+    ASSERT_TRUE(inputOr.has_value());
+    ASSERT_EQ(inputOr->spillPartition, nullptr);
+  }
+}
+
+TEST_P(HashJoinBridgeTest, reclaimReadyTableWithPendingProbeFuture) {
+  auto joinBridge = createJoinBridge();
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    joinBridge->addBuilder();
+  }
+  joinBridge->start();
+
+  auto probeFutures = createEmptyFutures(numProbers_);
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    ASSERT_FALSE(joinBridge->tableOrFuture(&probeFutures[i]).has_value());
+    ASSERT_TRUE(probeFutures[i].valid());
+  }
+
+  bool spillCallbackCalled = false;
+  auto spilledPartitions =
+      makeSingleFakeSpillPartitionSet(startPartitionBitOffset_);
+  const auto spilledPartitionIds = toSpillPartitionIdSet(spilledPartitions);
+  ASSERT_TRUE(joinBridge->setHashTable(
+      createFakeHashTable(),
+      {},
+      false,
+      nullptr,
+      [&](std::shared_ptr<BaseHashTable> table) {
+        EXPECT_NE(table, nullptr);
+        spillCallbackCalled = true;
+        return std::move(spilledPartitions);
+      }));
+
+  memory::MemoryReclaimer::Stats stats;
+  ASSERT_EQ(joinBridge->reclaim(0, stats), 0);
+  ASSERT_TRUE(spillCallbackCalled);
+
+  auto buildFutures = createEmptyFutures(numBuilders_);
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    ASSERT_FALSE(joinBridge->spillInputOrFuture(&buildFutures[i]).has_value());
+    ASSERT_TRUE(buildFutures[i].valid());
+  }
+
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    probeFutures[i].wait();
+    auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+    ASSERT_TRUE(tableOr.has_value());
+    ASSERT_NE(tableOr->table, nullptr);
+    ASSERT_FALSE(tableOr->restoredPartitionId.has_value());
+    ASSERT_EQ(tableOr->spillPartitionIds, spilledPartitionIds);
+  }
+
+  ASSERT_TRUE(joinBridge->probeFinished());
+  std::optional<SpillPartitionId> restoredPartitionId;
+  int32_t numSpilledFiles = 0;
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    buildFutures[i].wait();
+    auto inputOr = joinBridge->spillInputOrFuture(&buildFutures[i]);
+    ASSERT_TRUE(inputOr.has_value());
+    ASSERT_NE(inputOr->spillPartition, nullptr);
+    restoredPartitionId = inputOr->spillPartition->id();
+    ASSERT_TRUE(spilledPartitionIds.contains(restoredPartitionId.value()));
+    numSpilledFiles += inputOr->spillPartition->numFiles();
+  }
+  ASSERT_EQ(numSpilledFiles, numSpillFilesPerPartition_);
+
+  ASSERT_FALSE(joinBridge->setHashTable(createFakeHashTable(), {}, false));
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+    ASSERT_TRUE(tableOr.has_value());
+    ASSERT_NE(tableOr->table, nullptr);
+    ASSERT_EQ(tableOr->restoredPartitionId, restoredPartitionId);
+  }
+}
+
+TEST_P(HashJoinBridgeTest, reclaimReadyTableKeepsTableIfNoPartitionsSpilled) {
+  auto joinBridge = createJoinBridge();
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    joinBridge->addBuilder();
+  }
+  joinBridge->start();
+
+  bool spillCallbackCalled = false;
+  BaseHashTable* rawTable = nullptr;
+  auto table = createFakeHashTable();
+  rawTable = table.get();
+  ASSERT_TRUE(joinBridge->setHashTable(
+      std::move(table),
+      {},
+      false,
+      nullptr,
+      [&](std::shared_ptr<BaseHashTable> table) {
+        EXPECT_NE(table, nullptr);
+        spillCallbackCalled = true;
+        return SpillPartitionSet{};
+      }));
+
+  memory::MemoryReclaimer::Stats stats;
+  ASSERT_EQ(joinBridge->reclaim(0, stats), 0);
+  ASSERT_TRUE(spillCallbackCalled);
+
+  auto probeFutures = createEmptyFutures(numProbers_);
+  for (int32_t i = 0; i < numProbers_; ++i) {
+    auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+    ASSERT_TRUE(tableOr.has_value());
+    ASSERT_FALSE(tableOr->hasNullKeys);
+    ASSERT_EQ(tableOr->table.get(), rawTable);
+    ASSERT_TRUE(tableOr->spillPartitionIds.empty());
+    ASSERT_FALSE(tableOr->restoredPartitionId.has_value());
+  }
+
+  auto buildFutures = createEmptyFutures(numBuilders_);
+  ASSERT_FALSE(joinBridge->probeFinished());
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    auto inputOr = joinBridge->spillInputOrFuture(&buildFutures[i]);
+    ASSERT_TRUE(inputOr.has_value());
+    ASSERT_EQ(inputOr->spillPartition, nullptr);
+  }
+}
+
+TEST_P(HashJoinBridgeTest, reclaimReadyTableSkippedIfBuildAlreadySpilled) {
+  auto joinBridge = createJoinBridge();
+  for (int32_t i = 0; i < numBuilders_; ++i) {
+    joinBridge->addBuilder();
+  }
+  joinBridge->start();
+
+  bool spillCallbackCalled = false;
+  auto buildSpillPartitions =
+      makeFakeSpillPartitionSet(startPartitionBitOffset_);
+  const auto buildSpillPartitionIds =
+      toSpillPartitionIdSet(buildSpillPartitions);
+  ASSERT_TRUE(joinBridge->setHashTable(
+      createFakeHashTable(),
+      std::move(buildSpillPartitions),
+      false,
+      nullptr,
+      [&](std::shared_ptr<BaseHashTable>) {
+        spillCallbackCalled = true;
+        return makeFakeSpillPartitionSet(startPartitionBitOffset_);
+      }));
+
+  memory::MemoryReclaimer::Stats stats;
+  ASSERT_EQ(joinBridge->reclaim(1, stats), 0);
+  ASSERT_FALSE(spillCallbackCalled);
+
+  auto future = ContinueFuture::makeEmpty();
+  auto tableOr = joinBridge->tableOrFuture(&future);
+  ASSERT_TRUE(tableOr.has_value());
+  ASSERT_FALSE(future.valid());
+  ASSERT_NE(tableOr->table, nullptr);
+  ASSERT_EQ(tableOr->spillPartitionIds, buildSpillPartitionIds);
 }
 
 TEST_P(HashJoinBridgeTest, multiThreading) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #577 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

#### Background

After HashBuild finishes building and before HashProbe starts, the build-side hash table remains resident in HashJoinBridge waiting to be consumed by the probe side. Currently, this resident hash table memory cannot be reclaimed by the node-level memory reclaimer, which may cause task OOM under memory pressure.

This PR supports spilling the hash table that has already been published to HashJoinBridge but has not yet been consumed by HashProbe. This allows memory arbitration to reclaim this memory before HashProbe starts.

##### Changes

##### 1. Support bridge-level hash table spill

- Create a table spill callback in `HashBuild::finishHashBuild()` before publishing the hash table, and pass it to `HashJoinBridge::setHashTable()`.
    - Add table spill state management in `HashJoinBridge`:
      - `tableSpillFunc_`
      - `tableSpillInProgress_`
      - `probeStarted_`
    - `HashJoinBridge::reclaim()` triggers resident hash table spill when all of the following conditions are met:
      - probe has not started;
      - the bridge currently has a build result;
      - there is no pending spill partition;
      - the table spill callback is still valid;
      - no table spill is currently in progress.
    - After spill succeeds, clear the resident table and publish the generated spill partitions for the probe side to restore and read.

##### 2. Support fallback to bridge reclaim in HashJoinMemoryReclaimer

- `HashJoinMemoryReclaimer` now holds the corresponding `HashJoinBridge`.
    - When reclaiming from the hash build operator pool is insufficient, it falls back to `HashJoinBridge::reclaim()` to try to reclaim the hash table that is still waiting in the bridge before probe starts.

    ##### 3. Reuse spill stats accumulation logic

    - Add `OperatorStats::addSpillStats()` to extract and reuse the spill stats accumulation logic from `addSpillDetails()`.
    - Bridge table spill stats are merged into operator stats through `HashBuild::stats(clear)`.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
