### PR TITLE
add mem limit for streaming agg

### DIFF
--- a/bolt/exec/StreamingAggregation.cpp
+++ b/bolt/exec/StreamingAggregation.cpp
@@ -44,6 +44,7 @@ StreamingAggregation::StreamingAggregation(
               ? "PartialStreamingAggregation"
               : "StreamingAggregation"),
       outputBatchSize_{outputBatchRows()},
+      outputBytes_(outputBatchByteSize()),
       groupNumberThreshold_{2 * outputBatchSize_},
       aggregationNode_{aggregationNode},
       step_{aggregationNode->step()} {
@@ -51,6 +52,12 @@ StreamingAggregation::StreamingAggregation(
     BOLT_UNSUPPORTED(
         "Streaming aggregation doesn't support ignoring null keys yet");
   }
+}
+
+int64_t StreamingAggregation::outputBatchByteSize() const {
+  const auto& queryConfig =
+      this->operatorCtx()->task()->queryCtx()->queryConfig();
+  return queryConfig.preferredOutputBatchBytes();
 }
 
 void StreamingAggregation::initialize() {
@@ -321,19 +328,29 @@ RowVectorPtr StreamingAggregation::getOutput() {
   }
 
   RowVectorPtr output;
+  uint32_t outputSize = 0;
   if (numGroups_ > outputBatchSize_) {
-    output = createOutput(outputBatchSize_);
+    outputSize = outputBatchSize_;
+  } else if (
+      numGroups_ > 1 &&
+      rows_->estimateRowSize().value_or(0) * rows_->numRows() >
+          outputBytes_) {
+    outputSize = numGroups_ - 1;
+          }
+
+  if (outputSize > 0) {
+    output = createOutput(outputSize);
 
     // Rotate the entries in the groups_ vector to move the remaining groups to
     // the beginning and place reusable groups at the end.
     std::vector<char*> copy(groups_.size());
-    std::copy(groups_.begin() + outputBatchSize_, groups_.end(), copy.begin());
+    std::copy(groups_.begin() + outputSize, groups_.end(), copy.begin());
     std::copy(
         groups_.begin(),
-        groups_.begin() + outputBatchSize_,
-        copy.begin() + groups_.size() - outputBatchSize_);
+        groups_.begin() + outputSize,
+        copy.begin() + groups_.size() - outputSize);
     groups_ = std::move(copy);
-    numGroups_ -= outputBatchSize_;
+    numGroups_ -= outputSize;
   }
 
   return output;

--- a/bolt/exec/StreamingAggregation.cpp
+++ b/bolt/exec/StreamingAggregation.cpp
@@ -333,10 +333,9 @@ RowVectorPtr StreamingAggregation::getOutput() {
     outputSize = outputBatchSize_;
   } else if (
       numGroups_ > 1 &&
-      rows_->estimateRowSize().value_or(0) * rows_->numRows() >
-          outputBytes_) {
+      rows_->estimateRowSize().value_or(0) * rows_->numRows() > outputBytes_) {
     outputSize = numGroups_ - 1;
-          }
+  }
 
   if (outputSize > 0) {
     output = createOutput(outputSize);

--- a/bolt/exec/StreamingAggregation.h
+++ b/bolt/exec/StreamingAggregation.h
@@ -36,6 +36,8 @@
 #include "bolt/exec/DistinctAggregations.h"
 #include "bolt/exec/Operator.h"
 #include "bolt/exec/SortedAggregations.h"
+#include "bolt/exec/Task.h"
+
 namespace bytedance::bolt::exec {
 
 class RowContainer;
@@ -97,9 +99,14 @@ class StreamingAggregation : public Operator {
   // Initialize the aggregations setting allocator and offsets.
   void initializeAggregates(uint32_t numKeys);
 
+  // Returns the bytes size for the output batch.
+  int64_t outputBatchByteSize() const;
+
   /// Maximum number of rows in the output batch.
   const vector_size_t outputBatchSize_;
 
+  /// Maximum bytes of the output batch.
+  const int64_t outputBytes_;
   // Will hold on accept new input if groups_ size large than
   // groupNumberThreshold_
   const vector_size_t groupNumberThreshold_;

--- a/bolt/exec/tests/StreamingAggregationTest.cpp
+++ b/bolt/exec/tests/StreamingAggregationTest.cpp
@@ -30,6 +30,7 @@
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/Expressions.h"
+#include "bolt/exec/PlanNodeStats.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/OperatorTestBase.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
@@ -590,7 +591,7 @@ TEST_F(StreamingAggregationTest, flushOnPreferredOutputBatchBytes) {
   // With byte-based flushing, the operator must produce more than one output
   // vector for `numRows` distinct groups.
   ASSERT_GT(aggStats.outputVectors, 1);
-  ASSERT_EQ(aggStats.outputPositions, numRows);
+  ASSERT_EQ(aggStats.outputRows, numRows);
 }
 
 TEST_F(StreamingAggregationTest, noFlushWithLargePreferredOutputBatchBytes) {
@@ -623,5 +624,5 @@ TEST_F(StreamingAggregationTest, noFlushWithLargePreferredOutputBatchBytes) {
   const auto& aggStats = planStats.at(aggrNodeId);
   // All groups should be flushed at end-of-input as a single output vector.
   ASSERT_EQ(aggStats.outputVectors, 1);
-  ASSERT_EQ(aggStats.outputPositions, numRows);
+  ASSERT_EQ(aggStats.outputRows, numRows);
 }

--- a/bolt/exec/tests/StreamingAggregationTest.cpp
+++ b/bolt/exec/tests/StreamingAggregationTest.cpp
@@ -552,3 +552,78 @@ TEST_F(StreamingAggregationTest, distinctAggregations) {
   testMultiKeyDistinctAggregation(multiKeys, 1024);
   testMultiKeyDistinctAggregation(multiKeys, 3);
 }
+
+TEST_F(StreamingAggregationTest, flushOnPreferredOutputBatchBytes) {
+  // Construct an input with many distinct keys so that streaming aggregation
+  // accumulates a large number of groups, each carrying a non-trivial payload
+  // (an array_agg accumulator) so the total estimated byte size grows quickly.
+  const vector_size_t numRows = 1024;
+  auto keys = makeFlatVector<int64_t>(numRows, [](auto row) { return row; });
+  auto payload =
+      makeFlatVector<int64_t>(numRows, [](auto row) { return row * 7; });
+  auto data = makeRowVector({keys, payload});
+  createDuckDbTable({data});
+
+  core::PlanNodeId aggrNodeId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .streamingAggregation(
+                      {"c0"},
+                      {"array_agg(c1)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .capturePlanNodeId(aggrNodeId)
+                  .planNode();
+
+  // Use a larger row-based batch size so that the row threshold alone won't
+  // trigger flushing. The byte-based threshold is set extremely small so it
+  // must trigger early flushing of multiple output vectors.
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+          .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+          .assertResults("SELECT c0, array_agg(c1) FROM tmp GROUP BY c0");
+
+  auto planStats = exec::toPlanStats(task->taskStats());
+  const auto& aggStats = planStats.at(aggrNodeId);
+  // With byte-based flushing, the operator must produce more than one output
+  // vector for `numRows` distinct groups.
+  ASSERT_GT(aggStats.outputVectors, 1);
+  ASSERT_EQ(aggStats.outputPositions, numRows);
+}
+
+TEST_F(StreamingAggregationTest, noFlushWithLargePreferredOutputBatchBytes) {
+  const vector_size_t numRows = 256;
+  auto keys = makeFlatVector<int64_t>(numRows, [](auto row) { return row; });
+  auto payload =
+      makeFlatVector<int64_t>(numRows, [](auto row) { return row; });
+  auto data = makeRowVector({keys, payload});
+  createDuckDbTable({data});
+
+  core::PlanNodeId aggrNodeId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .streamingAggregation(
+                      {"c0"},
+                      {"sum(c1)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .capturePlanNodeId(aggrNodeId)
+                  .planNode();
+
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+          .config(
+              core::QueryConfig::kPreferredOutputBatchBytes,
+              std::to_string(1UL << 30))
+          .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+
+  auto planStats = exec::toPlanStats(task->taskStats());
+  const auto& aggStats = planStats.at(aggrNodeId);
+  // All groups should be flushed at end-of-input as a single output vector.
+  ASSERT_EQ(aggStats.outputVectors, 1);
+  ASSERT_EQ(aggStats.outputPositions, numRows);
+}

--- a/bolt/exec/tests/StreamingAggregationTest.cpp
+++ b/bolt/exec/tests/StreamingAggregationTest.cpp
@@ -596,8 +596,7 @@ TEST_F(StreamingAggregationTest, flushOnPreferredOutputBatchBytes) {
 TEST_F(StreamingAggregationTest, noFlushWithLargePreferredOutputBatchBytes) {
   const vector_size_t numRows = 256;
   auto keys = makeFlatVector<int64_t>(numRows, [](auto row) { return row; });
-  auto payload =
-      makeFlatVector<int64_t>(numRows, [](auto row) { return row; });
+  auto payload = makeFlatVector<int64_t>(numRows, [](auto row) { return row; });
   auto data = makeRowVector({keys, payload});
   createDuckDbTable({data});
 
@@ -613,13 +612,12 @@ TEST_F(StreamingAggregationTest, noFlushWithLargePreferredOutputBatchBytes) {
                   .capturePlanNodeId(aggrNodeId)
                   .planNode();
 
-  auto task =
-      AssertQueryBuilder(plan, duckDbQueryRunner_)
-          .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
-          .config(
-              core::QueryConfig::kPreferredOutputBatchBytes,
-              std::to_string(1UL << 30))
-          .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+                  .config(
+                      core::QueryConfig::kPreferredOutputBatchBytes,
+                      std::to_string(1UL << 30))
+                  .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
 
   auto planStats = exec::toPlanStats(task->taskStats());
   const auto& aggStats = planStats.at(aggrNodeId);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

StreamingAggregation now also respects preferred_output_batch_bytes (not just preferred_output_batch_rows), flushing numGroups_ - 1 groups early when estimated_row_size * num_rows exceeds the byte budget; the last group is kept so it can still merge matching rows from the next input batch.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- add memory limit for StreamingAggregation
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
