### PR TITLE
Support 'is_json_object()' function for Flink

### DIFF
--- a/bolt/functions/prestosql/SIMDJsonFunctions.h
+++ b/bolt/functions/prestosql/SIMDJsonFunctions.h
@@ -84,6 +84,23 @@ struct SIMDIsJsonScalarFunction {
 };
 
 template <typename T>
+struct SIMDIsJsonObjectFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE static void call(
+      bool& result,
+      const arg_type<Json>& json) {
+    ParserContext ctx(json.data(), json.size());
+    try {
+      ctx.parseDocument();
+      result = (ctx.jsonDoc.type() == simdjson::ondemand::json_type::object);
+    } catch (const simdjson::simdjson_error&) {
+      result = false;
+    }
+  }
+};
+
+template <typename T>
 struct SonicIsJsonScalarFunction {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 
@@ -106,6 +123,23 @@ struct SonicIsJsonScalarFunction {
 };
 
 template <typename T>
+struct SonicIsJsonObjectFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE static void call(
+      bool& result,
+      const arg_type<Json>& json) {
+    sonic_json::Document jsonDoc;
+    jsonDoc.Parse(json.data(), json.size());
+    if (jsonDoc.HasParseError()) {
+      result = false;
+      return;
+    }
+    result = jsonDoc.IsObject();
+  }
+};
+
+template <typename T>
 class WrapperIsJsonScalarFunction {
  public:
   BOLT_DEFINE_FUNCTION_TYPES(T);
@@ -122,6 +156,29 @@ class WrapperIsJsonScalarFunction {
       SonicIsJsonScalarFunction<T>::call(result, json);
     } else {
       SIMDIsJsonScalarFunction<T>::call(result, json);
+    }
+  }
+
+  bool useSonic = true;
+};
+
+template <typename T>
+class WrapperIsJsonObjectFunction {
+ public:
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Json>* /*json*/) {
+    useSonic = config.enableSonicIsJsonScalar();
+  }
+
+  FOLLY_ALWAYS_INLINE void call(bool& result, const arg_type<Json>& json) {
+    if (useSonic) {
+      SonicIsJsonObjectFunction<T>::call(result, json);
+    } else {
+      SIMDIsJsonObjectFunction<T>::call(result, json);
     }
   }
 

--- a/bolt/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/bolt/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -42,6 +42,11 @@ void registerJsonFunctions(const std::string& prefix) {
   registerFunction<WrapperIsJsonScalarFunction, bool, Varchar>(
       {prefix + "is_json_scalar"});
 
+  registerFunction<WrapperIsJsonObjectFunction, bool, Json>(
+      {prefix + "is_json_object"});
+  registerFunction<WrapperIsJsonObjectFunction, bool, Varchar>(
+      {prefix + "is_json_object"});
+
   registerFunction<WrapperJsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});
   registerFunction<WrapperJsonExtractScalarFunction, Varchar, Varchar, Varchar>(

--- a/bolt/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/bolt/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -104,6 +104,16 @@ class JsonFunctionsTest : public functions::test::FunctionBaseTest {
     return jsonResult;
   }
 
+  std::optional<bool> isJsonObject(std::optional<std::string> json) {
+    auto [jsonVector, varcharVector] = makeVectors(json);
+    auto jsonResult =
+        evaluateOnce<bool>("is_json_object(c0)", makeRowVector({jsonVector}));
+    auto varcharResult = evaluateOnce<bool>(
+        "is_json_object(c0)", makeRowVector({varcharVector}));
+    EXPECT_EQ(jsonResult, varcharResult);
+    return jsonResult;
+  }
+
   std::optional<int64_t> jsonArrayLength(std::optional<std::string> json) {
     auto [jsonVector, varcharVector] = makeVectors(json);
     auto jsonResult = evaluateOnce<int64_t>(
@@ -314,6 +324,13 @@ TEST_F(JsonFunctionsTest, isJsonScalarSignatures) {
   ASSERT_EQ(1, signatures.count("(varchar) -> boolean"));
 }
 
+TEST_F(JsonFunctionsTest, isJsonObjectSignatures) {
+  auto signatures = getSignatureStrings("is_json_object");
+  ASSERT_EQ(2, signatures.size());
+  ASSERT_EQ(1, signatures.count("(json) -> boolean"));
+  ASSERT_EQ(1, signatures.count("(varchar) -> boolean"));
+}
+
 TEST_F(JsonFunctionsTest, jsonArrayLengthSignatures) {
   auto signatures = getSignatureStrings("json_array_length");
   ASSERT_EQ(2, signatures.size());
@@ -368,6 +385,21 @@ TEST_F(JsonFunctionsTest, isJsonScalar) {
   EXPECT_EQ(isJsonScalar(R"({"k1":"v1"})"), false);
   EXPECT_EQ(isJsonScalar(R"({"k1":[0,1,2]})"), false);
   EXPECT_EQ(isJsonScalar(R"({"k1":""})"), false);
+}
+
+TEST_F(JsonFunctionsTest, isJsonObject) {
+  EXPECT_EQ(isJsonObject(R"({"k1":"v1"})"), true);
+  EXPECT_EQ(isJsonObject(R"({"k1":[0,1,2]})"), true);
+  EXPECT_EQ(isJsonObject(R"({})"), true);
+
+  EXPECT_EQ(isJsonObject(R"(1)"), false);
+  EXPECT_EQ(isJsonObject(R"("hello")"), false);
+  EXPECT_EQ(isJsonObject(R"(true)"), false);
+  EXPECT_EQ(isJsonObject(R"(null)"), false);
+  EXPECT_EQ(isJsonObject(R"([1,2])"), false);
+
+  EXPECT_EQ(isJsonObject(R"(not_json)"), false);
+  EXPECT_EQ(isJsonObject(R"()"), false);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayLength) {


### PR DESCRIPTION
'is_json_object()' is a function supported on Flink. This commit is to support this function in both Bolt and Blint for the support of native 'is_json_object()' on Flink.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [x] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
