### PR TITLE
[fix] align spark to_utc_timestamp DST-gap handling with Spark

### DIFF
--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -654,6 +654,9 @@ struct ToUtcTimestampFunction {
     auto fromTimezone = timezone_
         ? timezone_
         : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+    const auto adjusted = fromTimezone->correct_nonexistent_time(
+        std::chrono::seconds(result.getSeconds()));
+    result = Timestamp(adjusted.count(), result.getNanos());
     result.toGMT(*fromTimezone);
   }
 

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -2875,6 +2875,20 @@ TEST_F(SparkSqlDateTimeFunctionsTest, toUtcTimestamp) {
   EXPECT_EQ(
       "2015-01-24 00:00:00.000000000",
       toUtcTimestamp("2015-01-24 05:30:00", "Asia/Kolkata"));
+  EXPECT_EQ(
+      "2021-03-28 01:32:20.000000000",
+      toUtcTimestamp("2021-03-28 01:32:20", "Europe/London"));
+
+  auto londonGapTimestamp = std::make_optional<Timestamp>(
+      util::fromTimestampString("2021-03-28 01:32:20", 19, nullptr));
+  auto londonGapToShanghai = evaluateOnce<Timestamp>(
+      "from_utc_timestamp(to_utc_timestamp(c0, c1), 'Asia/Shanghai')",
+      londonGapTimestamp,
+      std::make_optional<std::string>("Europe/London"));
+  EXPECT_EQ(
+      "2021-03-28 09:32:20.000000000",
+      timestampToString(londonGapToShanghai.value()));
+
   BOLT_ASSERT_THROW(
       toUtcTimestamp("2015-01-24 00:00:00", "Asia/Ooty"),
       "Unknown time zone: 'Asia/Ooty");


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #593

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Normalize DST-gap local timestamps before to_utc_timestamp conversion so Bolt follows Spark’s forward-shift behavior instead of throwing.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Align spark to_utc_timestamp DST-gap handling with Spark
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
