### PR TITLE
[fix] register unix_timestamp(date, format) for Bolt

### DIFF
--- a/bolt/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/bolt/functions/sparksql/registration/RegisterDatetime.cpp
@@ -65,6 +65,11 @@ void registerDatetimeFunctions(const std::string& prefix) {
       int64_t,
       Varchar,
       Varchar>({prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
+  registerFunction<
+      UnixTimestampParseWithFormatFunction,
+      int64_t,
+      Date,
+      Varchar>({prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
 
   registerFunction<
       UnixTimestampParseWithFormatAndTimestampFunction,

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -533,6 +533,28 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampDate) {
   EXPECT_EQ(std::nullopt, unixTimestamp(std::nullopt));
 }
 
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampDateWithFormat) {
+  const auto unixTimestamp = [&](std::optional<int32_t> date,
+                                 std::optional<StringView> format) {
+    return evaluateOnce<int64_t>(
+        "unix_timestamp(c0, c1)",
+        makeNullableFlatVector<int32_t>({date}, DATE()),
+        makeNullableFlatVector<StringView>({format}));
+  };
+
+  EXPECT_EQ(0, unixTimestamp(DATE()->toDays("1970-01-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(
+      1563922800, unixTimestamp(DATE()->toDays("2019-07-24"), "yyyyMMdd"));
+
+  setQueryTimeZone("Asia/Shanghai");
+  EXPECT_EQ(
+      1437667200, unixTimestamp(DATE()->toDays("2015-07-24"), "yyyy-MM-dd"));
+
+  EXPECT_EQ(std::nullopt, unixTimestamp(std::nullopt, "yyyy-MM-dd"));
+  EXPECT_EQ(
+      std::nullopt, unixTimestamp(DATE()->toDays("2015-07-24"), std::nullopt));
+}
+
 TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampTimestamp) {
   const auto unixTimestamp = [&](std::optional<Timestamp> timestamp) {
     return evaluateOnce<int64_t>("unix_timestamp(c0)", timestamp);

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -545,7 +545,7 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampDateWithFormat) {
 
   EXPECT_EQ(0, unixTimestamp(DATE()->toDays("1970-01-01"), "yyyy-MM-dd"));
   EXPECT_EQ(
-      1563922800, unixTimestamp(DATE()->toDays("2019-07-24"), "yyyyMMdd"));
+      1563926400, unixTimestamp(DATE()->toDays("2019-07-24"), "yyyyMMdd"));
 
   setQueryTimeZone("Asia/Shanghai");
   EXPECT_EQ(

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -538,8 +538,9 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampDateWithFormat) {
                                  std::optional<StringView> format) {
     return evaluateOnce<int64_t>(
         "unix_timestamp(c0, c1)",
-        makeNullableFlatVector<int32_t>({date}, DATE()),
-        makeNullableFlatVector<StringView>({format}));
+        makeRowVector(
+            {makeNullableFlatVector<int32_t>({date}, DATE()),
+             makeNullableFlatVector<StringView>({format})}));
   };
 
   EXPECT_EQ(0, unixTimestamp(DATE()->toDays("1970-01-01"), "yyyy-MM-dd"));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #595

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The unix_timestamp(date, format) overload was missing from datetime function registration. The fix adds this missing registration in bolt/functions/sparksql/registration/RegisterDatetime.cpp and corresponding ut coverage in
  bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- register unix_timestamp(date, format) for Bolt
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
