### PR TITLE
fix: Fix "call to 'nwords' is ambiguous" error

### DIFF
--- a/bolt/common/base/benchmarks/BitUtilBenchmark.cpp
+++ b/bolt/common/base/benchmarks/BitUtilBenchmark.cpp
@@ -161,7 +161,7 @@ void BM_forEachBit(
     size_t numBits,
     std::optional<size_t> bitToClear = std::nullopt) {
   folly::BenchmarkSuspender suspender;
-  uint32_t size = bits::nwords(numBits);
+  uint32_t size = bits::nwords(static_cast<uint64_t>(numBits));
   std::vector<uint64_t> data(size);
   uint64_t* rawData = data.data();
   bits::fillBits(rawData, 0, numBits, true);

--- a/bolt/dwio/common/Reader.cpp
+++ b/bolt/dwio/common/Reader.cpp
@@ -106,7 +106,8 @@ VectorPtr RowReader::projectColumns(
   std::vector<std::string> names(numColumns);
   std::vector<TypePtr> types(numColumns);
   std::vector<VectorPtr> children(numColumns);
-  std::vector<uint64_t> passed(bits::nwords(input->size()), -1);
+  std::vector<uint64_t> passed(
+      bits::nwords(static_cast<uint64_t>(input->size())), -1);
   for (auto& childSpec : spec.children()) {
     VectorPtr child;
     if (childSpec->isConstant()) {

--- a/bolt/dwio/common/tests/DecoderUtilTest.cpp
+++ b/bolt/dwio/common/tests/DecoderUtilTest.cpp
@@ -110,7 +110,8 @@ class DecoderUtilTest : public testing::Test {
   void testNonNullFromSparse(uint64_t* nulls, RowSet rows) {
     raw_vector<int32_t> referenceInner;
     raw_vector<int32_t> referenceOuter;
-    std::vector<uint64_t> referenceNulls(bits::nwords(rows.size()), ~0ULL);
+    std::vector<uint64_t> referenceNulls(
+        bits::nwords(static_cast<uint64_t>(rows.size())), ~0ULL);
     int32_t referenceSkip;
     auto referenceAnyNull =
         nonNullRowsFromSparseReference<isFilter, outputNulls>(
@@ -122,7 +123,8 @@ class DecoderUtilTest : public testing::Test {
             referenceSkip);
     raw_vector<int32_t> testInner;
     raw_vector<int32_t> testOuter;
-    std::vector<uint64_t> testNulls(bits::nwords(rows.size()), ~0ULL);
+    std::vector<uint64_t> testNulls(
+        bits::nwords(static_cast<uint64_t>(rows.size())), ~0ULL);
     int32_t testSkip;
     auto testAnyNull = nonNullRowsFromSparse<isFilter, outputNulls>(
         nulls, rows, testInner, testOuter, testNulls.data(), testSkip);

--- a/bolt/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -595,7 +595,8 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
       selectedInMap.setValid(row, true);
     }
     int32_t totalChildValues = 0;
-    rowColumnBits_.resize(bits::nwords(rows.size() * children_.size()));
+    rowColumnBits_.resize(
+        bits::nwords(static_cast<uint64_t>(rows.size() * children_.size())));
     std::fill(rowColumnBits_.begin(), rowColumnBits_.end(), 0);
     nullsInChildValues_ = false;
     for (auto i = 0; i < children_.size(); ++i) {

--- a/bolt/dwio/dwrf/test/TestByteRle.cpp
+++ b/bolt/dwio/dwrf/test/TestByteRle.cpp
@@ -988,7 +988,8 @@ TEST(BooleanRle, runsTestWithNull) {
       new SeekableArrayInputStream(buffer, BOLT_ARRAY_SIZE(buffer)));
   std::unique_ptr<ByteRleDecoder> rle = createBooleanDecoder(std::move(stream));
   std::vector<char> data(72);
-  std::vector<uint64_t> nulls(bits::nwords(data.size()), bits::kNotNull64);
+  std::vector<uint64_t> nulls(
+      bits::nwords(static_cast<uint64_t>(data.size())), bits::kNotNull64);
   rle->next(data.data(), data.size(), nulls.data());
   for (size_t i = 0; i < data.size(); ++i) {
     EXPECT_EQ(i % 18 < 9 ? 1 : 0, bits::isBitSet(data.data(), i))

--- a/bolt/dwio/dwrf/test/TestRle.cpp
+++ b/bolt/dwio/dwrf/test/TestRle.cpp
@@ -58,7 +58,7 @@ std::vector<int64_t> decodeRLEv2(
     size_t remaining = count - i;
     size_t nread = std::min(n, remaining);
     if (nulls) {
-      remainingNulls.reserve(bits::nwords(nread));
+      remainingNulls.reserve(bits::nwords(static_cast<uint64_t>(nread)));
       for (int32_t j = 0; j < nread; j++) {
         bits::setNull(
             remainingNulls.data(), j, bits::isBitNull(nulls, j + totalRead));

--- a/bolt/exec/ContainerRowSerde.cpp
+++ b/bolt/exec/ContainerRowSerde.cpp
@@ -245,7 +245,8 @@ void serializeOne<TypeKind::ROW>(
   // deserialization.
   auto childrenSize = type.size();
   auto children = row->children();
-  std::vector<uint64_t> nulls(bits::nwords(childrenSize));
+  std::vector<uint64_t> nulls(
+      bits::nwords(static_cast<uint64_t>(childrenSize)));
   for (auto i = 0; i < childrenSize; ++i) {
     if (i >= children.size() || !children[i] ||
         children[i]->isNullAt(wrappedIndex)) {

--- a/bolt/exec/tests/utils/RowBasedSerde.cpp
+++ b/bolt/exec/tests/utils/RowBasedSerde.cpp
@@ -80,7 +80,8 @@ void serializeOne<TypeKind::ROW>(
   // deserialization.
   auto childrenSize = type.size();
   auto children = row->children();
-  std::vector<uint64_t> nulls(bits::nwords(childrenSize));
+  std::vector<uint64_t> nulls(
+      bits::nwords(static_cast<uint64_t>(childrenSize)));
   for (auto i = 0; i < childrenSize; ++i) {
     if (i >= children.size() || !children[i] ||
         children[i]->isNullAt(wrappedIndex)) {

--- a/bolt/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -413,8 +413,8 @@ TEST_F(PrestoHasherTest, timestampWithTimezone) {
         std::vector<std::optional<int64_t>> timestamps;
         std::vector<std::optional<int16_t>> timeZoneIds;
         auto size = timestampWithTimeZones.size();
-        BufferPtr nulls =
-            AlignedBuffer::allocate<uint64_t>(bits::nwords(size), pool());
+        BufferPtr nulls = AlignedBuffer::allocate<uint64_t>(
+            bits::nwords(static_cast<uint64_t>(size)), pool());
         auto rawNulls = nulls->asMutable<uint64_t>();
         timestamps.reserve(size);
         timeZoneIds.reserve(size);

--- a/bolt/row/UnsafeRow.h
+++ b/bolt/row/UnsafeRow.h
@@ -321,7 +321,7 @@ class UnsafeRow {
    * @return the null set length in bytes
    */
   static const size_t getNullLength(size_t elementCount) {
-    return bits::nwords(elementCount) * kFieldWidthBytes;
+    return bits::nwords(static_cast<uint64_t>(elementCount)) * kFieldWidthBytes;
   }
 
   /**

--- a/bolt/serializers/PrestoSerializer.cpp
+++ b/bolt/serializers/PrestoSerializer.cpp
@@ -2112,7 +2112,8 @@ int32_t rowsToRanges(
   ScratchPtr<vector_size_t, 64> innerRowsHolder(scratch);
   if (rawNulls) {
     ScratchPtr<uint64_t, 4> nullsHolder(scratch);
-    auto* nulls = nullsHolder.get(bits::nwords(rows.size()));
+    auto* nulls =
+        nullsHolder.get(bits::nwords(static_cast<uint64_t>(rows.size())));
     simd::gatherBits(rawNulls, rows, nulls);
     auto* mutableNonNullRows = nonNullHolder.get(numRows);
     auto* mutableInnerRows = innerRowsHolder.get(numRows);
@@ -2349,7 +2350,8 @@ void serializeFlatVector(
   }
 
   ScratchPtr<uint64_t, 4> nullsHolder(scratch);
-  uint64_t* nulls = nullsHolder.get(bits::nwords(rows.size()));
+  uint64_t* nulls =
+      nullsHolder.get(bits::nwords(static_cast<uint64_t>(rows.size())));
   simd::gatherBits(vector->rawNulls(), rows, nulls);
   if (std::is_same_v<T, Timestamp>) {
     appendTimestamps(
@@ -2391,12 +2393,14 @@ void serializeFlatVector<TypeKind::BOOLEAN>(
   int32_t numValueBits;
   if (!flatVector->mayHaveNulls()) {
     stream->appendNonNull(rows.size());
-    valueBits = bitsHolder.get(bits::nwords(rows.size()));
+    valueBits =
+        bitsHolder.get(bits::nwords(static_cast<uint64_t>(rows.size())));
     simd::gatherBits(
         reinterpret_cast<const uint64_t*>(rawValues), rows, valueBits);
     numValueBits = rows.size();
   } else {
-    uint64_t* nulls = bitsHolder.get(bits::nwords(rows.size()));
+    uint64_t* nulls =
+        bitsHolder.get(bits::nwords(static_cast<uint64_t>(rows.size())));
     simd::gatherBits(vector->rawNulls(), rows, nulls);
     ScratchPtr<vector_size_t, 64> nonNullsHolder(scratch);
     auto* nonNulls = nonNullsHolder.get(rows.size());
@@ -2531,7 +2535,8 @@ void serializeRowVector(
   auto innerRows = rows.data();
   auto numInnerRows = rows.size();
   if (auto rawNulls = vector->rawNulls()) {
-    auto nulls = nullsHolder.get(bits::nwords(rows.size()));
+    auto nulls =
+        nullsHolder.get(bits::nwords(static_cast<uint64_t>(rows.size())));
     simd::gatherBits(rawNulls, rows, nulls);
     auto* mutableInnerRows = innerRowsHolder.get(rows.size());
     numInnerRows =
@@ -2971,7 +2976,7 @@ void estimateFlatSerializedSize(
     auto rawNulls = vector->rawNulls();
     ScratchPtr<uint64_t, 4> nullsHolder(scratch);
     ScratchPtr<int32_t, 64> nonNullsHolder(scratch);
-    auto nulls = nullsHolder.get(bits::nwords(numRows));
+    auto nulls = nullsHolder.get(bits::nwords(static_cast<uint64_t>(numRows)));
     simd::gatherBits(rawNulls, rows, nulls);
     auto nonNulls = nonNullsHolder.get(numRows);
     const auto numNonNull = simd::indicesOfSetBits(nulls, 0, numRows, nonNulls);
@@ -2999,7 +3004,7 @@ void estimateFlatSerializedSizeVarcharOrVarbinary(
   } else {
     ScratchPtr<uint64_t, 4> nullsHolder(scratch);
     ScratchPtr<int32_t, 64> nonNullsHolder(scratch);
-    auto nulls = nullsHolder.get(bits::nwords(numRows));
+    auto nulls = nullsHolder.get(bits::nwords(static_cast<uint64_t>(numRows)));
     simd::gatherBits(rawNulls, rows, nulls);
     auto* nonNulls = nonNullsHolder.get(numRows);
     auto numNonNull = simd::indicesOfSetBits(nulls, 0, numRows, nonNulls);
@@ -3156,7 +3161,8 @@ void estimateSerializedSizeInt(
       const auto numRows = rows.size();
       int32_t numInner = numRows;
       if (vector->mayHaveNulls()) {
-        auto nulls = nullsHolder.get(bits::nwords(numRows));
+        auto nulls =
+            nullsHolder.get(bits::nwords(static_cast<uint64_t>(numRows)));
         simd::gatherBits(vector->rawNulls(), rows, nulls);
         auto mutableInnerRows = innerRowsHolder.get(numRows);
         numInner = simd::indicesOfSetBits(nulls, 0, numRows, mutableInnerRows);


### PR DESCRIPTION
### What problem does this PR solve?

"fix bits::copyBits coredump caused by negative leafNullsSize_ " (#529)
introduced nwords overload functions and this caused c++ failed with the
following error when running c++:

```
FAILED: bolt/serializers/CMakeFiles/bolt_presto_serializer.dir/PrestoSerializer.cpp.o 
/Users/yingsu/deps-install/bin/ccache /usr/bin/c++ -DARROW_STATIC -DBOLT_ENABLE_HDFS -DBOLT_ENABLE_ORC -DBOLT_ENABLE_PARQUET -DBOLT_ENABLE_TXT -DENABLE_BOLT_JIT=1 -DGFLAGS_DLL_DECLARE_FLAG="" -DGFLAGS_DLL_DEFINE_FLAG="" -DGLOG_USE_GLOG_EXPORT="" -DLZMA_API_STATIC -DPARQUET_STATIC -DSODIUM_STATIC -DUSE_OS_TZDB=1 -DUTF8PROC_STATIC -DU_STATIC_IMPLEMENTATION -I/Users/yingsu/repo/bytedance1/bolt -I/Users/yingsu/repo/bytedance1/bolt/bolt -I/Users/yingsu/repo/bytedance1/bolt/bolt/type -I/Users/yingsu/repo/bytedance1/bolt/bolt/buffer -isystem /Users/yingsu/.conan2/p/b/follyc2cb8ec8ac0eb/p/include -isystem /Users/yingsu/.conan2/p/b/fmt47a0905166704/p/include -isystem /Users/yingsu/.conan2/p/b/boost99d13c9580365/p/include -isystem /Users/yingsu/.conan2/p/b/doubl023af8dd76353/p/include -isystem /Users/yingsu/.conan2/p/b/gflag3c6b775a47d60/p/include -isystem /Users/yingsu/.conan2/p/b/glog4df91254260be/p/include -isystem /Users/yingsu/.conan2/p/b/libev2b9afd721a65e/p/include -isystem /Users/yingsu/.conan2/p/b/opensca9270a7b86cd/p/include -isystem /Users/yingsu/.conan2/p/b/lz4e5f45a31f9332/p/include -isystem /Users/yingsu/.conan2/p/b/bzip23ed1e8b25a4e6/p/include -isystem /Users/yingsu/.conan2/p/b/snapp71fdf3c9b958d/p/include -isystem /Users/yingsu/.conan2/p/b/zlib055dce792a6f8/p/include -isystem /Users/yingsu/.conan2/p/b/zstd068c8f47399ab/p/include -isystem /Users/yingsu/.conan2/p/b/libso06e6bf05db5c0/p/include -isystem /Users/yingsu/.conan2/p/b/libdw9d24b71415247/p/include -isystem /Users/yingsu/.conan2/p/xsimd3368e44453bd9/p/include -isystem /Users/yingsu/.conan2/p/b/cityhfd1b6a98863e8/p/include -isystem /Users/yingsu/.conan2/p/b/xxhas7448ba02638a4/p/include -isystem /Users/yingsu/.conan2/p/b/ryud4894e04b4535/p/include -isystem /Users/yingsu/.conan2/p/b/dated5d33655147ae/p/include -isystem /Users/yingsu/.conan2/p/b/re2dd3f811ee65b6/p/include -isystem /Users/yingsu/.conan2/p/b/arrowadfcc0cb1c6e7/p/include -isystem /Users/yingsu/.conan2/p/b/protofa1bbbd74f5b8/p/include -isystem /Users/yingsu/.conan2/p/b/thrif9d51d6c869e49/p/include -isystem /Users/yingsu/.conan2/p/b/icuc036c7aebc432/p/include -isystem /Users/yingsu/.conan2/p/b/utf8pad67ca34b17b1/p/include -Werror=return-type -mcpu=apple-m1+crc  -D USE_BOLT_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-psabi        -Wno-range-loop-analysis          -Wno-mismatched-tags          -Wno-nullability-completeness -g -std=gnu++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -fPIC -fcolor-diagnostics   -D OS_MACOSX -fcolor-diagnostics -flax-vector-conversions -fsigned-char -MD -MT bolt/serializers/CMakeFiles/bolt_presto_serializer.dir/PrestoSerializer.cpp.o -MF bolt/serializers/CMakeFiles/bolt_presto_serializer.dir/PrestoSerializer.cpp.o.d -o bolt/serializers/CMakeFiles/bolt_presto_serializer.dir/PrestoSerializer.cpp.o -c /Users/yingsu/repo/bytedance1/bolt/bolt/serializers/PrestoSerializer.cpp

../../bolt/serializers/PrestoSerializer.cpp:2115:35: error: call to 'nwords' is ambiguous
 2115 |     auto* nulls = nullsHolder.get(bits::nwords(rows.size()));
      |                                   ^~~~~~~~~~~~
../../bolt/common/base/BitUtil.h:128:27: note: candidate function
  128 | constexpr inline uint64_t nwords(int32_t bits) {
      |                           ^
../../bolt/common/base/BitUtil.h:132:27: note: candidate function
  132 | constexpr inline uint64_t nwords(uint32_t bits) {
      |                           ^
../../bolt/common/base/BitUtil.h:136:27: note: candidate function
  136 | constexpr inline uint64_t nwords(int64_t bits) {
      |                           ^
../../bolt/common/base/BitUtil.h:141:27: note: candidate function
  141 | constexpr inline uint64_t nwords(uint64_t bits) {
      |                           ^
```


### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This commit fixes it by adding explict cast on the ambiguous callsites.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note: 
N/A

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
