### PR TITLE
Support the FlinkSQL-Styled Timestamp and Interval features

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -1112,6 +1112,36 @@ void doCastArrayToVarchar(
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
   const bool legacyComplex = isInSpark &&
       (queryConfig.isSparkLegacyCastComplexTypesToStringEnabled() != "false");
+  if (queryConfig.enableFlinkCompatible() &&
+      arrayElements->type()->isTimestamp()) {
+    auto flatElements = resultElements->as<FlatVector<StringView>>();
+    nestedRows.applyToSelected([&](auto row) INLINE_LAMBDA {
+      if (flatElements->isNullAt(row)) {
+        return;
+      }
+      auto value = flatElements->valueAt(row);
+      int32_t dot = -1;
+      for (int32_t i = 0; i < value.size(); ++i) {
+        if (value.data()[i] == '.') {
+          dot = i;
+          break;
+        }
+      }
+      if (dot == -1) {
+        return;
+      }
+      bool allZeros = true;
+      for (int32_t i = dot + 1; i < value.size(); ++i) {
+        if (value.data()[i] != '0') {
+          allZeros = false;
+          break;
+        }
+      }
+      if (allZeros) {
+        flatElements->set(row, StringView(value.data(), dot));
+      }
+    });
+  }
 
   auto rawElements = resultElements->as<FlatVector<StringView>>()->rawValues();
   rows.applyToSelected([&](auto row) INLINE_LAMBDA {

--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -493,6 +493,15 @@ class Converter {
               }
             }
             to.set(output);
+          } else if (isInSpark) {
+            constexpr TimestampToStringOptions options = {
+                .precision = TimestampToStringOptions::Precision::kMicroseconds,
+                .leadingPositiveSign = true,
+                .skipTrailingZeros = true,
+                .zeroPaddingYear = true,
+                .dateTimeSeparator = ' '};
+            ts.toTimezone(*timeZone_);
+            to.set(ts.toString(options));
           } else {
             to.set(from.toString(
                 TimestampToStringOptions::Precision::kMilliseconds, timeZone_));

--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -298,6 +298,7 @@ class Converter {
     if (queryConfig.adjustTimestampToTimezone() && !sessionTzName.empty()) {
       timeZone_ = tz::locateZone(sessionTzName);
     }
+    isFlinkCompatible_ = queryConfig.enableFlinkCompatible();
   }
 
   TO_KIND(BooleanKind) convert(const FromType& from, ToType& to) {
@@ -473,25 +474,66 @@ class Converter {
       try {
         auto ts = from;
         if (timeZone_) {
-          ts.toTimezone(*(timeZone_));
-        }
-        if (isInSpark) {
-          constexpr TimestampToStringOptions options = {
-              .precision = TimestampToStringOptions::Precision::kMicroseconds,
-              .leadingPositiveSign = true,
-              .skipTrailingZeros = true,
-              .zeroPaddingYear = true,
-              .dateTimeSeparator = ' '};
-          to.set(ts.toString(options));
-        } else {
-          TimestampToStringOptions options;
-          options.precision =
-              TimestampToStringOptions::Precision::kMilliseconds;
-          if constexpr (!legacy) {
+          if (isFlinkCompatible_) {
+            TimestampToStringOptions options;
+            options.precision =
+                TimestampToStringOptions::Precision::kNanoseconds;
+            options.skipTrailingZeros = true;
             options.zeroPaddingYear = true;
             options.dateTimeSeparator = ' ';
+            ts.toTimezone(*timeZone_);
+            auto output = ts.toString(options);
+            auto dot = output.find('.');
+            if (dot == std::string::npos) {
+              output.append(".000");
+            } else {
+              const auto fractionalSize = output.size() - dot - 1;
+              if (fractionalSize < 3) {
+                output.append(3 - fractionalSize, '0');
+              }
+            }
+            to.set(output);
+          } else {
+            to.set(from.toString(
+                TimestampToStringOptions::Precision::kMilliseconds, timeZone_));
           }
-          to.set(ts.toString(options));
+        } else {
+          if (isFlinkCompatible_) {
+            TimestampToStringOptions options;
+            options.precision =
+                TimestampToStringOptions::Precision::kNanoseconds;
+            options.skipTrailingZeros = true;
+            options.zeroPaddingYear = true;
+            options.dateTimeSeparator = ' ';
+            auto output = ts.toString(options);
+            auto dot = output.find('.');
+            if (dot == std::string::npos) {
+              output.append(".000");
+            } else {
+              const auto fractionalSize = output.size() - dot - 1;
+              if (fractionalSize < 3) {
+                output.append(3 - fractionalSize, '0');
+              }
+            }
+            to.set(output);
+          } else if (isInSpark) {
+            constexpr TimestampToStringOptions options = {
+                .precision = TimestampToStringOptions::Precision::kMicroseconds,
+                .leadingPositiveSign = true,
+                .skipTrailingZeros = true,
+                .zeroPaddingYear = true,
+                .dateTimeSeparator = ' '};
+            to.set(ts.toString(options));
+          } else {
+            TimestampToStringOptions options;
+            options.precision =
+                TimestampToStringOptions::Precision::kMilliseconds;
+            if constexpr (!legacy) {
+              options.zeroPaddingYear = true;
+              options.dateTimeSeparator = ' ';
+            }
+            to.set(ts.toString(options));
+          }
         }
       } catch (...) {
         return ConvertStatus::OTHER_FAILURE;
@@ -737,6 +779,7 @@ class Converter {
   int toPrecision_ = 0;
   int toScale_ = 0;
   const tz::TimeZone* timeZone_ = nullptr;
+  bool isFlinkCompatible_ = false;
 
   bool canAsInlinedStr_ = false;
 };

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -3217,6 +3217,26 @@ TEST_F(CastExprTest, mapCastStringFlinkCompatible) {
             "[{1=11, 3=10}, {0=10, 2=11}, {1=11, 1=10}]",
             "[{0=null}, {0=10}]",
         }));
+
+    std::vector<std::optional<std::vector<std::optional<Timestamp>>>>
+        arrayOfTimestampData = {
+            std::vector<std::optional<Timestamp>>{
+                Timestamp(946729316, 0),
+                Timestamp(946729316, 123),
+                std::nullopt},
+            std::vector<std::optional<Timestamp>>{
+                Timestamp(946729316, 129900000)},
+            std::nullopt,
+        };
+    auto arrayOfTimestamp = makeNullableArrayVector<Timestamp>(
+        arrayOfTimestampData, ARRAY(TIMESTAMP()));
+    testCast(
+        arrayOfTimestamp,
+        makeNullableFlatVector<StringView>({
+            "[2000-01-01 12:21:56, 2000-01-01 12:21:56.000000123, null]",
+            "[2000-01-01 12:21:56.1299]",
+            std::nullopt,
+        }));
   };
 
   setFlinkCompatible(true);

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -852,6 +852,25 @@ TEST_F(CastExprTest, timestampToString) {
           std::nullopt,
       });
 }
+
+TEST_F(CastExprTest, timestampToStringFlinkCompatible) {
+  setLegacyCast(false);
+  setFlinkCompatible(true);
+  testCast<Timestamp, std::string>(
+      "string",
+      {
+          Timestamp(946729316, 0),
+          Timestamp(946729316, 123),
+          Timestamp(946729316, 129900000),
+          Timestamp(946729316, 999999999),
+      },
+      {
+          "2000-01-01 12:21:56.000",
+          "2000-01-01 12:21:56.000000123",
+          "2000-01-01 12:21:56.1299",
+          "2000-01-01 12:21:56.999999999",
+      });
+}
 #endif
 
 TEST_F(CastExprTest, dateToTimestamp) {

--- a/bolt/functions/flinksql/DateTimeFunctions.h
+++ b/bolt/functions/flinksql/DateTimeFunctions.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <string>
 namespace bytedance::bolt::functions::flinksql {
 
 template <typename T>
@@ -145,6 +146,39 @@ struct FlinkFromUnixtimeFunction : public sparksql::FromUnixtimeFunction<T> {
       const arg_type<Varchar>& timeZoneString) {
     return sparksql::FromUnixtimeFunction<T>::call(
         result, unixtime == LongMinValue ? 0 : unixtime, formatString);
+  }
+};
+
+template <typename T>
+struct FlinkTimestampToStringV2Function {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Timestamp>& timestamp,
+      const arg_type<int32_t>& precision) {
+    int32_t trimmedPrecision = precision;
+    if (trimmedPrecision < 0) {
+      trimmedPrecision = 0;
+    } else if (trimmedPrecision > 9) {
+      trimmedPrecision = 9;
+    }
+    TimestampToStringOptions options;
+    options.precision = TimestampToStringOptions::Precision::kNanoseconds;
+    options.zeroPaddingYear = true;
+    options.dateTimeSeparator = ' ';
+    auto output = timestamp.toString(options);
+    auto dot = output.find('.');
+    if (dot != std::string::npos) {
+      while (output.size() - dot - 1 > static_cast<size_t>(trimmedPrecision) &&
+             output.back() == '0') {
+        output.pop_back();
+      }
+      if (trimmedPrecision == 0 && output.back() == '.') {
+        output.pop_back();
+      }
+    }
+    result.copy_from(output);
   }
 };
 

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -67,6 +67,11 @@ static void registerDatetimeFunctions(const std::string& prefix) {
       int64_t,
       Varchar,
       Varchar>({prefix + "flink_from_unixtime"});
+  registerFunction<
+      FlinkTimestampToStringV2Function,
+      Varchar,
+      Timestamp,
+      int32_t>({prefix + "flink_timestamp_to_string_v2"});
 }
 
 static void registerMathFunctions(const std::string& prefix) {

--- a/bolt/functions/flinksql/tests/FlinkSqlDataTimeFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/FlinkSqlDataTimeFunctionsTest.cpp
@@ -154,5 +154,34 @@ TEST_F(FlinkSqlDateTimeFunctionsTest, fromUnixtimeWithTimezone) {
       "1970-01-01 08:00:00",
       fromUnixtimeOnce(LongMinValue, "yyyy-MM-dd HH:mm:ss", "Asia/Shanghai"));
 }
+
+TEST_F(FlinkSqlDateTimeFunctionsTest, timestampToStringV2) {
+  const auto formatOnce = [&](Timestamp timestamp, int32_t precision) {
+    return evaluateOnce<std::string>(
+        "flink_timestamp_to_string_v2(c0, c1)",
+        makeRowVector(
+            {makeFlatVector<Timestamp>({timestamp}),
+             makeFlatVector<int32_t>({precision})}));
+  };
+
+  EXPECT_EQ(
+      std::optional<std::string>("2000-01-01 12:21:56"),
+      formatOnce(Timestamp(946729316, 0), 0));
+  EXPECT_EQ(
+      std::optional<std::string>("2000-01-01 12:21:56.123"),
+      formatOnce(Timestamp(946729316, 123000000), 3));
+  EXPECT_EQ(
+      std::optional<std::string>("2000-01-01 12:21:56.123456789"),
+      formatOnce(Timestamp(946729316, 123456789), 3));
+  EXPECT_EQ(
+      std::optional<std::string>("2000-01-01 12:21:56.000000123"),
+      formatOnce(Timestamp(946729316, 123), 9));
+  EXPECT_EQ(
+      std::optional<std::string>("2000-01-01 12:21:56.000000123"),
+      formatOnce(Timestamp(946729316, 123), 12));
+  EXPECT_EQ(
+      std::optional<std::string>("2000-01-01 12:21:56.1"),
+      formatOnce(Timestamp(946729316, 100000000), -1));
+}
 } // namespace
 } // namespace bytedance::bolt::functions::flinksql::test

--- a/bolt/functions/flinksql/tests/JsonFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/JsonFunctionsTest.cpp
@@ -31,6 +31,11 @@ class JsonFunctionsTest : public FlinkFunctionBaseTest {
   }
 };
 
+TEST_F(JsonFunctionsTest, flinkCompatibleConfigEnabled) {
+  setFlinkCompatible(true);
+  EXPECT_TRUE(queryCtx_->queryConfig().enableFlinkCompatible());
+}
+
 TEST_F(JsonFunctionsTest, jsonStrToMap) {
   auto evaluateExpr = [&](std::optional<StringView> json,
                           std::optional<bool> logFailuresOnly = std::nullopt) {


### PR DESCRIPTION
### What problem does this PR solve?

FlinkSQL also supports Timestamp and Interval. But there are some discrepancies between Flink and Bolt. This PR is to align align all the differences and make sure the Bolt execution result for Flink aligns with FlinkSQL. This PR also aligns the Timestamp casting to String with Flink style.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
