### PR TITLE
[fix] Returns NULL for invalid JSON or incompatible values in from_json

### DIFF
--- a/bolt/functions/sparksql/specialforms/FromJson.cpp
+++ b/bolt/functions/sparksql/specialforms/FromJson.cpp
@@ -489,13 +489,21 @@ class FromJsonFunction final : public exec::VectorFunction {
   static simdjson::error_code extractJsonToWriter(
       simdjson::ondemand::document& doc,
       exec::VectorWriter<Any>& writer) {
-    if (doc.is_null()) {
-      writer.commitNull();
-    } else {
-      SIMDJSON_TRY(
-          ExtractJsonTypeImpl<simdjson::ondemand::document&>::apply<kind>(
-              doc, writer.current(), true));
-      writer.commit(true);
+    try {
+      if (doc.is_null()) {
+        writer.commitNull();
+      } else {
+        SIMDJSON_TRY(
+            ExtractJsonTypeImpl<simdjson::ondemand::document&>::apply<kind>(
+                doc, writer.current(), true));
+        writer.commit(true);
+      }
+    } catch (const simdjson::simdjson_error& e) {
+      // Scalar top-level JSON documents (e.g. '"abc"', '1', 'true') should
+      // not escape as exceptions for complex root schemas. Let the caller map
+      // simdjson errors to NULL, which matches Spark's permissive from_json
+      // behavior under partial-results mode.
+      return e.error();
     }
     return simdjson::SUCCESS;
   }

--- a/bolt/functions/sparksql/tests/FromJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/FromJsonTest.cpp
@@ -265,5 +265,23 @@ TEST_F(FromJsonTest, invalidJson) {
   testFromJson(input, makeRowVector({"a"}, {expected}));
 }
 
+TEST_F(FromJsonTest, scalarRootDocumentDoesNotThrow) {
+  auto scalarInput = makeFlatVector<std::string>({R"("abc")", "1", "true"});
+
+  auto expectedArray = makeNullableArrayVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  testFromJson(scalarInput, expectedArray);
+
+  auto expectedMap = makeNullableMapVector<std::string, int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  testFromJson(scalarInput, expectedMap);
+
+  auto expectedRow = makeRowVector(
+      {"a"},
+      {makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt})});
+  testFromJson(scalarInput, expectedRow);
+}
+
 } // namespace
 } // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #606

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This commit fixes the bug by catching root-level simdjson exceptions in Spark from_json and turning them into NULL-producing error codes instead of query-failing exceptions

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixes the bug by catching root-level simdjson exceptions in Spark from_json and turning them into NULL-producing error codes instead of query-failing exceptions
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
