### PR TITLE
[fix]: jit bug

### DIFF
--- a/bolt/exec/RowsStreamingWindowBuild.cpp
+++ b/bolt/exec/RowsStreamingWindowBuild.cpp
@@ -59,7 +59,8 @@ void RowsStreamingWindowBuild<needSort>::buildNextInputOrPartition(
             data_.get(),
             folly::Range<char**>(nullptr, nullptr),
             inversedInputChannels_,
-            sortKeyInfo_));
+            sortKeyInfo_,
+            enableJit_));
   }
 
   windowPartitions_[inputCurrentPartition_]->addNewRows(inputRows_);
@@ -86,7 +87,8 @@ void RowsStreamingWindowBuild<needSort>::buildNextInputOrPartitionFromSpill(
               data_.get(),
               folly::Range<char**>(nullptr, nullptr),
               inversedInputChannels_,
-              sortKeyInfo_));
+              sortKeyInfo_,
+              enableJit_));
     }
     windowPartitions_[inputCurrentPartition_]->addNewRows(
         windowPartitions_[inputCurrentPartition_]

--- a/bolt/exec/RowsStreamingWindowPartition.cpp
+++ b/bolt/exec/RowsStreamingWindowPartition.cpp
@@ -22,8 +22,9 @@ RowsStreamingWindowPartition<R>::RowsStreamingWindowPartition(
     RowContainer* data,
     const folly::Range<char**>& rows,
     const std::vector<column_index_t>& inputMapping,
-    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
-    : WindowPartitionImpl<R>(data, rows, inputMapping, sortKeyInfo) {
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo,
+    bool enableJit)
+    : WindowPartitionImpl<R>(data, rows, inputMapping, sortKeyInfo, enableJit) {
   partitionStartRows_.push_back(0);
   bufferStarts_.push_back(0);
 }

--- a/bolt/exec/RowsStreamingWindowPartition.h
+++ b/bolt/exec/RowsStreamingWindowPartition.h
@@ -30,7 +30,8 @@ class RowsStreamingWindowPartition : public WindowPartitionImpl<R> {
       const folly::Range<char**>& rows,
       const std::vector<column_index_t>& inputMapping,
       const std::vector<std::pair<column_index_t, core::SortOrder>>&
-          sortKeyInfo);
+          sortKeyInfo,
+      bool enableJit = false);
 
   // Returns the number of rows in the current partial window partition,
   // including the offset within the full partition.

--- a/bolt/exec/SortWindowBuild.cpp
+++ b/bolt/exec/SortWindowBuild.cpp
@@ -436,7 +436,11 @@ std::shared_ptr<WindowPartition> SortWindowBuild::nextPartition() {
     BOLT_CHECK(!sortRows_.empty(), "No window partitions available");
     auto partition = folly::Range(sortRows_.data(), sortRows_.size());
     return std::make_shared<WindowPartitionImpl<RowFormat::kRowContainer>>(
-        data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+        data_.get(),
+        partition,
+        inversedInputChannels_,
+        sortKeyInfo_,
+        enableJit_);
   }
 
   if (rowBasedSpillSortMerger_ != nullptr) {
@@ -479,7 +483,11 @@ std::shared_ptr<WindowPartition> SortWindowBuild::nextPartition() {
         sortRows_.data() + partitionStartRows_[currentPartition_],
         partitionSize);
     return std::make_shared<WindowPartitionImpl<RowFormat::kSerializedRows>>(
-        data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+        data_.get(),
+        partition,
+        inversedInputChannels_,
+        sortKeyInfo_,
+        enableJit_);
   }
 
   BOLT_CHECK(!partitionStartRows_.empty(), "No window partitions available")
@@ -496,7 +504,7 @@ std::shared_ptr<WindowPartition> SortWindowBuild::nextPartition() {
   auto partition = folly::Range(
       sortRows_.data() + partitionStartRows_[currentPartition_], partitionSize);
   return std::make_shared<WindowPartitionImpl<RowFormat::kRowContainer>>(
-      data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+      data_.get(), partition, inversedInputChannels_, sortKeyInfo_, enableJit_);
 }
 
 bool SortWindowBuild::hasNextPartition() {

--- a/bolt/exec/SpillableWindowBuild.cpp
+++ b/bolt/exec/SpillableWindowBuild.cpp
@@ -602,7 +602,8 @@ SpillableWindowBuild<needSort>::nextPartition() {
           spillers_[currentPartition_]->stats().spilledRows,
           outputType_,
           &inputChannels_,
-          pool_);
+          pool_,
+          enableJit_);
     } else {
       return std::make_shared<SpilledWindowPartition<RowFormat::kRowContainer>>(
           data_.get(),
@@ -614,14 +615,19 @@ SpillableWindowBuild<needSort>::nextPartition() {
           spillers_[currentPartition_]->stats().spilledRows,
           outputType_,
           &inputChannels_,
-          pool_);
+          pool_,
+          enableJit_);
     }
   } else if (rowBasedSpillSortMerger_) {
     return std::make_shared<WindowPartitionImpl<RowFormat::kSerializedRows>>(
-        data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+        data_.get(),
+        partition,
+        inversedInputChannels_,
+        sortKeyInfo_,
+        enableJit_);
   }
   return std::make_shared<WindowPartitionImpl<RowFormat::kRowContainer>>(
-      data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+      data_.get(), partition, inversedInputChannels_, sortKeyInfo_, enableJit_);
 }
 
 template <bool needSort>
@@ -633,10 +639,14 @@ SpillableWindowBuild<needSort>::createPartialPartition() {
   auto partition = folly::Range(inputRows_.data(), partitionSize);
   if (rowBasedSpillSortMerger_) {
     return std::make_unique<WindowPartitionImpl<RowFormat::kSerializedRows>>(
-        data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+        data_.get(),
+        partition,
+        inversedInputChannels_,
+        sortKeyInfo_,
+        enableJit_);
   }
   return std::make_unique<WindowPartitionImpl<RowFormat::kRowContainer>>(
-      data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+      data_.get(), partition, inversedInputChannels_, sortKeyInfo_, enableJit_);
 }
 
 template <bool needSort>

--- a/bolt/exec/StreamingWindowBuild.cpp
+++ b/bolt/exec/StreamingWindowBuild.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<WindowPartition> StreamingWindowBuild::nextPartition() {
       partitionSize);
 
   return std::make_shared<WindowPartitionImpl<RowFormat::kRowContainer>>(
-      data_.get(), partition, inversedInputChannels_, sortKeyInfo_);
+      data_.get(), partition, inversedInputChannels_, sortKeyInfo_, enableJit_);
 }
 
 bool StreamingWindowBuild::hasNextPartition() {

--- a/bolt/exec/Window.cpp
+++ b/bolt/exec/Window.cpp
@@ -769,13 +769,7 @@ void Window::computePeerAndFrameBuffers(
   }
 
   std::tie(peerStartRow_, peerEndRow_) = currentPartition_->computePeerBuffers(
-      startRow,
-      endRow,
-      peerStartRow_,
-      peerEndRow_,
-      rawPeerStarts,
-      rawPeerEnds,
-      enableJit);
+      startRow, endRow, peerStartRow_, peerEndRow_, rawPeerStarts, rawPeerEnds);
   for (auto i = 0; i < numFuncs; i++) {
     const auto& windowFrame = windowFrames_[i];
     // Default all rows to have validFrames. The invalidity of frames is only

--- a/bolt/exec/WindowPartition.cpp
+++ b/bolt/exec/WindowPartition.cpp
@@ -36,11 +36,13 @@ WindowPartition::WindowPartition(
     RowContainer* data,
     const folly::Range<char**>& rows,
     const std::vector<column_index_t>& inputMapping,
-    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo,
+    bool enableJit)
     : data_(data),
       partition_(rows),
       inputMapping_(inputMapping),
-      sortKeyInfo_(sortKeyInfo) {
+      sortKeyInfo_(sortKeyInfo),
+      enableJit_(enableJit) {
   for (int i = 0; i < inputMapping_.size(); i++) {
     columns_.emplace_back(data_->columnAt(inputMapping_[i]));
   }
@@ -132,10 +134,8 @@ WindowPartition::extractNulls(
                    : std::nullopt;
 }
 
-bool WindowPartition::compareRowsWithSortKeys(
-    const char* lhs,
-    const char* rhs,
-    RowRowCompare rowCmpRowFunc_) const {
+bool WindowPartition::compareRowsWithSortKeys(const char* lhs, const char* rhs)
+    const {
   if (lhs == rhs) {
     return false;
   }
@@ -157,43 +157,9 @@ std::pair<vector_size_t, vector_size_t> WindowPartition::computePeerBuffers(
     vector_size_t prevPeerStart,
     vector_size_t prevPeerEnd,
     vector_size_t* rawPeerStarts,
-    vector_size_t* rawPeerEnds,
-    bool enableJit) const {
-  RowRowCompare rowCmpRowFunc_ = nullptr;
-
-#ifdef ENABLE_BOLT_JIT
-  if (enableJit) {
-    std::vector<column_index_t> sortKeyIndexs;
-    std::vector<CompareFlags> cmpFlags;
-    std::vector<TypePtr> sortKeyTypes;
-    bytedance::bolt::jit::CompiledModuleSP jitModuleRow_;
-    for (auto& key : sortKeyInfo_) {
-      auto columnIndex = key.first;
-      sortKeyIndexs.push_back(columnIndex);
-      sortKeyTypes.push_back(data_->columnTypes()[columnIndex]);
-      cmpFlags.push_back(CompareFlags{
-          key.second.isNullsFirst(), key.second.isAscending(), false});
-    }
-    if (data_ != nullptr && enableJit && RowContainer::JITable(sortKeyTypes)) {
-      if (cmpFlags.empty()) {
-        cmpFlags.resize(sortKeyTypes.size(), CompareFlags());
-      }
-      auto [jitMod, fn] = data_->codegenCompare(
-          sortKeyTypes,
-          cmpFlags,
-          bytedance::bolt::jit::CmpType::CMP_SPILL,
-          true,
-          sortKeyIndexs);
-      jitModuleRow_ = std::move(jitMod);
-      rowCmpRowFunc_ = (RowRowCompare)jitModuleRow_->getFuncPtr(fn);
-    }
-  }
-#endif
-
+    vector_size_t* rawPeerEnds) const {
   auto peerCompare = [&](const char* lhs, const char* rhs) -> bool {
-    return sortKeyInfo_.size() == 0
-        ? false
-        : compareRowsWithSortKeys(lhs, rhs, rowCmpRowFunc_);
+    return sortKeyInfo_.size() == 0 ? false : compareRowsWithSortKeys(lhs, rhs);
   };
 
   BOLT_CHECK_LE(end, numRows());
@@ -356,8 +322,9 @@ WindowPartitionImpl<T>::WindowPartitionImpl(
     RowContainer* data,
     const folly::Range<char**>& rows,
     const std::vector<column_index_t>& inputMapping,
-    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
-    : WindowPartition(data, rows, inputMapping, sortKeyInfo) {}
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo,
+    bool enableJit)
+    : WindowPartition(data, rows, inputMapping, sortKeyInfo, enableJit) {}
 
 template <RowFormat T>
 void WindowPartitionImpl<T>::extractColumn(
@@ -420,8 +387,7 @@ void WindowPartitionImpl<T>::extractColumn(
 template <RowFormat T>
 bool WindowPartitionImpl<T>::compareRowsWithSortKeys(
     const char* lhs,
-    const char* rhs,
-    RowRowCompare rowCmpRowFunc_) const {
+    const char* rhs) const {
   if constexpr (T == RowFormat::kRowContainer) {
     if (lhs == rhs) {
       return false;
@@ -440,10 +406,37 @@ bool WindowPartitionImpl<T>::compareRowsWithSortKeys(
     if (lhs == rhs) {
       return false;
     }
+#ifdef ENABLE_BOLT_JIT
+    if (enableJit_ && rowCmpRowFunc_ == nullptr) {
+      std::vector<column_index_t> sortKeyIndexs;
+      std::vector<CompareFlags> cmpFlags;
+      std::vector<TypePtr> sortKeyTypes;
+      for (auto& key : sortKeyInfo_) {
+        auto columnIndex = key.first;
+        sortKeyIndexs.push_back(columnIndex);
+        sortKeyTypes.push_back(data_->columnTypes()[columnIndex]);
+        cmpFlags.push_back(CompareFlags{
+            key.second.isNullsFirst(), key.second.isAscending(), false});
+      }
+      if (RowContainer::JITable(sortKeyTypes)) {
+        if (cmpFlags.empty()) {
+          cmpFlags.resize(sortKeyTypes.size(), CompareFlags());
+        }
+        auto [jitMod, fn] = data_->codegenCompare(
+            sortKeyTypes,
+            cmpFlags,
+            bytedance::bolt::jit::CmpType::CMP_SPILL,
+            true,
+            sortKeyIndexs);
+        jitModuleRow_ = std::move(jitMod);
+        rowCmpRowFunc_ = (RowRowCompare)jitModuleRow_->getFuncPtr(fn);
+      }
+    }
     if (rowCmpRowFunc_) {
       auto result = rowCmpRowFunc_(lhs, rhs);
       return result < 0;
     }
+#endif
 
     auto types = data_->columnTypes();
     for (auto& key : sortKeyInfo_) {
@@ -648,8 +641,9 @@ SpilledWindowPartition<R>::SpilledWindowPartition(
     const uint64_t numRows,
     const RowTypePtr& outputType,
     const std::vector<column_index_t>* outputChannels,
-    bolt::memory::MemoryPool* pool)
-    : WindowPartitionImpl<R>(data, rows, inputMapping, sortKeyInfo),
+    bolt::memory::MemoryPool* pool,
+    bool enableJit)
+    : WindowPartitionImpl<R>(data, rows, inputMapping, sortKeyInfo, enableJit),
       merge_(std::move(merge)),
       aggregateResults_(std::move(aggregateResults)),
       numRows_(numRows),

--- a/bolt/exec/WindowPartition.h
+++ b/bolt/exec/WindowPartition.h
@@ -56,7 +56,8 @@ class WindowPartition {
       const folly::Range<char**>& rows,
       const std::vector<column_index_t>& inputMapping,
       const std::vector<std::pair<column_index_t, core::SortOrder>>&
-          sortKeyInfo);
+          sortKeyInfo,
+      bool enableJit = false);
 
   virtual ~WindowPartition() = default;
 
@@ -191,8 +192,7 @@ class WindowPartition {
       vector_size_t prevPeerStart,
       vector_size_t prevPeerEnd,
       vector_size_t* rawPeerStarts,
-      vector_size_t* rawPeerEnds,
-      bool enableJit = false) const;
+      vector_size_t* rawPeerEnds) const;
 
   /// Sets in 'rawFrameBounds' the frame boundary for the k range
   /// preceding/following frame.
@@ -250,10 +250,7 @@ class WindowPartition {
   };
 
  private:
-  virtual bool compareRowsWithSortKeys(
-      const char* lhs,
-      const char* rhs,
-      RowRowCompare rowCmpRowFunc_ = nullptr) const;
+  virtual bool compareRowsWithSortKeys(const char* lhs, const char* rhs) const;
 
   // Searches for frameColumn[startRow] in orderByColumn[startRow+-]
   // preceding or following based on the range search params.
@@ -302,6 +299,15 @@ class WindowPartition {
   // corresponding indexes of their input arguments into this vector.
   // They will request for column vector values at the respective index.
   std::vector<exec::RowColumn> columns_;
+
+  bool enableJit_{false};
+
+#ifdef ENABLE_BOLT_JIT
+  // Cached JIT module for peer row comparison in computePeerBuffers.
+  // Must be a member to keep the compiled module alive across calls.
+  mutable bolt::jit::CompiledModuleSP jitModuleRow_{nullptr};
+  mutable RowRowCompare rowCmpRowFunc_{nullptr};
+#endif
 };
 
 enum class RowFormat { kRowContainer, kSerializedRows };
@@ -314,7 +320,8 @@ class WindowPartitionImpl : public WindowPartition {
       const folly::Range<char**>& rows,
       const std::vector<column_index_t>& inputMapping,
       const std::vector<std::pair<column_index_t, core::SortOrder>>&
-          sortKeyInfo);
+          sortKeyInfo,
+      bool enableJit = false);
 
   /// Copies the values at 'columnIndex' into 'result' (starting at
   /// 'resultOffset') for the rows at positions in the 'rowNumbers'
@@ -334,10 +341,7 @@ class WindowPartitionImpl : public WindowPartition {
       const VectorPtr& result,
       bool exactSize = false) const override;
 
-  bool compareRowsWithSortKeys(
-      const char* lhs,
-      const char* rhs,
-      RowRowCompare rowCmpRowFunc_ = nullptr) const override;
+  bool compareRowsWithSortKeys(const char* lhs, const char* rhs) const override;
 
   /// Sets in 'rawFrameBounds' the frame boundary for the k range
   /// preceding/following frame.
@@ -391,7 +395,8 @@ class SpilledWindowPartition : public WindowPartitionImpl<R> {
       uint64_t numRows,
       const RowTypePtr& outputType,
       const std::vector<column_index_t>* outputChannels,
-      bolt::memory::MemoryPool* pool);
+      bolt::memory::MemoryPool* pool,
+      bool enableJit = false);
 
   bool isSpilled() override {
     return true;

--- a/bolt/jit/CompiledModule.cpp
+++ b/bolt/jit/CompiledModule.cpp
@@ -45,9 +45,13 @@ void CompiledModule::setCodeSize(size_t codeSize) {
   codeSize_ = codeSize;
 }
 
-void CompiledModule::setUserData(void* data) noexcept {
-  userData_.store(data, std::memory_order_release);
+bool CompiledModule::compareExchangeUserData(
+    void* expected,
+    void* desired) noexcept {
+  return userData_.compare_exchange_strong(
+      expected, desired, std::memory_order_acq_rel, std::memory_order_acquire);
 }
+
 void* CompiledModule::getUserData() const noexcept {
   return userData_.load(std::memory_order_acquire);
 }

--- a/bolt/jit/CompiledModule.h
+++ b/bolt/jit/CompiledModule.h
@@ -42,7 +42,7 @@ struct CompiledModule {
   // type-erasured user data, CompiledModule does not own the data and won't
   // manage its lifetime. The caller should make sure the data is valid during
   // the module's lifetime.
-  void setUserData(void* data) noexcept;
+  bool compareExchangeUserData(void* expected, void* desired) noexcept;
   void* getUserData() const noexcept;
 
   ~CompiledModule();

--- a/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
+++ b/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
@@ -137,14 +137,19 @@ CompiledModuleSP RowContainerCodeGenerator::codegen() {
           break;
       }
     }
-    if (cacheTypes->size() > 0 && module->getUserData() == nullptr) {
-      module->setUserData(static_cast<void*>(cacheTypes.release()));
-      module->appendCleanCallback([mod = module.get()] {
-        auto* cacheTypes = static_cast<std::vector<bytedance::bolt::TypePtr>*>(
-            mod->getUserData());
-        delete cacheTypes;
-        mod->setUserData(nullptr);
-      });
+
+    if (cacheTypes->size() > 0) {
+      auto* userData = static_cast<void*>(cacheTypes.get());
+      if (module->compareExchangeUserData(nullptr, userData)) {
+        cacheTypes.release();
+        module->appendCleanCallback([mod = module.get()] {
+          auto* raw = mod->getUserData();
+          mod->compareExchangeUserData(raw, nullptr);
+          auto* cacheTypes =
+              static_cast<std::vector<bytedance::bolt::TypePtr>*>(raw);
+          delete cacheTypes;
+        });
+      }
     }
   }
   return module;

--- a/bolt/jit/tests/RowContainerIRTest.cpp
+++ b/bolt/jit/tests/RowContainerIRTest.cpp
@@ -24,14 +24,34 @@
 #include "bolt/jit/ThrustJITv2.h"
 #include "bolt/jit/tests/JitTestBase.h"
 
+#include <atomic>
+#include <barrier>
 #include <cmath>
 #include <limits>
+#include <thread>
 #include <tuple>
 #include <type_traits>
 
 using int128_t = __int128;
 
 namespace bytedance::bolt::jit::test {
+
+namespace {
+
+class TestRowContainerCodeGenerator : public RowContainerCodeGenerator {
+ public:
+  explicit TestRowContainerCodeGenerator(std::string funcName)
+      : funcName_(std::move(funcName)) {}
+
+  std::string GetCmpFuncName() override {
+    return funcName_;
+  }
+
+ private:
+  std::string funcName_;
+};
+
+} // namespace
 
 template <typename T>
 concept TupleLike = requires(T a) {
@@ -500,6 +520,45 @@ TEST_F(RowContainerJitTest, stringview) {
     free(r);
   }
   rows.clear();
+}
+
+TEST_F(RowContainerJitTest, complex_types_cache_in_user_data) {
+  jit->ClearCacheForTest();
+
+  auto bigintType = BIGINT();
+  auto arrayType = ARRAY(INTEGER());
+  auto mapType = MAP(INTEGER(), VARCHAR());
+  auto rowType = ROW({{"nested", BIGINT()}});
+
+  auto codegenModule = [&]() {
+    TestRowContainerCodeGenerator gen("row_container_user_data_complex_types");
+    gen.setOpType(CmpType::EQUAL)
+        .setHasNullKeys(false)
+        .setKeyTypes({bigintType, arrayType, mapType, rowType})
+        .setKeyOffsets({0, 8, 16, 24});
+    return gen.codegen();
+  };
+
+  constexpr size_t kConcurrentCodegenCount = 32;
+  std::barrier syncPoint(kConcurrentCodegenCount);
+  std::vector<CompiledModuleSP> modules(kConcurrentCodegenCount);
+  std::vector<std::thread> threads;
+  threads.reserve(kConcurrentCodegenCount);
+  for (size_t i = 0; i < kConcurrentCodegenCount; ++i) {
+    threads.emplace_back([&, i]() {
+      syncPoint.arrive_and_wait();
+      modules[i] = codegenModule();
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  auto module = modules.front();
+  ASSERT_NE(module, nullptr);
+  for (const auto& concurrentModule : modules) {
+    ASSERT_EQ(concurrentModule.get(), module.get());
+  }
 }
 
 } // namespace bytedance::bolt::jit::test


### PR DESCRIPTION
* fix datarace issue for UserData
* fix life cycle of CompiledModule for window

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #608

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
