### PR TITLE
[chore]  Adopt C++23 as the default standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,7 @@ endif()
 # Required so bolt code can be used in a dynamic library
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # execute_process( COMMAND bash -c "( source

--- a/bolt/common/memory/tests/CMakeLists.txt
+++ b/bolt/common/memory/tests/CMakeLists.txt
@@ -48,8 +48,6 @@ add_executable(
   StreamArenaTest.cpp
 )
 
-target_compile_features(bolt_memory_test PRIVATE cxx_std_20)
-
 if(NOT APPLE)
   find_package(jemalloc CONFIG REQUIRED)
 endif()

--- a/bolt/common/token/CMakeLists.txt
+++ b/bolt/common/token/CMakeLists.txt
@@ -14,6 +14,5 @@
 # limitations under the License.
 
 bolt_add_library(bolt_token_extractor ITokenExtractor.cpp)
-target_compile_features(bolt_token_extractor PRIVATE cxx_std_20)
 
 target_link_libraries(bolt_token_extractor xxHash::xxhash Folly::folly)

--- a/bolt/exec/CMakeLists.txt
+++ b/bolt/exec/CMakeLists.txt
@@ -122,8 +122,6 @@ bolt_add_library(
   WindowPartition.cpp
 )
 
-target_compile_features(bolt_exec PRIVATE cxx_std_20)
-
 set_target_properties(bolt_exec PROPERTIES ENABLE_EXPORTS ON)
 
 if(${ENABLE_BOLT_JIT})

--- a/bolt/exec/tests/CMakeLists.txt
+++ b/bolt/exec/tests/CMakeLists.txt
@@ -125,8 +125,6 @@ add_executable(bolt_exec_unested_test Main.cpp UnnestTest.cpp)
 
 add_executable(bolt_exec_table_writer_test Main.cpp TableWriteTest.cpp)
 
-target_compile_features(bolt_exec_test PRIVATE cxx_std_20)
-
 add_executable(
   bolt_exec_infra_test
   AssertQueryBuilderTest.cpp

--- a/bolt/functions/prestosql/json/CMakeLists.txt
+++ b/bolt/functions/prestosql/json/CMakeLists.txt
@@ -44,7 +44,6 @@ target_link_libraries(
   sonic-cpp::sonic-cpp
   Folly::folly
 )
-target_compile_features(bolt_functions_json PRIVATE cxx_std_20)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/functions/prestosql/types/CMakeLists.txt
+++ b/bolt/functions/prestosql/types/CMakeLists.txt
@@ -27,9 +27,6 @@
 
 bolt_add_library(bolt_presto_types HyperLogLogType.cpp JsonType.cpp TimestampWithTimeZoneType.cpp)
 
-# JsonType.cpp needs to rely on the concept attribute in C++20
-target_compile_features(bolt_presto_types PRIVATE cxx_std_20)
-
 find_package(ryu CONFIG REQUIRED)
 
 target_link_libraries(

--- a/bolt/jit/tests/CMakeLists.txt
+++ b/bolt/jit/tests/CMakeLists.txt
@@ -19,7 +19,6 @@ if(${ENABLE_BOLT_JIT})
     RowContainerIRTest.cpp
     ThrustJITv2Test.cpp
   )
-  target_compile_features(bolt_thrustjit_test PUBLIC cxx_std_20)
   target_link_libraries(
     bolt_thrustjit_test PRIVATE
     bolt_testutils


### PR DESCRIPTION
All the compiling errors have been fixed. Now, we can switch the project default to C++23 and remove redundant per-target C++20 settings.

This prepares the codebase for future coroutine adoption, enables more modern language features, and positions us to benefit from ongoing standard library improvements and performance optimizations.

Note that,  right now the conan profile is not changed by default.  It is OK for Bolt to use binary dependencies which is built in C++17/20.   And this won't force Bolt's user(Gluten) to bump up C++ standard, Gluten can still use 17 or 20.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #610

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
