### PR TITLE
[fix] Fix oversized BYTE_ARRAY parquet data pages

### DIFF
--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -36,8 +36,11 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -92,6 +95,17 @@ namespace bytedance::bolt::parquet::arrow {
 using util::CodecOptions;
 
 namespace {
+
+int32_t CheckPageHeaderSize(std::string_view sizeName, int64_t size) {
+  if (size < 0 || size > std::numeric_limits<int32_t>::max()) {
+    throw ParquetException(
+        std::string(sizeName),
+        " page size cannot be represented in a Parquet PageHeader int32 "
+        "field: ",
+        size);
+  }
+  return static_cast<int32_t>(size);
+}
 
 // Visitor that extracts the value buffer from a FlatArray at a given offset.
 struct ValueBufferSlicer {
@@ -350,25 +364,30 @@ class SerializedPageWriter : public PageWriter {
     dict_page_header.__set_is_sorted(page.is_sorted());
 
     const uint8_t* output_data_buffer = compressed_data->data();
-    int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
+    int64_t output_data_len = compressed_data->size();
+    const int32_t uncompressed_page_size =
+        CheckPageHeaderSize("Uncompressed dictionary", uncompressed_size);
+    int32_t compressed_page_size =
+        CheckPageHeaderSize("Compressed dictionary", output_data_len);
 
     if (data_encryptor_.get()) {
       UpdateEncryption(encryption::kDictionaryPage);
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
-          data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
+          data_encryptor_->CiphertextSizeDelta() + compressed_page_size,
+          false));
       output_data_len = data_encryptor_->Encrypt(
           compressed_data->data(),
-          output_data_len,
+          compressed_page_size,
           encryption_buffer_->mutable_data());
       output_data_buffer = encryption_buffer_->data();
+      compressed_page_size =
+          CheckPageHeaderSize("Compressed dictionary", output_data_len);
     }
 
     format::PageHeader page_header;
     page_header.__set_type(format::PageType::DICTIONARY_PAGE);
-    page_header.__set_uncompressed_page_size(
-        static_cast<int32_t>(uncompressed_size));
-    page_header.__set_compressed_page_size(
-        static_cast<int32_t>(output_data_len));
+    page_header.__set_uncompressed_page_size(uncompressed_page_size);
+    page_header.__set_compressed_page_size(compressed_page_size);
     page_header.__set_dictionary_page_header(dict_page_header);
     if (page_checksum_verification_) {
       uint32_t crc32 =
@@ -452,24 +471,29 @@ class SerializedPageWriter : public PageWriter {
     const int64_t uncompressed_size = page.uncompressed_size();
     std::shared_ptr<Buffer> compressed_data = page.buffer();
     const uint8_t* output_data_buffer = compressed_data->data();
-    int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
+    int64_t output_data_len = compressed_data->size();
+    const int32_t uncompressed_page_size =
+        CheckPageHeaderSize("Uncompressed data", uncompressed_size);
+    int32_t compressed_page_size =
+        CheckPageHeaderSize("Compressed data", output_data_len);
 
     if (data_encryptor_.get()) {
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
-          data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
+          data_encryptor_->CiphertextSizeDelta() + compressed_page_size,
+          false));
       UpdateEncryption(encryption::kDataPage);
       output_data_len = data_encryptor_->Encrypt(
           compressed_data->data(),
-          output_data_len,
+          compressed_page_size,
           encryption_buffer_->mutable_data());
       output_data_buffer = encryption_buffer_->data();
+      compressed_page_size =
+          CheckPageHeaderSize("Compressed data", output_data_len);
     }
 
     format::PageHeader page_header;
-    page_header.__set_uncompressed_page_size(
-        static_cast<int32_t>(uncompressed_size));
-    page_header.__set_compressed_page_size(
-        static_cast<int32_t>(output_data_len));
+    page_header.__set_uncompressed_page_size(uncompressed_page_size);
+    page_header.__set_compressed_page_size(compressed_page_size);
 
     if (page_checksum_verification_) {
       uint32_t crc32 =
@@ -2754,8 +2778,56 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
     ARROW_UNSUPPORTED();
   }
 
+  constexpr int64_t kDataPageSizeSlack = 64L * 1024 * 1024;
+  const int64_t dataPageByteLimit = std::min<int64_t>(
+      data_pagesize_, std::numeric_limits<int32_t>::max() - kDataPageSizeSlack);
+
+  auto valueLength = [&](int64_t index) {
+    if (::arrow::is_binary_like(array.type_id())) {
+      return static_cast<int64_t>(
+          checked_cast<const ::arrow::BinaryArray&>(array).value_length(index));
+    }
+    DCHECK(::arrow::is_large_binary_like(array.type_id()));
+    return static_cast<int64_t>(
+        checked_cast<const ::arrow::LargeBinaryArray&>(array).value_length(
+            index));
+  };
+
+  auto valueRangeByteLength = [&](int64_t start, int64_t count) {
+    if (::arrow::is_binary_like(array.type_id())) {
+      const auto& binaryArray =
+          checked_cast<const ::arrow::BinaryArray&>(array);
+      return static_cast<int64_t>(
+          binaryArray.value_offset(start + count) -
+          binaryArray.value_offset(start));
+    }
+    DCHECK(::arrow::is_large_binary_like(array.type_id()));
+    const auto& largeBinaryArray =
+        checked_cast<const ::arrow::LargeBinaryArray&>(array);
+    return static_cast<int64_t>(
+        largeBinaryArray.value_offset(start + count) -
+        largeBinaryArray.value_offset(start));
+  };
+
+  auto hasSpacedValue = [&](int64_t levelIndex) {
+    if (def_levels == nullptr || level_info_.def_level == 0) {
+      return true;
+    }
+    return def_levels[levelIndex] >= level_info_.repeated_ancestor_def_level;
+  };
+
+  auto hasNonNullValue = [&](int64_t levelIndex, int64_t valueIndex) {
+    if (def_levels != nullptr &&
+        def_levels[levelIndex] != level_info_.def_level) {
+      return false;
+    }
+    return array.IsValid(valueIndex);
+  };
+
   int64_t value_offset = 0;
-  auto WriteChunk = [&](int64_t offset, int64_t batch_size, bool check_page) {
+  auto WriteSubChunk = [&](int64_t offset,
+                           int64_t batch_size,
+                           bool check_page) {
     int64_t batch_num_values = 0;
     int64_t batch_num_spaced_values = 0;
     int64_t null_count = 0;
@@ -2788,6 +2860,76 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
         batch_size, batch_num_values, batch_size - non_null, check_page);
     CheckDictionarySizeLimit();
     value_offset += batch_num_spaced_values;
+  };
+
+  auto WriteChunk = [&](int64_t offset, int64_t batch_size, bool check_page) {
+    const bool split_by_byte_size =
+        check_page && !IsDictionaryEncoding(current_encoder_->encoding());
+    if (!split_by_byte_size) {
+      WriteSubChunk(offset, batch_size, check_page);
+      return;
+    }
+
+    if (def_levels == nullptr || level_info_.def_level == 0) {
+      const int64_t batch_encoded_bytes =
+          valueRangeByteLength(value_offset, batch_size) +
+          batch_size * static_cast<int64_t>(sizeof(uint32_t));
+      if (current_encoder_->EstimatedDataEncodedSize() + batch_encoded_bytes <=
+          dataPageByteLimit) {
+        WriteSubChunk(offset, batch_size, check_page);
+        return;
+      }
+    }
+
+    int64_t local_offset = offset;
+    int64_t remaining = batch_size;
+    while (remaining > 0) {
+      int64_t subchunk_levels = 0;
+      int64_t subchunk_spaced_values = 0;
+      int64_t subchunk_encoded_bytes = 0;
+
+      while (subchunk_levels < remaining) {
+        const int64_t level_index = local_offset + subchunk_levels;
+        const bool can_break_before_level =
+            !pages_change_on_record_boundaries() || rep_levels == nullptr ||
+            rep_levels[level_index] == 0;
+
+        int64_t value_bytes = 0;
+        if (hasSpacedValue(level_index)) {
+          const int64_t value_index = value_offset + subchunk_spaced_values;
+          if (hasNonNullValue(level_index, value_index)) {
+            value_bytes = static_cast<int64_t>(sizeof(uint32_t)) +
+                valueLength(value_index);
+          }
+        }
+
+        if (check_page && split_by_byte_size && can_break_before_level &&
+            current_encoder_->EstimatedDataEncodedSize() +
+                    subchunk_encoded_bytes + value_bytes >
+                dataPageByteLimit) {
+          if (subchunk_levels == 0) {
+            if (num_buffered_values_ > 0) {
+              AddDataPage();
+            }
+          } else {
+            break;
+          }
+        }
+
+        if (hasSpacedValue(level_index)) {
+          ++subchunk_spaced_values;
+        }
+        subchunk_encoded_bytes += value_bytes;
+        ++subchunk_levels;
+      }
+
+      if (subchunk_levels == 0) {
+        throw ParquetException("Unable to split BYTE_ARRAY write chunk");
+      }
+      WriteSubChunk(local_offset, subchunk_levels, check_page);
+      local_offset += subchunk_levels;
+      remaining -= subchunk_levels;
+    }
   };
 
   PARQUET_CATCH_NOT_OK(DoInBatches(

--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -96,13 +96,20 @@ using util::CodecOptions;
 
 namespace {
 
-int32_t CheckPageHeaderSize(std::string_view sizeName, int64_t size) {
-  if (size < 0 || size > std::numeric_limits<int32_t>::max()) {
-    throw ParquetException(
-        std::string(sizeName),
-        " page size cannot be represented in a Parquet PageHeader int32 "
-        "field: ",
-        size);
+[[noreturn]] void ThrowPageHeaderSizeError(
+    std::string_view sizeName,
+    int64_t size) {
+  throw ParquetException(
+      std::string(sizeName),
+      " page size cannot be represented in a Parquet PageHeader int32 "
+      "field: ",
+      size);
+}
+
+inline int32_t CheckPageHeaderSize(std::string_view sizeName, int64_t size) {
+  if (ARROW_PREDICT_FALSE(
+          size < 0 || size > std::numeric_limits<int32_t>::max())) {
+    ThrowPageHeaderSizeError(sizeName, size);
   }
   return static_cast<int32_t>(size);
 }
@@ -667,12 +674,13 @@ class SerializedPageWriter : public PageWriter {
   void UpdateEncryption(int8_t module_type) {
     switch (module_type) {
       case encryption::kColumnMetaData: {
-        meta_encryptor_->UpdateAad(encryption::CreateModuleAad(
-            meta_encryptor_->file_aad(),
-            module_type,
-            row_group_ordinal_,
-            column_ordinal_,
-            kNonPageOrdinal));
+        meta_encryptor_->UpdateAad(
+            encryption::CreateModuleAad(
+                meta_encryptor_->file_aad(),
+                module_type,
+                row_group_ordinal_,
+                column_ordinal_,
+                kNonPageOrdinal));
         break;
       }
       case encryption::kDataPage: {
@@ -686,21 +694,23 @@ class SerializedPageWriter : public PageWriter {
         break;
       }
       case encryption::kDictionaryPageHeader: {
-        meta_encryptor_->UpdateAad(encryption::CreateModuleAad(
-            meta_encryptor_->file_aad(),
-            module_type,
-            row_group_ordinal_,
-            column_ordinal_,
-            kNonPageOrdinal));
+        meta_encryptor_->UpdateAad(
+            encryption::CreateModuleAad(
+                meta_encryptor_->file_aad(),
+                module_type,
+                row_group_ordinal_,
+                column_ordinal_,
+                kNonPageOrdinal));
         break;
       }
       case encryption::kDictionaryPage: {
-        data_encryptor_->UpdateAad(encryption::CreateModuleAad(
-            data_encryptor_->file_aad(),
-            module_type,
-            row_group_ordinal_,
-            column_ordinal_,
-            kNonPageOrdinal));
+        data_encryptor_->UpdateAad(
+            encryption::CreateModuleAad(
+                data_encryptor_->file_aad(),
+                module_type,
+                row_group_ordinal_,
+                column_ordinal_,
+                kNonPageOrdinal));
         break;
       }
       default:
@@ -1940,8 +1950,12 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     if (array->data()->offset > 0) {
       RETURN_NOT_OK(util::VisitArrayInline(*array, &slicer, &buffers[1]));
     }
-    return ::arrow::MakeArray(std::make_shared<ArrayData>(
-        array->type(), array->length(), std::move(buffers), new_null_count));
+    return ::arrow::MakeArray(
+        std::make_shared<ArrayData>(
+            array->type(),
+            array->length(),
+            std::move(buffers),
+            new_null_count));
   }
 
   void WriteLevelsSpaced(

--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -674,13 +674,12 @@ class SerializedPageWriter : public PageWriter {
   void UpdateEncryption(int8_t module_type) {
     switch (module_type) {
       case encryption::kColumnMetaData: {
-        meta_encryptor_->UpdateAad(
-            encryption::CreateModuleAad(
-                meta_encryptor_->file_aad(),
-                module_type,
-                row_group_ordinal_,
-                column_ordinal_,
-                kNonPageOrdinal));
+        meta_encryptor_->UpdateAad(encryption::CreateModuleAad(
+            meta_encryptor_->file_aad(),
+            module_type,
+            row_group_ordinal_,
+            column_ordinal_,
+            kNonPageOrdinal));
         break;
       }
       case encryption::kDataPage: {
@@ -694,23 +693,21 @@ class SerializedPageWriter : public PageWriter {
         break;
       }
       case encryption::kDictionaryPageHeader: {
-        meta_encryptor_->UpdateAad(
-            encryption::CreateModuleAad(
-                meta_encryptor_->file_aad(),
-                module_type,
-                row_group_ordinal_,
-                column_ordinal_,
-                kNonPageOrdinal));
+        meta_encryptor_->UpdateAad(encryption::CreateModuleAad(
+            meta_encryptor_->file_aad(),
+            module_type,
+            row_group_ordinal_,
+            column_ordinal_,
+            kNonPageOrdinal));
         break;
       }
       case encryption::kDictionaryPage: {
-        data_encryptor_->UpdateAad(
-            encryption::CreateModuleAad(
-                data_encryptor_->file_aad(),
-                module_type,
-                row_group_ordinal_,
-                column_ordinal_,
-                kNonPageOrdinal));
+        data_encryptor_->UpdateAad(encryption::CreateModuleAad(
+            data_encryptor_->file_aad(),
+            module_type,
+            row_group_ordinal_,
+            column_ordinal_,
+            kNonPageOrdinal));
         break;
       }
       default:
@@ -1950,12 +1947,8 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     if (array->data()->offset > 0) {
       RETURN_NOT_OK(util::VisitArrayInline(*array, &slicer, &buffers[1]));
     }
-    return ::arrow::MakeArray(
-        std::make_shared<ArrayData>(
-            array->type(),
-            array->length(),
-            std::move(buffers),
-            new_null_count));
+    return ::arrow::MakeArray(std::make_shared<ArrayData>(
+        array->type(), array->length(), std::move(buffers), new_null_count));
   }
 
   void WriteLevelsSpaced(

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -24,6 +24,8 @@
 #include "bolt/dwio/parquet/writer/Writer.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
 
+#include <filesystem>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 using namespace bytedance::bolt;
@@ -65,7 +67,7 @@ class ParquetWriterBenchmark {
 
   ~ParquetWriterBenchmark() {}
 
-  void writeToFile(
+  uint64_t writeToFile(
       const std::vector<RowVectorPtr>& batches,
       bool /*forRowGroupSkip*/) {
     for (auto& batch : batches) {
@@ -73,9 +75,10 @@ class ParquetWriterBenchmark {
     }
     writer_->flush();
     writer_->close();
+    return std::filesystem::file_size(fileFolder_->path + "/" + fileName_);
   }
 
-  void writeSingleColumn(
+  uint64_t writeSingleColumn(
       const std::string& columnName,
       const TypePtr& type,
       uint8_t nullsRateX100,
@@ -89,7 +92,7 @@ class ParquetWriterBenchmark {
                        .withNullsForField(Subfield(columnName), nullsRateX100)
                        .build();
     suspender.dismiss();
-    writeToFile(*batches, true);
+    return writeToFile(*batches, true);
   }
 
  private:
@@ -105,16 +108,18 @@ class ParquetWriterBenchmark {
 };
 
 void run(
-    uint32_t,
+    uint32_t iterations,
     const std::string& columnName,
     const TypePtr& type,
     uint8_t nullsRateX100,
     uint32_t batchSize,
     bool disableDictionary) {
   RowTypePtr rowType = ROW({columnName}, {type});
-  ParquetWriterBenchmark benchmark(disableDictionary, rowType);
-  BIGINT()->toString();
-  benchmark.writeSingleColumn(columnName, type, nullsRateX100, batchSize);
+  for (uint32_t i = 0; i < iterations; ++i) {
+    ParquetWriterBenchmark benchmark(disableDictionary, rowType);
+    folly::doNotOptimizeAway(benchmark.writeSingleColumn(
+        columnName, type, nullsRateX100, batchSize));
+  }
 }
 
 #define PARQUET_BENCHMARKS_NULLS(_type_, _name_, _null_)                      \
@@ -131,6 +136,41 @@ void run(
 #define PARQUET_BENCHMARKS(_type_, _name_) \
   PARQUET_BENCHMARKS_NULLS(_type_, _name_, 20)
 
+// Benchmarks targeting the BYTE_ARRAY non-dictionary write path that is
+// affected by the oversized parquet data page fix. The data sizes here are
+// well below the int32 page-size limit, so these benchmarks measure the
+// overhead introduced for the common (non-oversized) case.
+#define PARQUET_BENCHMARKS_NULLS_NO_DICT(_type_, _name_, _null_) \
+  BENCHMARK_NAMED_PARAM(                                         \
+      run,                                                       \
+      _name_##_batch_4k_no_dict_null##_null_,                    \
+      #_name_,                                                   \
+      _type_,                                                    \
+      _null_,                                                    \
+      4096,                                                      \
+      true);                                                     \
+  BENCHMARK_NAMED_PARAM(                                         \
+      run,                                                       \
+      _name_##_batch_32k_no_dict_null##_null_,                   \
+      #_name_,                                                   \
+      _type_,                                                    \
+      _null_,                                                    \
+      32768,                                                     \
+      true);                                                     \
+  BENCHMARK_NAMED_PARAM(                                         \
+      run,                                                       \
+      _name_##_batch_256k_no_dict_null##_null_,                  \
+      #_name_,                                                   \
+      _type_,                                                    \
+      _null_,                                                    \
+      262144,                                                    \
+      true);                                                     \
+  BENCHMARK_DRAW_LINE();
+
+#define PARQUET_BENCHMARKS_NO_DICT(_type_, _name_)    \
+  PARQUET_BENCHMARKS_NULLS_NO_DICT(_type_, _name_, 0) \
+  PARQUET_BENCHMARKS_NULLS_NO_DICT(_type_, _name_, 20)
+
 PARQUET_BENCHMARKS(VARCHAR(), Varchar);
 PARQUET_BENCHMARKS(BIGINT(), BigInt);
 PARQUET_BENCHMARKS(DOUBLE(), Double);
@@ -138,6 +178,12 @@ PARQUET_BENCHMARKS(DECIMAL(18, 3), ShortDecimalType);
 PARQUET_BENCHMARKS(DECIMAL(38, 3), LongDecimalType);
 PARQUET_BENCHMARKS(MAP(BIGINT(), BIGINT()), Map);
 PARQUET_BENCHMARKS(ARRAY(BIGINT()), List);
+
+// Plain-encoded VARCHAR exercises the new BYTE_ARRAY page-splitting code path
+// added by the oversized-page fix. The nested ARRAY<VARCHAR> case additionally
+// drives the per-level loop branch (def_levels != nullptr && def_level > 0).
+PARQUET_BENCHMARKS_NO_DICT(VARCHAR(), VarcharPlain);
+PARQUET_BENCHMARKS_NO_DICT(ARRAY(VARCHAR()), VarcharListPlain);
 
 // TODO: Add all data types
 

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -675,6 +675,123 @@ TEST_F(ParquetWriterTest, columnPageSize) {
   ASSERT_EQ(4, chunk2PageEncodingStats[0].count); // data page num
 }
 
+TEST_F(ParquetWriterTest, byteArrayPageSizeSplitsLargeVarcharPages) {
+  std::string c0{"c0"};
+  auto schema = ROW({c0}, {VARCHAR()});
+  const vector_size_t kRows = 20;
+  std::string parquetPath = tempPath_->path + "/varcharPageSize.parquet";
+
+  auto data = makeRowVector({makeFlatVector<std::string>(
+      kRows,
+      [](auto row) {
+        return std::string(40, static_cast<char>('a' + row % 26));
+      },
+      [](auto row) { return row % 5 == 0; })});
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.enableDictionary = false;
+  writerOptions.columnDataPageSizeMap[c0] = 100;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, kRows, schema, data);
+
+  auto reader = createLocalParquetReader(parquetPath);
+  auto chunkPageEncodingStats =
+      reader->fileMetaData().rowGroup(0).columnChunk(0).pageEncodingStats();
+  ASSERT_EQ(1, chunkPageEncodingStats.size());
+  ASSERT_GT(chunkPageEncodingStats[0].count, 1);
+}
+
+TEST_F(ParquetWriterTest, byteArrayPageSizeSplitsLargeVarbinaryPages) {
+  std::string c0{"c0"};
+  auto schema = ROW({c0}, {VARBINARY()});
+  const vector_size_t kRows = 20;
+  std::string parquetPath = tempPath_->path + "/varbinaryPageSize.parquet";
+
+  auto data = makeRowVector({makeFlatVector<std::string>(
+      kRows,
+      [](auto row) {
+        return std::string(40, static_cast<char>('a' + row % 26));
+      },
+      [](auto row) { return row % 7 == 0; },
+      VARBINARY())});
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.enableDictionary = false;
+  writerOptions.columnDataPageSizeMap[c0] = 100;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, kRows, schema, data);
+
+  auto reader = createLocalParquetReader(parquetPath);
+  auto chunkPageEncodingStats =
+      reader->fileMetaData().rowGroup(0).columnChunk(0).pageEncodingStats();
+  ASSERT_EQ(1, chunkPageEncodingStats.size());
+  ASSERT_GT(chunkPageEncodingStats[0].count, 1);
+}
+
+TEST_F(ParquetWriterTest, byteArrayPageSizeSplitsAfterDictionaryFallback) {
+  std::string c0{"c0"};
+  auto schema = ROW({c0}, {VARCHAR()});
+  const vector_size_t kDictionaryRows = 4;
+  const vector_size_t kPlainRows = 20;
+  std::string parquetPath =
+      tempPath_->path + "/dictionaryFallbackPageSize.parquet";
+
+  auto dictionaryData =
+      makeRowVector({makeFlatVector<std::string>(kDictionaryRows, [](auto row) {
+        return std::string("dict-") + std::to_string(row) + "-" +
+            std::string(40, static_cast<char>('a' + row % 26));
+      })});
+  auto plainData = makeRowVector({makeFlatVector<std::string>(
+      kPlainRows,
+      [](auto row) {
+        return std::string("value-") + std::to_string(row) + "-" +
+            std::string(40, static_cast<char>('a' + row % 26));
+      },
+      [](auto row) { return row % 6 == 0; })});
+  auto mergedData =
+      BaseVector::create(schema, kDictionaryRows + kPlainRows, pool_.get());
+  mergedData->copy(dictionaryData.get(), 0, 0, dictionaryData->size());
+  mergedData->copy(
+      plainData.get(), dictionaryData->size(), 0, plainData->size());
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.enableDictionary = true;
+  writerOptions.columnDictionaryPageSizeLimitMap[c0] = 64;
+  writerOptions.columnDataPageSizeMap[c0] = 100;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(dictionaryData);
+  writer->write(plainData);
+  writer->close();
+
+  assertRead(parquetPath, kDictionaryRows + kPlainRows, schema, mergedData);
+
+  auto reader = createLocalParquetReader(parquetPath);
+  auto chunkPageEncodingStats =
+      reader->fileMetaData().rowGroup(0).columnChunk(0).pageEncodingStats();
+  int32_t dictionaryPageCount = 0;
+  int32_t dataPageCount = 0;
+  int32_t plainDataPageCount = 0;
+  for (const auto& stats : chunkPageEncodingStats) {
+    if (stats.page_type == thrift::PageType::DICTIONARY_PAGE) {
+      dictionaryPageCount += stats.count;
+    } else if (stats.page_type == thrift::PageType::DATA_PAGE) {
+      dataPageCount += stats.count;
+      if (stats.encoding == thrift::Encoding::PLAIN) {
+        plainDataPageCount += stats.count;
+      }
+    }
+  }
+  ASSERT_EQ(1, dictionaryPageCount);
+  ASSERT_GT(dataPageCount, 1);
+  ASSERT_GT(plainDataPageCount, 1);
+}
+
 TEST_F(ParquetWriterTest, arrowPool) {
   const size_t kRows = 4 * 1024;
   auto type = getType();


### PR DESCRIPTION
### What problem does this PR solve?
This PR fixes oversized Parquet data pages for `BYTE_ARRAY` columns, including `VARCHAR` and `VARBINARY`.

Previously, plain `BYTE_ARRAY` writes appended a full write batch into the encoder before checking the data page size. If one batch contained enough encoded bytes, the writer could produce a data page much larger than the configured page size. In extreme cases, page sizes could exceed the Parquet `PageHeader` int32 fields.

This PR:
- Splits plain `BYTE_ARRAY` writes by encoded byte size before appending to the encoder.
- Uses Arrow binary offsets as a fast path for flat batches, avoiding per-value scanning unless the batch may exceed the page limit.
- Respects record boundaries when page boundaries must align with records.
- Adds int32 guards for data and dictionary page header sizes.
- Adds writer tests for `VARCHAR`, `VARBINARY`, and dictionary fallback.

Issue Number: close #612

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR fixes oversized BYTE_ARRAY Parquet data pages by splitting plain-encoded BYTE_ARRAY writes before the page size can exceed the Parquet `PageHeader` int32 limit.

Changes include:

- Validate dictionary and data page sizes before writing them into Parquet `PageHeader` int32 fields.
- Split plain-encoded BYTE_ARRAY chunks by encoded byte size for VARCHAR / VARBINARY.
- Preserve dictionary encoding behavior and apply BYTE_ARRAY page splitting after dictionary fallback to plain encoding.
- Use Arrow offsets to cheaply estimate whether the current batch can fit in the current page.
- Fall back to precise per-level splitting only when the batch is close to the data page byte limit.
- Add tests for VARCHAR, VARBINARY, and dictionary fallback cases.
- Fix the Parquet writer benchmark harness to honor folly benchmark iterations and avoid optimized-away results.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Benchmark target:
    bolt_dwio_parquet_writer_benchmark

    Build:
    cmake --build --preset conan-release --target bolt_dwio_parquet_writer_benchmark

    Baseline:
    implementation before the BYTE_ARRAY page-splitting refactor/optimization

    Current:
    this PR

    Note:
    The benchmark harness was fixed to honor folly benchmark iterations.
    Without this, some fast cases reported 0.00fs / Infinity and were not reliable.

    Targeted BYTE_ARRAY non-dictionary path:
    --bm_regex='VarcharPlain.*no_dict|VarcharListPlain.*no_dict'
    --bm_max_secs=1
    --bm_min_usec=100000

    VarcharPlain 4k null0          15.90ms -> 13.55ms   -14.8%
    VarcharPlain 32k null0        116.61ms -> 95.79ms   -17.8%
    VarcharPlain 256k null0         1.04s  -> 870.75ms  -15.9%

    VarcharPlain 4k null20         18.66ms -> 15.82ms   -15.2%
    VarcharPlain 32k null20       141.76ms -> 120.16ms  -15.2%
    VarcharPlain 256k null20        1.20s  -> 1.03s     -14.1%

    VarcharListPlain 4k null0     114.51ms -> 101.46ms  -11.4%
    VarcharListPlain 32k null0    906.03ms -> 854.19ms  -5.7%
    VarcharListPlain 256k null0     7.82s  -> 7.12s     -9.0%

    VarcharListPlain 4k null20    105.21ms -> 94.35ms   -10.3%
    VarcharListPlain 32k null20   839.07ms -> 821.86ms  -2.1%
    VarcharListPlain 256k null20    6.99s  -> 6.30s     -9.8%

    Additional existing writer benchmark coverage:
    --bm_regex='Varchar_batch|BigInt_batch|Double_batch|ShortDecimalType_batch|LongDecimalType_batch|Map_batch|List_batch'
    --bm_max_secs=1
    --bm_min_usec=100000

    Covered existing benchmark types:
    - Varchar dictionary encoding
    - BigInt
    - Double
    - ShortDecimalType
    - LongDecimalType
    - Map
    - List

    Result:
    No clear performance regression was observed in non-BYTE_ARRAY-targeted paths.
    Some large complex-type cases showed several-percent run-to-run variance, so suspicious cases were rerun individually.

    List-only rerun:
    List_batch_256k_dict    3972.93ms -> 3932.61ms   -1.0%
    List_batch_1M_dict        17.13s  -> 16.69s      -2.5%

    The page-header size check fast path is kept lightweight:
    - normal path is inline
    - overflow branch is guarded by ARROW_PREDICT_FALSE
    - throw helper is marked [[noreturn]]
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed oversized BYTE_ARRAY Parquet data pages by splitting plain-encoded VARCHAR / VARBINARY pages before they exceed Parquet PageHeader int32 size limits.
- Optimized the common BYTE_ARRAY write path to avoid per-level splitting checks unless the batch is close to the page size limit.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
