### PR TITLE
[feat][bytelake] Bytelake / Hudi MoR connector reader with dedup

### DIFF
--- a/bolt/connectors/hive/CMakeLists.txt
+++ b/bolt/connectors/hive/CMakeLists.txt
@@ -54,6 +54,12 @@ bolt_add_library(
   PartitionIdGenerator.cpp
   SplitReader.cpp
   TableHandle.cpp
+  bytelake/BytelakeHashDedup.cpp
+  bytelake/BytelakeKeyPacker.cpp
+  bytelake/BytelakeScanSpecUtil.cpp
+  bytelake/BytelakeConnectorSplit.cpp
+  bytelake/BytelakeConnectorUtil.cpp
+  bytelake/BytelakeSplitReader.cpp
 )
 
 set(ENABLED_DWIO_FORMATS "")

--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -43,6 +43,9 @@
 #include "bolt/connectors/hive/PaimonMiscHelpers.h"
 #include "bolt/connectors/hive/PaimonSplitReader.h"
 #include "bolt/connectors/hive/SplitReader.h"
+#include "bolt/connectors/hive/bytelake/BytelakeConnectorUtil.h"
+#include "bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h"
+#include "bolt/connectors/hive/bytelake/BytelakeSplitReader.h"
 #include "bolt/dwio/common/ReaderFactory.h"
 #include "bolt/dwio/common/exception/Exception.h"
 #include "bolt/expression/FieldReference.h"
@@ -335,6 +338,10 @@ bool isPaimonConnectorSplit(const std::shared_ptr<ConnectorSplit>& split) {
   return std::dynamic_pointer_cast<PaimonConnectorSplit>(split) != nullptr;
 }
 
+bool isBytelakeConnectorSplit(const std::shared_ptr<ConnectorSplit>& split) {
+  return std::dynamic_pointer_cast<BytelakeConnectorSplit>(split) != nullptr;
+}
+
 std::unique_ptr<SplitReader> HiveDataSource::createConfiguredSplitReader(
     const std::shared_ptr<HiveConnectorSplit>& split,
     const bool isPartOfPaimonSplit) {
@@ -404,13 +411,17 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   if (isPaimonConnectorSplit(split)) {
     addSplit(std::dynamic_pointer_cast<PaimonConnectorSplit>(split));
     return;
+  } else if (isBytelakeConnectorSplit(split)) {
+    addSplit(std::dynamic_pointer_cast<BytelakeConnectorSplit>(split));
+    return;
   }
 
   addSplit(std::dynamic_pointer_cast<HiveConnectorSplit>(split));
 }
 
-bolt::RowTypePtr HiveDataSource::getRowTypeForFile(
-    std::shared_ptr<PaimonConnectorSplit> split) {
+template <typename SplitType>
+bolt::RowTypePtr HiveDataSource::getRowTypeForFileImpl(
+    std::shared_ptr<SplitType> split) {
   std::vector<int> columnCacheBlackList;
   auto hiveSplit = split->hiveSplits[0];
   auto fileHandle =
@@ -595,6 +606,91 @@ void HiveDataSource::addSplit(
   }
 
   splitReader_ = createConfiguredSplitReader(split, false);
+}
+
+void HiveDataSource::addSplit(
+    const std::shared_ptr<BytelakeConnectorSplit>& split) {
+  split_ = split;
+
+  if (splitReader_) {
+    splitReader_.reset();
+  }
+
+  const auto& splitInfo = split->hiveSplits[0]->customSplitInfo;
+
+  auto fileType = getRowTypeForFile(split);
+  const auto& fileColNames = fileType->names();
+  const auto& fileColTypes = fileType->children();
+
+  auto primaryKeyNames =
+      getBytelakePrimaryKeys(hiveTableHandle_->tableName(), splitInfo);
+  auto precombineKeyNames = getBytelakePrecombineFields(splitInfo);
+  auto deletedFieldName = getBytelakeDeletedField(splitInfo);
+
+  // Build a local extended (names, types) for keyOnlySchema construction
+  // only; we don't mutate scanSpec_ or readerOutputType_ so Phase 3 reads
+  // the user output schema directly.
+  auto tmpNames = readerOutputType_->names();
+  auto tmpTypes = std::vector<TypePtr>(
+      readerOutputType_->children().begin(),
+      readerOutputType_->children().end());
+
+  auto findOrAppendLocal = [&](const std::string& colName) -> int {
+    auto iter = std::find(tmpNames.begin(), tmpNames.end(), colName);
+    if (iter != tmpNames.end()) {
+      return static_cast<int>(iter - tmpNames.begin());
+    }
+    auto fileIdx =
+        std::find(fileColNames.begin(), fileColNames.end(), colName) -
+        fileColNames.begin();
+    tmpNames.push_back(colName);
+    tmpTypes.push_back(fileColTypes[fileIdx]);
+    return static_cast<int>(tmpNames.size() - 1);
+  };
+
+  std::vector<int> pkIndices;
+  pkIndices.reserve(primaryKeyNames.size());
+  for (const auto& n : primaryKeyNames) {
+    pkIndices.push_back(findOrAppendLocal(n));
+  }
+  std::vector<int> pcIndices;
+  pcIndices.reserve(precombineKeyNames.size());
+  for (const auto& n : precombineKeyNames) {
+    pcIndices.push_back(findOrAppendLocal(n));
+  }
+  const int isDeletedIndex = findOrAppendLocal(deletedFieldName);
+
+  auto tmpExtendedRowType = ROW(std::move(tmpNames), std::move(tmpTypes));
+  auto keyOnlySchema = makeBytelakeKeyOnlySchema(
+      tmpExtendedRowType, pkIndices, pcIndices, isDeletedIndex);
+
+  // Phase 3 readers: user schema and scanSpec, unmodified.
+  std::vector<std::unique_ptr<SplitReader>> hiveSplitReaders;
+  for (auto& hiveSplit : split->hiveSplits) {
+    hiveSplitReaders.push_back(
+        createConfiguredSplitReader(hiveSplit, false));
+  }
+
+  // Phase 1 readers: swap to keyOnly state for construction, then restore.
+  std::vector<std::unique_ptr<SplitReader>> keyOnlySplitReaders;
+  {
+    auto savedScanSpec = scanSpec_;
+    auto savedReaderOutputType = readerOutputType_;
+    scanSpec_ = keyOnlySchema.scanSpec;
+    readerOutputType_ = keyOnlySchema.rowType;
+    for (auto& hiveSplit : split->hiveSplits) {
+      keyOnlySplitReaders.push_back(
+          createConfiguredSplitReader(hiveSplit, false));
+    }
+    scanSpec_ = savedScanSpec;
+    readerOutputType_ = savedReaderOutputType;
+  }
+
+  splitReader_ = std::make_unique<BytelakeSplitReader>(
+      std::move(hiveSplitReaders),
+      ioStats_,
+      std::move(keyOnlySplitReaders),
+      std::move(keyOnlySchema));
 }
 
 vector_size_t getLength(std::shared_ptr<ConnectorSplit>& split) {

--- a/bolt/connectors/hive/HiveDataSource.h
+++ b/bolt/connectors/hive/HiveDataSource.h
@@ -38,6 +38,7 @@
 #include "bolt/connectors/hive/PaimonConnectorSplit.h"
 #include "bolt/connectors/hive/SplitReader.h"
 #include "bolt/connectors/hive/TableHandle.h"
+#include "bolt/connectors/hive/bytelake/BytelakeConnectorSplit.h"
 #include "bolt/core/QueryConfig.h"
 #include "bolt/dwio/common/BufferedInput.h"
 #include "bolt/dwio/common/Reader.h"
@@ -151,8 +152,19 @@ class HiveDataSource : public DataSource {
   // filterEvalCtx_.selectedIndices and selectedBits are not updated.
   vector_size_t evaluateRemainingFilter(RowVectorPtr& rowVector);
 
+  template <typename SplitType>
+  bolt::RowTypePtr getRowTypeForFileImpl(
+      std::shared_ptr<SplitType> split);
+
   bolt::RowTypePtr getRowTypeForFile(
-      std::shared_ptr<PaimonConnectorSplit> split);
+      std::shared_ptr<PaimonConnectorSplit> split) {
+    return getRowTypeForFileImpl(split);
+  }
+
+  bolt::RowTypePtr getRowTypeForFile(
+    std::shared_ptr<BytelakeConnectorSplit> split) {
+    return getRowTypeForFileImpl(split);
+  }
 
   // Clear split_ after split has been fully processed.  Keep readers around
   // to hold adaptation.
@@ -168,6 +180,8 @@ class HiveDataSource : public DataSource {
   void addSplit(const std::shared_ptr<PaimonConnectorSplit>& split);
 
   void addSplit(const std::shared_ptr<HiveConnectorSplit>& split);
+
+  void addSplit(const std::shared_ptr<BytelakeConnectorSplit>& split);
 
   std::vector<std::string> getPaimonPrimaryKeys(
       const std::unordered_map<std::string, std::string>& tableParameters);

--- a/bolt/connectors/hive/SplitReader.cpp
+++ b/bolt/connectors/hive/SplitReader.cpp
@@ -122,6 +122,12 @@ std::unique_ptr<SplitReader> SplitReader::create(
     const std::shared_ptr<HiveConfig>& hiveConfig,
     const std::shared_ptr<io::IoStatistics>& ioStats,
     const bool isPartOfPaimonSplit) {
+
+  // LOG(ERROR) << "Hive split info: " << folly::toJson(hiveSplit->serialize());
+  // for (auto splitInfo : hiveSplit->customSplitInfo) {
+  //   LOG(ERROR) << splitInfo.first << "->" << splitInfo.second;
+  // }
+
   return std::make_unique<SplitReader>(
       hiveSplit,
       hiveTableHandle,
@@ -546,6 +552,13 @@ uint64_t SplitReader::next(int64_t size, VectorPtr& output) {
   }
 
   return rows;
+}
+
+uint64_t SplitReader::next(
+    int64_t size,
+    VectorPtr& output,
+    const dwio::common::Mutation* mutation) {
+  return baseRowReader_->next(size, output, mutation);
 }
 
 // Adds constant metadata columns into the result.

--- a/bolt/connectors/hive/SplitReader.h
+++ b/bolt/connectors/hive/SplitReader.h
@@ -34,6 +34,7 @@
 #include "bolt/connectors/hive/HiveConnectorSplit.h"
 #include "bolt/connectors/hive/HiveSplitReaderBase.h"
 #include "bolt/connectors/hive/PaimonMetadataColumn.h"
+#include "bolt/dwio/common/Mutation.h"
 #include "bolt/dwio/common/Options.h"
 
 DECLARE_string(testing_only_set_scan_exception_mesg_for_prepare);
@@ -125,6 +126,14 @@ class SplitReader : public HiveSplitReaderBase {
       const HiveConnectorSplitCacheLimit* hiveConnectorSplitCacheLimit);
 
   virtual uint64_t next(int64_t size, VectorPtr& output);
+
+  // Variant that forwards a caller-owned Mutation (e.g. a row-skip bitmap)
+  // directly to the underlying RowReader. Bypasses Paimon deletion-vector
+  // handling; do not mix with Paimon-configured readers.
+  uint64_t next(
+      int64_t size,
+      VectorPtr& output,
+      const dwio::common::Mutation* mutation);
 
   void resetFilterCaches();
 

--- a/bolt/connectors/hive/bytelake/BytelakeConnectorSplit.cpp
+++ b/bolt/connectors/hive/bytelake/BytelakeConnectorSplit.cpp
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeConnectorSplit.h"
+namespace bytedance::bolt::connector::hive {
+
+// static
+std::shared_ptr<BytelakeConnectorSplit> BytelakeConnectorSplit::create(
+    const folly::dynamic& obj) {
+  BOLT_CHECK(obj["name"].asString() == "BytelakeConnectorSplit");
+
+  std::string connectorId = obj["connectorId"].asString();
+  const folly::dynamic& hiveSplitsArray = obj["hiveSplits"];
+  std::vector<std::shared_ptr<HiveConnectorSplit>> hiveSplits;
+
+  for (const auto& item : hiveSplitsArray) {
+    hiveSplits.push_back(HiveConnectorSplit::create(item));
+  }
+
+  return std::make_shared<BytelakeConnectorSplit>(
+      connectorId, std::move(hiveSplits));
+}
+
+// static
+void BytelakeConnectorSplit::registerSerDe() {
+  auto& registry = DeserializationRegistryForSharedPtr();
+  registry.Register("BytelakeConnectorSplit", BytelakeConnectorSplit::create);
+}
+} // namespace bytedance::bolt::connector::hive
+

--- a/bolt/connectors/hive/bytelake/BytelakeConnectorSplit.h
+++ b/bolt/connectors/hive/bytelake/BytelakeConnectorSplit.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include "bolt/connectors/Connector.h"
+#include "bolt/connectors/hive/HiveConnectorSplit.h"
+namespace bytedance::bolt::connector::hive {
+
+struct BytelakeConnectorSplit : public connector::ConnectorSplit {
+  explicit BytelakeConnectorSplit(
+      const std::string& connectorId,
+      std::vector<std::shared_ptr<HiveConnectorSplit>> _hiveSplits)
+      : connector::ConnectorSplit(connectorId), hiveSplits(_hiveSplits) {
+    BOLT_CHECK_GE(hiveSplits.size(), 1, "No splits");
+  }
+
+  std::string toString() const override {
+    std::string result;
+    for (const auto& split : hiveSplits) {
+      if (!result.empty()) {
+        result += ", ";
+      }
+      result += split->toString();
+    }
+
+    return fmt::format("[BytelakeConnectorSplit: {}]", result);
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "BytelakeConnectorSplit";
+    obj["connectorId"] = connectorId;
+
+    folly::dynamic hiveSplitsArr = folly::dynamic::array;
+    for (const auto& hiveSplit : hiveSplits) {
+      BOLT_CHECK_NOT_NULL(hiveSplit, "Null HiveConnectorSplit in hiveSplits");
+      hiveSplitsArr.push_back(hiveSplit->serialize());
+    }
+
+    obj["hiveSplits"] = hiveSplitsArr;
+    return obj;
+  }
+
+  static std::shared_ptr<BytelakeConnectorSplit> create(
+      const folly::dynamic& obj);
+
+  static void registerSerDe();
+
+  std::vector<std::shared_ptr<HiveConnectorSplit>> hiveSplits;
+};
+
+} // namespace bytedance::bolt::connector::hive
+

--- a/bolt/connectors/hive/bytelake/BytelakeConnectorUtil.cpp
+++ b/bolt/connectors/hive/bytelake/BytelakeConnectorUtil.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sstream>
+#include "bolt/connectors/hive/bytelake/BytelakeConnectorUtil.h"
+#include "bolt/connectors/hive/bytelake/BytelakeConstants.h"
+
+namespace bytedance::bolt::connector::hive {
+
+std::vector<std::string> splitByDelimiter(const std::string& s, char delimiter) {
+  std::vector<std::string> tokens;
+  std::string token;
+  std::stringstream ss(s);
+
+  while (std::getline(ss, token, delimiter)) {
+    tokens.push_back(token);
+  }
+
+  return tokens;
+}
+
+std::vector<std::string> getBytelakePrimaryKeys(
+    const std::string& tableName,
+    const std::unordered_map<std::string, std::string>& tableParameters) {
+  auto primaryKeyIter = tableParameters.find(connector::bytelake::kPrimaryKey);
+  if (primaryKeyIter == tableParameters.end()) {
+    throw std::invalid_argument(fmt::format(
+        "No primary key in table {}", tableName));
+  }
+
+  std::string primaryKeys = primaryKeyIter->second;
+  return splitByDelimiter(primaryKeys, ',');
+}
+
+std::vector<std::string> getBytelakePrecombineFields(
+    const std::unordered_map<std::string, std::string>& tableParameters) {
+  auto precombineFieldIter =
+      tableParameters.find(connector::bytelake::kPrecombineKey);
+
+  std::vector<std::string> precombineFields;
+  if (precombineFieldIter != tableParameters.end()) {
+    precombineFields = splitByDelimiter(precombineFieldIter->second, ',');
+  }
+
+  std::string commitTimeField = connector::bytelake::kMetaCommitTime;
+  precombineFields.push_back(commitTimeField);
+
+  return precombineFields;
+}
+
+std::string getBytelakeDeletedField(
+    const std::unordered_map<std::string, std::string>& tableParameters) {
+  std::string deletedField = connector::bytelake::kHoodieIsDeleted;
+  return deletedField;
+}
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeConnectorUtil.h
+++ b/bolt/connectors/hive/bytelake/BytelakeConnectorUtil.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "bolt/connectors/Connector.h"
+#include "bolt/connectors/hive/FileHandle.h"
+#include "bolt/connectors/hive/HiveConnectorSplit.h"
+#include "bolt/connectors/hive/bytelake/BytelakeConnectorSplit.h"
+#include "bolt/dwio/common/BufferedInput.h"
+#include "bolt/dwio/common/Reader.h"
+
+namespace bytedance::bolt::connector::hive {
+
+class HiveColumnHandle;
+class HiveConfig;
+struct HiveConnectorSplit;
+
+std::vector<std::string> splitByDelimiter(const std::string& s, char delimiter);
+
+std::vector<std::string> getBytelakePrimaryKeys(
+    const std::string& tableName,
+    const std::unordered_map<std::string, std::string>& tableParameters);
+
+std::vector<std::string> getBytelakePrecombineFields(
+    const std::unordered_map<std::string, std::string>& tableParameters);
+
+std::string getBytelakeDeletedField(
+    const std::unordered_map<std::string, std::string>& tableParameters);
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeConstants.h
+++ b/bolt/connectors/hive/bytelake/BytelakeConstants.h
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+namespace bytedance::bolt::connector::bytelake {
+
+static constexpr uint32_t kMAX_BATCH_SIZE = 4096;
+
+static constexpr const char* kPrimaryKey = "bytelake.recordkey.fields";
+static constexpr const char* kPrecombineKey = "bytelake.precombine.fields";
+
+static constexpr const char* kCheckMetaCommitTime = "check_meta_commit_time.enabled";
+static constexpr const char* kMetaCommitTime = "_hoodie_commit_time";
+static constexpr const char* kHoodieIsDeleted = "_hoodie_is_deleted";
+
+} // namespace bytedance::bolt::connector::bytelake

--- a/bolt/connectors/hive/bytelake/BytelakeHashDedup.cpp
+++ b/bolt/connectors/hive/bytelake/BytelakeHashDedup.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeHashDedup.h"
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/connectors/hive/bytelake/BytelakeKeyPacker.h"
+#include "bolt/vector/SelectivityVector.h"
+
+namespace bytedance::bolt::connector::hive {
+
+BytelakeHashDedup::BytelakeHashDedup(
+    const BytelakeKeyOnlySchema& schema,
+    size_t numFiles)
+    : numPkColumns_(schema.numPkColumns),
+      numPrecombineColumns_(schema.numPrecombineColumns),
+      keyRowType_(schema.rowType),
+      losersPerFile_(numFiles) {
+  BOLT_CHECK_GT(numPkColumns_, 0, "BytelakeHashDedup requires at least 1 PK column");
+  BOLT_CHECK_GE(numPrecombineColumns_, 0);
+  BOLT_CHECK_NOT_NULL(keyRowType_);
+  BOLT_CHECK_EQ(
+      keyRowType_->size(),
+      static_cast<size_t>(numPkColumns_ + numPrecombineColumns_ + 1),
+      "keyRowType size must equal numPk + numPrecombine + 1 (for isDeleted)");
+}
+
+void BytelakeHashDedup::addBatch(
+    const RowVectorPtr& batch,
+    uint32_t fileIdx,
+    uint32_t batchStartRow) {
+  BOLT_CHECK_NOT_NULL(batch);
+  BOLT_CHECK_LT(
+      static_cast<size_t>(fileIdx),
+      losersPerFile_.size(),
+      "fileIdx out of range for losersPerFile_");
+
+  const vector_size_t n = batch->size();
+  if (n == 0) {
+    return;
+  }
+
+  SelectivityVector allRows(n);
+
+  std::vector<DecodedVector> pkDecoded(numPkColumns_);
+  std::vector<const DecodedVector*> pkDecoders(numPkColumns_);
+  std::vector<TypeKind> pkKinds(numPkColumns_);
+  for (int i = 0; i < numPkColumns_; ++i) {
+    pkDecoded[i].decode(*batch->childAt(i), allRows);
+    pkDecoders[i] = &pkDecoded[i];
+    pkKinds[i] = keyRowType_->childAt(i)->kind();
+  }
+
+  std::vector<DecodedVector> pcDecoded(numPrecombineColumns_);
+  std::vector<const DecodedVector*> pcDecoders(numPrecombineColumns_);
+  std::vector<TypeKind> pcKinds(numPrecombineColumns_);
+  for (int i = 0; i < numPrecombineColumns_; ++i) {
+    pcDecoded[i].decode(*batch->childAt(numPkColumns_ + i), allRows);
+    pcDecoders[i] = &pcDecoded[i];
+    pcKinds[i] = keyRowType_->childAt(numPkColumns_ + i)->kind();
+  }
+
+  DecodedVector isDeletedDecoded;
+  const int isDeletedChannel = numPkColumns_ + numPrecombineColumns_;
+  isDeletedDecoded.decode(*batch->childAt(isDeletedChannel), allRows);
+
+  for (vector_size_t row = 0; row < n; ++row) {
+    std::string pk = packCompositeKey(pkDecoders, pkKinds, row);
+    std::string pc = packCompositeKey(pcDecoders, pcKinds, row);
+    // Null isDeleted treated as not-deleted (old files without the column).
+    const bool isDel = !isDeletedDecoded.isNullAt(row) &&
+        isDeletedDecoded.valueAt<bool>(row);
+    const BytelakeRowOrigin origin{
+        fileIdx, batchStartRow + static_cast<uint32_t>(row)};
+
+    auto it = table_.find(pk);
+    if (it == table_.end()) {
+      table_.emplace(
+          std::move(pk), BestEntry{std::move(pc), origin, isDel});
+    } else if (pc > it->second.packedPrecombine) {
+      // New row wins; old winner becomes a loser.
+      const auto displaced = it->second.origin;
+      losersPerFile_[displaced.fileIdx].push_back(displaced.rowInFile);
+      it->second = BestEntry{std::move(pc), origin, isDel};
+    } else {
+      // Tie or lower: first-seen wins (Hudi default).
+      losersPerFile_[fileIdx].push_back(origin.rowInFile);
+    }
+  }
+}
+
+std::vector<std::vector<uint32_t>> BytelakeHashDedup::takeLosers() && {
+  // Hudi MoR: tombstone winners (latest version = delete) must not appear
+  // in output. Fold them into losersPerFile_ so Phase 3's bitmap skips
+  // them — production plans omit `WHERE NOT _hoodie_is_deleted` downstream.
+  for (const auto& kv : table_) {
+    if (kv.second.isDeleted) {
+      losersPerFile_[kv.second.origin.fileIdx].push_back(
+          kv.second.origin.rowInFile);
+    }
+  }
+  return std::move(losersPerFile_);
+}
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeHashDedup.h
+++ b/bolt/connectors/hive/bytelake/BytelakeHashDedup.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "bolt/connectors/hive/bytelake/BytelakeRowOrigin.h"
+#include "bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h"
+#include "bolt/vector/ComplexVector.h"
+
+namespace bytedance::bolt::connector::hive {
+
+// Streaming hash-based dedup for bytelake two-pass Phase 1+2. PK is packed
+// into a std::string (via BytelakeKeyPacker) used as the F14FastMap key;
+// per-PK winner is the row with max precombine, others are recorded as
+// losers per file.
+class BytelakeHashDedup {
+ public:
+  // schema layout: PK columns, then precombine columns, then isDeleted
+  // (last). numFiles sizes the per-file losers vector; addBatch's fileIdx
+  // must be < numFiles.
+  BytelakeHashDedup(const BytelakeKeyOnlySchema& schema, size_t numFiles);
+
+  // Process one batch from file `fileIdx`. Key columns must be
+  // force-materialized. batchStartRow is the file row of batch[0] (requires
+  // filter-free Phase 1 ScanSpec for cumulative sizes to match physical
+  // file positions).
+  void addBatch(
+      const RowVectorPtr& batch,
+      uint32_t fileIdx,
+      uint32_t batchStartRow);
+
+  // Move-out losers per file. Includes both losers from PK contest AND
+  // deleted-tombstone winners (Hudi MoR: deleted PKs must not appear).
+  // Order within each per-file vector is unspecified.
+  std::vector<std::vector<uint32_t>> takeLosers() &&;
+
+  size_t numWinners() const {
+    return table_.size();
+  }
+
+ private:
+  struct BestEntry {
+    std::string packedPrecombine;
+    BytelakeRowOrigin origin;
+    bool isDeleted;
+  };
+
+  const int numPkColumns_;
+  const int numPrecombineColumns_;
+  RowTypePtr keyRowType_;
+
+  folly::F14FastMap<std::string, BestEntry> table_;
+  std::vector<std::vector<uint32_t>> losersPerFile_;
+};
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeKeyPacker.cpp
+++ b/bolt/connectors/hive/bytelake/BytelakeKeyPacker.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeKeyPacker.h"
+
+#include "bolt/common/base/Exceptions.h"
+
+namespace bytedance::bolt::connector::hive {
+
+void appendBigint(std::string& out, int64_t value) {
+  // Flip sign bit so two's-complement maps to unsigned with the same order.
+  uint64_t u = static_cast<uint64_t>(value) ^ (uint64_t{1} << 63);
+  out.push_back(static_cast<char>((u >> 56) & 0xFF));
+  out.push_back(static_cast<char>((u >> 48) & 0xFF));
+  out.push_back(static_cast<char>((u >> 40) & 0xFF));
+  out.push_back(static_cast<char>((u >> 32) & 0xFF));
+  out.push_back(static_cast<char>((u >> 24) & 0xFF));
+  out.push_back(static_cast<char>((u >> 16) & 0xFF));
+  out.push_back(static_cast<char>((u >> 8) & 0xFF));
+  out.push_back(static_cast<char>(u & 0xFF));
+}
+
+void appendVarchar(std::string& out, StringView value) {
+  uint32_t len = static_cast<uint32_t>(value.size());
+  out.push_back(static_cast<char>((len >> 24) & 0xFF));
+  out.push_back(static_cast<char>((len >> 16) & 0xFF));
+  out.push_back(static_cast<char>((len >> 8) & 0xFF));
+  out.push_back(static_cast<char>(len & 0xFF));
+  out.append(value.data(), value.size());
+}
+
+std::string packCompositeKey(
+    const std::vector<const DecodedVector*>& decoders,
+    const std::vector<TypeKind>& kinds,
+    vector_size_t row) {
+  BOLT_CHECK_EQ(decoders.size(), kinds.size());
+  std::string out;
+  out.reserve(decoders.size() * 16);
+  for (size_t i = 0; i < decoders.size(); ++i) {
+    switch (kinds[i]) {
+      case TypeKind::BIGINT:
+        appendBigint(out, decoders[i]->valueAt<int64_t>(row));
+        break;
+      case TypeKind::VARCHAR:
+        appendVarchar(out, decoders[i]->valueAt<StringView>(row));
+        break;
+      default:
+        BOLT_FAIL(
+            "Unsupported TypeKind in packCompositeKey: {}",
+            mapTypeKindToName(kinds[i]));
+    }
+  }
+  return out;
+}
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeKeyPacker.h
+++ b/bolt/connectors/hive/bytelake/BytelakeKeyPacker.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "bolt/type/StringView.h"
+#include "bolt/type/Type.h"
+#include "bolt/vector/DecodedVector.h"
+
+namespace bytedance::bolt::connector::hive {
+
+// Append int64 in memcmp-safe form: 8 bytes big-endian with sign bit
+// flipped, so byte-wise memcmp matches numeric order (incl. negatives).
+void appendBigint(std::string& out, int64_t value);
+
+// Append a string with 4-byte big-endian length prefix + raw bytes.
+// Length prefix disambiguates multi-column packs (e.g. ("abc","def") vs
+// ("abcdef","")). Note: memcmp orders by (length, content) for differing
+// lengths; production fixed-width precombine columns (e.g. 14-char
+// commit_time) avoid this corner.
+void appendVarchar(std::string& out, StringView value);
+
+// Pack a row's multi-column key into a single string (PK or precombine).
+// Result supports equality (hash key) and memcmp ordering (precombine
+// compare). Supports BIGINT / VARCHAR; nulls are not allowed by contract.
+std::string packCompositeKey(
+    const std::vector<const DecodedVector*>& decoders,
+    const std::vector<TypeKind>& kinds,
+    vector_size_t row);
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeRowOrigin.h
+++ b/bolt/connectors/hive/bytelake/BytelakeRowOrigin.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace bytedance::bolt::connector::hive {
+
+// Compact 8-byte (fileIdx, rowInFile) identifier for a row within a bucket.
+// Both fields are uint32_t — gives ~4B headroom on each dimension with no
+// padding waste in the struct layout.
+struct BytelakeRowOrigin {
+  uint32_t fileIdx;
+  uint32_t rowInFile;
+};
+
+static_assert(
+    sizeof(BytelakeRowOrigin) == 8,
+    "BytelakeRowOrigin must be 8 bytes (uint32_t + uint32_t)");
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.cpp
+++ b/bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h"
+
+#include "bolt/common/base/Exceptions.h"
+
+namespace bytedance::bolt::connector::hive {
+
+BytelakeKeyOnlySchema makeBytelakeKeyOnlySchema(
+    const RowTypePtr& fullRowType,
+    const std::vector<int>& pkChannelsInFullSchema,
+    const std::vector<int>& precombineChannelsInFullSchema,
+    int isDeletedChannelInFullSchema) {
+  BOLT_CHECK_NOT_NULL(fullRowType);
+  BOLT_CHECK(
+      !pkChannelsInFullSchema.empty(),
+      "Bytelake requires at least one PK column");
+
+  const size_t totalSize = pkChannelsInFullSchema.size() +
+      precombineChannelsInFullSchema.size() + 1;
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(totalSize);
+  types.reserve(totalSize);
+
+  auto spec = std::make_shared<common::ScanSpec>("root");
+
+  auto appendColumn = [&](int srcChannel) {
+    BOLT_CHECK_GE(srcChannel, 0);
+    BOLT_CHECK_LT(srcChannel, fullRowType->size());
+    const auto& name = fullRowType->nameOf(srcChannel);
+    const auto& type = fullRowType->childAt(srcChannel);
+    const auto dstChannel = static_cast<column_index_t>(names.size());
+    names.push_back(name);
+    types.push_back(type);
+    spec->addFieldRecursively(name, *type, dstChannel);
+  };
+
+  // Layout: [PK..., precombine..., isDeleted]
+  for (int ch : pkChannelsInFullSchema) {
+    appendColumn(ch);
+  }
+  for (int ch : precombineChannelsInFullSchema) {
+    appendColumn(ch);
+  }
+  appendColumn(isDeletedChannelInFullSchema);
+
+  BytelakeKeyOnlySchema schema;
+  schema.rowType = ROW(std::move(names), std::move(types));
+  schema.scanSpec = std::move(spec);
+  schema.numPkColumns = static_cast<int>(pkChannelsInFullSchema.size());
+  schema.numPrecombineColumns =
+      static_cast<int>(precombineChannelsInFullSchema.size());
+  return schema;
+}
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h
+++ b/bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "bolt/dwio/common/ScanSpec.h"
+#include "bolt/type/Type.h"
+
+namespace bytedance::bolt::connector::hive {
+
+// Reduced (key-only) reader schema + matching ScanSpec for Phase 1 read.
+// Layout (channels 0..rowType->size()-1):
+//   [0, numPkColumns)                         PK columns
+//   [numPkColumns, +numPrecombineColumns)     precombine columns
+//   [last]                                    isDeleted (_hoodie_is_deleted)
+struct BytelakeKeyOnlySchema {
+  RowTypePtr rowType;
+  std::shared_ptr<common::ScanSpec> scanSpec;
+  int numPkColumns;
+  int numPrecombineColumns;
+};
+
+// Pack PK/precombine/isDeleted channels from a wide fullRowType into a
+// compact key-only rowType + filter-free ScanSpec, in the layout above.
+// Caller guarantees: channels unique and in fullRowType bounds; at least
+// one PK channel.
+BytelakeKeyOnlySchema makeBytelakeKeyOnlySchema(
+    const RowTypePtr& fullRowType,
+    const std::vector<int>& pkChannelsInFullSchema,
+    const std::vector<int>& precombineChannelsInFullSchema,
+    int isDeletedChannelInFullSchema);
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeSplitReader.cpp
+++ b/bolt/connectors/hive/bytelake/BytelakeSplitReader.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeSplitReader.h"
+#include "bolt/common/time/Timer.h"
+#include "bolt/vector/SelectivityVector.h"
+
+namespace bytedance::bolt::connector::hive {
+
+BytelakeSplitReader::BytelakeSplitReader(
+    std::vector<std::unique_ptr<SplitReader>> splitReaders,
+    const std::shared_ptr<io::IoStatistics> ioStats,
+    std::vector<std::unique_ptr<SplitReader>> keyOnlySplitReaders,
+    std::optional<BytelakeKeyOnlySchema> keyOnlySchema)
+    : splitReaders_(std::move(splitReaders)),
+      keyOnlySplitReaders_(std::move(keyOnlySplitReaders)),
+      keyOnlySchema_(std::move(keyOnlySchema)),
+      ioStats_(ioStats) {}
+
+std::vector<uint64_t> BytelakeSplitReader::buildBatchBitmap(
+    size_t fileIdx,
+    uint64_t baseRow,
+    uint64_t sliceSize) const {
+  const auto& sortedLosers = losersPerFile_[fileIdx];
+  auto lo = std::lower_bound(
+      sortedLosers.begin(),
+      sortedLosers.end(),
+      static_cast<uint32_t>(baseRow));
+  auto hi = std::lower_bound(
+      lo,
+      sortedLosers.end(),
+      static_cast<uint32_t>(baseRow + sliceSize));
+
+  if (lo == hi) {
+    return {};
+  }
+
+  // Bit i = skip i-th row of this batch (file row baseRow + i).
+  std::vector<uint64_t> bitmap((sliceSize + 63) / 64, 0);
+  for (auto it = lo; it != hi; ++it) {
+    const uint32_t localPos = *it - static_cast<uint32_t>(baseRow);
+    bitmap[localPos / 64] |= (uint64_t{1} << (localPos % 64));
+  }
+  return bitmap;
+}
+
+uint64_t BytelakeSplitReader::next(int64_t size, VectorPtr& output) {
+  // Lazily run Phase 1+2 on first next() — defers the expensive key-only
+  // scan until the operator actually starts pulling.
+  if (!losersBuilt_) {
+    buildLosers();
+    losersBuilt_ = true;
+  }
+
+  // Phase 3: stream winner rows from full-schema readers, applying a
+  // per-batch Mutation bitmap covering this batch's loser positions.
+  while (currentFileIdx_ < splitReaders_.size()) {
+    const uint64_t fileRowCount = fileRowCounts_[currentFileIdx_];
+
+    if (currentFileRow_ >= fileRowCount) {
+      ++currentFileIdx_;
+      currentFileRow_ = 0;
+      continue;
+    }
+
+    // Reader may return fewer rows than sliceSize (e.g. row-group boundary);
+    // trailing bits in the bitmap are safely ignored.
+    const uint64_t sliceSize =
+        std::min<uint64_t>(size, fileRowCount - currentFileRow_);
+    const auto bitmap =
+        buildBatchBitmap(currentFileIdx_, currentFileRow_, sliceSize);
+
+    dwio::common::Mutation mutation;
+    mutation.deletedRows = bitmap.empty() ? nullptr : bitmap.data();
+
+    const uint64_t rowsRead = splitReaders_[currentFileIdx_]->next(
+        size, output, &mutation);
+
+    // Fail-safe: reader hit EOF before our tracking expected. Advance
+    // rather than spinning.
+    if (rowsRead == 0) {
+      ++currentFileIdx_;
+      currentFileRow_ = 0;
+      continue;
+    }
+
+    currentFileRow_ += rowsRead;
+
+    auto rowVec = std::dynamic_pointer_cast<RowVector>(output);
+    const vector_size_t emitted = rowVec ? rowVec->size() : 0;
+    if (emitted > 0) {
+      return static_cast<uint64_t>(emitted);
+    }
+    // Empty batch (all rows were losers): continue same file.
+  }
+
+  output = BaseVector::create(output->type(), 0, output->pool());
+  return 0;
+}
+
+void BytelakeSplitReader::buildLosers() {
+  BOLT_CHECK(
+      keyOnlySchema_.has_value(),
+      "buildLosers() requires keyOnlySchema_ populated by HiveDataSource");
+  BOLT_CHECK_EQ(
+      keyOnlySplitReaders_.size(),
+      splitReaders_.size(),
+      "keyOnlySplitReaders_ count must match splitReaders_");
+
+  const auto buildStartTime = getCurrentTimeMicro();
+  const size_t numFiles = keyOnlySplitReaders_.size();
+  BytelakeHashDedup dedup(keyOnlySchema_.value(), numFiles);
+  fileRowCounts_.assign(numFiles, 0);
+
+  for (size_t fileIdx = 0; fileIdx < numFiles; ++fileIdx) {
+    auto* reader = keyOnlySplitReaders_[fileIdx].get();
+    uint32_t batchStartRow = 0;
+
+    while (true) {
+      VectorPtr batch =
+          BaseVector::create(keyOnlySchema_->rowType, 0, reader->pool());
+      uint64_t rowsRead = reader->next(bytelake::kMAX_BATCH_SIZE, batch);
+      if (rowsRead == 0) {
+        break;
+      }
+      auto rowVec = std::static_pointer_cast<RowVector>(batch);
+      if (rowVec->size() == 0) {
+        continue;
+      }
+
+      // Force materialize key columns before reader advances — Bolt's
+      // LazyVector becomes invalid once the next reader.next() runs
+      // (ColumnLoader version check).
+      for (column_index_t i = 0; i < rowVec->childrenSize(); ++i) {
+        rowVec->childAt(i)->loadedVector();
+      }
+
+      dedup.addBatch(rowVec, static_cast<uint32_t>(fileIdx), batchStartRow);
+      batchStartRow += static_cast<uint32_t>(rowVec->size());
+    }
+
+    // Phase 1 ScanSpec is filter-free, so total read == physical row count.
+    fileRowCounts_[fileIdx] = batchStartRow;
+  }
+
+  losersPerFile_ = std::move(dedup).takeLosers();
+
+  // Sort so next() can binary-search the batch range per call.
+  for (auto& vec : losersPerFile_) {
+    std::sort(vec.begin(), vec.end());
+  }
+
+  // Account Phase 1+2 wall time as merge time (parallel to legacy K-way
+  // merge timing for monitoring continuity).
+  const auto buildTimeNs = (getCurrentTimeMicro() - buildStartTime) * 1000;
+  ioStats_->incTotalMergeTime(buildTimeNs);
+}
+
+bool BytelakeSplitReader::allPrefetchIssued() const {
+  bool result = true;
+  for (const auto& splitReader : splitReaders_) {
+    result = result && splitReader->allPrefetchIssued();
+  }
+  return result;
+}
+
+bool BytelakeSplitReader::emptySplit() const {
+  bool result = true;
+  for (const auto& splitReader : splitReaders_) {
+    result = result && splitReader->emptySplit();
+  }
+  return result;
+}
+
+void BytelakeSplitReader::resetFilterCaches() {
+  for (const auto& splitReader : splitReaders_) {
+    splitReader->resetFilterCaches();
+  }
+}
+
+int64_t BytelakeSplitReader::estimatedRowSize() const {
+  return splitReaders_[0]->estimatedRowSize();
+}
+
+void BytelakeSplitReader::updateRuntimeStats(
+    dwio::common::RuntimeStatistics& stats) const {
+  for (const auto& splitReader : splitReaders_) {
+    splitReader->updateRuntimeStats(stats);
+  }
+  // Include Phase 1 key-only I/O so monitoring sees the real cost.
+  for (const auto& splitReader : keyOnlySplitReaders_) {
+    splitReader->updateRuntimeStats(stats);
+  }
+}
+
+void BytelakeSplitReader::resetSplit() {
+  for (const auto& splitReader : splitReaders_) {
+    splitReader->resetSplit();
+  }
+  for (const auto& splitReader : keyOnlySplitReaders_) {
+    splitReader->resetSplit();
+  }
+  losersBuilt_ = false;
+  losersPerFile_.clear();
+  fileRowCounts_.clear();
+  currentFileIdx_ = 0;
+  currentFileRow_ = 0;
+}
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/bytelake/BytelakeSplitReader.h
+++ b/bolt/connectors/hive/bytelake/BytelakeSplitReader.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include "bolt/connectors/hive/HiveSplitReaderBase.h"
+#include "bolt/connectors/hive/bytelake/BytelakeConstants.h"
+#include "bolt/connectors/hive/bytelake/BytelakeHashDedup.h"
+#include "bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h"
+#include "bolt/connectors/hive/SplitReader.h"
+
+namespace bytedance::bolt {
+class BaseVector;
+using VectorPtr = std::shared_ptr<BaseVector>;
+}
+
+namespace bytedance::bolt::connector::hive {
+
+class BytelakeSplitReader : public HiveSplitReaderBase {
+ public:
+  BytelakeSplitReader(
+      std::vector<std::unique_ptr<SplitReader>> splitReaders,
+      const std::shared_ptr<io::IoStatistics> ioStats,
+      // One key-only SplitReader per file, reading PK + precombine + isDeleted.
+      std::vector<std::unique_ptr<SplitReader>> keyOnlySplitReaders,
+      std::optional<BytelakeKeyOnlySchema> keyOnlySchema);
+
+  virtual uint64_t next(int64_t size, VectorPtr& output) override;
+
+  virtual bool allPrefetchIssued() const override;
+
+  virtual bool emptySplit() const override;
+
+  virtual void resetFilterCaches() override;
+
+  virtual int64_t estimatedRowSize() const override;
+
+  virtual void updateRuntimeStats(
+      dwio::common::RuntimeStatistics& stats) const override;
+
+  virtual void resetSplit() override;
+
+  // Phase 1+2: stream key-only batches through BytelakeHashDedup, populating
+  // losersPerFile_ and fileRowCounts_. Called once per split (gated by losersBuilt_).
+  void buildLosers();
+
+  // Build a batch-local skip bitmap for splitReaders_[fileIdx]'s next read
+  // of [baseRow, baseRow + sliceSize). Returns empty vector if no losers
+  // fall in that range (caller should pass nullptr to Mutation).
+  std::vector<uint64_t> buildBatchBitmap(
+      size_t fileIdx,
+      uint64_t baseRow,
+      uint64_t sliceSize) const;
+
+ protected:
+  std::vector<std::unique_ptr<SplitReader>> splitReaders_;
+
+  // Phase 1 readers + reduced key schema (parallel to splitReaders_).
+  std::vector<std::unique_ptr<SplitReader>> keyOnlySplitReaders_;
+  std::optional<BytelakeKeyOnlySchema> keyOnlySchema_;
+
+  // Per-file sorted rowInFile positions to skip in Phase 3.
+  std::vector<std::vector<uint32_t>> losersPerFile_;
+
+  // Per-file total row count from Phase 1 (needs filter-free ScanSpec).
+  std::vector<uint64_t> fileRowCounts_;
+
+  // Set true after buildLosers() runs; reset by resetSplit().
+  bool losersBuilt_ = false;
+
+  // Phase 3 streaming cursor: current file index and consumed raw rows in it.
+  size_t currentFileIdx_ = 0;
+  uint64_t currentFileRow_ = 0;
+
+  const std::shared_ptr<io::IoStatistics> ioStats_;
+};
+
+} // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/tests/BytelakeHashDedupTest.cpp
+++ b/bolt/connectors/hive/tests/BytelakeHashDedupTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeHashDedup.h"
+
+#include <algorithm>
+
+#include "bolt/common/memory/Memory.h"
+#include "bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h"
+#include "bolt/vector/tests/utils/VectorTestBase.h"
+#include "gtest/gtest.h"
+
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::connector::hive;
+
+class BytelakeHashDedupTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  // Common schema: 1 VARCHAR PK ("pk") + 1 BIGINT precombine ("ts")
+  // + BOOLEAN isDeleted ("deleted"). 3 columns total.
+  BytelakeKeyOnlySchema simpleSchema() {
+    auto full = ROW(
+        {"pk", "ts", "deleted"},
+        {VARCHAR(), BIGINT(), BOOLEAN()});
+    return makeBytelakeKeyOnlySchema(full, /*pk=*/{0}, /*pc=*/{1}, /*vk=*/2);
+  }
+
+  // Helper: build a key batch matching simpleSchema().
+  RowVectorPtr makeBatch(
+      std::vector<std::string> pks,
+      std::vector<int64_t> tss,
+      std::vector<bool> deletes) {
+    return makeRowVector({
+        makeFlatVector<std::string>(pks),
+        makeFlatVector<int64_t>(tss),
+        makeFlatVector<bool>(deletes),
+    });
+  }
+
+  // Sort a per-file losers vector for stable comparison.
+  static std::vector<uint32_t> sorted(std::vector<uint32_t> v) {
+    std::sort(v.begin(), v.end());
+    return v;
+  }
+};
+
+TEST_F(BytelakeHashDedupTest, singlePkSingleRow) {
+  // One row → one winner, zero losers.
+  BytelakeHashDedup dedup(simpleSchema(), /*numFiles=*/1);
+  auto batch = makeBatch({"a"}, {100}, {false});
+  dedup.addBatch(batch, /*fileIdx=*/0, /*batchStartRow=*/0);
+
+  EXPECT_EQ(dedup.numWinners(), 1u);
+  auto losers = std::move(dedup).takeLosers();
+  ASSERT_EQ(losers.size(), 1u);
+  EXPECT_TRUE(losers[0].empty());
+}
+
+TEST_F(BytelakeHashDedupTest, samePkDifferentPrecombineKeepsMax) {
+  // Two rows same PK, different precombine — higher wins.
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  auto batch = makeBatch({"a", "a"}, {100, 200}, {false, false});
+  dedup.addBatch(batch, 0, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 1u);
+  auto losers = std::move(dedup).takeLosers();
+  // Row 0 (precombine=100) is the loser; row 1 (precombine=200) wins.
+  EXPECT_EQ(losers[0], (std::vector<uint32_t>{0}));
+}
+
+TEST_F(BytelakeHashDedupTest, samePkTieKeepsFirstSeen) {
+  // Equal precombine: first-seen wins, second-seen becomes loser.
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  auto batch = makeBatch({"a", "a"}, {100, 100}, {false, false});
+  dedup.addBatch(batch, 0, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 1u);
+  auto losers = std::move(dedup).takeLosers();
+  EXPECT_EQ(losers[0], (std::vector<uint32_t>{1}));
+}
+
+TEST_F(BytelakeHashDedupTest, multipleBatchesSameFile) {
+  // Batch 1 (file 0, startRow=0): ("a",10) ("b",20)
+  // Batch 2 (file 0, startRow=2): ("a",30) ("b",15)
+  // After all:
+  //   PK="a" winner = file 0 row 2 (precombine=30); row 0 is loser
+  //   PK="b" winner = file 0 row 1 (precombine=20); row 3 is loser
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  dedup.addBatch(makeBatch({"a", "b"}, {10, 20}, {false, false}), 0, 0);
+  dedup.addBatch(makeBatch({"a", "b"}, {30, 15}, {false, false}), 0, 2);
+
+  EXPECT_EQ(dedup.numWinners(), 2u);
+  auto losers = std::move(dedup).takeLosers();
+  EXPECT_EQ(sorted(losers[0]), (std::vector<uint32_t>{0, 3}));
+}
+
+TEST_F(BytelakeHashDedupTest, crossFileDedup) {
+  // File 0 row 0: PK="a" precombine=100 → initial winner
+  // File 1 row 0: PK="a" precombine=200 → wins; file 0 row 0 displaced
+  BytelakeHashDedup dedup(simpleSchema(), 2);
+  dedup.addBatch(makeBatch({"a"}, {100}, {false}), /*fileIdx=*/0, 0);
+  dedup.addBatch(makeBatch({"a"}, {200}, {false}), /*fileIdx=*/1, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 1u);
+  auto losers = std::move(dedup).takeLosers();
+  ASSERT_EQ(losers.size(), 2u);
+  EXPECT_EQ(losers[0], (std::vector<uint32_t>{0})); // file 0 row 0 displaced
+  EXPECT_TRUE(losers[1].empty());                    // file 1 row 0 won
+}
+
+TEST_F(BytelakeHashDedupTest, batchStartRowAccumulates) {
+  // Confirm rowInFile arithmetic uses batchStartRow correctly.
+  // Batch starting at row 100 — losers should report rowInFile >= 100.
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  dedup.addBatch(makeBatch({"a", "a"}, {1, 2}, {false, false}), 0, 100);
+
+  auto losers = std::move(dedup).takeLosers();
+  // Row 0 in batch = rowInFile 100; loser since row 1 (rowInFile 101) wins.
+  EXPECT_EQ(losers[0], (std::vector<uint32_t>{100}));
+}
+
+TEST_F(BytelakeHashDedupTest, distinctPksAllWinners) {
+  // 3 distinct PKs → 3 winners, zero losers.
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  dedup.addBatch(makeBatch({"a", "b", "c"}, {1, 2, 3}, {false, false, false}), 0, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 3u);
+  auto losers = std::move(dedup).takeLosers();
+  EXPECT_TRUE(losers[0].empty());
+}
+
+TEST_F(BytelakeHashDedupTest, emptyBatchIsNoop) {
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  dedup.addBatch(makeBatch({}, {}, {}), 0, 0);
+  EXPECT_EQ(dedup.numWinners(), 0u);
+}
+
+TEST_F(BytelakeHashDedupTest, deleteWinnerAddedToLosers) {
+  // Hudi MoR: if the winning row is a delete tombstone (isDeleted=true),
+  // takeLosers folds its origin into the skip list. Combined with the
+  // actual losers, the resulting bitmap drops the entire PK from output.
+  BytelakeHashDedup dedup(simpleSchema(), 1);
+  dedup.addBatch(makeBatch({"a", "a"}, {100, 200}, {false, true}), 0, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 1u);
+  auto losers = std::move(dedup).takeLosers();
+  // Row 0 lost to row 1; row 1 won but is a tombstone — both skipped.
+  EXPECT_EQ(sorted(losers[0]), (std::vector<uint32_t>{0, 1}));
+}
+
+TEST_F(BytelakeHashDedupTest, multiColumnPk) {
+  // Composite PK = (BIGINT, VARCHAR). Same PK only when both columns match.
+  auto full = ROW(
+      {"pk1", "pk2", "ts", "deleted"},
+      {BIGINT(), VARCHAR(), BIGINT(), BOOLEAN()});
+  auto schema = makeBytelakeKeyOnlySchema(
+      full, /*pk=*/{0, 1}, /*pc=*/{2}, /*vk=*/3);
+  BytelakeHashDedup dedup(schema, 1);
+
+  // Rows:
+  //   (1, "a", 10, F)  → PK=(1,"a") winner
+  //   (1, "b", 20, F)  → PK=(1,"b") winner (different PK)
+  //   (2, "a", 30, F)  → PK=(2,"a") winner (different PK)
+  //   (1, "a", 50, F)  → same PK as row 0; precombine=50 > 10 → row 0 displaced
+  auto batch = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 1}),
+      makeFlatVector<std::string>({"a", "b", "a", "a"}),
+      makeFlatVector<int64_t>({10, 20, 30, 50}),
+      makeFlatVector<bool>({false, false, false, false}),
+  });
+  dedup.addBatch(batch, 0, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 3u);
+  auto losers = std::move(dedup).takeLosers();
+  EXPECT_EQ(losers[0], (std::vector<uint32_t>{0}));
+}
+
+TEST_F(BytelakeHashDedupTest, multiColumnPrecombine) {
+  // Composite precombine = (BIGINT, VARCHAR). Compared in column order.
+  auto full = ROW(
+      {"pk", "ts", "commit_time", "deleted"},
+      {VARCHAR(), BIGINT(), VARCHAR(), BOOLEAN()});
+  auto schema = makeBytelakeKeyOnlySchema(
+      full, /*pk=*/{0}, /*pc=*/{1, 2}, /*vk=*/3);
+  BytelakeHashDedup dedup(schema, 1);
+
+  // All same PK="a", different (ts, commit_time):
+  //   row 0: (100, "20260514") → initial winner
+  //   row 1: (100, "20260515") → same ts, commit_time > → wins, row 0 loser
+  //   row 2: (50,  "20260601") → ts < → loses
+  //   row 3: (200, "20260101") → ts > → wins, row 1 displaced
+  auto batch = makeRowVector({
+      makeFlatVector<std::string>({"a", "a", "a", "a"}),
+      makeFlatVector<int64_t>({100, 100, 50, 200}),
+      makeFlatVector<std::string>(
+          {"20260514", "20260515", "20260601", "20260101"}),
+      makeFlatVector<bool>({false, false, false, false}),
+  });
+  dedup.addBatch(batch, 0, 0);
+
+  EXPECT_EQ(dedup.numWinners(), 1u);
+  auto losers = std::move(dedup).takeLosers();
+  // Final winner is row 3. Losers (in any order): {0, 1, 2}.
+  EXPECT_EQ(sorted(losers[0]), (std::vector<uint32_t>{0, 1, 2}));
+}
+
+TEST_F(BytelakeHashDedupTest, fileIdxOutOfRangeRejects) {
+  BytelakeHashDedup dedup(simpleSchema(), /*numFiles=*/2);
+  // fileIdx=2 is out of range (valid range is [0, 2)).
+  EXPECT_ANY_THROW(
+      dedup.addBatch(makeBatch({"a"}, {1}, {false}), /*fileIdx=*/2, 0));
+}

--- a/bolt/connectors/hive/tests/BytelakeKeyPackerTest.cpp
+++ b/bolt/connectors/hive/tests/BytelakeKeyPackerTest.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeKeyPacker.h"
+
+#include <climits>
+
+#include "gtest/gtest.h"
+
+using namespace bytedance::bolt::connector::hive;
+using namespace bytedance::bolt;
+
+// ---- appendBigint encoding ----
+
+TEST(BytelakeKeyPackerTest, bigintProducesEightBytes) {
+  std::string s;
+  appendBigint(s, 0);
+  EXPECT_EQ(s.size(), 8u);
+}
+
+TEST(BytelakeKeyPackerTest, bigintZeroEncoding) {
+  // Sign-bit flip: 0 -> 0x80 in the top byte.
+  std::string s;
+  appendBigint(s, 0);
+  EXPECT_EQ(static_cast<unsigned char>(s[0]), 0x80);
+  for (int i = 1; i < 8; ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(s[i]), 0x00);
+  }
+}
+
+TEST(BytelakeKeyPackerTest, bigintMinAndMax) {
+  // After sign-flip:
+  //   INT64_MIN (0x8000...0000) -> 0x0000...0000
+  //   INT64_MAX (0x7FFF...FFFF) -> 0xFFFF...FFFF
+  std::string minPack, maxPack;
+  appendBigint(minPack, INT64_MIN);
+  appendBigint(maxPack, INT64_MAX);
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(minPack[i]), 0x00) << "min[" << i << "]";
+    EXPECT_EQ(static_cast<unsigned char>(maxPack[i]), 0xFF) << "max[" << i << "]";
+  }
+}
+
+TEST(BytelakeKeyPackerTest, bigintMemcmpOrderingMatchesNumeric) {
+  std::vector<int64_t> values = {
+      INT64_MIN, -1000000, -1, 0, 1, 1000000, INT64_MAX};
+  std::vector<std::string> packs;
+  for (auto v : values) {
+    std::string p;
+    appendBigint(p, v);
+    packs.push_back(std::move(p));
+  }
+  for (size_t i = 0; i + 1 < packs.size(); ++i) {
+    EXPECT_LT(packs[i], packs[i + 1])
+        << "values[" << i << "]=" << values[i] << " < " << values[i + 1];
+  }
+}
+
+TEST(BytelakeKeyPackerTest, bigintEqualValuesEqualBytes) {
+  std::string a, b;
+  appendBigint(a, 42);
+  appendBigint(b, 42);
+  EXPECT_EQ(a, b);
+}
+
+// ---- appendVarchar encoding ----
+
+TEST(BytelakeKeyPackerTest, varcharLengthPrefix) {
+  std::string s;
+  appendVarchar(s, StringView("hello"));
+  ASSERT_EQ(s.size(), 4u + 5u);
+  // Length prefix: 5 big-endian.
+  EXPECT_EQ(static_cast<unsigned char>(s[0]), 0x00);
+  EXPECT_EQ(static_cast<unsigned char>(s[1]), 0x00);
+  EXPECT_EQ(static_cast<unsigned char>(s[2]), 0x00);
+  EXPECT_EQ(static_cast<unsigned char>(s[3]), 0x05);
+  EXPECT_EQ(s.substr(4), "hello");
+}
+
+TEST(BytelakeKeyPackerTest, varcharEmpty) {
+  std::string s;
+  appendVarchar(s, StringView(""));
+  EXPECT_EQ(s.size(), 4u);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(s[i]), 0);
+  }
+}
+
+TEST(BytelakeKeyPackerTest, varcharSameLengthOrdering) {
+  std::string a, b, c;
+  appendVarchar(a, StringView("abc"));
+  appendVarchar(b, StringView("abd"));
+  appendVarchar(c, StringView("abe"));
+  EXPECT_LT(a, b);
+  EXPECT_LT(b, c);
+}
+
+TEST(BytelakeKeyPackerTest, varcharFixedLengthOrderingMatchesContent) {
+  // Production scenario: all _hoodie_commit_time strings have the same
+  // fixed length (e.g., "yyyyMMddHHmmss" = 14 chars). With identical length
+  // prefixes, ordering falls through to lexicographic content compare.
+  std::string a, b;
+  appendVarchar(a, StringView("20260513000000"));
+  appendVarchar(b, StringView("20260514000000"));
+  EXPECT_LT(a, b);
+}
+
+TEST(BytelakeKeyPackerTest, varcharEqualValuesEqualBytes) {
+  std::string a, b;
+  appendVarchar(a, StringView("hello"));
+  appendVarchar(b, StringView("hello"));
+  EXPECT_EQ(a, b);
+}
+
+// ---- Multi-column safety ----
+
+TEST(BytelakeKeyPackerTest, multiColumnDistinctEvenIfConcatLooksSame) {
+  // Without the length prefix, ("abc","def") and ("abcdef","") would pack
+  // identically. The 4-byte length prefix makes them distinct.
+  std::string a, b;
+  appendVarchar(a, StringView("abc"));
+  appendVarchar(a, StringView("def"));
+  appendVarchar(b, StringView("abcdef"));
+  appendVarchar(b, StringView(""));
+  EXPECT_NE(a, b);
+}
+
+TEST(BytelakeKeyPackerTest, multiColumnMixedBigintAndVarchar) {
+  // (1, "a") < (1, "b") < (2, "a") under composite ordering.
+  auto pack = [](int64_t b, const char* s) {
+    std::string out;
+    appendBigint(out, b);
+    appendVarchar(out, StringView(s));
+    return out;
+  };
+  auto a = pack(1, "a");
+  auto b = pack(1, "b");
+  auto c = pack(2, "a");
+  EXPECT_LT(a, b);
+  EXPECT_LT(b, c);
+}
+
+TEST(BytelakeKeyPackerTest, multiColumnEqualValues) {
+  auto pack = [](int64_t b, const char* s) {
+    std::string out;
+    appendBigint(out, b);
+    appendVarchar(out, StringView(s));
+    return out;
+  };
+  EXPECT_EQ(pack(42, "foo"), pack(42, "foo"));
+}
+
+// ---- packCompositeKey via DecodedVector ----
+// (Lower-level appendBigint / appendVarchar already cover encoding. Here
+// we only verify packCompositeKey delegates correctly.)
+
+namespace {
+// Build a DecodedVector over a fresh FlatVector. Returns the vector and
+// fills `decoded` (in/out) without touching ownership of out-vec.
+template <typename T>
+VectorPtr makeFlatAndDecode(
+    memory::MemoryPool* pool,
+    const std::vector<T>& values,
+    DecodedVector& decoded) {
+  auto rowType = CppToType<T>::create();
+  auto vec = BaseVector::create(rowType, values.size(), pool);
+  auto flat = vec->template asFlatVector<T>();
+  for (size_t i = 0; i < values.size(); ++i) {
+    flat->set(i, values[i]);
+  }
+  SelectivityVector rows(values.size());
+  decoded.decode(*vec, rows);
+  return vec;
+}
+} // namespace
+
+TEST(BytelakeKeyPackerTest, packCompositeKeyUnsupportedTypeThrows) {
+  // Construct a single-column setup with a non-supported TypeKind to verify
+  // BOLT_FAIL fires. Use a stack DecodedVector default-constructed and pass
+  // BOOLEAN to packCompositeKey.
+  DecodedVector dv;
+  std::vector<const DecodedVector*> decoders{&dv};
+  std::vector<TypeKind> kinds{TypeKind::BOOLEAN};
+  // We don't actually need decoded data to fire the type check.
+  EXPECT_ANY_THROW(packCompositeKey(decoders, kinds, 0));
+}

--- a/bolt/connectors/hive/tests/BytelakeScanSpecUtilTest.cpp
+++ b/bolt/connectors/hive/tests/BytelakeScanSpecUtilTest.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/connectors/hive/bytelake/BytelakeScanSpecUtil.h"
+
+#include "gtest/gtest.h"
+
+using namespace bytedance::bolt::connector::hive;
+using namespace bytedance::bolt;
+
+namespace {
+
+RowTypePtr makeRowType(std::vector<std::pair<std::string, TypePtr>> fields) {
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(fields.size());
+  types.reserve(fields.size());
+  for (auto& f : fields) {
+    names.push_back(std::move(f.first));
+    types.push_back(std::move(f.second));
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+} // namespace
+
+TEST(BytelakeScanSpecUtilTest, singlePkSinglePrecombine) {
+  // Minimal viable shape: 1 PK + 1 precombine + 1 isDeleted.
+  auto full = makeRowType({
+      {"a", BIGINT()},
+      {"pk", VARCHAR()},
+      {"c", DOUBLE()},
+      {"ts", BIGINT()},
+      {"deleted", BOOLEAN()},
+  });
+  auto schema = makeBytelakeKeyOnlySchema(full, {1}, {3}, 4);
+
+  // Layout: [pk, ts, deleted] at reduced channels 0, 1, 2.
+  ASSERT_EQ(schema.rowType->size(), 3u);
+  EXPECT_EQ(schema.rowType->nameOf(0), "pk");
+  EXPECT_EQ(schema.rowType->nameOf(1), "ts");
+  EXPECT_EQ(schema.rowType->nameOf(2), "deleted");
+
+  EXPECT_EQ(schema.numPkColumns, 1);
+  EXPECT_EQ(schema.numPrecombineColumns, 1);
+  // isDeleted is at channel = numPk + numPrecombine = 2.
+
+  auto& children = schema.scanSpec->children();
+  ASSERT_EQ(children.size(), 3u);
+  EXPECT_EQ(children[0]->channel(), 0);
+  EXPECT_EQ(children[0]->fieldName(), "pk");
+  EXPECT_EQ(children[1]->channel(), 1);
+  EXPECT_EQ(children[1]->fieldName(), "ts");
+  EXPECT_EQ(children[2]->channel(), 2);
+  EXPECT_EQ(children[2]->fieldName(), "deleted");
+}
+
+TEST(BytelakeScanSpecUtilTest, productionLikeShape) {
+  // Realistic: 1 PK (unique_id) + 2 precombine (ts, _hoodie_commit_time)
+  // + isDeleted (_hoodie_is_deleted), all sparse in a wide schema.
+  auto full = makeRowType({
+      {"col0", BIGINT()},
+      {"unique_id", VARCHAR()},
+      {"col2", BIGINT()},
+      {"ts", BIGINT()},
+      {"_hoodie_commit_time", VARCHAR()},
+      {"_hoodie_is_deleted", BOOLEAN()},
+      {"col6", VARCHAR()},
+  });
+  auto schema = makeBytelakeKeyOnlySchema(
+      full,
+      /*pk=*/{1},
+      /*precombine=*/{3, 4},
+      /*isDeleted=*/5);
+
+  // Reduced rowType: [unique_id, ts, _hoodie_commit_time, _hoodie_is_deleted]
+  ASSERT_EQ(schema.rowType->size(), 4u);
+  EXPECT_EQ(schema.rowType->nameOf(0), "unique_id");
+  EXPECT_EQ(schema.rowType->nameOf(1), "ts");
+  EXPECT_EQ(schema.rowType->nameOf(2), "_hoodie_commit_time");
+  EXPECT_EQ(schema.rowType->nameOf(3), "_hoodie_is_deleted");
+  EXPECT_TRUE(schema.rowType->childAt(0)->isVarchar());
+  EXPECT_TRUE(schema.rowType->childAt(1)->isBigint());
+  EXPECT_TRUE(schema.rowType->childAt(2)->isVarchar());
+  EXPECT_TRUE(schema.rowType->childAt(3)->isBoolean());
+
+  EXPECT_EQ(schema.numPkColumns, 1);
+  EXPECT_EQ(schema.numPrecombineColumns, 2);
+  // isDeleted at reduced channel = 1 + 2 = 3 (last column).
+
+  auto& children = schema.scanSpec->children();
+  ASSERT_EQ(children.size(), 4u);
+  EXPECT_EQ(children[0]->channel(), 0);
+  EXPECT_EQ(children[1]->channel(), 1);
+  EXPECT_EQ(children[2]->channel(), 2);
+  EXPECT_EQ(children[3]->channel(), 3);
+  EXPECT_EQ(children[0]->fieldName(), "unique_id");
+  EXPECT_EQ(children[1]->fieldName(), "ts");
+  EXPECT_EQ(children[2]->fieldName(), "_hoodie_commit_time");
+  EXPECT_EQ(children[3]->fieldName(), "_hoodie_is_deleted");
+  for (auto& c : children) {
+    EXPECT_TRUE(c->projectOut());
+  }
+}
+
+TEST(BytelakeScanSpecUtilTest, multiColumnPk) {
+  // Composite PK case: 2 PK cols + 1 precombine + isDeleted.
+  auto full = makeRowType({
+      {"date", VARCHAR()},
+      {"hour", VARCHAR()},
+      {"user_id", BIGINT()},
+      {"event_seq", BIGINT()},
+      {"deleted", BOOLEAN()},
+  });
+  auto schema = makeBytelakeKeyOnlySchema(
+      full,
+      /*pk=*/{0, 2},
+      /*precombine=*/{3},
+      /*isDeleted=*/4);
+
+  // Layout: [date, user_id, event_seq, deleted]
+  ASSERT_EQ(schema.rowType->size(), 4u);
+  EXPECT_EQ(schema.rowType->nameOf(0), "date");
+  EXPECT_EQ(schema.rowType->nameOf(1), "user_id");
+  EXPECT_EQ(schema.rowType->nameOf(2), "event_seq");
+  EXPECT_EQ(schema.rowType->nameOf(3), "deleted");
+
+  EXPECT_EQ(schema.numPkColumns, 2);
+  EXPECT_EQ(schema.numPrecombineColumns, 1);
+}
+
+TEST(BytelakeScanSpecUtilTest, emptyPrecombineAllowed) {
+  // Rare case: no precombine keys (just PK + isDeleted).
+  auto full = makeRowType({
+      {"pk", VARCHAR()},
+      {"deleted", BOOLEAN()},
+  });
+  auto schema = makeBytelakeKeyOnlySchema(
+      full,
+      /*pk=*/{0},
+      /*precombine=*/{},
+      /*isDeleted=*/1);
+
+  ASSERT_EQ(schema.rowType->size(), 2u);
+  EXPECT_EQ(schema.rowType->nameOf(0), "pk");
+  EXPECT_EQ(schema.rowType->nameOf(1), "deleted");
+
+  EXPECT_EQ(schema.numPkColumns, 1);
+  EXPECT_EQ(schema.numPrecombineColumns, 0);
+}
+
+TEST(BytelakeScanSpecUtilTest, channelsCanBeFarApartInWideSchema) {
+  // Simulate the bytelake post-addColumnsIfNotExists shape where
+  // _hoodie_* columns get appended at high indices.
+  std::vector<std::pair<std::string, TypePtr>> fields;
+  fields.reserve(500);
+  for (int i = 0; i < 500; ++i) {
+    fields.emplace_back("col" + std::to_string(i), BIGINT());
+  }
+  // PK at small index (col 42), precombine + isDeleted appended at end.
+  fields[42] = {"unique_id", VARCHAR()};
+  fields.emplace_back("_hoodie_commit_time", VARCHAR()); // index 500
+  fields.emplace_back("_hoodie_is_deleted", BOOLEAN()); // index 501
+  auto full = makeRowType(std::move(fields));
+
+  auto schema = makeBytelakeKeyOnlySchema(
+      full,
+      /*pk=*/{42},
+      /*precombine=*/{31, 500}, // ts at 31, commit_time at 500
+      /*isDeleted=*/501);
+
+  // Reduced rowType has 4 cols at channels 0..3.
+  ASSERT_EQ(schema.rowType->size(), 4u);
+  EXPECT_EQ(schema.rowType->nameOf(0), "unique_id");
+  EXPECT_EQ(schema.rowType->nameOf(1), "col31");
+  EXPECT_EQ(schema.rowType->nameOf(2), "_hoodie_commit_time");
+  EXPECT_EQ(schema.rowType->nameOf(3), "_hoodie_is_deleted");
+
+  EXPECT_EQ(schema.numPkColumns, 1);
+  EXPECT_EQ(schema.numPrecombineColumns, 2);
+
+  auto& children = schema.scanSpec->children();
+  ASSERT_EQ(children.size(), 4u);
+  for (size_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(children[i]->channel(), static_cast<int>(i));
+  }
+}
+
+TEST(BytelakeScanSpecUtilTest, emptyPkRejected) {
+  // PK is required; helper should fail when missing.
+  auto full =
+      makeRowType({{"pk", VARCHAR()}, {"ts", BIGINT()}, {"deleted", BOOLEAN()}});
+  EXPECT_ANY_THROW(
+      makeBytelakeKeyOnlySchema(full, /*pk=*/{}, /*precombine=*/{1}, /*isDeleted=*/2));
+}

--- a/bolt/connectors/hive/tests/CMakeLists.txt
+++ b/bolt/connectors/hive/tests/CMakeLists.txt
@@ -27,6 +27,9 @@
 
 add_executable(
   bolt_hive_connector_test
+  BytelakeHashDedupTest.cpp
+  BytelakeKeyPackerTest.cpp
+  BytelakeScanSpecUtilTest.cpp
   FileHandleTest.cpp
   HiveConfigTest.cpp
   HiveConnectorSerDeTest.cpp


### PR DESCRIPTION
⏺ ### What problem does this PR solve?

  The bytelake (Hudi MoR) read path currently relies on a downstream
  `row_number() = 1` window function to deduplicate same-PK rows. It
  works correctness-wise (the window operator can spill), but at scale
  it is slow: every raw row flows through the full pipeline — shuffle,
  window state, writer — before duplicates are dropped. For wide tables
  (500+ columns) the cost of materializing rows that will be discarded
  dominates the job.

  This PR moves the dedup into the Hive connector so only winner rows
  ever leave the scan, eliminating the shuffle and the per-PK window
  state.

  ### Type of Change
  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [x] 🚀 Performance improvement (optimization)
  - [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] 🔨 Refactoring (no logic changes)
  - [ ] 🔧 Build/CI or Infrastructure changes
  - [ ] 📝 Documentation only

  ### Description

  Adds a `BytelakeSplitReader` that handles `BytelakeConnectorSplit`
  inside `HiveDataSource` via a new `addSplit` overload. It implements a
  two-pass scan over each bucket:

  **Phase 1+2** (`buildLosers`, lazily on first `next()`):
  - One key-only `SplitReader` per file reads only PK + precombine +
    isDeleted columns (typically 3-4 out of ~500).
  - `BytelakeHashDedup` tracks the per-PK winner (max precombine) in an
    `F14FastMap` keyed by packed PK bytes. Displaced winners and same-PK
    rejects are recorded per file as "losers". Tombstone winners
    (`_hoodie_is_deleted = true`) are also folded into the loser list so
    Hudi MoR delete semantics are enforced at the connector (production
    query plan omits the `WHERE NOT _hoodie_is_deleted` predicate).
  - Per-file losers are sorted once so the streaming phase can use
    `lower_bound` for the batch slice.

  **Phase 3** (`next()` streaming):
  - Per-file full-schema `SplitReader` reads user output columns.
  - For each batch, a per-batch `Mutation::deletedRows` bitmap is built
    from the sorted-losers slice covering `[currentFileRow_,
    currentFileRow_ + sliceSize)`. The reader applies it to skip losers
    at the column-reader level.
  - Output flows directly to `TableScan` in the user schema (no
    projection, because the full-schema reader is configured with the
    unmodified user `scanSpec_`).

  `BytelakeKeyPacker` produces memcmp-safe encodings for BIGINT (sign-bit
  flip + big-endian) and VARCHAR (length-prefixed) so packed PK strings
  can serve as both hash keys and ordered precombine comparison values.

  `BytelakeScanSpecUtil` builds a compact key-only `RowType` +
  filter-free `ScanSpec` for the Phase 1 reader, packing PK/precombine/
  isDeleted columns into dense channels regardless of where they sit in
  the wide source schema.

  Existing Paimon / plain-Hive paths are untouched; bytelake splits are
  detected via `isBytelakeConnectorSplit` and dispatched separately.

  ### Performance Impact
  - [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
  - [x] **Positive Impact**: I have run benchmarks.
      <details>
      <summary>Click to view Benchmark Results</summary>

      ```text
      Per-task INSERT on the largest daily partition
      (~26.8 TiB total, ~16k tasks, ~1.5 GiB / 1.9 M rows per task):

      metric               baseline (window)   two-pass     change
      Duration median      30 min              13 min       −57% (2.3×)
      Duration max         37 min              17 min       −54%
      GC time median       39 s                1 s          −97%
      Peak JVM memory      216 MiB             16 MiB       −93%
      Output records       matches baseline    matches      ✓

      Correctness verified via COUNT(*) parity at task level and
      end-to-end INSERT row-count parity. Job-level size dedup ratio
      (17.2%) matches the design estimate of 17.5%.
      ```
      </details>
  - [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

  ### Release Note

  ```text
  Release Note:
  - Added a two-pass dedup path in the Hive connector for bytelake
    (Hudi MoR) tables. On wide-table INSERT workloads this replaces the
    downstream row_number() = 1 window function with in-connector dedup,
    cutting per-task median wall time by ~57% (30 min → 13 min on the
    production 26.8 TiB / ~16k-task workload).

  Checklist (For Author)

  - I have added/updated unit tests (ctest).
  - I have verified the code with local build (Release/Debug).
  - I have run clang-format / linters.
  - (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
  - No need to test or manual test.

  Breaking Changes

  - No
