### PR TITLE
fix: add guard to avoid spill again in shuffle writer tryEvict

### DIFF
--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -166,6 +166,9 @@ arrow::Status BoltRowBasedSortShuffleWriter::initFromRowVector(
 }
 
 arrow::Status BoltRowBasedSortShuffleWriter::tryEvict(int64_t) {
+  // add EvictGuard to avoid recursive evict
+  BOLT_CHECK(evictState_ == EvictState::kEvictable);
+  EvictGuard evictGuard{evictState_};
   BOLT_DCHECK(vectorLayout_ != RowVectorLayout::kInvalid);
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     RETURN_NOT_OK(partitionWriter_->evict(sortedRows_, partitionBytes_, false));

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -2202,6 +2202,7 @@ int32_t BoltShuffleWriter::calculatePreallocBufferSize(
 
 // for CompositeRowVector
 arrow::Status BoltShuffleWriter::tryEvict(int64_t) {
+  // add EvictGuard to avoid recursive evict
   BOLT_CHECK(evictState_ == EvictState::kEvictable);
   EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -2202,6 +2202,8 @@ int32_t BoltShuffleWriter::calculatePreallocBufferSize(
 
 // for CompositeRowVector
 arrow::Status BoltShuffleWriter::tryEvict(int64_t) {
+  BOLT_CHECK(evictState_ == EvictState::kEvictable);
+  EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);
     for (auto pid = 0; pid < numPartitions_; ++pid) {

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -299,6 +299,7 @@ arrow::Status BoltShuffleWriterV2::stop() {
 }
 
 arrow::Status BoltShuffleWriterV2::tryEvict(int64_t memLimit) {
+  // add EvictGuard to avoid recursive evict
   BOLT_CHECK(evictState_ == EvictState::kEvictable);
   EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -299,6 +299,8 @@ arrow::Status BoltShuffleWriterV2::stop() {
 }
 
 arrow::Status BoltShuffleWriterV2::tryEvict(int64_t memLimit) {
+  BOLT_CHECK(evictState_ == EvictState::kEvictable);
+  EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);
     RETURN_NOT_OK(evictFullPartitions());


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #617 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

There is currently no guard in `tryEvict`, so when shuffle offload is not enabled, the shuffle writer may trigger a spill again from within `tryEvict`, potentially corrupting the shuffle writer's state.

We add an `EvictGuard` in `tryEvict` to ensure it never triggers `reclaimFixedSize` again. Since `tryEvict` and `reclaimFixedSize` never call each other directly, and `tryEvict` cannot be invoked implicitly by `reclaimFixedSize`, it is safe to add the `EvictGuard` here.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.

    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fix failed when shuffle writer trigger spill again when call `tryEvict`.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
