### PR TITLE
[fix] avoid int32 overflow in presto serializer offsets

### DIFF
--- a/bolt/serializers/PrestoSerializer.cpp
+++ b/bolt/serializers/PrestoSerializer.cpp
@@ -30,6 +30,8 @@
 
 #include "bolt/serializers/PrestoSerializer.h"
 #include <folly/compression/Zstd.h>
+
+#include <limits>
 #include "bolt/common/base/Crc.h"
 #include "bolt/common/memory/ByteStream.h"
 #include "bolt/common/memory/RawVector.h"
@@ -3249,7 +3251,7 @@ void flushUncompressed(
     int32_t numRows,
     OutputStream* out,
     PrestoOutputStreamListener* listener) {
-  int32_t offset = out->tellp();
+  const auto offset = out->tellp();
 
   char codecMask = 0;
 #ifdef BOLT_ENABLE_CRC
@@ -3291,13 +3293,23 @@ void flushUncompressed(
 #endif
 
   // Fill in uncompressedSizeInBytes & sizeInBytes
-  int32_t size = (int32_t)out->tellp() - offset;
+  const auto endOffset = out->tellp();
+  const auto size = static_cast<int64_t>(endOffset - offset);
   BOLT_CHECK(
-      size > 0,
-      "uncompressed size {} should be positive, numRows {}",
+      size > kHeaderSize,
+      "serialized page size {} should exceed header size {}, numRows {}",
       size,
+      kHeaderSize,
       numRows);
-  int32_t uncompressedSize = size - kHeaderSize;
+
+  const int64_t uncompressedSize64 = size - kHeaderSize;
+  BOLT_CHECK(
+      uncompressedSize64 <= std::numeric_limits<int32_t>::max(),
+      "uncompressed size {} exceeds INT32_MAX, numRows {}",
+      uncompressedSize64,
+      numRows);
+  const auto uncompressedSize = static_cast<int32_t>(uncompressedSize64);
+
 #ifdef BOLT_ENABLE_CRC
   int64_t crc = 0;
   if (listener) {
@@ -3305,13 +3317,13 @@ void flushUncompressed(
   }
 #endif
 
-  out->seekp(offset + kSizeInBytesOffset);
+  out->seekp(offset + static_cast<std::streampos>(kSizeInBytesOffset));
   writeInt32(out, uncompressedSize);
   writeInt32(out, uncompressedSize);
 #ifdef BOLT_ENABLE_CRC
   writeInt64(out, crc);
 #endif
-  out->seekp(offset + size);
+  out->seekp(endOffset);
 }
 
 void flushSerialization(
@@ -3342,7 +3354,7 @@ void flushSerialization(
   if (listener) {
     listener->pause();
   }
-  const int32_t endSize = output->tellp();
+  const auto endSize = output->tellp();
   // Fill in crc
   int64_t crc = 0;
   if (listener) {
@@ -3382,12 +3394,18 @@ void flushCompressed(
     stream->flush(&out);
   }
 
-  const int32_t uncompressedSize = out.tellp();
+  const auto uncompressedSize64 = out.tellp();
   BOLT_CHECK(
-      uncompressedSize > 0,
+      uncompressedSize64 > 0,
       "uncompressedSize {} should be positive, numRows {}",
-      uncompressedSize,
+      uncompressedSize64,
       numRows);
+  BOLT_CHECK(
+      uncompressedSize64 <= std::numeric_limits<int32_t>::max(),
+      "uncompressedSize {} exceeds INT32_MAX, numRows {}",
+      uncompressedSize64,
+      numRows);
+  const auto uncompressedSize = static_cast<int32_t>(uncompressedSize64);
   auto iobuf = out.getIOBuf();
 
   // compress

--- a/bolt/serializers/tests/PrestoSerializerTest.cpp
+++ b/bolt/serializers/tests/PrestoSerializerTest.cpp
@@ -31,6 +31,9 @@
 #include "bolt/serializers/PrestoSerializer.h"
 #include <folly/Random.h>
 #include <gtest/gtest.h>
+
+#include <limits>
+
 #include <vector>
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/memory/ByteStream.h"
@@ -720,6 +723,73 @@ TEST_P(PrestoSerializerTest, ioBufRoundTrip) {
 
     assertEqualVectors(inputRowVector, outputRowVector);
   }
+}
+
+TEST_P(PrestoSerializerTest, largeAbsoluteOffsetDoesNotOverflowWhenFlushing) {
+  auto rowVector = makeTestVector(1024);
+  auto paramOptions = getParamSerdeOptions(nullptr);
+  auto arena = std::make_unique<StreamArena>(pool_.get());
+  auto rowType = asRowType(rowVector->type());
+  auto serializer = serde_->createSerializer(
+      rowType, rowVector->size(), arena.get(), &paramOptions);
+  serializer->append(rowVector);
+
+  class LargeOffsetOutputStream : public OutputStream {
+   public:
+    explicit LargeOffsetOutputStream(
+        std::streampos initialPos,
+        OutputStreamListener* listener = nullptr)
+        : OutputStream(listener), pos_(initialPos), maxPos_(initialPos) {}
+
+    void write(const char* s, std::streamsize count) override {
+      pos_ += count;
+      if (maxPos_ < pos_) {
+        maxPos_ = pos_;
+      }
+      if (listener_) {
+        listener_->onWrite(s, count);
+      }
+    }
+
+    std::streampos tellp() const override {
+      return pos_;
+    }
+
+    void seekp(std::streampos pos) override {
+      if (static_cast<int64_t>(pos) < 0) {
+        sawNegativeSeek_ = true;
+      }
+      pos_ = pos;
+      if (maxPos_ < pos_) {
+        maxPos_ = pos_;
+      }
+    }
+
+    std::streampos maxPos() const {
+      return maxPos_;
+    }
+
+    bool sawNegativeSeek() const {
+      return sawNegativeSeek_;
+    }
+
+   private:
+    std::streampos pos_;
+    std::streampos maxPos_;
+    bool sawNegativeSeek_{false};
+  };
+
+  const auto initialPos =
+      static_cast<std::streampos>(std::numeric_limits<int32_t>::max() - 128);
+  bytedance::bolt::serializer::presto::PrestoOutputStreamListener listener;
+  LargeOffsetOutputStream out(initialPos, &listener);
+
+  serializer->flush(&out);
+
+  EXPECT_FALSE(out.sawNegativeSeek());
+  EXPECT_GT(
+      static_cast<int64_t>(out.maxPos()), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(out.tellp(), out.maxPos());
 }
 
 #ifdef IS_BUILDING_WITH_ASAN


### PR DESCRIPTION
## Background

The Presto serializer back-fills the page header / CRC during `flush`. However, several places in the implementation prematurely narrow stream offsets to `int32_t`. When the cumulative output position exceeds `INT32_MAX`, computations such as `offset + size` overflow, eventually causing `seekp` to seek to a wrong (negative) position.

## Changes

- `bolt/serializers/PrestoSerializer.cpp`
  - Keep `offset` / `endOffset` / `endSize` as the stream-native position type instead of narrowing to `int32_t` early.
  - Only narrow to `int32_t` when actually writing the on-wire size field, with explicit overflow checks.
  - In `flushUncompressed`, validate that `uncompressedSize = size - kHeaderSize <= INT32_MAX`.
  - In `flushCompressed`, keep the protocol-level `uncompressedSize <= INT32_MAX` check.
- `bolt/serializers/tests/PrestoSerializerTest.cpp`
  - Add a regression test that exercises a large absolute offset scenario, verifying that flushing across `INT32_MAX` does not produce a negative `seekp`.

## Verification

Added a unit test `PrestoSerializerTest.largeAbsoluteOffsetDoesNotOverflowWhenFlushing` that asserts no negative `seekp` is observed and that `tellp()` ultimately exceeds `INT32_MAX`.