### PR TITLE
fix(arrays_zip): fix arity off-by-one and split Spark/Presto signatures

### DIFF
--- a/bolt/functions/prestosql/Zip.cpp
+++ b/bolt/functions/prestosql/Zip.cpp
@@ -38,16 +38,20 @@ namespace bytedance::bolt::functions {
 namespace {
 
 class ZipFunction : public exec::VectorFunction {
-  static const auto kMinArity = 2;
-  static const auto kMaxArity = 7;
+  // Hard ceiling used purely to bound the type-variable string buffer.
+  // Per-engine min/max arity is provided to signatures() at registration time.
+  static constexpr int kMaxArityCeiling = 32;
 
  public:
-  /// This class implements the zip function.
+  /// This class implements the zip / arrays_zip function.
   ///
   /// DEFINITION:
   /// zip(ARRAY[T], ARRAY[U]) -> ARRAY(ROW[T,U])
   /// where we create a ROW[Ti, Ui] for every ith element in ARRAY[T], ARRAY[U].
   /// The smaller array is padded with nulls.
+  /// Row-level NULL semantics (any-arg-null-on-row -> null-result-on-row) are
+  /// handled by the framework's default null-behavior; this function only
+  /// runs on rows where every arg is non-null.
   ///
   /// IMPLEMENTATION:
   ///  1. The general idea is to create a new dictionary vector for each input
@@ -62,7 +66,8 @@ class ZipFunction : public exec::VectorFunction {
   ///  Note:
   ///   - We make no copy's of any constituent elements and are agnostic to
   ///   types.
-  ///   - For compatibility with Presto a maximum arity of 7 is enforced.
+  ///   - Presto `zip` is registered for arity [2, 7]; Spark `arrays_zip`
+  ///     is registered for arity [1, kMaxArityCeiling].
 
   void apply(
       const SelectivityVector& rows,
@@ -243,24 +248,30 @@ class ZipFunction : public exec::VectorFunction {
     context.moveOrCopyResult(arrayVector, rows, result);
   }
 
-  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    static const auto kAritySize = (kMaxArity - kMinArity) + 1;
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
+      int minArity,
+      int maxArity) {
+    BOLT_CHECK_GE(minArity, 1, "ZipFunction arity must be >= 1");
+    BOLT_CHECK_LE(
+        maxArity,
+        kMaxArityCeiling,
+        "ZipFunction maxArity exceeds compiled-in ceiling");
+    BOLT_CHECK_LE(minArity, maxArity, "minArity must be <= maxArity");
+
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
-    signatures.reserve(kAritySize);
+    signatures.reserve(maxArity - minArity + 1);
 
-    std::vector<std::string> elementTypeNames(kAritySize);
-
-    for (int i = 0; i < kAritySize; i++) {
+    std::vector<std::string> elementTypeNames(maxArity);
+    for (int i = 0; i < maxArity; i++) {
       elementTypeNames[i] = fmt::format("E{:02d}", i);
     }
 
-    // Build all signatures from kMinArity to kMaxArity.
-    for (int i = 1; i < kAritySize; i++) {
+    // Build all signatures with arity in [minArity, maxArity].
+    for (int arity = minArity; arity <= maxArity; ++arity) {
       auto builder = exec::FunctionSignatureBuilder();
       std::vector<std::string> allTypeVars;
-      allTypeVars.reserve(i + 1);
-
-      for (int j = 0; j < i + 1; j++) {
+      allTypeVars.reserve(arity);
+      for (int j = 0; j < arity; ++j) {
         allTypeVars.emplace_back(elementTypeNames[j]);
         builder.typeVariable(elementTypeNames[j]);
         builder.argumentType(fmt::format("array({})", elementTypeNames[j]));
@@ -272,12 +283,34 @@ class ZipFunction : public exec::VectorFunction {
 
     return signatures;
   }
+
+  // Presto `zip`: per PrestoDB docs, arity is fixed in [2, 7].
+  static std::vector<std::shared_ptr<exec::FunctionSignature>>
+  prestoSignatures() {
+    return signatures(/*minArity=*/2, /*maxArity=*/7);
+  }
+
+  // Spark `arrays_zip`: variadic; arity 0 is constant-folded by Catalyst and
+  // never reaches the native evaluator, so only arity >= 1 is registered.
+  // Upper bound is the compiled-in ceiling.
+  static std::vector<std::shared_ptr<exec::FunctionSignature>>
+  sparkSignatures() {
+    return signatures(/*minArity=*/1, /*maxArity=*/kMaxArityCeiling);
+  }
 };
 
 } // namespace
 
+// Presto `zip(...)`: arity in [2, 7] to match PrestoDB documented signatures.
 BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_zip,
-    ZipFunction::signatures(),
+    udf_zip_presto,
+    ZipFunction::prestoSignatures(),
+    std::make_unique<ZipFunction>());
+
+// Spark `arrays_zip(...)`: arity in [1, kMaxArityCeiling] to match Spark
+// `ArraysZip`, whose only hard limit is the schema's struct width.
+BOLT_DECLARE_VECTOR_FUNCTION(
+    udf_zip_spark,
+    ZipFunction::sparkSignatures(),
     std::make_unique<ZipFunction>());
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/bolt/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -152,7 +152,7 @@ void registerArrayFunctions(const std::string& prefix) {
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_except, prefix + "array_except");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, prefix + "arrays_overlap");
   registerBigintSliceFunction(prefix);
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_zip, prefix + "zip");
+  BOLT_REGISTER_VECTOR_FUNCTION(udf_zip_presto, prefix + "zip");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_zip_with, prefix + "zip_with");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_position, prefix + "array_position");
 

--- a/bolt/functions/prestosql/tests/ZipTest.cpp
+++ b/bolt/functions/prestosql/tests/ZipTest.cpp
@@ -431,18 +431,26 @@ TEST_F(ZipTest, flatArraysWithGapInElements) {
   assertEqualVectors(expected, result);
 }
 
-// Single arg not supported.
+// Single arg not supported for Presto `zip` (arity range is [2, 7]).
 TEST_F(ZipTest, singleArgument) {
   auto vector = makeNullableArrayVector<int64_t>(
       {{1, 2, 3, 4}, {3, 4, 5}, {std::nullopt}});
   BOLT_ASSERT_THROW(
       evaluate<ArrayVector>("zip(c0)", makeRowVector({vector})),
-      "Scalar function signature is not supported: zip(ARRAY<BIGINT>). Supported signatures: "
-      "(array(E00),array(E01)) -> array(row(E00,E01)), (array(E00),array(E01),array(E02)) -> "
-      "array(row(E00,E01,E02)), (array(E00),array(E01),array(E02),array(E03)) -> array(row(E0"
-      "0,E01,E02,E03)), (array(E00),array(E01),array(E02),array(E03),array(E04)) -> array(row"
-      "(E00,E01,E02,E03,E04)), (array(E00),array(E01),array(E02),array(E03),array(E04),array("
-      "E05)) -> array(row(E00,E01,E02,E03,E04,E05))");
+      "Scalar function signature is not supported: zip(ARRAY<BIGINT>).");
+}
+
+// Presto `zip` is documented as accepting 2..7 array arguments.
+// Verify the Spark-only arity expansion (1, 8+) is NOT exposed to Presto.
+TEST_F(ZipTest, prestoArityBoundsAreEnforced) {
+  auto a = makeArrayVector<int64_t>({{1, 2, 3}, {}, {7, 8}});
+
+  // Arity 8 is beyond Presto's documented max of 7.
+  BOLT_ASSERT_THROW(
+      evaluate<ArrayVector>(
+          "zip(c0, c0, c0, c0, c0, c0, c0, c0)",
+          makeRowVector({a, a, a, a, a, a, a, a})),
+      "not supported");
 }
 
 } // namespace

--- a/bolt/functions/sparksql/registration/RegisterArray.cpp
+++ b/bolt/functions/sparksql/registration/RegisterArray.cpp
@@ -60,7 +60,7 @@ void registerSparkArrayFunctions(const std::string& prefix) {
       udf_array_slice_sum, prefix + "array_slice_sum");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_any_match, prefix + "exists");
 
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_zip, prefix + "arrays_zip");
+  BOLT_REGISTER_VECTOR_FUNCTION(udf_zip_spark, prefix + "arrays_zip");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_zip_with, prefix + "zip_with");
 
   BOLT_REGISTER_VECTOR_FUNCTION(udf_all_match, prefix + "forall")

--- a/bolt/functions/sparksql/tests/ArraysZipTest.cpp
+++ b/bolt/functions/sparksql/tests/ArraysZipTest.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace bytedance::bolt::test;
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class ArraysZipTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+// Single-arg `arrays_zip(a)` is supported in Spark; result is array of single
+// field structs. Verifies the Spark-side registration accepts arity 1, which
+// Presto `zip` still rejects (Presto signatures are [2, 7]).
+TEST_F(ArraysZipTest, singleArg) {
+  auto a = makeArrayVector<int64_t>({{1, 2, 3}, {}, {7, 8}});
+
+  auto field0 = makeFlatVector<int64_t>({1, 2, 3, 7, 8});
+  auto rowVector = makeRowVector({field0});
+  auto expected = makeArrayVector({0, 3, 3}, rowVector);
+
+  testExpression("arrays_zip(c0)", {a}, expected);
+}
+
+// Equal-length zip on two arrays.
+TEST_F(ArraysZipTest, twoArraysEqualLength) {
+  auto a = makeArrayVector<int64_t>({{1, 2, 3}, {4, 5}});
+  auto b = makeArrayVector<int64_t>({{10, 20, 30}, {40, 50}});
+
+  auto field0 = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto field1 = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto rowVector = makeRowVector({field0, field1});
+  auto expected = makeArrayVector({0, 3}, rowVector);
+
+  testExpression("arrays_zip(c0, c1)", {a, b}, expected);
+}
+
+// Unequal-length: shorter array padded with NULL on the right.
+TEST_F(ArraysZipTest, unequalLengthPadsNull) {
+  auto a = makeArrayVector<int64_t>({{1, 2, 3}, {4}});
+  auto b = makeArrayVector<int64_t>({{10, 20}, {40, 50, 60}});
+
+  auto field0 =
+      makeNullableFlatVector<int64_t>({1, 2, 3, 4, std::nullopt, std::nullopt});
+  auto field1 =
+      makeNullableFlatVector<int64_t>({10, 20, std::nullopt, 40, 50, 60});
+  auto rowVector = makeRowVector({field0, field1});
+  auto expected = makeArrayVector({0, 3}, rowVector);
+
+  testExpression("arrays_zip(c0, c1)", {a, b}, expected);
+}
+
+// Inner element NULLs are preserved verbatim and are NOT treated as missing.
+TEST_F(ArraysZipTest, innerNullsArePreserved) {
+  auto a = makeNullableArrayVector<int64_t>(
+      {{{1, std::nullopt, 3}, {std::nullopt}}});
+  auto b = makeNullableArrayVector<int64_t>(
+      {{{std::nullopt, 20, 30}, {std::nullopt}}});
+
+  auto field0 =
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt});
+  auto field1 =
+      makeNullableFlatVector<int64_t>({std::nullopt, 20, 30, std::nullopt});
+  auto rowVector = makeRowVector({field0, field1});
+  auto expected = makeArrayVector({0, 3}, rowVector);
+
+  testExpression("arrays_zip(c0, c1)", {a, b}, expected);
+}
+
+// Cover the original failing pattern: 10 array inputs.
+// Before the fix only arity 2..6 were registered (off-by-one + Presto's
+// MAX_ARITY=7 cap), so `arrays_zip(c0..c9)` would throw
+// "Scalar function arrays_zip not registered".
+TEST_F(ArraysZipTest, tenArguments) {
+  auto a0 = makeArrayVector<int64_t>({{1, 2}, {3}});
+  auto a1 = makeArrayVector<int64_t>({{10}, {30, 31}});
+  auto a2 = makeArrayVector<int64_t>({{100, 101}, {300}});
+  auto a3 = makeArrayVector<int64_t>({{1}, {3}});
+  auto a4 = makeArrayVector<int64_t>({{2}, {4}});
+  auto a5 = makeArrayVector<int64_t>({{5}, {6}});
+  auto a6 = makeArrayVector<int64_t>({{7}, {8}});
+  auto a7 = makeArrayVector<int64_t>({{9}, {10}});
+  auto a8 = makeArrayVector<int64_t>({{11}, {12}});
+  auto a9 = makeArrayVector<int64_t>({{13}, {14}});
+
+  auto result = evaluate(
+      "arrays_zip(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)",
+      makeRowVector({a0, a1, a2, a3, a4, a5, a6, a7, a8, a9}));
+
+  // Sanity: result is array<row<10 fields>> with the right top-level shape.
+  auto arrayResult = result->as<ArrayVector>();
+  ASSERT_NE(arrayResult, nullptr);
+  EXPECT_EQ(arrayResult->size(), 2);
+  // Row 0: max len = 2, Row 1: max len = 2.
+  EXPECT_EQ(arrayResult->sizeAt(0), 2);
+  EXPECT_EQ(arrayResult->sizeAt(1), 2);
+
+  auto rows = arrayResult->elements()->as<RowVector>();
+  ASSERT_NE(rows, nullptr);
+  EXPECT_EQ(rows->childrenSize(), 10);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   ArrayShuffleTest.cpp
   ArraySliceSumTest.cpp
   ArrayUnionTest.cpp
+  ArraysZipTest.cpp
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
   BitwiseTest.cpp


### PR DESCRIPTION
## Background

When a Spark SQL with `arrays_zip(a1, a2, ..., a10)` (10 array columns) runs on Bolt via Gluten, the executor fails with:

```
Scalar function arrays_zip not registered with arguments:
  (ARRAY<VARCHAR> x 10)
Found function registered with the following signatures:
  arity = 2,3,4,5,6
```

Two issues in `bolt/functions/prestosql/Zip.cpp`:

1. The signature-building loop has an off-by-one (`for (int i = 1; i < kAritySize; i++)`) so with `kMinArity=2, kMaxArity=7` it only registers signatures for arity 2..6 instead of 2..7. This produces the 5-signature set seen in the error.
2. `kMaxArity = 7` (Presto MAX_ARITY) is too small for Spark `arrays_zip`, whose arity is effectively unbounded; production already uses 10+ arrays.

Note: the row-level NULL semantics needed for both engines (any-arg-null on a row -> null result on that row) are already provided by the `VectorFunction` framework via the default null-behavior, so this MR does NOT touch `apply()` -- the existing logic is correct and equivalent to native Spark on real data.

## Changes

- Refactor `ZipFunction::signatures()` to take `(minArity, maxArity)` as parameters, fixing the off-by-one (`for arity in [minArity, maxArity]`).
- Add two arity-range presets:
    * `prestoSignatures()` -> `[2, 7]` -- matches PrestoDB `ZipFunction.java`.
    * `sparkSignatures()`  -> `[1, kMaxArityCeiling]` -- matches Spark `arrays_zip`, with 32 kept as a compiled-in safety bound. Arity 0 (`arrays_zip()`) is constant-folded by Catalyst before reaching the native evaluator, so it does not need a native signature.
- Split the single `udf_zip` tag into two distinct vector-function tags:
    * `udf_zip_presto` registered as `"zip"`        in `prestosql` namespace.
    * `udf_zip_spark`  registered as `"arrays_zip"` in `sparksql` namespace.
  Both tags share the same `ZipFunction` implementation (single source of
  truth for runtime behavior); only the registered signature sets differ.
- `prestosql/registration/ArrayFunctionsRegistration.cpp` and
  `sparksql/registration/RegisterArray.cpp` updated to wire the new tags.

## Tests

- New `bolt/functions/sparksql/tests/ArraysZipTest.cpp` with five cases: `singleArg`, `twoArraysEqualLength`, `unequalLengthPadsNull`, `innerNullsArePreserved`, `tenArguments` (covers the original 10-arg failure pattern). Wired into `sparksql/tests/CMakeLists.txt`.
- `prestosql/tests/ZipTest.cpp`:
    * `singleArgument` -- relax the brittle hard-coded supported-signatures listing (which baked in the old 5-signature set) to assert only the function-not-supported prefix.
    * New `prestoArityBoundsAreEnforced` -- asserts arity 8 on `zip` is still rejected, proving the Spark widening did not leak into Presto.

## Gluten compatibility

Gluten maps Spark `ArraysZip` -> substrait function name `"arrays_zip"` (`gluten-substrait/.../ExpressionMappings.scala:256` + `shims/common/.../ExpressionNames.scala:281`). Function names are unchanged by this MR, only the per-engine arity ranges are tightened/widened. No Gluten-side registration changes are required.

## Refs

- Spark `ArraysZip` expression: `org.apache.spark.sql.catalyst.expressions.ArraysZip`
- PrestoDB `ZipFunction.java` (MIN_ARITY=2, MAX_ARITY=7).
- Original failure: `application_1779865918999_305437`.


Change-Id: I26fb50d0d126730f3b571712ec62e86343c4a3a2

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #622 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
