### PR TITLE
fix(parquet): lazily load pending repdefs during page seek

### DIFF
--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -262,6 +262,18 @@ void PageReader::setPageRowInfo(bool forRepDef) {
     numRowsInPage_ = numRepDefsInPage_;
   } else if (hasChunkRepDefs_) {
     ++pageIndex_;
+
+    // The repeated reader normally decodes rep/def metadata far enough before
+    // the value reader seeks into a non-top-level data page. However, sparse
+    // selective reads can make the value path reach the next physical page
+    // exactly when only the already-consumed rep/def page counts are present in
+    // numLeavesInPage_. If more preloaded rep/def batches are available, decode
+    // them here instead of failing the scan immediately.
+    while (pageIndex_ >= static_cast<int32_t>(numLeavesInPage_.size()) &&
+           !preloadedRepDefs_.empty()) {
+      loadMoreRepDefs();
+    }
+
     BOLT_CHECK_LT(
         pageIndex_,
         numLeavesInPage_.size(),

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -74,6 +74,8 @@ struct CryptoContext {
 /// encodings and presents the combination of pages and encoded values as a
 /// continuous stream accessible via readWithVisitor().
 class PageReader {
+  friend class PageReaderTestPeer;
+
  public:
   PageReader(
       std::unique_ptr<dwio::common::SeekableInputStream> stream,

--- a/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -28,6 +28,7 @@
  * --------------------------------------------------------------------------
  */
 
+#include <cstring>
 #include "bolt/dwio/parquet/reader/PageReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 using namespace bytedance::bolt;
@@ -36,6 +37,117 @@ using namespace bytedance::bolt::dwio::common;
 using namespace bytedance::bolt::parquet;
 
 class ParquetPageReaderTest : public ParquetTestBase {};
+
+namespace bytedance::bolt::parquet {
+
+class PageReaderTestPeer {
+ public:
+  static raw_vector<char> makeRepDefBatch(
+      int32_t numRepDefs,
+      int16_t repetitionLevel,
+      int16_t definitionLevel,
+      int32_t maxRepeat,
+      int32_t maxDefine) {
+    raw_vector<char> batch;
+    append<int32_t>(batch, numRepDefs);
+    appendLevels(batch, numRepDefs, repetitionLevel, maxRepeat);
+    appendLevels(batch, numRepDefs, definitionLevel, maxDefine);
+    return batch;
+  }
+
+  static void initializeForPendingRepDefs(PageReader& pageReader) {
+    pageReader.hasChunkRepDefs_ = true;
+    pageReader.pageIndex_ = 0;
+    pageReader.numLeavesInPage_ = {1};
+    pageReader.preloadedRepDefs_.push_back(makeRepDefBatch(
+        1,
+        0,
+        pageReader.maxDefine_,
+        pageReader.maxRepeat_,
+        pageReader.maxDefine_));
+  }
+
+  static void setPageRowInfo(PageReader& pageReader) {
+    pageReader.setPageRowInfo(false);
+  }
+
+  static int32_t pageIndex(const PageReader& pageReader) {
+    return pageReader.pageIndex_;
+  }
+
+  static int32_t numRowsInPage(const PageReader& pageReader) {
+    return pageReader.numRowsInPage_;
+  }
+
+  static size_t numKnownRepDefPages(const PageReader& pageReader) {
+    return pageReader.numLeavesInPage_.size();
+  }
+
+  static size_t numPendingRepDefBatches(const PageReader& pageReader) {
+    return pageReader.preloadedRepDefs_.size();
+  }
+
+ private:
+  template <typename T>
+  static void append(raw_vector<char>& out, T value) {
+    const auto offset = out.size();
+    out.resize(offset + sizeof(T));
+    std::memcpy(out.data() + offset, &value, sizeof(T));
+  }
+
+  static void appendLevels(
+      raw_vector<char>& out,
+      int32_t numLevels,
+      int16_t level,
+      int32_t maxLevel) {
+    const auto bitWidth = ::arrow::bit_util::NumRequiredBits(maxLevel);
+    std::vector<uint8_t> encoded(
+        ::arrow::util::RleEncoder::MaxBufferSize(bitWidth, numLevels) +
+        ::arrow::util::RleEncoder::MinBufferSize(bitWidth));
+    ::arrow::util::RleEncoder encoder(encoded.data(), encoded.size(), bitWidth);
+    for (auto i = 0; i < numLevels; ++i) {
+      encoder.Put(level);
+    }
+    const auto encodedSize = encoder.Flush();
+    append<uint32_t>(out, encodedSize);
+    const auto offset = out.size();
+    out.resize(offset + encodedSize);
+    std::memcpy(out.data() + offset, encoded.data(), encodedSize);
+  }
+};
+
+} // namespace bytedance::bolt::parquet
+
+TEST_F(ParquetPageReaderTest, loadsPendingRepDefsBeforePageRowInfoCheck) {
+  auto fileType = std::make_shared<ParquetTypeWithId>(
+      VARCHAR(),
+      std::vector<std::shared_ptr<const dwio::common::TypeWithId>>{},
+      0,
+      0,
+      0,
+      "items.list.element",
+      thrift::Type::BYTE_ARRAY,
+      std::nullopt,
+      thrift::ConvertedType::UTF8,
+      1,
+      2,
+      true,
+      false);
+  PageReader pageReader(
+      nullptr,
+      *leafPool_,
+      fileType,
+      thrift::CompressionCodec::UNCOMPRESSED,
+      0,
+      nullptr);
+  PageReaderTestPeer::initializeForPendingRepDefs(pageReader);
+
+  ASSERT_NO_THROW(PageReaderTestPeer::setPageRowInfo(pageReader));
+  EXPECT_EQ(PageReaderTestPeer::pageIndex(pageReader), 1);
+  EXPECT_EQ(PageReaderTestPeer::numRowsInPage(pageReader), 1);
+  EXPECT_EQ(PageReaderTestPeer::numKnownRepDefPages(pageReader), 2);
+  EXPECT_EQ(PageReaderTestPeer::numPendingRepDefBatches(pageReader), 0);
+}
 
 TEST_F(ParquetPageReaderTest, smallPage) {
   auto readFile =

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1504,6 +1504,66 @@ TEST_F(ParquetReaderTest, skip) {
   EXPECT_EQ(0, rowReader->next(1000, result));
 }
 
+TEST_F(ParquetReaderTest, sparseSkipAcrossRepeatedPagesWithBatchedRepDefs) {
+  constexpr int32_t kNumRows = 6'000;
+  constexpr int32_t kTargetRow = 5'000;
+  const std::string payload(256, 'x');
+
+  auto ids = makeFlatVector<int64_t>(
+      kNumRows, [](auto row) { return static_cast<int64_t>(row); });
+  std::vector<std::string> values;
+  values.reserve(kNumRows);
+  std::vector<std::vector<StringView>> arrays;
+  arrays.reserve(kNumRows);
+  for (auto i = 0; i < kNumRows; ++i) {
+    values.push_back(fmt::format("{}-{}", i, payload));
+    arrays.push_back({StringView(values.back())});
+  }
+
+  auto rowType = ROW({"id", "items"}, {BIGINT(), ARRAY(VARCHAR())});
+  auto data = makeRowVector({ids, makeArrayVector<StringView>(arrays)});
+
+  auto tempFile = exec::test::TempFilePath::create();
+  auto writeFile =
+      std::make_unique<LocalWriteFile>(tempFile->path, true, false);
+  auto sink = std::make_unique<dwio::common::WriteFileSink>(
+      std::move(writeFile), tempFile->path);
+
+  bytedance::bolt::parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  writerOptions.enableDictionary = false;
+  writerOptions.dataPageSize = 1024;
+  writerOptions.columnDataPageSizeMap["items.list.element"] = 1024;
+  writerOptions.writeBatchBytes = 1ULL << 30;
+  writerOptions.minBatchSize = 1;
+  auto writer = std::make_unique<bytedance::bolt::parquet::Writer>(
+      std::move(sink), writerOptions, rowType);
+  writer->write(data);
+  writer->close();
+
+  bytedance::bolt::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileSchema(rowType);
+  readerOptions.setFileFormat(dwio::common::FileFormat::PARQUET);
+  auto reader = createReader(tempFile->path, readerOptions);
+
+  auto rowReaderOpts = getReaderOpts(rowType);
+  rowReaderOpts.setDecodeRepDefPageCount(1);
+  rowReaderOpts.setParquetRepDefMemoryLimit(1);
+  auto scanSpec = makeScanSpec(rowType);
+  scanSpec->getOrCreateChild(Subfield("id"))
+      ->setFilter(exec::equal(kTargetRow));
+  rowReaderOpts.setScanSpec(scanSpec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+  ASSERT_NO_THROW({
+    auto rowsRead = rowReader->next(1, result);
+    ASSERT_EQ(rowsRead, 1);
+  });
+
+  assertEqualVectorPart(data, result, kTargetRow);
+}
+
 TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string filename("varbinary_flba.parquet");
   const std::string sample(getExampleFilePath(filename));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #624 

Repeated Parquet columns keep two streams of state in sync:

  1. the value pages that contain the actual leaf values, and
  2. the repetition/definition levels that describe how those leaf values map back to top-level rows.

  For chunk-level repetition/definition levels, `PageReader` materializes per-page leaf counts in `numLeavesInPage_` and uses `pageIndex_` to look up the count for the current non-top-level data page.

  Sparse selective reads can make the value reader reach a later physical page while `numLeavesInPage_` only contains metadata for pages decoded from earlier rep/def batches. This does not necessarily mean the file
  or seek is invalid: `preloadRepDefs()` may already have staged more rep/def batches in `preloadedRepDefs_`, but those batches have not yet been decoded into `numLeavesInPage_`.

  The old code checked `pageIndex_` against `numLeavesInPage_` immediately and could fail with:


  Seeking past known `repdefs` for non top level column page N

  This PR fixes that by lazily decoding pending rep/def batches before enforcing the existing bounds check.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

  This PR updates `PageReader::setPageRowInfo()` for non-top-level repeated columns.

  Before this change, PageReader advanced `pageIndex_` and immediately checked whether the current page was already covered by `numLeavesInPage_`.

  That was too eager when `preloadedRepDefs_` was non-empty. In that case, the metadata may already be available but still encoded in a pending rep/def batch.

  The new logic decodes pending rep/def batches until either:

  1. the current `pageIndex_` is covered by `numLeavesInPage_`, or
  2. there are no pending rep/def batches left.

  The original bounds check remains in place, so truly inconsistent state still fails. The reader only recovers when the needed metadata was already preloaded.

  The fix is:
```
  while (pageIndex_ >= static_cast<int32_t>(numLeavesInPage_.size()) &&
         !preloadedRepDefs_.empty()) {
    loadMoreRepDefs();
  }
```

  This PR also adds regression coverage:

  1. A focused PageReader regression test that constructs the exact problematic state:
    • one known page in `numLeavesInPage_`,
    • the next page requested by `pageIndex_`,
    • one pending encoded rep/def batch in `preloadedRepDefs_`.
  Without the lazy load, this test throws the same Seeking past known repdefs error. With the fix, the pending batch is materialized and the page row info is populated.
  2. An end-to-end reader scenario with `ARRAY<VARCHAR>`, small Parquet pages, batched rep/def settings, and a sparse filter to exercise the same reader path through public APIs.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a native Parquet reader failure where sparse reads of repeated columns could seek past currently materialized rep/def page metadata even though more rep/def batches were already preloaded.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
