### PR TITLE
fix: don't CHECK evictState_ in shuffle writer tryEvict on reclaim

### DIFF
--- a/bolt/common/memory/sparksql/tests/MemoryTestUtils.h
+++ b/bolt/common/memory/sparksql/tests/MemoryTestUtils.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "bolt/common/memory/MemoryArbitrator.h"
+#include "bolt/common/memory/sparksql/ConfigurationResolver.h"
 #include "bolt/common/memory/sparksql/NativeMemoryManagerFactory.h"
 #include "bolt/common/memory/sparksql/Spiller.h"
 
@@ -43,6 +45,42 @@ class TestSpiller final : public memory::sparksql::Spiller {
   std::weak_ptr<BoltMemoryManager> memoryManager_;
 };
 
+// A spiller that actually reclaims Bolt operators
+// spiller gluten registers in production. When the task memory pool can't
+// grant memory, TaskMemoryManager::acquireExecutionMemory invokes the
+// consumer's spill which (in the kSpill phase) calls this; it reclaims the
+// aggregate memory pool, which pauses the task and walks operator reclaimers
+// (Task/Operator::MemoryReclaimer -> e.g. SparkShuffleWriter::reclaim).
+class OperatorReclaimSpiller final : public memory::sparksql::Spiller {
+ public:
+  explicit OperatorReclaimSpiller(const BoltMemoryManagerPtr& memoryManager)
+      : memoryManager_(memoryManager) {}
+
+  int64_t spill(MemoryTargetWeakPtr self, int64_t size) override {
+    auto manager = memoryManager_.lock();
+    if (!manager) {
+      return 0;
+    }
+    auto pool = manager->getAggregateMemoryPool();
+    // Reclaim must run under a memory-arbitration context (same as
+    // ListenableArbitrator::shrinkCapacity). It
+    // walks the operator reclaimers (Task/Operator::MemoryReclaimer), pausing
+    // the task as needed.
+    bytedance::bolt::memory::ScopedMemoryArbitrationContext arbitrationCtx{
+        pool.get()};
+    bytedance::bolt::memory::MemoryReclaimer::Stats stats;
+    return static_cast<int64_t>(
+        pool->reclaim(static_cast<uint64_t>(size), 0, stats));
+  }
+
+  const std::set<SpillerPhase>& applicablePhases() override {
+    return SpillerHelper::phaseSetSpillOnly();
+  }
+
+ private:
+  std::weak_ptr<BoltMemoryManager> memoryManager_;
+};
+
 // A helper to create MemoryManager for tests, hard memory limit is set to
 // memoryLimit. Note: there should be only one TestMemoryManagerHolder in
 // certain scope.
@@ -55,7 +93,8 @@ class TestSpiller final : public memory::sparksql::Spiller {
 class TestMemoryManagerHolder {
  public:
   static std::shared_ptr<TestMemoryManagerHolder> create(
-      int64_t memoryLimit = memory::kMaxMemory) {
+      int64_t memoryLimit = memory::kMaxMemory,
+      bool withOperatorReclaim = false) {
     if (!ExecutionMemoryPool::inited()) {
       ExecutionMemoryPool::init(true, memoryLimit, 1, {}, 10000);
     } else {
@@ -80,6 +119,13 @@ class TestMemoryManagerHolder {
     auto genericSpiller =
         std::static_pointer_cast<memory::sparksql::Spiller>(spiller);
     instance->appendSpiller(genericSpiller);
+    if (withOperatorReclaim) {
+      std::shared_ptr<OperatorReclaimSpiller> reclaimSpiller =
+          std::make_shared<OperatorReclaimSpiller>(instance->getManager());
+      auto genericReclaimSpiller =
+          std::static_pointer_cast<memory::sparksql::Spiller>(reclaimSpiller);
+      instance->appendSpiller(genericReclaimSpiller);
+    }
     return std::shared_ptr<TestMemoryManagerHolder>(
         new TestMemoryManagerHolder(instance, tmm, memoryLimit));
   }

--- a/bolt/exec/tests/utils/CMakeLists.txt
+++ b/bolt/exec/tests/utils/CMakeLists.txt
@@ -36,6 +36,7 @@ bolt_add_library(
   Cursor.cpp
   HiveConnectorTestBase.cpp
   LocalExchangeSource.cpp
+  MemoryHogOperator.cpp
   OperatorTestBase.cpp
   PlanBuilder.cpp
   PortUtil.cpp

--- a/bolt/exec/tests/utils/MemoryHogOperator.cpp
+++ b/bolt/exec/tests/utils/MemoryHogOperator.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/exec/tests/utils/MemoryHogOperator.h"
+
+namespace bytedance::bolt::exec::test {
+namespace {
+const bool kMemoryHogOperatorRegistered = [] {
+  Operator::registerOperator(std::make_unique<MemoryHogTranslator>());
+  return true;
+}();
+} // namespace
+
+MemoryHogNode::MemoryHogNode(
+    const core::PlanNodeId& id,
+    RowTypePtr outputType,
+    std::vector<RowVectorPtr> batches,
+    int32_t triggerAt,
+    int64_t allocBytes)
+    : PlanNode(id),
+      outputType_(std::move(outputType)),
+      batches_(std::move(batches)),
+      triggerAt_(triggerAt),
+      allocBytes_(allocBytes) {}
+
+} // namespace bytedance::bolt::exec::test

--- a/bolt/exec/tests/utils/MemoryHogOperator.h
+++ b/bolt/exec/tests/utils/MemoryHogOperator.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/core/PlanNode.h"
+#include "bolt/exec/Operator.h"
+
+namespace bytedance::bolt::exec::test {
+
+/// A leaf source operator that emits a fixed list of batches and, right before
+/// emitting the batch at 'triggerAt', allocates 'allocBytes' from its own
+/// operator memory pool and frees it again. The allocation creates real memory
+/// pressure on the task, which can be used to drive a spill or a cross-operator
+/// memory reclaim (e.g. to reclaim a downstream operator that is idle between
+/// batches).
+///
+/// The translator is registered automatically at static-init time (see
+/// MemoryHogOperator.cpp), so callers only need to add a MemoryHogNode to their
+/// plan.
+class MemoryHogNode : public core::PlanNode {
+ public:
+  // Defined out-of-line in MemoryHogOperator.cpp so that constructing a
+  // MemoryHogNode pulls that translation unit in, which in turn runs the
+  // static registration of the operator translator.
+  MemoryHogNode(
+      const core::PlanNodeId& id,
+      RowTypePtr outputType,
+      std::vector<RowVectorPtr> batches,
+      int32_t triggerAt,
+      int64_t allocBytes);
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    static const std::vector<core::PlanNodePtr> kEmpty;
+    return kEmpty;
+  }
+
+  std::string_view name() const override {
+    return "MemoryHog";
+  }
+
+  const std::vector<RowVectorPtr>& batches() const {
+    return batches_;
+  }
+
+  int32_t triggerAt() const {
+    return triggerAt_;
+  }
+
+  int64_t allocBytes() const {
+    return allocBytes_;
+  }
+
+  folly::dynamic serialize() const override {
+    return PlanNode::serialize();
+  }
+
+ private:
+  void addDetails(std::stringstream& stream) const override {
+    stream << "MemoryHog";
+  }
+
+  const RowTypePtr outputType_;
+  const std::vector<RowVectorPtr> batches_;
+  const int32_t triggerAt_;
+  const int64_t allocBytes_;
+};
+
+class MemoryHogOperator : public SourceOperator {
+ public:
+  MemoryHogOperator(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      std::shared_ptr<const MemoryHogNode> node)
+      : SourceOperator(
+            driverCtx,
+            node->outputType(),
+            operatorId,
+            node->id(),
+            "MemoryHog"),
+        batches_(node->batches()),
+        triggerAt_(node->triggerAt()),
+        allocBytes_(node->allocBytes()) {}
+
+  RowVectorPtr getOutput() override {
+    if (current_ >= static_cast<int32_t>(batches_.size())) {
+      return nullptr;
+    }
+    if (current_ == triggerAt_) {
+      // Allocate from this operator's pool to create memory pressure on the
+      // task, then free it. This drives the task's spill / reclaim path.
+      void* buffer = pool()->allocate(allocBytes_);
+      pool()->free(buffer, allocBytes_);
+    }
+    return batches_[current_++];
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /*unused*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return current_ >= static_cast<int32_t>(batches_.size());
+  }
+
+ private:
+  const std::vector<RowVectorPtr> batches_;
+  const int32_t triggerAt_;
+  const int64_t allocBytes_;
+  int32_t current_ = 0;
+};
+
+class MemoryHogTranslator : public Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto hogNode = std::dynamic_pointer_cast<const MemoryHogNode>(node)) {
+      return std::make_unique<MemoryHogOperator>(id, ctx, hogNode);
+    }
+    return nullptr;
+  }
+};
+
+} // namespace bytedance::bolt::exec::test

--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -166,8 +166,7 @@ arrow::Status BoltRowBasedSortShuffleWriter::initFromRowVector(
 }
 
 arrow::Status BoltRowBasedSortShuffleWriter::tryEvict(int64_t) {
-  // add EvictGuard to avoid recursive evict
-  BOLT_CHECK(evictState_ == EvictState::kEvictable);
+  // Mark as unevictable to avoid recursive spill.
   EvictGuard evictGuard{evictState_};
   BOLT_DCHECK(vectorLayout_ != RowVectorLayout::kInvalid);
   if (vectorLayout_ == RowVectorLayout::kColumnar) {

--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -166,7 +166,7 @@ arrow::Status BoltRowBasedSortShuffleWriter::initFromRowVector(
 }
 
 arrow::Status BoltRowBasedSortShuffleWriter::tryEvict(int64_t) {
-  // Mark as unevictable to avoid recursive spill.
+  // add EvictGuard to avoid recursive evict
   EvictGuard evictGuard{evictState_};
   BOLT_DCHECK(vectorLayout_ != RowVectorLayout::kInvalid);
   if (vectorLayout_ == RowVectorLayout::kColumnar) {

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -2310,7 +2310,7 @@ int32_t BoltShuffleWriter::calculatePreallocBufferSize(
 
 // for CompositeRowVector
 arrow::Status BoltShuffleWriter::tryEvict(int64_t) {
-  // Mark as unevictable to avoid recursive spill.
+  // add EvictGuard to avoid recursive evict
   EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -2310,8 +2310,7 @@ int32_t BoltShuffleWriter::calculatePreallocBufferSize(
 
 // for CompositeRowVector
 arrow::Status BoltShuffleWriter::tryEvict(int64_t) {
-  // add EvictGuard to avoid recursive evict
-  BOLT_CHECK(evictState_ == EvictState::kEvictable);
+  // Mark as unevictable to avoid recursive spill.
   EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -296,7 +296,7 @@ arrow::Status BoltShuffleWriterV2::stop() {
 }
 
 arrow::Status BoltShuffleWriterV2::tryEvict(int64_t memLimit) {
-  // Mark as unevictable to avoid recursive spill.
+  // add EvictGuard to avoid recursive evict
   EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -296,8 +296,7 @@ arrow::Status BoltShuffleWriterV2::stop() {
 }
 
 arrow::Status BoltShuffleWriterV2::tryEvict(int64_t memLimit) {
-  // add EvictGuard to avoid recursive evict
-  BOLT_CHECK(evictState_ == EvictState::kEvictable);
+  // Mark as unevictable to avoid recursive spill.
   EvictGuard evictGuard{evictState_};
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);

--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -15,12 +15,24 @@
  */
 
 #include <vector/ComplexVector.h>
+#include <filesystem>
+#include "bolt/common/caching/AsyncDataCache.h"
+#include "bolt/common/memory/sparksql/tests/MemoryTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
+#include "bolt/core/PlanNode.h"
+#include "bolt/exec/tests/utils/Cursor.h"
+#include "bolt/exec/tests/utils/MemoryHogOperator.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
+#include "bolt/shuffle/sparksql/partitioner/Partitioning.h"
 #include "bolt/shuffle/sparksql/tests/ShuffleTestBase.h"
 
 using namespace bytedance::bolt::common::testutil;
+using namespace bytedance::bolt::memory::sparksql::test;
 
 namespace bytedance::bolt::shuffle::sparksql::test {
+
+using bytedance::bolt::exec::test::MemoryHogNode;
 
 // A test suite for shuffle memory related tests
 class ShuffleMemoryTest : public ShuffleTestBase {
@@ -191,6 +203,85 @@ TEST_F(ShuffleMemoryTest, testCompositeRowEvictBeforeInit) {
   // expect OOM for composite row vector large than memory limit rather than
   // coredump
   EXPECT_THROW(executeTestWithCustomInput(param, inputData), BoltRuntimeError);
+}
+
+TEST_F(ShuffleMemoryTest, testRowBasedReclaimViaMemoryPressure) {
+  using namespace bytedance::bolt::exec::test;
+
+  constexpr int32_t kNumPartitions = 4;
+  constexpr int32_t kRowCount = 1024;
+  std::string str(8 * 1024, 'x');
+
+  // Batches with pid as the first column (required by the writer). Feed enough
+  // batches before the trigger so the writer buffers a sizable, reclaimable
+  // amount (so reclaiming it frees enough for the hog's allocation to then
+  // fit).
+  constexpr int32_t kNumBatches = 8;
+  constexpr int32_t kTriggerAt = 6;
+  auto rowType = ROW({"pid", "c0"}, {INTEGER(), VARCHAR()});
+  std::vector<RowVectorPtr> batches;
+  for (int b = 0; b < kNumBatches; ++b) {
+    auto pidVector = makeFlatVector<int32_t>(
+        kRowCount, [](auto row) { return row % kNumPartitions; });
+    auto dataVector = makeFlatVector<StringView>(
+        kRowCount, [&](auto /*row*/) { return StringView(str); });
+    batches.push_back(makeRowVector({"pid", "c0"}, {pidVector, dataVector}));
+  }
+
+  // Enable the operator reclaim spiller (gluten's kSpill spiller analog) on the
+  // test memory manager.
+  const int64_t memoryLimit = 128 * 1024 * 1024;
+  auto memoryManagerHolder = TestMemoryManagerHolder::create(
+      memoryLimit, /*withOperatorReclaim=*/true);
+
+  auto tempDir = TempDirectoryPath::create();
+  std::string localDir = tempDir->path + "/local_dir";
+  std::filesystem::create_directories(localDir);
+
+  ShuffleWriterOptions writerOptions;
+  writerOptions.partitioning = Partitioning::kHash;
+  writerOptions.forceShuffleWriterType = 3; // RowBased
+  writerOptions.partitionWriterOptions.numPartitions = kNumPartitions;
+  writerOptions.partitionWriterOptions.partitionWriterType =
+      PartitionWriterType::kLocal;
+  writerOptions.partitionWriterOptions.dataFile =
+      tempDir->path + "/shuffle_data.bin";
+  writerOptions.partitionWriterOptions.configuredDirs = {localDir};
+  writerOptions.partitionWriterOptions.numSubDirs = 1;
+  writerOptions.taskAttemptId = memoryManagerHolder->taskAttemptId();
+
+  // MemoryHog -> SparkShuffleWriter. Before emitting batch kTriggerAt (after
+  // the writer has buffered the earlier batches and returned to kInit), the hog
+  // allocates allocBytes. That exceeds the free capacity and forces a spill,
+  // but is < the limit so it fits once the idle writer is reclaimed.
+  auto sourceNode = std::make_shared<MemoryHogNode>(
+      "source",
+      rowType,
+      batches,
+      kTriggerAt,
+      /*allocBytes=*/100 * 1024 * 1024);
+  core::PlanNodeId writerId("writer");
+  ShuffleWriterMetrics metrics;
+  auto reportCallback = [&](const ShuffleWriterMetrics& m) { metrics = m; };
+  auto writerNode = std::make_shared<SparkShuffleWriterNode>(
+      writerId, writerOptions, reportCallback, sourceNode);
+
+  CursorParameters params;
+  params.planNode = writerNode;
+  params.serialExecution = true;
+  params.queryCtx = core::QueryCtx::create(
+      nullptr,
+      core::QueryConfig{{}},
+      {},
+      cache::AsyncDataCache::getInstance(),
+      memoryManagerHolder->rootPool());
+
+  auto cursor = TaskCursor::create(params);
+  // Should not throw when the shuffle writer is reclaimed.
+  EXPECT_NO_THROW({
+    while (cursor->moveNext()) {
+    }
+  });
 }
 
 } // namespace bytedance::bolt::shuffle::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #617 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

For the shuffle writer, the `reclaimFixedSize`/`tryEvict` call chains are as shown in the diagram, where each line represents a function call. The red lines (lines 1 and 2) caused a recursive spill, which led to #617. In PR #618, we added a guard to prevent this by checking `kEvictable` in `tryEvict`. However, `tryEvict` may also be called by `reclaimFixedSize` in `RowBasedShuffle` and `CompositeRowVectorShuffle`, so this check could raise unexpected exceptions.

Given these facts, we decided to remove this check. Reasoning:

1. `tryEvict` is normally called by split/stop, but it is also called by `reclaimFixedSize` in `RowBasedShuffle` and `CompositeRowVectorShuffle`. `tryEvict` is never called by itself directly.
2. `reclaimFixedSize` may be called when a spill is triggered by `tryEvict` or any other memory operation.
3. For the `tryEvict` (called by split/stop) → `reclaimFixedSize` path, the newly added guard prevents `reclaimFixedSize` from performing a real eviction, since `tryEvict` is already doing one.
4. For the `reclaimFixedSize` → `tryEvict` path, now that we have removed the check, `tryEvict` will not throw an exception. This is safe because it is called intentionally by `reclaimFixedSize`.
5. For the `reclaimFixedSize` → `reclaimFixedSize` path, the second `reclaimFixedSize` will be skipped since the state is already `kUnEvictable`.
6. For the `tryEvict` → `tryEvict` path (without `reclaimFixedSize`), this can never happen since `tryEvict` does not call itself recursively.
<img width="1628" height="802" alt="image" src="https://github.com/user-attachments/assets/75176a57-ce11-48b5-b0e4-2897ff850640" />


This PR also adds a way to trigger operator spill via `MemoryHogOperator`, which allocates memory at a specific point to trigger a shuffle spill and reproduce the exception in row-based shuffle.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
