### PR TITLE
Add native Flink SQL timestamp and hash functions

### DIFF
--- a/bolt/functions/flinksql/CMakeLists.txt
+++ b/bolt/functions/flinksql/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 bolt_add_library(
   bolt_functions_flink_impl
+  HashCodeFunction.cpp
   JsonFunctions.cpp
   ElementAt.cpp
   specialforms/FlinkCastExpr.cpp

--- a/bolt/functions/flinksql/DateTimeDiff.h
+++ b/bolt/functions/flinksql/DateTimeDiff.h
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+
+#include "bolt/functions/Macros.h"
+#include "bolt/functions/lib/TimeDiffUtils.h"
+#include "bolt/functions/lib/TimeUtils.h"
+#include "bolt/type/Timestamp.h"
+#include "bolt/type/TimestampConversion.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+namespace detail {
+
+// floorDiv/floorMod for month arithmetic. For supported timestamps the operands
+// are positive, but keep the math correct for any input.
+FOLLY_ALWAYS_INLINE int64_t floorDiv(int64_t a, int64_t b) {
+  int64_t q = a / b;
+  if ((a % b != 0) && ((a < 0) != (b < 0))) {
+    --q;
+  }
+  return q;
+}
+
+FOLLY_ALWAYS_INLINE int64_t floorMod(int64_t a, int64_t b) {
+  return a - floorDiv(a, b) * b;
+}
+
+FOLLY_ALWAYS_INLINE int32_t toJavaInt(int64_t value) {
+  const uint32_t bits = static_cast<uint32_t>(value);
+  int32_t result;
+  std::memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+// Adds `months` to a date expressed as days-since-epoch, clamping the day of
+// month to the last valid day (Calcite/Flink DateTimeUtils.addMonths).
+FOLLY_ALWAYS_INLINE int64_t addMonthsToDay(int64_t day, int64_t months) {
+  const auto civil = util::toCivilDateTime(
+      Timestamp(day * util::kSecsPerDay, 0),
+      /*allowOverflow=*/false,
+      /*isPrecision=*/true);
+  const int64_t total = static_cast<int64_t>(civil.date.year) * 12 +
+      (civil.date.month - 1) + months;
+  const int32_t year = static_cast<int32_t>(floorDiv(total, 12));
+  const int32_t month = static_cast<int32_t>(floorMod(total, 12)) + 1;
+  const int32_t dayOfMonth =
+      std::min(civil.date.day, util::getMaxDayOfMonth(year, month));
+  return util::daysSinceEpochFromDate(year, month, dayOfMonth);
+}
+
+// Whole months between two dates expressed as days-since-epoch
+// (Calcite/Flink DateTimeUtils.subtractMonths, date variant). Plain `inline`
+// rather than always-inline because it is self-recursive.
+inline int64_t subtractMonthsByDay(int64_t date0, int64_t date1) {
+  if (date0 < date1) {
+    return -subtractMonthsByDay(date1, date0);
+  }
+  int64_t m = (date0 - date1) / 31;
+  while (true) {
+    if (addMonthsToDay(date1, m) >= date0) {
+      break;
+    }
+    if (addMonthsToDay(date1, m + 1) > date0) {
+      break;
+    }
+    ++m;
+  }
+  return m;
+}
+
+// Whole months from `from` to `to` (Calcite/Flink timestamp variant, which
+// decrements when the clamped month boundary lands exactly on `to` but the
+// time-of-day within that day has not been reached). This differs from Presto's
+// shared diffTimestamp on month-end boundaries, hence the Flink-local copy.
+FOLLY_ALWAYS_INLINE int64_t
+subtractMonths(const Timestamp& from, const Timestamp& to) {
+  constexpr int64_t kMillisPerDay = 86'400'000;
+  const int64_t toMillis = to.toMillis();
+  const int64_t fromMillis = from.toMillis();
+  const int64_t toMillisOfDay = floorMod(toMillis, kMillisPerDay);
+  const int64_t toDay = floorDiv(toMillis, kMillisPerDay);
+  const int64_t fromMillisOfDay = floorMod(fromMillis, kMillisPerDay);
+  const int64_t fromDay = floorDiv(fromMillis, kMillisPerDay);
+  int64_t x = subtractMonthsByDay(toDay, fromDay);
+  if (addMonthsToDay(fromDay, x) == toDay && toMillisOfDay < fromMillisOfDay) {
+    --x;
+  }
+  return x;
+}
+
+} // namespace detail
+
+template <typename T>
+struct FlinkTimestampDiffFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  std::optional<DateTimeUnit> unit_;
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* unitString,
+      const arg_type<Timestamp>* /*ts1*/,
+      const arg_type<Timestamp>* /*ts2*/) {
+    if (unitString != nullptr) {
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* unitString,
+      const arg_type<Timestamp>* /*ts*/,
+      const arg_type<Date>* /*date*/) {
+    if (unitString != nullptr) {
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* unitString,
+      const arg_type<Date>* /*date*/,
+      const arg_type<Timestamp>* /*ts*/) {
+    if (unitString != nullptr) {
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* unitString,
+      const arg_type<Date>* /*date1*/,
+      const arg_type<Date>* /*date2*/) {
+    if (unitString != nullptr) {
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int32_t& result,
+      const arg_type<Varchar>& unitString,
+      const arg_type<Timestamp>& ts1,
+      const arg_type<Timestamp>& ts2) {
+    return computeDiff(result, unitString, ts1, ts2);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int32_t& result,
+      const arg_type<Varchar>& unitString,
+      const arg_type<Timestamp>& ts,
+      const arg_type<Date>& date) {
+    return computeDiff(result, unitString, ts, dateToTimestamp(date));
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int32_t& result,
+      const arg_type<Varchar>& unitString,
+      const arg_type<Date>& date,
+      const arg_type<Timestamp>& ts) {
+    return computeDiff(result, unitString, dateToTimestamp(date), ts);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int32_t& result,
+      const arg_type<Varchar>& unitString,
+      const arg_type<Date>& date1,
+      const arg_type<Date>& date2) {
+    return computeDiff(
+        result, unitString, dateToTimestamp(date1), dateToTimestamp(date2));
+  }
+
+ private:
+  static FOLLY_ALWAYS_INLINE Timestamp dateToTimestamp(int32_t date) {
+    return Timestamp(static_cast<int64_t>(date) * util::kSecsPerDay, 0);
+  }
+
+  FOLLY_ALWAYS_INLINE std::optional<DateTimeUnit> resolveUnit(
+      const arg_type<Varchar>& unitString) {
+    if (unit_.has_value()) {
+      return unit_;
+    }
+    return fromDateTimeUnitString(unitString, /*throwIfInvalid=*/false);
+  }
+
+  // Month/quarter/year follow Calcite/Flink end-of-month semantics; the
+  // fixed-ratio units are identical to Presto and reuse the shared helper.
+  static FOLLY_ALWAYS_INLINE int64_t
+  diffByUnit(DateTimeUnit unit, const Timestamp& from, const Timestamp& to) {
+    switch (unit) {
+      case DateTimeUnit::kMonth:
+        return detail::subtractMonths(from, to);
+      case DateTimeUnit::kQuarter:
+        return detail::subtractMonths(from, to) / 3;
+      case DateTimeUnit::kYear:
+        return detail::subtractMonths(from, to) / 12;
+      default:
+        return diffTimestamp(unit, from, to);
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE bool computeDiff(
+      int32_t& result,
+      const arg_type<Varchar>& unitString,
+      const Timestamp& from,
+      const Timestamp& to) {
+    auto unit = resolveUnit(unitString);
+    if (!unit.has_value()) {
+      // Flink validates the unit keyword at plan time, so an unrecognized unit
+      // cannot legitimately reach here; return SQL NULL rather than a sentinel.
+      return false;
+    }
+    // Java semantics: narrow the int64 result to int32 with two's-complement
+    // wrap, matching Flink's (int) cast (it does not saturate).
+    result = detail::toJavaInt(diffByUnit(unit.value(), from, to));
+    return true;
+  }
+};
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/HashCodeFunction.cpp
+++ b/bolt/functions/flinksql/HashCodeFunction.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/HashCodeFunction.h"
+#include "bolt/expression/DecodedArgs.h"
+#include "bolt/expression/VectorFunction.h"
+
+namespace bytedance::bolt::functions::flinksql {
+namespace {
+
+class HashCodeDecimalFunction final : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const final {
+    BOLT_CHECK_EQ(args.size(), 1);
+    context.ensureWritable(rows, outputType, result);
+    result->clearNulls(rows);
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto input = decodedArgs.at(0);
+    auto rawResult =
+        result->asUnchecked<FlatVector<int32_t>>()->mutableRawValues();
+
+    const auto& inputType = *args[0]->type();
+    const auto scale = getDecimalPrecisionScale(inputType).second;
+    if (inputType.isShortDecimal()) {
+      rows.applyToSelected([&](auto row) {
+        rawResult[row] = hash_code_detail::hashShortDecimal(
+            input->valueAt<int64_t>(row), scale);
+      });
+    } else {
+      BOLT_USER_CHECK(
+          inputType.isLongDecimal(),
+          "Expect decimal type, but got: {}",
+          args[0]->type()->toString());
+      rows.applyToSelected([&](auto row) {
+        rawResult[row] = hash_code_detail::hashLongDecimal(
+            input->valueAt<int128_t>(row), scale);
+      });
+    }
+  }
+};
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+hashCodeDecimalSignatures() {
+  return {exec::FunctionSignatureBuilder()
+              .integerVariable("precision")
+              .integerVariable("scale")
+              .returnType("integer")
+              .argumentType("DECIMAL(precision, scale)")
+              .build()};
+}
+
+std::unique_ptr<exec::VectorFunction> makeHashCodeDecimal() {
+  return std::make_unique<HashCodeDecimalFunction>();
+}
+
+} // namespace
+
+BOLT_DECLARE_VECTOR_FUNCTION(
+    flink_hash_code_decimal,
+    hashCodeDecimalSignatures(),
+    makeHashCodeDecimal());
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/HashCodeFunction.h
+++ b/bolt/functions/flinksql/HashCodeFunction.h
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+#include "bolt/core/QueryConfig.h"
+#include "bolt/functions/Macros.h"
+#include "bolt/functions/lib/string/StringCore.h"
+#include "bolt/type/Type.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+namespace hash_code_detail {
+
+FOLLY_ALWAYS_INLINE int32_t toJavaInt(uint32_t bits) {
+  int32_t value;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t combine(uint32_t hash, uint32_t unit) {
+  return hash * 31u + unit;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t rotl32(uint32_t value, int8_t distance) {
+  return (value << distance) | (value >> (32 - distance));
+}
+
+FOLLY_ALWAYS_INLINE uint32_t mixK1(uint32_t k1) {
+  k1 *= 0xcc9e2d51u;
+  k1 = rotl32(k1, 15);
+  k1 *= 0x1b873593u;
+  return k1;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t mixH1(uint32_t h1, uint32_t k1) {
+  h1 ^= k1;
+  h1 = rotl32(h1, 13);
+  h1 = h1 * 5u + 0xe6546b64u;
+  return h1;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t fmix(uint32_t h1, uint32_t length) {
+  h1 ^= length;
+  h1 ^= h1 >> 16;
+  h1 *= 0x85ebca6bu;
+  h1 ^= h1 >> 13;
+  h1 *= 0xc2b2ae35u;
+  h1 ^= h1 >> 16;
+  return h1;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t hashLong(int64_t val) {
+  const uint64_t bits = static_cast<uint64_t>(val);
+  return static_cast<uint32_t>(bits ^ (bits >> 32));
+}
+
+FOLLY_ALWAYS_INLINE int32_t javaAbs(uint32_t bits) {
+  if ((bits & 0x80000000u) == 0) {
+    return static_cast<int32_t>(bits);
+  }
+  if (bits == 0x80000000u) {
+    return std::numeric_limits<int32_t>::min();
+  }
+  return static_cast<int32_t>(0u - bits);
+}
+
+FOLLY_ALWAYS_INLINE uint32_t hashFloat(float val) {
+  uint32_t bits;
+  std::memcpy(&bits, &val, sizeof(bits));
+  return std::isnan(val) ? 0x7fc00000u : bits;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t hashDouble(double val) {
+  uint64_t bits;
+  std::memcpy(&bits, &val, sizeof(bits));
+  if (std::isnan(val)) {
+    bits = 0x7ff8000000000000ULL;
+  }
+  return static_cast<uint32_t>(bits ^ (bits >> 32));
+}
+
+FOLLY_ALWAYS_INLINE uint32_t hashString(StringView val) {
+  uint32_t hash = 0;
+  const char* p = val.data();
+  const char* end = p + val.size();
+  while (p < end) {
+    const uint8_t byte = static_cast<uint8_t>(*p);
+    if (byte < 0x80) {
+      hash = combine(hash, byte);
+      ++p;
+      continue;
+    }
+
+    int32_t size = 0;
+    const int32_t cp = stringCore::utf8proc_codepoint(p, end, &size);
+    if (cp < 0) {
+      hash = combine(hash, byte);
+      ++p;
+      continue;
+    }
+    if (cp <= 0xFFFF) {
+      hash = combine(hash, static_cast<uint32_t>(cp));
+    } else {
+      const int32_t c = cp - 0x10000;
+      hash = combine(hash, static_cast<uint32_t>(0xD800 + (c >> 10)));
+      hash = combine(hash, static_cast<uint32_t>(0xDC00 + (c & 0x3FF)));
+    }
+    p += size;
+  }
+  return hash;
+}
+
+FOLLY_ALWAYS_INLINE uint32_t signedTailByte(char byte) {
+  return static_cast<uint32_t>(
+      static_cast<int32_t>(static_cast<int8_t>(static_cast<uint8_t>(byte))));
+}
+
+FOLLY_ALWAYS_INLINE uint32_t hashUnsafeBytes(StringView val) {
+  constexpr uint32_t kDefaultSeed = 42u;
+  uint32_t h1 = kDefaultSeed;
+  const char* data = val.data();
+  const uint32_t length = static_cast<uint32_t>(val.size());
+  const uint32_t lengthAligned = length & 0xfffffffcu;
+
+  for (uint32_t i = 0; i < lengthAligned; i += 4) {
+    const auto b0 = static_cast<uint32_t>(static_cast<uint8_t>(data[i]));
+    const auto b1 = static_cast<uint32_t>(static_cast<uint8_t>(data[i + 1]));
+    const auto b2 = static_cast<uint32_t>(static_cast<uint8_t>(data[i + 2]));
+    const auto b3 = static_cast<uint32_t>(static_cast<uint8_t>(data[i + 3]));
+    h1 = mixH1(h1, mixK1(b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)));
+  }
+
+  for (uint32_t i = lengthAligned; i < length; ++i) {
+    h1 = mixH1(h1, mixK1(signedTailByte(data[i])));
+  }
+  return fmix(h1, length);
+}
+
+FOLLY_ALWAYS_INLINE uint32_t hashTimestamp(const Timestamp& val) {
+  return combine(
+      hashLong(val.toMillis()),
+      static_cast<uint32_t>(val.getNanos() % 1'000'000));
+}
+
+FOLLY_ALWAYS_INLINE int32_t hashShortDecimal(int64_t value, int32_t scale) {
+  const uint64_t magnitude = value < 0 ? 0u - static_cast<uint64_t>(value)
+                                       : static_cast<uint64_t>(value);
+  const uint32_t compactHash = static_cast<uint32_t>(
+      static_cast<uint32_t>(magnitude >> 32) * 31u +
+      static_cast<uint32_t>(magnitude));
+  const uint32_t signedHash = value < 0 ? 0u - compactHash : compactHash;
+  return toJavaInt(signedHash * 31u + static_cast<uint32_t>(scale));
+}
+
+FOLLY_ALWAYS_INLINE int32_t hashLongDecimal(int128_t value, int32_t scale) {
+  const bool negative = value < 0;
+  const __uint128_t magnitude = negative
+      ? __uint128_t{0} - static_cast<__uint128_t>(value)
+      : static_cast<__uint128_t>(value);
+
+  uint32_t hash = 0;
+  bool hasWord = false;
+  for (int32_t shift = 96; shift >= 0; shift -= 32) {
+    const auto word = static_cast<uint32_t>(magnitude >> shift);
+    if (!hasWord && word == 0) {
+      continue;
+    }
+    hasWord = true;
+    hash = hash * 31u + word;
+  }
+
+  const uint32_t signedHash = negative ? 0u - hash : hash;
+  return toJavaInt(signedHash * 31u + static_cast<uint32_t>(scale));
+}
+
+} // namespace hash_code_detail
+
+/// Flink HASH_CODE(expr). Returns each type's Java-style hashCode as INT.
+template <typename T>
+struct FlinkHashCodeFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename... Args>
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig&,
+      const Args*...) {
+    if (inputTypes.empty()) {
+      return;
+    }
+    isVarbinary_ = inputTypes[0]->isVarbinary();
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<int8_t>& val) {
+    result = static_cast<int32_t>(val);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<int16_t>& val) {
+    result = static_cast<int32_t>(val);
+  }
+
+  // Also serves DATE inputs (DATE is physically int32 days-since-epoch, and
+  // Java Integer.hashCode of the day count is the identity).
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<int32_t>& val) {
+    result = val;
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<int64_t>& val) {
+    result = hash_code_detail::toJavaInt(hash_code_detail::hashLong(val));
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<bool>& val) {
+    result = val ? 1231 : 1237;
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<float>& val) {
+    result = hash_code_detail::toJavaInt(hash_code_detail::hashFloat(val));
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<double>& val) {
+    result = hash_code_detail::toJavaInt(hash_code_detail::hashDouble(val));
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Varchar>& val) {
+    if (isVarbinary_) {
+      result =
+          hash_code_detail::toJavaInt(hash_code_detail::hashUnsafeBytes(val));
+    } else {
+      result = hash_code_detail::javaAbs(hash_code_detail::hashString(val));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      int32_t& result,
+      const arg_type<Timestamp>& val) {
+    result = hash_code_detail::toJavaInt(hash_code_detail::hashTimestamp(val));
+  }
+
+ private:
+  bool isVarbinary_{false};
+};
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/ToTimestampFunction.h
+++ b/bolt/functions/flinksql/ToTimestampFunction.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "bolt/functions/Macros.h"
+#include "bolt/functions/lib/DateTimeFormatter.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+template <typename T>
+struct FlinkToTimestampFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  using DateTimeFormatterPtr = std::shared_ptr<DateTimeFormatter>;
+
+  // Set only when the format argument is a constant (known at initialize time).
+  DateTimeFormatterPtr constFormatter_;
+  // One-entry memo so a non-constant format column does not rebuild the
+  // formatter on every row when consecutive rows share the same format.
+  std::string lastFormat_;
+  DateTimeFormatterPtr lastFormatter_;
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Varchar>* /*dateStr*/,
+      const arg_type<Varchar>* format) {
+    if (format != nullptr) {
+      constFormatter_ = buildJodaDateTimeFormatter(
+          std::string_view(format->data(), format->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& dateStr) {
+    return parseAuto(result, dateStr);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& dateStr,
+      const arg_type<Varchar>& format) {
+    const DateTimeFormatter* fmt;
+    if (constFormatter_ != nullptr) {
+      fmt = constFormatter_.get();
+    } else {
+      const auto formatView = std::string_view(format.data(), format.size());
+      if (lastFormatter_ == nullptr ||
+          std::string_view(lastFormat_) != formatView) {
+        lastFormatter_ = buildJodaDateTimeFormatter(formatView);
+        lastFormat_.assign(formatView.data(), formatView.size());
+      }
+      fmt = lastFormatter_.get();
+    }
+    return tryParse(*fmt, result, dateStr);
+  }
+
+ private:
+  static constexpr const char* kDateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+  static constexpr const char* kDateFormat = "yyyy-MM-dd";
+
+  static constexpr bool isAsciiWhitespace(char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+        c == '\v';
+  }
+
+  static std::string_view trimWhitespace(std::string_view input) {
+    while (!input.empty() && isAsciiWhitespace(input.front())) {
+      input.remove_prefix(1);
+    }
+    while (!input.empty() && isAsciiWhitespace(input.back())) {
+      input.remove_suffix(1);
+    }
+    return input;
+  }
+
+  static const DateTimeFormatter& dateTimeFormatter() {
+    static const DateTimeFormatterPtr fmt =
+        buildJodaDateTimeFormatter(kDateTimeFormat);
+    return *fmt;
+  }
+
+  static const DateTimeFormatter& dateFormatter() {
+    static const DateTimeFormatterPtr fmt =
+        buildJodaDateTimeFormatter(kDateFormat);
+    return *fmt;
+  }
+
+  static const DateTimeFormatter& fallbackDateFormatter() {
+    static const DateTimeFormatterPtr fmt =
+        buildJodaDateTimeFormatter("yyyy-M-d");
+    return *fmt;
+  }
+
+  static const DateTimeFormatter& fallbackDateTimeFormatter(size_t digits) {
+    static const std::array<DateTimeFormatterPtr, 10> fmts = {
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.S"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSSS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSSSS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSSSSS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSSSSSS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSSSSSSS"),
+        buildJodaDateTimeFormatter("yyyy-M-d HH:mm:ss.SSSSSSSSS"),
+    };
+    return *fmts[digits];
+  }
+
+  // Cached formatters for 'yyyy-MM-dd HH:mm:ss.S' .. with 1..9 fractional
+  // digits, indexed by (string length - 21).
+  static const DateTimeFormatter& fracFormatter(size_t index) {
+    static const std::array<DateTimeFormatterPtr, 9> fmts = {
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.S"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSSS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSSSS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSSS"),
+        buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSSSS"),
+    };
+    return *fmts[index];
+  }
+
+  FOLLY_ALWAYS_INLINE bool tryParseFallback(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& dateStr) const {
+    const auto trimmed =
+        trimWhitespace(std::string_view(dateStr.data(), dateStr.size()));
+    if (trimmed.empty()) {
+      return false;
+    }
+
+    const auto space = trimmed.find(' ');
+    const DateTimeFormatter* fmt;
+    if (space == std::string_view::npos) {
+      fmt = &fallbackDateFormatter();
+    } else {
+      const auto dot = trimmed.find('.', space + 1);
+      size_t digits = 0;
+      if (dot != std::string_view::npos) {
+        digits = trimmed.size() - dot - 1;
+        if (digits == 0 || digits > 9) {
+          return false;
+        }
+      }
+      fmt = &fallbackDateTimeFormatter(digits);
+    }
+
+    auto r = fmt->parse(trimmed, TimePolicy::CORRECTED);
+    if (r.hasError()) {
+      return false;
+    }
+    result = r.value().timestamp;
+    return true;
+  }
+
+  FOLLY_ALWAYS_INLINE bool tryParse(
+      const DateTimeFormatter& fmt,
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& dateStr) const {
+    auto r = fmt.parse(
+        std::string_view(dateStr.data(), dateStr.size()),
+        TimePolicy::CORRECTED);
+    if (r.hasError()) {
+      return tryParseFallback(result, dateStr);
+    }
+    result = r.value().timestamp;
+    return true;
+  }
+
+  // Single-arg TO_TIMESTAMP selects exactly one format from the input length,
+  // matching Flink's toTimestampData. A parse failure returns NULL.
+  FOLLY_ALWAYS_INLINE bool parseAuto(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& dateStr) {
+    const size_t len = dateStr.size();
+    if (len == 10) {
+      return tryParse(dateFormatter(), result, dateStr);
+    }
+    if (len >= 21 && len <= 29) {
+      return tryParse(fracFormatter(len - 21), result, dateStr);
+    }
+    return tryParse(dateTimeFormatter(), result, dateStr);
+  }
+};
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -18,9 +18,12 @@
 #include "bolt/expression/SpecialFormRegistry.h"
 #include "bolt/expression/VectorFunction.h"
 #include "bolt/functions/Registerer.h"
+#include "bolt/functions/flinksql/DateTimeDiff.h"
 #include "bolt/functions/flinksql/DateTimeFunctions.h"
+#include "bolt/functions/flinksql/HashCodeFunction.h"
 #include "bolt/functions/flinksql/Rand.h"
 #include "bolt/functions/flinksql/String.h"
+#include "bolt/functions/flinksql/ToTimestampFunction.h"
 #include "bolt/functions/flinksql/specialforms/FlinkCastExpr.h"
 
 namespace bytedance::bolt::functions {
@@ -72,6 +75,34 @@ static void registerDatetimeFunctions(const std::string& prefix) {
       Varchar,
       Timestamp,
       int32_t>({prefix + "flink_timestamp_to_string_v2"});
+
+  // TIMESTAMPDIFF(unit, timestamp1, timestamp2)
+  registerFunction<
+      FlinkTimestampDiffFunction,
+      int32_t,
+      Varchar,
+      Timestamp,
+      Timestamp>({prefix + "timestampdiff"});
+  registerFunction<
+      FlinkTimestampDiffFunction,
+      int32_t,
+      Varchar,
+      Timestamp,
+      Date>({prefix + "timestampdiff"});
+  registerFunction<
+      FlinkTimestampDiffFunction,
+      int32_t,
+      Varchar,
+      Date,
+      Timestamp>({prefix + "timestampdiff"});
+  registerFunction<FlinkTimestampDiffFunction, int32_t, Varchar, Date, Date>(
+      {prefix + "timestampdiff"});
+
+  // TO_TIMESTAMP(string) and TO_TIMESTAMP(string, format)
+  registerFunction<FlinkToTimestampFunction, Timestamp, Varchar>(
+      {prefix + "to_timestamp"});
+  registerFunction<FlinkToTimestampFunction, Timestamp, Varchar, Varchar>(
+      {prefix + "to_timestamp"});
 }
 
 static void registerMathFunctions(const std::string& prefix) {
@@ -95,6 +126,36 @@ static void registerArrayFunctions(const std::string& prefix) {
   registerFlinkElementAtFunction(prefix + "element_at");
 }
 
+static void registerHashFunctions(const std::string& prefix) {
+  // HASH_CODE(expr) for supported types
+  registerFunction<FlinkHashCodeFunction, int32_t, int8_t>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, int16_t>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, int32_t>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, int64_t>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, bool>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, float>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, double>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, Varchar>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, Varbinary>(
+      {prefix + "hash_code"});
+  BOLT_REGISTER_VECTOR_FUNCTION(flink_hash_code_decimal, prefix + "hash_code");
+  // DATE is physically int32 days-since-epoch, but signature binding matches on
+  // the logical type name, so it needs its own registration; the int32_t call
+  // overload (Integer.hashCode == identity) serves it.
+  registerFunction<FlinkHashCodeFunction, int32_t, Date>(
+      {prefix + "hash_code"});
+  registerFunction<FlinkHashCodeFunction, int32_t, Timestamp>(
+      {prefix + "hash_code"});
+}
+
 namespace {
 
 void registerSpecialFormFunctions(const std::string& prefix) {
@@ -112,6 +173,7 @@ void registerFunctions(const std::string& prefix) {
   registerMathFunctions(prefix);
   registerJsonFunctions(prefix);
   registerArrayFunctions(prefix);
+  registerHashFunctions(prefix);
   registerSpecialFormFunctions(prefix);
 }
 } // namespace flinksql

--- a/bolt/functions/flinksql/tests/FlinkSqlDataTimeFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/FlinkSqlDataTimeFunctionsTest.cpp
@@ -16,6 +16,7 @@
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/flinksql/tests/FlinkFunctionBaseTest.h"
+#include "bolt/type/HugeInt.h"
 
 #include <cstdint>
 #include <limits>
@@ -183,5 +184,368 @@ TEST_F(FlinkSqlDateTimeFunctionsTest, timestampToStringV2) {
       std::optional<std::string>("2000-01-01 12:21:56.1"),
       formatOnce(Timestamp(946729316, 100000000), -1));
 }
+TEST_F(FlinkSqlDateTimeFunctionsTest, timestampdiff) {
+  const auto timestampdiff = [&](const std::string& unit,
+                                 std::optional<Timestamp> start,
+                                 std::optional<Timestamp> end) {
+    return evaluateOnce<int32_t>(
+        fmt::format("timestampdiff('{}', c0, c1)", unit), start, end);
+  };
+
+  const auto parseTimestamp =
+      [&](const std::string& str) -> std::optional<Timestamp> {
+    bool isNull{false};
+    auto result = util::fromTimestampString(str.data(), str.size(), &isNull);
+    return isNull ? std::nullopt : std::optional<Timestamp>(result);
+  };
+
+  const auto parseDate = [&](const std::string& str) {
+    return parseTimestamp(str + " 00:00:00");
+  };
+
+  // Fixed-ratio units. These also cover the registered timestamp/timestamp,
+  // date/timestamp, timestamp/date, and date/date argument combinations.
+  EXPECT_EQ(
+      2,
+      timestampdiff(
+          "day",
+          parseTimestamp("2018-07-03 11:11:11"),
+          parseTimestamp("2018-07-05 11:11:11")));
+  EXPECT_EQ(
+      35,
+      timestampdiff(
+          "hour",
+          parseDate("2016-06-15"),
+          parseTimestamp("2016-06-16 11:11:11")));
+  EXPECT_EQ(
+      85,
+      timestampdiff(
+          "hour",
+          parseTimestamp("2016-06-15 11:00:00"),
+          parseDate("2016-06-19")));
+  EXPECT_EQ(
+      -72,
+      timestampdiff("hour", parseDate("2016-06-15"), parseDate("2016-06-12")));
+  EXPECT_EQ(
+      2,
+      timestampdiff(
+          "minute",
+          parseTimestamp("2023-12-31 23:59:00"),
+          parseTimestamp("2024-01-01 00:01:00")));
+  EXPECT_EQ(
+      259200,
+      timestampdiff(
+          "second", parseDate("2016-06-15"), parseDate("2016-06-18")));
+  EXPECT_EQ(
+      8,
+      timestampdiff(
+          "week",
+          parseTimestamp("2018-05-03 11:11:11"),
+          parseTimestamp("2018-07-03 11:12:12")));
+  EXPECT_EQ(
+      1000, timestampdiff("millisecond", Timestamp(0, 0), Timestamp(1, 0)));
+
+  // Month-like units use Flink/Calcite whole-month semantics, then divide for
+  // quarter/year.
+  EXPECT_EQ(
+      2,
+      timestampdiff(
+          "month",
+          parseTimestamp("2018-07-03 11:11:11"),
+          parseTimestamp("2018-09-05 11:11:11")));
+  EXPECT_EQ(
+      2,
+      timestampdiff(
+          "quarter",
+          parseTimestamp("2018-01-03 11:11:11"),
+          parseTimestamp("2018-09-05 11:11:11")));
+  EXPECT_EQ(
+      1,
+      timestampdiff(
+          "year",
+          parseTimestamp("2018-07-03 11:11:11"),
+          parseTimestamp("2019-07-05 11:11:11")));
+
+  // null inputs
+  EXPECT_EQ(
+      std::nullopt,
+      timestampdiff(
+          "day", std::nullopt, parseTimestamp("2016-02-24 12:42:25")));
+
+  // case-insensitive unit (Flink emits upper-case keywords)
+  EXPECT_EQ(
+      2,
+      timestampdiff(
+          "DAY",
+          parseTimestamp("2018-07-03 11:11:11"),
+          parseTimestamp("2018-07-05 11:11:11")));
+
+  // Calcite/Flink end-of-month semantics: the clamped month boundary lands on
+  // the target day, so the time-of-day decides whether a full month elapsed.
+  EXPECT_EQ(
+      0,
+      timestampdiff(
+          "month",
+          parseTimestamp("2021-01-31 23:00:00"),
+          parseTimestamp("2021-02-28 12:00:00")));
+  EXPECT_EQ(
+      1,
+      timestampdiff(
+          "month",
+          parseTimestamp("2021-01-31 11:00:00"),
+          parseTimestamp("2021-02-28 12:00:00")));
+  EXPECT_EQ(
+      1,
+      timestampdiff("month", parseDate("2021-01-31"), parseDate("2021-02-28")));
+  EXPECT_EQ(
+      0,
+      timestampdiff(
+          "year",
+          parseTimestamp("2020-02-29 23:00:00"),
+          parseTimestamp("2021-02-28 12:00:00")));
+
+  // int32 overflow wraps like Flink's (int) cast (2^31 seconds -> INT_MIN).
+  EXPECT_EQ(
+      std::numeric_limits<int32_t>::min(),
+      timestampdiff("second", Timestamp(0, 0), Timestamp(2147483648LL, 0)));
+
+  // Non-constant unit column exercises the per-row resolveUnit path.
+  {
+    auto unitVec = makeFlatVector<std::string>({"day", "hour", "month"});
+    auto startVec = makeFlatVector<Timestamp>({
+        *parseTimestamp("2018-07-03 11:11:11"),
+        *parseTimestamp("2018-07-03 11:11:11"),
+        *parseTimestamp("2018-01-03 11:11:11"),
+    });
+    auto endVec = makeFlatVector<Timestamp>({
+        *parseTimestamp("2018-07-05 11:11:11"),
+        *parseTimestamp("2018-07-04 12:12:11"),
+        *parseTimestamp("2018-09-05 11:11:11"),
+    });
+    auto result = evaluate<SimpleVector<int32_t>>(
+        "timestampdiff(c0, c1, c2)",
+        makeRowVector({unitVec, startVec, endVec}));
+    EXPECT_EQ(2, result->valueAt(0));
+    EXPECT_EQ(25, result->valueAt(1));
+    EXPECT_EQ(8, result->valueAt(2));
+  }
+
+  // invalid unit returns SQL NULL
+  EXPECT_EQ(
+      std::nullopt,
+      timestampdiff(
+          "invalid",
+          parseTimestamp("2018-07-03 11:11:11"),
+          parseTimestamp("2018-07-05 11:11:11")));
+}
+
+TEST_F(FlinkSqlDateTimeFunctionsTest, toTimestamp) {
+  const auto toTimestamp1 = [&](std::optional<std::string> str) {
+    return evaluateOnce<Timestamp>("to_timestamp(c0)", str);
+  };
+  const auto toTimestamp2 = [&](std::optional<std::string> str,
+                                std::optional<std::string> fmt) {
+    return evaluateOnce<Timestamp>("to_timestamp(c0, c1)", str, fmt);
+  };
+
+  // Single arg: date only (2016-12-31 00:00:00)
+  auto ts = toTimestamp1("2016-12-31");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(1483142400, ts->getSeconds());
+
+  // Single arg: datetime without fractional seconds
+  ts = toTimestamp1("2016-12-31 00:12:00");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(1483143120, ts->getSeconds());
+
+  // Single arg: fractional seconds (auto-detected)
+  ts = toTimestamp1("2016-12-31 00:12:00.123");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(1483143120, ts->getSeconds());
+  EXPECT_EQ(123000000, ts->getNanos());
+
+  // Flink falls back to Timestamp.valueOf/Date.valueOf for non-zero-padded
+  // month and day fields.
+  ts = toTimestamp1("1999-9-10 05:20:10");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(936940810, ts->getSeconds());
+
+  ts = toTimestamp1("1999-9-10");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(936921600, ts->getSeconds());
+
+  // Two args: date-only format
+  ts = toTimestamp2("2016-12-31", "yyyy-MM-dd");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(1483142400, ts->getSeconds());
+
+  ts = toTimestamp2("1999-9-10", "yyyy-MM-dd");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(936921600, ts->getSeconds());
+
+  // Two args: datetime with millisecond format
+  ts = toTimestamp2("2016-12-31 00:12:00.123", "yyyy-MM-dd HH:mm:ss.SSS");
+  ASSERT_TRUE(ts.has_value());
+  EXPECT_EQ(1483143120, ts->getSeconds());
+  EXPECT_EQ(123000000, ts->getNanos());
+
+  // Two args: non-constant format column must use each row's own format,
+  // not the first row's.
+  {
+    auto strVec = makeFlatVector<std::string>(
+        {"2016-12-31", "2016/12/31 01:02:03", "31-12-2016"});
+    auto fmtVec = makeFlatVector<std::string>(
+        {"yyyy-MM-dd", "yyyy/MM/dd HH:mm:ss", "dd-MM-yyyy"});
+    auto result = evaluate<SimpleVector<Timestamp>>(
+        "to_timestamp(c0, c1)", makeRowVector({strVec, fmtVec}));
+    EXPECT_EQ(1483142400, result->valueAt(0).getSeconds());
+    EXPECT_EQ(1483146123, result->valueAt(1).getSeconds());
+    EXPECT_EQ(1483142400, result->valueAt(2).getSeconds());
+  }
+
+  // null inputs
+  EXPECT_EQ(std::nullopt, toTimestamp1(std::nullopt));
+  EXPECT_EQ(std::nullopt, toTimestamp2("2016-12-31", std::nullopt));
+
+  // invalid input returns null
+  EXPECT_EQ(std::nullopt, toTimestamp1("not_a_date"));
+  EXPECT_EQ(std::nullopt, toTimestamp1("2016-12-31 trailing"));
+  EXPECT_EQ(std::nullopt, toTimestamp1("2016-12-31 00:12:00 trailing"));
+  EXPECT_EQ(std::nullopt, toTimestamp2("2016-12-31 trailing", "yyyy-MM-dd"));
+}
+
+TEST_F(FlinkSqlDateTimeFunctionsTest, hashCode) {
+  const auto hashBool = [&](std::optional<bool> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashInt = [&](std::optional<int32_t> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashBigint = [&](std::optional<int64_t> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashFloat = [&](std::optional<float> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashDouble = [&](std::optional<double> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashStr = [&](std::optional<std::string> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashTinyint = [&](std::optional<int8_t> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashSmallint = [&](std::optional<int16_t> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+  const auto hashTs = [&](std::optional<Timestamp> v) {
+    return evaluateOnce<int32_t>("hash_code(c0)", v);
+  };
+
+  // Boolean: Java Boolean.hashCode
+  EXPECT_EQ(1231, hashBool(true));
+  EXPECT_EQ(1237, hashBool(false));
+
+  // Tinyint/Smallint: Java Byte/Short.hashCode (identity)
+  EXPECT_EQ(42, hashTinyint(static_cast<int8_t>(42)));
+  EXPECT_EQ(-1, hashTinyint(static_cast<int8_t>(-1)));
+  EXPECT_EQ(42, hashSmallint(static_cast<int16_t>(42)));
+  EXPECT_EQ(-1, hashSmallint(static_cast<int16_t>(-1)));
+
+  // Integer: identity
+  EXPECT_EQ(0, hashInt(0));
+  EXPECT_EQ(42, hashInt(42));
+  EXPECT_EQ(-1, hashInt(-1));
+
+  // Bigint: Java Long.hashCode == (int)(v ^ (v >>> 32)).
+  EXPECT_EQ(42, hashBigint(42));
+  EXPECT_EQ(0, hashBigint(-1)); // (-1 ^ -1) low 32 bits == 0
+  EXPECT_EQ(1, hashBigint(1L << 32)); // 0x1_00000000 -> high^low == 1
+
+  // Float: Java Float.hashCode == floatToIntBits.
+  EXPECT_EQ(0, hashFloat(0.0f));
+  EXPECT_EQ(1109917696, hashFloat(42.0f)); // floatToIntBits(42.0f)==0x42280000
+  // -0.0f keeps its sign bit (NOT normalized to 0).
+  EXPECT_EQ(std::numeric_limits<int32_t>::min(), hashFloat(-0.0f));
+  // All NaN payloads canonicalize to 0x7fc00000.
+  EXPECT_EQ(2143289344, hashFloat(std::numeric_limits<float>::quiet_NaN()));
+
+  // Double: Java Double.hashCode == (int)(bits ^ (bits >>> 32)).
+  EXPECT_EQ(0, hashDouble(0.0));
+  EXPECT_EQ(1078263808, hashDouble(42.0)); // 0x40450000
+  EXPECT_EQ(std::numeric_limits<int32_t>::min(), hashDouble(-0.0));
+  EXPECT_EQ(2146959360, hashDouble(std::numeric_limits<double>::quiet_NaN()));
+
+  // Varchar: Flink uses Math.abs(Java String.hashCode) over UTF-16 code units.
+  EXPECT_EQ(0, hashStr(""));
+  EXPECT_EQ(97, hashStr("a"));
+  EXPECT_EQ(99162322, hashStr("hello"));
+  EXPECT_EQ(685785664, hashStr("zzzzzz")); // Java hash is negative.
+  EXPECT_EQ(
+      std::numeric_limits<int32_t>::min(),
+      hashStr("polygenelubricants")); // Math.abs(Integer.MIN_VALUE)
+  // Non-ASCII: a single BMP code unit, not its UTF-8 bytes.
+  EXPECT_EQ(233, hashStr("é")); // "é" -> 0x00E9
+  EXPECT_EQ(20013, hashStr("中")); // "中" -> 0x4E2D
+  // Supplementary code point -> UTF-16 surrogate pair.
+  EXPECT_EQ(1772899, hashStr("\U0001F600")); // "😀"
+
+  // Timestamp: Flink TimestampData.hashCode (millis hash plus nanoOfMillis).
+  EXPECT_EQ(0, hashTs(Timestamp(0, 0)));
+  EXPECT_EQ(531000, hashTs(Timestamp(1, 500000)));
+  // Sub-millisecond nanos affect the hash.
+  EXPECT_NE(
+      hashTs(Timestamp(946729316, 123000000)),
+      hashTs(Timestamp(946729316, 123000456)));
+
+  // Date: hash_code(DATE) resolves (own registration) and is the identity of
+  // days-since-epoch.
+  {
+    auto dateVec = makeFlatVector<int32_t>({0, 100, -5}, DATE());
+    auto result = evaluate<SimpleVector<int32_t>>(
+        "hash_code(c0)", makeRowVector({dateVec}));
+    EXPECT_EQ(0, result->valueAt(0));
+    EXPECT_EQ(100, result->valueAt(1));
+    EXPECT_EQ(-5, result->valueAt(2));
+  }
+
+  // Varbinary: Flink uses MurmurHashUtil.hashUnsafeBytes with seed 42.
+  {
+    auto binaryVec = makeFlatVector<std::string>(
+        {"", "a", "abc", std::string("\0\xff\x10", 3)}, VARBINARY());
+    auto result = evaluate<SimpleVector<int32_t>>(
+        "hash_code(c0)", makeRowVector({binaryVec}));
+    EXPECT_EQ(142593372, result->valueAt(0));
+    EXPECT_EQ(1485273170, result->valueAt(1));
+    EXPECT_EQ(1322437556, result->valueAt(2));
+    EXPECT_EQ(-339173231, result->valueAt(3));
+  }
+
+  // Decimal: Flink delegates to java.math.BigDecimal.hashCode().
+  {
+    auto shortDecimalVec =
+        makeFlatVector<int64_t>({12345, -12345, 0}, DECIMAL(10, 2));
+    auto shortResult = evaluate<SimpleVector<int32_t>>(
+        "hash_code(c0)", makeRowVector({shortDecimalVec}));
+    EXPECT_EQ(382697, shortResult->valueAt(0));
+    EXPECT_EQ(-382693, shortResult->valueAt(1));
+    EXPECT_EQ(2, shortResult->valueAt(2));
+
+    auto longDecimalVec = makeFlatVector<int128_t>(
+        {HugeInt::parse("123456789012345678901"),
+         HugeInt::parse("-123456789012345678901")},
+        DECIMAL(21, 2));
+    auto longResult = evaluate<SimpleVector<int32_t>>(
+        "hash_code(c0)", makeRowVector({longDecimalVec}));
+    EXPECT_EQ(1337890792, longResult->valueAt(0));
+    EXPECT_EQ(-1337890788, longResult->valueAt(1));
+  }
+
+  // null returns null
+  EXPECT_EQ(std::nullopt, hashInt(std::nullopt));
+  EXPECT_EQ(std::nullopt, hashStr(std::nullopt));
+}
+
 } // namespace
 } // namespace bytedance::bolt::functions::flinksql::test

--- a/bolt/functions/lib/TimeDiffUtils.h
+++ b/bolt/functions/lib/TimeDiffUtils.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/functions/lib/DateTimeFormatter.h"
+#include "bolt/type/Timestamp.h"
+#include "bolt/type/TimestampConversion.h"
+#include "bolt/type/Type.h"
+
+namespace bytedance::bolt::functions {
+
+FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
+    const DateTimeUnit unit,
+    const Timestamp& fromTimestamp,
+    const Timestamp& toTimestamp) {
+  if (fromTimestamp == toTimestamp) {
+    return 0;
+  }
+
+  const int8_t sign = fromTimestamp < toTimestamp ? 1 : -1;
+
+  const auto& low = sign == 1 ? fromTimestamp : toTimestamp;
+  const auto& high = sign == 1 ? toTimestamp : fromTimestamp;
+  const int64_t fromMillis = low.toMillis();
+  const int64_t toMillis = high.toMillis();
+  const int64_t deltaMillis = toMillis - fromMillis;
+
+  // Millisecond, second, minute, hour, day and week have fixed ratio.
+  switch (unit) {
+    case DateTimeUnit::kMillisecond:
+      return sign * deltaMillis;
+    case DateTimeUnit::kSecond:
+      return sign * (deltaMillis / kMillisInSecond);
+    case DateTimeUnit::kMinute:
+      return sign * (deltaMillis / kMillisInMinute);
+    case DateTimeUnit::kHour:
+      return sign * (deltaMillis / kMillisInHour);
+    case DateTimeUnit::kDay:
+      return sign * (deltaMillis / kMillisInDay);
+    case DateTimeUnit::kWeek:
+      return sign * (deltaMillis / kMillisInWeek);
+    default:
+      break;
+  }
+
+  // Month, quarter and year have variable numbers of days.
+  const auto fromCalDate =
+      util::toCivilDateTime(low, false /*allowOverflow*/, true /*isPrecision*/);
+  const auto toCalDate = util::toCivilDateTime(
+      high, false /*allowOverflow*/, true /*isPrecision*/);
+
+  auto dayMillis = [](const util::CivilDateTime& civil) -> int64_t {
+    return static_cast<int64_t>(civil.time.nanosecond / 1'000'000) +
+        int64_t(
+            civil.time.second + civil.time.minute * 60 +
+            civil.time.hour * 3'600) *
+        1'000;
+  };
+  const int64_t fromDayMillis = dayMillis(fromCalDate);
+  const int64_t toDayMillis = dayMillis(toCalDate);
+
+  const int32_t fromDay = fromCalDate.date.day;
+  const int32_t fromMonth = fromCalDate.date.month;
+  const int32_t toDay = toCalDate.date.day;
+  const int32_t toMonth = toCalDate.date.month;
+  const int32_t toLastYearMonthDay =
+      util::getMaxDayOfMonth(toCalDate.date.year, toCalDate.date.month);
+
+  if (unit == DateTimeUnit::kMonth || unit == DateTimeUnit::kQuarter) {
+    int64_t diff =
+        (int64_t(toCalDate.date.year) - int64_t(fromCalDate.date.year)) * 12 +
+        int64_t(toMonth) - int64_t(fromMonth);
+
+    if ((toDay != toLastYearMonthDay && fromDay > toDay) ||
+        (fromDay == toDay && fromDayMillis > toDayMillis)) {
+      diff--;
+    }
+
+    return sign * (unit == DateTimeUnit::kMonth ? diff : diff / 3);
+  }
+
+  if (unit == DateTimeUnit::kYear) {
+    int64_t diff =
+        int64_t(toCalDate.date.year) - int64_t(fromCalDate.date.year);
+
+    if (fromMonth > toMonth ||
+        (fromMonth == toMonth && fromDay > toDay &&
+         toDay != toLastYearMonthDay) ||
+        (fromMonth == toMonth && fromDay == toDay &&
+         fromDayMillis > toDayMillis)) {
+      diff--;
+    }
+    return sign * diff;
+  }
+
+  BOLT_UNREACHABLE("Unsupported datetime unit");
+}
+
+FOLLY_ALWAYS_INLINE int64_t diffDate(
+    const DateTimeUnit unit,
+    const int32_t fromDate,
+    const int32_t toDate) {
+  if (fromDate == toDate) {
+    return 0;
+  }
+  return diffTimestamp(
+      unit,
+      Timestamp(static_cast<int64_t>(fromDate) * util::kSecsPerDay, 0),
+      Timestamp(static_cast<int64_t>(toDate) * util::kSecsPerDay, 0));
+}
+
+} // namespace bytedance::bolt::functions

--- a/bolt/functions/prestosql/DateTimeImpl.h
+++ b/bolt/functions/prestosql/DateTimeImpl.h
@@ -36,6 +36,7 @@
 
 #include "bolt/common/base/Doubles.h"
 #include "bolt/functions/lib/DateTimeFormatter.h"
+#include "bolt/functions/lib/TimeDiffUtils.h"
 #include "bolt/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "bolt/type/Timestamp.h"
 #include "bolt/type/TimestampConversion.h"
@@ -192,113 +193,4 @@ FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
           timestamp.getNanos() % kNanosecondsInMillisecond);
 }
 
-FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
-    const DateTimeUnit unit,
-    const Timestamp& fromTimestamp,
-    const Timestamp& toTimestamp) {
-  if (fromTimestamp == toTimestamp) {
-    return 0;
-  }
-
-  const int8_t sign = fromTimestamp < toTimestamp ? 1 : -1;
-
-  const auto& low = sign == 1 ? fromTimestamp : toTimestamp;
-  const auto& high = sign == 1 ? toTimestamp : fromTimestamp;
-  const int64_t fromMillis = low.toMillis();
-  const int64_t toMillis = high.toMillis();
-  const int64_t deltaMillis = toMillis - fromMillis;
-
-  // Millisecond, second, minute, hour and day have fixed conversion ratio
-  switch (unit) {
-    case DateTimeUnit::kMillisecond: {
-      return sign * deltaMillis;
-    }
-    case DateTimeUnit::kSecond: {
-      return sign * (deltaMillis / kMillisInSecond);
-    }
-    case DateTimeUnit::kMinute: {
-      return sign * (deltaMillis / kMillisInMinute);
-    }
-    case DateTimeUnit::kHour: {
-      return sign * (deltaMillis / kMillisInHour);
-    }
-    case DateTimeUnit::kDay: {
-      return sign * (deltaMillis / kMillisInDay);
-    }
-    case DateTimeUnit::kWeek: {
-      return sign * (deltaMillis / kMillisInWeek);
-    }
-    default:
-      break;
-  }
-
-  // Month, quarter and year do not have fixed conversion ratio. Ex. a month can
-  // have 28, 29, 30 or 31 days. A year can have 365 or 366 days.
-  const auto fromCalDate =
-      util::toCivilDateTime(low, /*allowOverflow*/ false, /*isPrecision*/ true);
-  const auto toCalDate = util::toCivilDateTime(
-      high, /*allowOverflow*/ false, /*isPrecision*/ true);
-
-  auto dayMillis = [](const util::CivilDateTime& civil) -> int64_t {
-    return static_cast<int64_t>(civil.time.nanosecond / 1'000'000) +
-        int64_t(
-            civil.time.second + civil.time.minute * 60 +
-            civil.time.hour * 3'600) *
-        1'000;
-  };
-  const int64_t fromDayMillis = dayMillis(fromCalDate);
-  const int64_t toDayMillis = dayMillis(toCalDate);
-
-  const int32_t fromDay = fromCalDate.date.day;
-  const int32_t fromMonth = fromCalDate.date.month;
-  const int32_t toDay = toCalDate.date.day;
-  const int32_t toMonth = toCalDate.date.month;
-  const int32_t toLastYearMonthDay =
-      util::getMaxDayOfMonth(toCalDate.date.year, toCalDate.date.month);
-
-  if (unit == DateTimeUnit::kMonth || unit == DateTimeUnit::kQuarter) {
-    int64_t diff =
-        (int64_t(toCalDate.date.year) - int64_t(fromCalDate.date.year)) * 12 +
-        int64_t(toMonth) - int64_t(fromMonth);
-
-    if ((toDay != toLastYearMonthDay && fromDay > toDay) ||
-        (fromDay == toDay && fromDayMillis > toDayMillis)) {
-      diff--;
-    }
-
-    diff = (unit == DateTimeUnit::kMonth) ? diff : diff / 3;
-    return sign * diff;
-  }
-
-  if (unit == DateTimeUnit::kYear) {
-    int64_t diff =
-        int64_t(toCalDate.date.year) - int64_t(fromCalDate.date.year);
-
-    if (fromMonth > toMonth ||
-        (fromMonth == toMonth && fromDay > toDay &&
-         toDay != toLastYearMonthDay) ||
-        (fromMonth == toMonth && fromDay == toDay &&
-         fromDayMillis > toDayMillis)) {
-      diff--;
-    }
-    return sign * diff;
-  }
-
-  BOLT_UNREACHABLE("Unsupported datetime unit");
-}
-
-FOLLY_ALWAYS_INLINE
-int64_t diffDate(
-    const DateTimeUnit unit,
-    const int32_t fromDate,
-    const int32_t toDate) {
-  if (fromDate == toDate) {
-    return 0;
-  }
-  return diffTimestamp(
-      unit,
-      // prevent overflow
-      Timestamp((int64_t)fromDate * util::kSecsPerDay, 0),
-      Timestamp((int64_t)toDate * util::kSecsPerDay, 0));
-}
 } // namespace bytedance::bolt::functions


### PR DESCRIPTION
Fixes #638

## Summary

- Add native Flink SQL implementations for `TIMESTAMPDIFF`, `TO_TIMESTAMP`, and `HASH_CODE`.
- Register Flink SQL signatures for the supported Bolt type surface.
- Add coverage for Flink-compatible month differences, timestamp parsing fallback, and Java-style hash code results.

## Flink compatibility notes

- `TIMESTAMPDIFF` follows Flink/Calcite month boundary behavior through `SqlFunctionUtils.subtractMonths`.
- `TO_TIMESTAMP` keeps Flink's default format selection and fallback to `Timestamp.valueOf` / `Date.valueOf` for non-zero-padded dates.
- `HASH_CODE` follows Flink codegen behavior from `CodeGenUtils.hashCodeForType`.

