### PR TITLE
fix: avoid map_from_entries error on empty array(unknown)

### DIFF
--- a/bolt/functions/lib/MapFromEntries.cpp
+++ b/bolt/functions/lib/MapFromEntries.cpp
@@ -93,13 +93,19 @@ class MapFromEntriesFunction : public exec::VectorFunction {
     exec::LocalDecodedVector decodedRowVector(context);
     decodedRowVector.get()->decode(*inputValueVector);
     if (inputValueVector->typeKind() == TypeKind::UNKNOWN) {
-      // For presto, if the input array(unknown) then all rows should have
-      // errors.
+      // For Presto, if the input is array(unknown), rows with non-empty
+      // arrays should have errors since all entries would be null. Empty
+      // arrays produce empty maps without error.
       if constexpr (throwOnNull) {
         try {
           BOLT_USER_FAIL(kErrorMessageEntryNotNull);
         } catch (...) {
-          context.setErrors(rows, std::current_exception());
+          auto exceptionPtr = std::current_exception();
+          rows.applyToSelected([&](vector_size_t row) {
+            if (inputArray->sizeAt(row) > 0) {
+              context.setError(row, exceptionPtr);
+            }
+          });
         }
       }
       auto sizes = allocateSizes(rows.end(), context.pool());

--- a/bolt/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/bolt/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -455,6 +455,19 @@ TEST_F(MapFromEntriesTest, unknownInputs) {
   test("try(map_from_entries(null))");
 }
 
+TEST_F(MapFromEntriesTest, emptyArrayOfUnknown) {
+  // Empty array of unknown type should produce an empty map without error,
+  // even without try().
+  auto result = evaluate(
+      "map_from_entries(array_constructor())",
+      makeRowVector({makeFlatVector<int32_t>(2)}));
+  ASSERT_TRUE(result->type()->equivalent(*MAP(UNKNOWN(), UNKNOWN())));
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    EXPECT_FALSE(result->isNullAt(i));
+    EXPECT_EQ(result->as<MapVector>()->sizeAt(i), 0);
+  }
+}
+
 TEST_F(MapFromEntriesTest, nullRowEntriesWithSmallerChildren) {
   // Row vector is of size 3, children are of size 2 since row 2 is null.
   auto rowVector = makeRowVector(

--- a/bolt/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/bolt/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -453,7 +453,7 @@ TEST_F(MapFromEntriesTest, unknownInputs) {
   test("try(map_from_entries(array_constructor(row_constructor(null, null))))");
   test("try(map_from_entries(array_constructor(null)))");
   test("try(map_from_entries(null))");
-   // Empty array of unknown type should produce an empty map without error.
+  // Empty array of unknown type should produce an empty map without error.
   test("map_from_entries(array_constructor())");
 }
 

--- a/bolt/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/bolt/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -453,19 +453,8 @@ TEST_F(MapFromEntriesTest, unknownInputs) {
   test("try(map_from_entries(array_constructor(row_constructor(null, null))))");
   test("try(map_from_entries(array_constructor(null)))");
   test("try(map_from_entries(null))");
-}
-
-TEST_F(MapFromEntriesTest, emptyArrayOfUnknown) {
-  // Empty array of unknown type should produce an empty map without error,
-  // even without try().
-  auto result = evaluate(
-      "map_from_entries(array_constructor())",
-      makeRowVector({makeFlatVector<int32_t>(2)}));
-  ASSERT_TRUE(result->type()->equivalent(*MAP(UNKNOWN(), UNKNOWN())));
-  for (vector_size_t i = 0; i < result->size(); ++i) {
-    EXPECT_FALSE(result->isNullAt(i));
-    EXPECT_EQ(result->as<MapVector>()->sizeAt(i), 0);
-  }
+   // Empty array of unknown type should produce an empty map without error.
+  test("map_from_entries(array_constructor())");
 }
 
 TEST_F(MapFromEntriesTest, nullRowEntriesWithSmallerChildren) {


### PR DESCRIPTION
For Presto, map_from_entries on array(unknown) previously marked all selected rows as errored, even rows whose array was empty. Empty arrays should produce empty maps without raising "map entry cannot be null". Only flag the error on rows whose array size is greater than zero.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR --> 
- [ ✅ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ✅] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [✅ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ✅] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
