### PR TITLE
[Bolt]feat: Register function for map_from_arrays for SparkSQL

### DIFF
--- a/bolt/functions/lib/Map.h
+++ b/bolt/functions/lib/Map.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #include "bolt/expression/Expr.h"

--- a/bolt/functions/lib/Map.h
+++ b/bolt/functions/lib/Map.h
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+#pragma once
+
+#include "bolt/expression/Expr.h"
+#include "bolt/expression/VectorFunction.h"
+#include "bolt/functions/lib/CheckDuplicateKeys.h"
+
+namespace bytedance::bolt::functions {
+
+inline constexpr const char* kMapNullKeyErrorMessage = "map key cannot be null";
+inline constexpr const char* kMapIndeterminateKeyErrorMessage =
+    "map key cannot be indeterminate";
+
+/// Vector function implementing the map(array(K), array(V)) -> map(K, V)
+/// behaviour used by both Presto's `map` function and Spark's
+/// `map_from_arrays` function.
+///
+/// Template parameters:
+///  - AllowDuplicateKeys: when false, the function throws when duplicate keys
+///    are detected in any row.
+///  - DeduplicateKeys: when true, duplicate keys are deduplicated and only the
+///    last occurrence (per Spark `map_from_arrays` semantics with
+///    throw_exception_on_duplicate_map_keys=false) is preserved. Has no effect
+///    if AllowDuplicateKeys is false.
+template <bool AllowDuplicateKeys, bool DeduplicateKeys>
+class MapFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    // No arguments case (empty map).
+    if (args.empty()) {
+      auto emptyMapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          nullptr, // nulls
+          rows.end(),
+          allocateOffsets(rows.end(), context.pool()),
+          allocateSizes(rows.end(), context.pool()),
+          BaseVector::create(outputType->childAt(0), 0, context.pool()),
+          BaseVector::create(outputType->childAt(1), 0, context.pool()));
+
+      context.moveOrCopyResult(emptyMapVector, rows, result);
+      return;
+    }
+
+    BOLT_CHECK_EQ(args.size(), 2);
+
+    auto keys = args[0];
+    auto values = args[1];
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto decodedKeys = decodedArgs.at(0);
+    auto decodedValues = decodedArgs.at(1);
+
+    static const char* kArrayLengthsMismatch =
+        "Key and value arrays must be the same length";
+    auto checkNullsInKey =
+        [&](const auto& keysElements, auto offset, auto size) {
+          for (auto i = 0; i < size; ++i) {
+            BOLT_USER_CHECK(
+                !keysElements->isNullAt(offset + i), kMapNullKeyErrorMessage);
+
+            BOLT_USER_CHECK(
+                !keysElements->containsNullAt(offset + i),
+                "{}: {}",
+                kMapIndeterminateKeyErrorMessage,
+                keysElements->toString(offset + i));
+          }
+        };
+    // When context.throwOnError is false, some rows will be marked as
+    // 'failed'. These rows should not be processed further. 'remainingRows'
+    // will contain a subset of 'rows' that have passed all the checks (e.g.
+    // keys are not nulls and number of keys and values is the same).
+    exec::LocalSelectivityVector remainingRows(context, rows);
+
+    // If both vectors have identity mapping, check if we can take the zero-copy
+    // fast-path.
+    if (decodedKeys->isIdentityMapping() &&
+        decodedValues->isIdentityMapping() &&
+        canTakeFastPath(
+            keys->as<ArrayVector>(), values->as<ArrayVector>(), rows)) {
+      auto keysArray = keys->as<ArrayVector>();
+      auto valuesArray = values->as<ArrayVector>();
+
+      // Verify there are no null keys.
+      auto keysElements = keysArray->elements();
+      if (keysElements->mayHaveNulls() ||
+          keysElements->mayHaveNullsRecursive()) {
+        context.applyToSelectedNoThrow(rows, [&](auto row) {
+          auto offset = keysArray->offsetAt(row);
+          auto size = keysArray->sizeAt(row);
+          checkNullsInKey(keysElements, offset, size);
+        });
+      }
+
+      context.deselectErrors(*remainingRows);
+
+      auto mapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          keysArray->nulls(),
+          rows.end(),
+          keysArray->offsets(),
+          keysArray->sizes(),
+          keysArray->elements(),
+          valuesArray->elements());
+
+      if constexpr (!AllowDuplicateKeys) {
+        checkDuplicateKeys(mapVector, *remainingRows, context);
+      }
+      context.moveOrCopyResult(mapVector, rows, result);
+    } else if (decodedKeys->isConstantMapping()) {
+      // Constant keys.
+      auto keysIndex = decodedKeys->index(rows.begin());
+      auto valueIndices = decodedValues->indices();
+
+      auto keysArray = decodedKeys->base()->as<ArrayVector>();
+      auto valuesArray = decodedValues->base()->as<ArrayVector>();
+
+      // Verify there are no null keys and no duplicate keys.
+      auto numKeys = keysArray->sizeAt(keysIndex);
+      auto keysElements = keysArray->elements();
+      auto keysOffset = keysArray->offsetAt(keysIndex);
+
+      // Sort indices of keys so that values at the indices are in ascending
+      // order. Then compare adjacent values through these indices to check for
+      // duplicate keys.
+      std::vector<vector_size_t> sortedIndices(numKeys);
+      std::iota(sortedIndices.begin(), sortedIndices.end(), keysOffset);
+      keysElements->sortIndices(sortedIndices, CompareFlags());
+      try {
+        if (keysElements->mayHaveNulls() ||
+            keysElements->mayHaveNullsRecursive()) {
+          checkNullsInKey(keysElements, keysOffset, numKeys);
+        }
+
+        if constexpr (!AllowDuplicateKeys) {
+          checkDuplicateConstantKeys(sortedIndices, keysElements);
+        }
+      } catch (const std::exception&) {
+        context.setErrors(rows, std::current_exception());
+      }
+
+      // Check array lengths
+      context.applyToSelectedNoThrow(*remainingRows, [&](vector_size_t row) {
+        BOLT_USER_CHECK_EQ(
+            numKeys,
+            valuesArray->sizeAt(valueIndices[row]),
+            "{}",
+            kArrayLengthsMismatch);
+      });
+
+      context.deselectErrors(*remainingRows);
+
+      if constexpr (AllowDuplicateKeys && DeduplicateKeys) {
+        sortedIndices = deduplicateKeys(sortedIndices, keysElements);
+        numKeys = sortedIndices.size();
+      }
+
+      vector_size_t totalElements = remainingRows->countSelected() * numKeys;
+
+      BufferPtr offsets = allocateOffsets(rows.end(), context.pool());
+      auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+      BufferPtr sizes = allocateSizes(rows.end(), context.pool());
+      auto rawSizes = sizes->asMutable<vector_size_t>();
+
+      BufferPtr keysIndices = allocateIndices(totalElements, context.pool());
+      auto rawKeysIndices = keysIndices->asMutable<vector_size_t>();
+
+      BufferPtr valuesIndices = allocateIndices(totalElements, context.pool());
+      auto rawValuesIndices = valuesIndices->asMutable<vector_size_t>();
+
+      vector_size_t offset = 0;
+      remainingRows->applyToSelected([&](vector_size_t row) {
+        rawOffsets[row] = offset;
+        rawSizes[row] = numKeys;
+
+        auto valuesOffset = valuesArray->offsetAt(valueIndices[row]);
+        for (vector_size_t i = 0; i < numKeys; i++) {
+          // Make keys in the result vector sorted to optimize subsequent
+          // processing on this result.
+          rawKeysIndices[offset + i] = sortedIndices[i];
+          rawValuesIndices[offset + i] =
+              valuesOffset + (sortedIndices[i] - keysOffset);
+        }
+
+        offset += numKeys;
+      });
+
+      auto wrappedKeys = BaseVector::wrapInDictionary(
+          nullptr, keysIndices, totalElements, keysArray->elements());
+
+      auto wrappedValues = BaseVector::wrapInDictionary(
+          nullptr, valuesIndices, totalElements, valuesArray->elements());
+
+      auto mapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          nullptr,
+          rows.end(),
+          offsets,
+          sizes,
+          wrappedKeys,
+          wrappedValues,
+          std::nullopt,
+          true);
+      context.moveOrCopyResult(mapVector, *remainingRows, result);
+    } else {
+      auto keyIndices = decodedKeys->indices();
+      auto valueIndices = decodedValues->indices();
+
+      auto keysArray = decodedKeys->base()->as<ArrayVector>();
+      auto valuesArray = decodedValues->base()->as<ArrayVector>();
+
+      // Verify there are no null keys.
+      auto keysElements = keysArray->elements();
+      if (keysElements->mayHaveNulls() ||
+          keysElements->mayHaveNullsRecursive()) {
+        context.applyToSelectedNoThrow(*remainingRows, [&](auto row) {
+          auto offset = keysArray->offsetAt(keyIndices[row]);
+          auto size = keysArray->sizeAt(keyIndices[row]);
+          checkNullsInKey(keysElements, offset, size);
+        });
+        context.deselectErrors(*remainingRows);
+      }
+
+      // Check array lengths
+      context.applyToSelectedNoThrow(*remainingRows, [&](vector_size_t row) {
+        BOLT_USER_CHECK_EQ(
+            keysArray->sizeAt(keyIndices[row]),
+            valuesArray->sizeAt(valueIndices[row]),
+            "{}",
+            kArrayLengthsMismatch);
+      });
+
+      context.deselectErrors(*remainingRows);
+
+      vector_size_t totalElements = 0;
+      remainingRows->applyToSelected([&](auto row) {
+        totalElements += keysArray->sizeAt(keyIndices[row]);
+      });
+
+      BufferPtr offsets = allocateOffsets(rows.end(), context.pool());
+      auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+      BufferPtr sizes = allocateSizes(rows.end(), context.pool());
+      auto rawSizes = sizes->asMutable<vector_size_t>();
+
+      BufferPtr valuesIndices = allocateIndices(totalElements, context.pool());
+      auto rawValuesIndices = valuesIndices->asMutable<vector_size_t>();
+
+      BufferPtr keysIndices = allocateIndices(totalElements, context.pool());
+      auto rawKeysIndices = keysIndices->asMutable<vector_size_t>();
+
+      vector_size_t offset = 0;
+      if constexpr (AllowDuplicateKeys && DeduplicateKeys) {
+        vector_size_t dedupElements = 0;
+        remainingRows->applyToSelected([&](vector_size_t row) {
+          auto size = keysArray->sizeAt(keyIndices[row]);
+          auto keysOffset = keysArray->offsetAt(keyIndices[row]);
+          auto valuesOffset = valuesArray->offsetAt(valueIndices[row]);
+
+          // Sort indices of keys so that values at the indices are in
+          // ascending order. Then compare adjacent values through these
+          // indices to detect duplicate keys.
+          std::vector<vector_size_t> rowSortedIndices(size);
+          std::iota(rowSortedIndices.begin(), rowSortedIndices.end(),
+                    keysOffset);
+          keysElements->sortIndices(rowSortedIndices, CompareFlags());
+          auto dedupSortedIndices =
+              deduplicateKeys(rowSortedIndices, keysElements);
+          auto numKeys = dedupSortedIndices.size();
+          for (vector_size_t i = 0; i < numKeys; i++) {
+            rawKeysIndices[offset + i] = dedupSortedIndices[i];
+            rawValuesIndices[offset + i] =
+                valuesOffset + (dedupSortedIndices[i] - keysOffset);
+            ++dedupElements;
+          }
+          rawOffsets[row] = offset;
+          rawSizes[row] = numKeys;
+
+          offset += numKeys;
+        });
+        totalElements = dedupElements;
+      } else {
+        remainingRows->applyToSelected([&](vector_size_t row) {
+          auto size = keysArray->sizeAt(keyIndices[row]);
+          rawOffsets[row] = offset;
+          rawSizes[row] = size;
+
+          auto keysOffset = keysArray->offsetAt(keyIndices[row]);
+          auto valuesOffset = valuesArray->offsetAt(valueIndices[row]);
+          for (vector_size_t i = 0; i < size; i++) {
+            rawKeysIndices[offset + i] = keysOffset + i;
+            rawValuesIndices[offset + i] = valuesOffset + i;
+          }
+
+          offset += size;
+        });
+      }
+
+      auto wrappedKeys = BaseVector::wrapInDictionary(
+          nullptr, keysIndices, totalElements, keysArray->elements());
+
+      auto wrappedValues = BaseVector::wrapInDictionary(
+          nullptr, valuesIndices, totalElements, valuesArray->elements());
+
+      auto mapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          nullptr,
+          rows.end(),
+          offsets,
+          sizes,
+          wrappedKeys,
+          wrappedValues);
+      if constexpr (!AllowDuplicateKeys) {
+        checkDuplicateKeys(mapVector, *remainingRows, context);
+      }
+      context.moveOrCopyResult(mapVector, *remainingRows, result);
+    }
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // array(K), array(V) -> map(K,V)
+    return {exec::FunctionSignatureBuilder()
+                .knownTypeVariable("K")
+                .typeVariable("V")
+                .returnType("map(K,V)")
+                .argumentType("array(K)")
+                .argumentType("array(V)")
+                .build()};
+  }
+
+ private:
+  // Can only take the fast path if keys and values have an equal
+  // number of arrays and the offsets and sizes of these arrays match
+  // 1:1. The map must be well formed for all elements, also ones not
+  // in 'rows' in apply(). This is because canonicalize() will touch
+  // all elements in any case.
+  bool canTakeFastPath(
+      ArrayVector* keys,
+      ArrayVector* values,
+      const SelectivityVector& rows) const {
+    // We can't take the fast path if we need to deduplicate keys.
+    if constexpr (DeduplicateKeys) {
+      return false;
+    }
+    BOLT_CHECK_GE(keys->size(), rows.end());
+    BOLT_CHECK_GE(values->size(), rows.end());
+    // the fast path takes a reference to the keys and values and the
+    // offsets and sizes from keys. This is valid only if the keys and
+    // values align for all rows for both size and offset. Anything
+    // else will break canonicalize().
+    if (keys->size() != values->size()) {
+      return false;
+    }
+    for (auto row = 0; row < keys->size(); ++row) {
+      if (keys->isNullAt(row)) {
+        continue;
+      }
+
+      if (values->isNullAt(row)) {
+        return false;
+      }
+
+      if (keys->offsetAt(row) != values->offsetAt(row) ||
+          keys->sizeAt(row) != values->sizeAt(row)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::optional<vector_size_t> findDuplicateKeys(
+      const std::vector<vector_size_t>& sortedIndices,
+      const VectorPtr& keysElements) const {
+    for (auto i = 1; i < sortedIndices.size(); ++i) {
+      if (keysElements->equalValueAt(
+              keysElements.get(), sortedIndices[i], sortedIndices[i - 1])) {
+        return sortedIndices[i];
+      }
+    }
+    return std::nullopt;
+  }
+
+  void checkDuplicateConstantKeys(
+      const std::vector<vector_size_t>& sortedIndices,
+      const VectorPtr& keysElements) const {
+    static const char* kDuplicateKey =
+        "Duplicate map keys ({}) are not allowed";
+
+    if (auto duplicateIndex = findDuplicateKeys(sortedIndices, keysElements)) {
+      auto duplicateKey = keysElements->wrappedVector()->toString(
+          keysElements->wrappedIndex(duplicateIndex.value()));
+      BOLT_USER_FAIL(kDuplicateKey, duplicateKey);
+    }
+  }
+
+  // Compare adjacent values through sorted key indices to remove duplicate
+  // keys, retaining the last occurrence (the entry whose original index in
+  // the input array is the largest among duplicates).
+  std::vector<vector_size_t> deduplicateKeys(
+      const std::vector<vector_size_t>& sortedIndices,
+      const VectorPtr& keysElements) const {
+    std::vector<vector_size_t> dedupIndices;
+    if (sortedIndices.empty()) {
+      return dedupIndices;
+    }
+    for (vector_size_t i = 0; i + 1 < static_cast<vector_size_t>(
+                                         sortedIndices.size());
+         ++i) {
+      if (!keysElements->equalValueAt(
+              keysElements.get(), sortedIndices[i], sortedIndices[i + 1])) {
+        dedupIndices.push_back(sortedIndices[i]);
+      }
+    }
+    dedupIndices.push_back(sortedIndices.back());
+    return dedupIndices;
+  }
+};
+
+} // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/Map.h
+++ b/bolt/functions/lib/Map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,20 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * --------------------------------------------------------------------------
- * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
- *
- * This file has been modified by ByteDance Ltd. and/or its affiliates.
- *
- * Original file was released under the Apache License 2.0,
- * with the full license text available at:
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * This modified file is released under the same license.
- * --------------------------------------------------------------------------
  */
+ 
 #pragma once
 
 #include "bolt/expression/Expr.h"
@@ -296,8 +284,8 @@ class MapFunction : public exec::VectorFunction {
           // ascending order. Then compare adjacent values through these
           // indices to detect duplicate keys.
           std::vector<vector_size_t> rowSortedIndices(size);
-          std::iota(rowSortedIndices.begin(), rowSortedIndices.end(),
-                    keysOffset);
+          std::iota(
+              rowSortedIndices.begin(), rowSortedIndices.end(), keysOffset);
           keysElements->sortIndices(rowSortedIndices, CompareFlags());
           auto dedupSortedIndices =
               deduplicateKeys(rowSortedIndices, keysElements);
@@ -439,8 +427,8 @@ class MapFunction : public exec::VectorFunction {
     if (sortedIndices.empty()) {
       return dedupIndices;
     }
-    for (vector_size_t i = 0; i + 1 < static_cast<vector_size_t>(
-                                         sortedIndices.size());
+    for (vector_size_t i = 0;
+         i + 1 < static_cast<vector_size_t>(sortedIndices.size());
          ++i) {
       if (!keysElements->equalValueAt(
               keysElements.get(), sortedIndices[i], sortedIndices[i + 1])) {

--- a/bolt/functions/prestosql/Map.cpp
+++ b/bolt/functions/prestosql/Map.cpp
@@ -28,8 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/expression/VectorFunction.h"
 #include "bolt/functions/lib/Map.h"
+#include "bolt/expression/VectorFunction.h"
 
 namespace bytedance::bolt::functions {
 

--- a/bolt/functions/sparksql/CMakeLists.txt
+++ b/bolt/functions/sparksql/CMakeLists.txt
@@ -44,6 +44,7 @@ bolt_add_library(
   LeastGreatest.cpp
   MakeTimestamp.cpp
   Map.cpp
+  MapFromArrays.cpp
   RegexFunctions.cpp
   # Register.cpp
   # RegisterArithmetic.cpp

--- a/bolt/functions/sparksql/MapFromArrays.cpp
+++ b/bolt/functions/sparksql/MapFromArrays.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,20 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * --------------------------------------------------------------------------
- * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
- *
- * This file has been modified by ByteDance Ltd. and/or its affiliates.
- *
- * Original file was released under the Apache License 2.0,
- * with the full license text available at:
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * This modified file is released under the same license.
- * --------------------------------------------------------------------------
  */
+ 
 #include "bolt/functions/sparksql/MapFromArrays.h"
 
 #include "bolt/core/QueryConfig.h"

--- a/bolt/functions/sparksql/MapFromArrays.cpp
+++ b/bolt/functions/sparksql/MapFromArrays.cpp
@@ -17,8 +17,7 @@
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
- * This file has been modified by ByteDance Ltd. and/or its affiliates on
- * 2025-11-11.
+ * This file has been modified by ByteDance Ltd. and/or its affiliates.
  *
  * Original file was released under the Apache License 2.0,
  * with the full license text available at:
@@ -27,25 +26,33 @@
  * This modified file is released under the same license.
  * --------------------------------------------------------------------------
  */
+#include "bolt/functions/sparksql/MapFromArrays.h"
 
-#include "bolt/expression/VectorFunction.h"
-#include "bolt/functions/lib/Map.h"
+#include "bolt/core/QueryConfig.h"
 
-namespace bytedance::bolt::functions {
+namespace bytedance::bolt::functions::sparksql {
 
-BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_map,
-    (MapFunction</*AllowDuplicateKeys=*/false, /*DeduplicateKeys=*/false>::
-         signatures()),
-    (std::make_unique<MapFunction<
-         /*AllowDuplicateKeys=*/false,
-         /*DeduplicateKeys=*/false>>()));
+std::shared_ptr<exec::VectorFunction> makeMapFromArrays(
+    const std::string& /*name*/,
+    const std::vector<exec::VectorFunctionArg>& /*inputArgs*/,
+    const core::QueryConfig& config) {
+  if (config.throwExceptionOnDuplicateMapKeys()) {
+    return std::make_shared<
+        MapFunction</*AllowDuplicateKeys=*/false, /*DeduplicateKeys=*/false>>();
+  }
+  return std::make_shared<
+      MapFunction</*AllowDuplicateKeys=*/true, /*DeduplicateKeys=*/true>>();
+}
 
-BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_map_allow_duplicates,
-    (MapFunction</*AllowDuplicateKeys=*/true, /*DeduplicateKeys=*/false>::
-         signatures()),
-    (std::make_unique<MapFunction<
-         /*AllowDuplicateKeys=*/true,
-         /*DeduplicateKeys=*/false>>()));
-} // namespace bytedance::bolt::functions
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+getMapFromArraysSignature() {
+  return MapFunction</*AllowDuplicateKeys=*/false, /*DeduplicateKeys=*/false>::
+      signatures();
+}
+
+void registerMapFromArrays(const std::string& name) {
+  exec::registerStatefulVectorFunction(
+      name, getMapFromArraysSignature(), makeMapFromArrays);
+}
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/MapFromArrays.cpp
+++ b/bolt/functions/sparksql/MapFromArrays.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "bolt/functions/sparksql/MapFromArrays.h"
 
 #include "bolt/core/QueryConfig.h"

--- a/bolt/functions/sparksql/MapFromArrays.h
+++ b/bolt/functions/sparksql/MapFromArrays.h
@@ -17,8 +17,7 @@
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
- * This file has been modified by ByteDance Ltd. and/or its affiliates on
- * 2025-11-11.
+ * This file has been modified by ByteDance Ltd. and/or its affiliates.
  *
  * Original file was released under the Apache License 2.0,
  * with the full license text available at:
@@ -27,25 +26,25 @@
  * This modified file is released under the same license.
  * --------------------------------------------------------------------------
  */
+#pragma once
 
-#include "bolt/expression/VectorFunction.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "bolt/expression/Expr.h"
 #include "bolt/functions/lib/Map.h"
 
-namespace bytedance::bolt::functions {
+namespace bytedance::bolt::functions::sparksql {
 
-BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_map,
-    (MapFunction</*AllowDuplicateKeys=*/false, /*DeduplicateKeys=*/false>::
-         signatures()),
-    (std::make_unique<MapFunction<
-         /*AllowDuplicateKeys=*/false,
-         /*DeduplicateKeys=*/false>>()));
+std::shared_ptr<exec::VectorFunction> makeMapFromArrays(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
 
-BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_map_allow_duplicates,
-    (MapFunction</*AllowDuplicateKeys=*/true, /*DeduplicateKeys=*/false>::
-         signatures()),
-    (std::make_unique<MapFunction<
-         /*AllowDuplicateKeys=*/true,
-         /*DeduplicateKeys=*/false>>()));
-} // namespace bytedance::bolt::functions
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+getMapFromArraysSignature();
+
+void registerMapFromArrays(const std::string& name);
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/MapFromArrays.h
+++ b/bolt/functions/sparksql/MapFromArrays.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #include <memory>

--- a/bolt/functions/sparksql/MapFromArrays.h
+++ b/bolt/functions/sparksql/MapFromArrays.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,20 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * --------------------------------------------------------------------------
- * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
- *
- * This file has been modified by ByteDance Ltd. and/or its affiliates.
- *
- * Original file was released under the Apache License 2.0,
- * with the full license text available at:
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * This modified file is released under the same license.
- * --------------------------------------------------------------------------
  */
+ 
 #pragma once
 
 #include <memory>

--- a/bolt/functions/sparksql/registration/RegisterMap.cpp
+++ b/bolt/functions/sparksql/registration/RegisterMap.cpp
@@ -32,6 +32,7 @@
 #include "bolt/functions/lib/MapFromEntries.h"
 #include "bolt/functions/lib/RegistrationHelpers.h"
 #include "bolt/functions/lib/Size.h"
+#include "bolt/functions/sparksql/MapFromArrays.h"
 namespace bytedance::bolt::functions {
 extern void registerElementAtFunction(
     const std::string& name,
@@ -41,8 +42,7 @@ void registerSparkMapFunctions(const std::string& prefix) {
   BOLT_REGISTER_VECTOR_FUNCTION(udf_map_filter, prefix + "map_filter");
   // Complex types.
 
-  BOLT_REGISTER_VECTOR_FUNCTION(
-      udf_map_allow_duplicates, prefix + "map_from_arrays");
+  sparksql::registerMapFromArrays(prefix + "map_from_arrays");
   registerMapFromEntriesFunction(prefix + "map_from_entries", false);
   registerMapConcatFunction(prefix + "map_concat");
   registerMapConcatEmptyNullsFunction(prefix + "map_concat");

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(
   MakeDecimalTest.cpp
   MakeTimestampTest.cpp
   MapConcatTest.cpp
+  MapFromArraysTest.cpp
   MapTest.cpp
   MaskTest.cpp
   MightContainTest.cpp

--- a/bolt/functions/sparksql/tests/MapFromArraysTest.cpp
+++ b/bolt/functions/sparksql/tests/MapFromArraysTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,19 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * --------------------------------------------------------------------------
- * Copyright (c) ByteDance Ltd. and/or its affiliates.
- * SPDX-License-Identifier: Apache-2.0
- *
- * This file has been modified by ByteDance Ltd. and/or its affiliates.
- *
- * Original file was released under the Apache License 2.0,
- * with the full license text available at:
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * This modified file is released under the same license.
- * --------------------------------------------------------------------------
  */
 
 #include <stdint.h>

--- a/bolt/functions/sparksql/tests/MapFromArraysTest.cpp
+++ b/bolt/functions/sparksql/tests/MapFromArraysTest.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class MapFromArraysTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename K = int64_t, typename V = std::string>
+  void testMapFromArrays(
+      const std::string& expression,
+      const std::vector<VectorPtr>& parameters,
+      const VectorPtr& expected) {
+    auto result = evaluate<MapVector>(expression, makeRowVector(parameters));
+    ::bytedance::bolt::test::assertEqualVectors(expected, result);
+  }
+
+  void testMapFromArraysFails(
+      const std::string& expression,
+      const std::vector<VectorPtr>& parameters,
+      const std::string& errorMsg) {
+    BOLT_ASSERT_USER_THROW(
+        evaluate<MapVector>(expression, makeRowVector(parameters)), errorMsg);
+  }
+};
+
+TEST_F(MapFromArraysTest, basics) {
+  auto inputVector1 = makeArrayVector<int32_t>({{}, {1, 2}, {3, 4, 5}});
+  auto inputVector2 =
+      makeArrayVector<StringView>({{}, {"a", "b"}, {"c", "d", "e"}});
+
+  auto mapVector = makeMapVector<int32_t, StringView>(
+      {{}, {{1, "a"}, {2, "b"}}, {{3, "c"}, {4, "d"}, {5, "e"}}});
+
+  testMapFromArrays(
+      "map_from_arrays(c0, c1)", {inputVector1, inputVector2}, mapVector);
+}
+
+TEST_F(MapFromArraysTest, duplicateKeysLastWin) {
+  // Don't throw exception when duplicate keys are found; the last occurrence
+  // wins.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kThrowExceptionOnDuplicateMapKeys, "false"},
+  });
+  auto inputVector1 = makeArrayVector<int32_t>({{1, 1}, {3, 4, 3}});
+  auto inputVector2 =
+      makeArrayVector<StringView>({{"a", "b"}, {"c", "d", "e"}});
+
+  auto mapVector =
+      makeMapVector<int32_t, StringView>({{{1, "b"}}, {{3, "e"}, {4, "d"}}});
+
+  testMapFromArrays(
+      "map_from_arrays(c0, c1)", {inputVector1, inputVector2}, mapVector);
+}
+
+TEST_F(MapFromArraysTest, duplicateKeysThrowException) {
+  // Throws exception when duplicate keys are found.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kThrowExceptionOnDuplicateMapKeys, "true"},
+  });
+  auto inputVector1 = makeArrayVector<int32_t>({{1, 1}, {3, 4, 3}});
+  auto inputVector2 =
+      makeArrayVector<StringView>({{"a", "b"}, {"c", "d", "e"}});
+
+  auto errorMsg = "Duplicate map keys (1) are not allowed";
+
+  testMapFromArraysFails(
+      "map_from_arrays(c0, c1)", {inputVector1, inputVector2}, errorMsg);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ✅] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ✅] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ✅] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ✅] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>


referred from: https://github.com/facebookincubator/velox/pull/10280 
