### PR TITLE
perf(expr): enable flat no-null fast path for common batches

### DIFF
--- a/bolt/benchmarks/basic/CMakeLists.txt
+++ b/bolt/benchmarks/basic/CMakeLists.txt
@@ -86,6 +86,11 @@ target_link_libraries(
 add_executable(bolt_cast_benchmark CastBenchmark.cpp)
 target_link_libraries(bolt_cast_benchmark ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib)
 
+add_executable(bolt_benchmark_expr_flat_no_nulls ExprFlatNoNullsBenchmark.cpp)
+target_link_libraries(
+  bolt_benchmark_expr_flat_no_nulls ${BOLT_BENCHMARK_DEPS} bolt_functions_prestosql
+)
+
 add_executable(bolt_format_datetime_benchmark FormatDateTimeBenchmark.cpp)
 target_link_libraries(
   bolt_format_datetime_benchmark ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib bolt_functions_spark

--- a/bolt/benchmarks/basic/ExprFlatNoNullsBenchmark.cpp
+++ b/bolt/benchmarks/basic/ExprFlatNoNullsBenchmark.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-06-16.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "bolt/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "bolt/core/QueryConfig.h"
+#include "bolt/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace bytedance::bolt;
+
+namespace {
+
+class ConfigurableBenchmarkBuilder : public ExpressionBenchmarkBuilder {
+ public:
+  void setConfig(const std::string& key, const std::string& value) {
+    queryCtx_->testingOverrideConfigUnsafe({{key, value}});
+  }
+};
+
+void addArithmeticBenchmarks(
+    ExpressionBenchmarkBuilder& builder,
+    const std::string& prefix) {
+  for (auto vectorSize : {1'024, 4'096, 40'960}) {
+    builder
+        .addBenchmarkSet(
+            fmt::format("{}_arith_batch{}", prefix, vectorSize),
+            ROW({"a", "b", "c", "d"}, {DOUBLE(), DOUBLE(), DOUBLE(), DOUBLE()}))
+        .withFuzzerOptions(
+            {.vectorSize = static_cast<size_t>(vectorSize), .nullRatio = 0})
+        .addExpression("add_ab", "a + b")
+        .addExpression("complex_7n", "(a + b) * c + (a - d) * b")
+        .addExpression(
+            "deep_15n_d8", "((((((a + b) * c - d) + a) * b - c) + d) * a - b)")
+        .withIterations(1'000)
+        .disableTesting();
+  }
+}
+
+void addComparisonBenchmarks(
+    ExpressionBenchmarkBuilder& builder,
+    const std::string& prefix) {
+  for (auto vectorSize : {1'024, 4'096, 40'960}) {
+    builder
+        .addBenchmarkSet(
+            fmt::format("{}_cmp_batch{}", prefix, vectorSize),
+            ROW({"a", "b"}, {DOUBLE(), DOUBLE()}))
+        .withFuzzerOptions(
+            {.vectorSize = static_cast<size_t>(vectorSize), .nullRatio = 0})
+        .addExpression("eq_ab", "a = b")
+        .withIterations(1'000);
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+
+  ConfigurableBenchmarkBuilder fastPathOn;
+  addArithmeticBenchmarks(fastPathOn, "on");
+  addComparisonBenchmarks(fastPathOn, "on");
+
+  ConfigurableBenchmarkBuilder fastPathOff;
+  fastPathOff.setConfig(core::QueryConfig::kExprEvalFlatNoNulls, "false");
+  addArithmeticBenchmarks(fastPathOff, "off");
+  addComparisonBenchmarks(fastPathOff, "off");
+
+  fastPathOn.testBenchmarks();
+  fastPathOff.testBenchmarks();
+  fastPathOn.registerBenchmarks();
+  fastPathOff.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -79,6 +79,11 @@ class QueryConfig {
   static constexpr const char* kExprEvalSimplified =
       "expression.eval_simplified";
 
+  /// Whether to enable the FlatNoNulls fast path for expression evaluation.
+  /// True by default.
+  static constexpr const char* kExprEvalFlatNoNulls =
+      "expression.eval_flat_no_nulls";
+
   /// Whether to track CPU usage for individual expressions (supported by call
   /// and cast expressions). False by default. Can be expensive when processing
   /// small batches, e.g. < 10K rows.
@@ -1038,6 +1043,10 @@ class QueryConfig {
 
   bool exprEvalSimplified() const {
     return get<bool>(kExprEvalSimplified, false);
+  }
+
+  bool exprEvalFlatNoNulls() const {
+    return get<bool>(kExprEvalFlatNoNulls, true);
   }
 
   /// Returns true if spilling is enabled.

--- a/bolt/expression/Expr.cpp
+++ b/bolt/expression/Expr.cpp
@@ -134,6 +134,11 @@ void checkOrSetEmptyResult(
     result = BaseVector::createNullConstant(type, 0, pool);
   }
 }
+
+bool exprEvalFlatNoNullsEnabled(const EvalCtx& context) {
+  auto* queryCtx = context.execCtx()->queryCtx();
+  return !queryCtx || queryCtx->queryConfig().exprEvalFlatNoNulls();
+}
 } // namespace
 
 Expr::Expr(
@@ -800,7 +805,7 @@ void Expr::eval(
     VectorPtr& result,
     const ExprSet* parentExprSet) {
   if (supportsFlatNoNullsFastPath_ && context.throwOnError() &&
-      context.inputFlatNoNulls() && rows.countSelected() < 1'000) {
+      context.inputFlatNoNulls() && exprEvalFlatNoNullsEnabled(context)) {
     evalFlatNoNulls(rows, context, result, parentExprSet);
     checkResultInternalState(result);
     return;

--- a/bolt/expression/tests/ExprTest.cpp
+++ b/bolt/expression/tests/ExprTest.cpp
@@ -3165,6 +3165,43 @@ TEST_P(ParameterizedExprTest, flatNoNullsFastPath) {
   ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath());
 }
 
+TEST_P(ParameterizedExprTest, flatNoNullsFastPathDisabledByConfig) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int32_t>({10, 20, 30}),
+      });
+
+  auto expected = makeFlatVector<int32_t>({11, 22, 33});
+  auto result = evaluate("a + b", data);
+  assertEqualVectors(expected, result);
+
+  std::unordered_map<std::string, std::string> configData(
+      {{core::QueryConfig::kExprEvalFlatNoNulls, "false"}});
+  auto queryCtx = bolt::core::QueryCtx::create(
+      nullptr, core::QueryConfig(std::move(configData)));
+  auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+
+  result = evaluateMultiple({"a + b"}, data, std::nullopt, execCtx.get())[0];
+  assertEqualVectors(expected, result);
+}
+
+TEST_P(ParameterizedExprTest, flatNoNullsFastPathDefaultForCommonBatchSize) {
+  constexpr vector_size_t size = 1'024;
+  auto data = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      });
+
+  auto expected =
+      makeFlatVector<int32_t>(size, [](auto row) { return row * 3; });
+  auto result = evaluate("a + b", data);
+  assertEqualVectors(expected, result);
+}
+
 TEST_P(ParameterizedExprTest, commonSubExpressionWithEncodedInput) {
   // This test case does a sanity check of the code path that reuses
   // precomputed results for common sub-expressions.

--- a/conanfile.py
+++ b/conanfile.py
@@ -566,6 +566,8 @@ class BoltConan(ConanFile):
             tc.cache_variables["BOLT_BUILD_BENCHMARKS"] = "ON"
             tc.cache_variables["BOLT_BUILD_TESTING"] = "ON"
             tc.cache_variables["BOLT_BUILD_BENCHMARKS_BASIC"] = "ON"
+        elif os.getenv("BOLT_BUILD_BENCHMARKS_BASIC", "OFF") == "ON":
+            tc.cache_variables["BOLT_BUILD_BENCHMARKS_BASIC"] = "ON"
 
         tc.generate()
 


### PR DESCRIPTION
### What problem does this PR solve?

Expression evaluation has a FlatNoNulls path that avoids generic null and encoding handling when all inputs are flat or constant, non-null, and the expression tree guarantees flat non-null primitive outputs.

The previous sub-1000-row gate prevents the path from being used for common engine batch sizes: the default preferred output batch is 1024 rows, and many operators also evaluate 4096-row batches. This means common projection and filter expressions can miss the optimized path even when all semantic guards are satisfied.

Issue Number: N/A

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (optimization)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no logic changes)
- [ ] Build/CI or Infrastructure changes
- [ ] Documentation only

### Description

Remove the row-count gate and keep the existing semantic guards: the optimized path is still limited to supported expression trees, throw-on-error evaluation, and flat/constant no-null input.

Add `expression.eval_flat_no_nulls`, defaulting to true, as a rollback knob if a workload-specific regression is found.

Add unit coverage for the config and common 1024-row batch behavior, plus a benchmark target that compares the optimized path on and off.

### Performance Impact
- [ ] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] Positive Impact: I have run benchmarks. <details> <summary>Click to view Benchmark Results</summary>

    ```text
    _build/Release/bolt/benchmarks/basic/bolt_benchmark_expr_flat_no_nulls --benchmark

    on_arith_batch1024##add_ab       145.83us
    off_arith_batch1024##add_ab      354.07us  (2.43x faster)

    on_arith_batch1024##complex_7n   627.89us
    off_arith_batch1024##complex_7n  1.64ms    (2.61x faster)

    on_arith_batch1024##deep_15n_d8  945.74us
    off_arith_batch1024##deep_15n_d8 2.60ms    (2.75x faster)

    on_arith_batch4096##add_ab       566.07us
    off_arith_batch4096##add_ab      806.98us  (1.43x faster)
    ```
    </details>
- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:
```text
Release Note:
- Optimized flat no-null expression evaluation for common batch sizes.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
