### PR TITLE
feat(sparksql): Add Spark-specific sequence function for integer types

### DIFF
--- a/bolt/functions/lib/CMakeLists.txt
+++ b/bolt/functions/lib/CMakeLists.txt
@@ -66,6 +66,7 @@ bolt_add_library(
   MapUpdate.cpp
   Re2Functions.cpp
   Repeat.cpp
+  Sequence.cpp
   Slice.cpp
   SimpleComparisonMatcher.cpp
   Size.cpp

--- a/bolt/functions/lib/Sequence.cpp
+++ b/bolt/functions/lib/Sequence.cpp
@@ -59,14 +59,14 @@ template <>
 int8_t add(int8_t value, int8_t step, int32_t sequence) {
   const auto delta =
       static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
-  return value + delta;
+  return static_cast<int8_t>(value + delta);
 }
 
 template <>
 int16_t add(int16_t value, int16_t step, int32_t sequence) {
   const auto delta =
       static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
-  return value + delta;
+  return static_cast<int16_t>(value + delta);
 }
 
 template <>
@@ -75,21 +75,21 @@ int64_t add(int64_t value, int64_t step, int32_t sequence) {
       static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
   // Since step is calculated from start and stop,
   // the sum of 'value' and 'add' is within int64_t.
-  return value + delta;
+  return static_cast<int64_t>(value + delta);
 }
 
 template <>
 int32_t add(int32_t value, int64_t step, int32_t sequence) {
   const auto delta =
       static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
-  return value + delta;
+  return static_cast<int32_t>(value + delta);
 }
 
 template <>
 Timestamp add(Timestamp value, int64_t step, int32_t sequence) {
   const auto delta =
       static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
-  return Timestamp::fromMillis(value.toMillis() + delta);
+  return Timestamp::fromMillis(static_cast<int64_t>(value.toMillis() + delta));
 }
 
 template <>
@@ -148,12 +148,7 @@ void SequenceFunction<T, K>::apply(
   const bool isDate = args[0]->type()->isDate();
   context.applyToSelectedNoThrow(rows, [&](auto row) {
     rawSizes[row] = checkArguments(
-        startVector,
-        stopVector,
-        stepVector,
-        row,
-        isDate,
-        isIntervalYearMonth);
+        startVector, stopVector, stepVector, row, isDate, isIntervalYearMonth);
     numElements += rawSizes[row];
   });
 

--- a/bolt/functions/lib/Sequence.cpp
+++ b/bolt/functions/lib/Sequence.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/lib/Sequence.h"
+#include "bolt/expression/DecodedArgs.h"
+#include "bolt/functions/lib/TimeDiffUtils.h"
+#include "bolt/functions/prestosql/DateTimeImpl.h"
+
+namespace bytedance::bolt::functions {
+namespace {
+
+template <typename T>
+int64_t toInt64(T value);
+
+template <>
+int64_t toInt64(int8_t value) {
+  return value;
+}
+
+template <>
+int64_t toInt64(int16_t value) {
+  return value;
+}
+
+template <>
+int64_t toInt64(int32_t value) {
+  return value;
+}
+
+template <>
+int64_t toInt64(int64_t value) {
+  return value;
+}
+
+template <>
+int64_t toInt64(Timestamp value) {
+  return value.toMillis();
+}
+
+using Days = int64_t;
+using Months = int32_t;
+template <typename T, typename K>
+T add(T value, K step, int32_t sequence);
+
+template <>
+int8_t add(int8_t value, int8_t step, int32_t sequence) {
+  const auto delta =
+      static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
+  return value + delta;
+}
+
+template <>
+int16_t add(int16_t value, int16_t step, int32_t sequence) {
+  const auto delta =
+      static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
+  return value + delta;
+}
+
+template <>
+int64_t add(int64_t value, int64_t step, int32_t sequence) {
+  const auto delta =
+      static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
+  // Since step is calculated from start and stop,
+  // the sum of 'value' and 'add' is within int64_t.
+  return value + delta;
+}
+
+template <>
+int32_t add(int32_t value, int64_t step, int32_t sequence) {
+  const auto delta =
+      static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
+  return value + delta;
+}
+
+template <>
+Timestamp add(Timestamp value, int64_t step, int32_t sequence) {
+  const auto delta =
+      static_cast<int128_t>(step) * static_cast<int128_t>(sequence);
+  return Timestamp::fromMillis(value.toMillis() + delta);
+}
+
+template <>
+int32_t add(int32_t value, Months step, int32_t sequence) {
+  return addToDate(value, DateTimeUnit::kMonth, step * sequence);
+}
+
+template <>
+Timestamp add(Timestamp value, Months step, int32_t sequence) {
+  return addToTimestamp(value, DateTimeUnit::kMonth, step * sequence);
+}
+
+template <typename T>
+int128_t getStepCount(T start, T end, int32_t step) {
+  BOLT_FAIL("Unexpected start/end type for argument INTERVAL_YEAR_MONTH");
+}
+
+template <>
+int128_t getStepCount(int32_t start, int32_t end, int32_t step) {
+  return diffDate(DateTimeUnit::kMonth, start, end) / step + 1;
+}
+
+template <>
+int128_t getStepCount(Timestamp start, Timestamp end, int32_t step) {
+  return diffTimestamp(DateTimeUnit::kMonth, start, end) / step + 1;
+}
+
+} // namespace
+
+template <typename T, typename K>
+void SequenceFunction<T, K>::apply(
+    const SelectivityVector& rows,
+    std::vector<VectorPtr>& args,
+    const TypePtr& outputType,
+    exec::EvalCtx& context,
+    VectorPtr& result) const {
+  exec::DecodedArgs decodedArgs(rows, args, context);
+  auto startVector = decodedArgs.at(0);
+  auto stopVector = decodedArgs.at(1);
+  DecodedVector* stepVector = nullptr;
+  bool isIntervalYearMonth = false;
+  if (args.size() == 3) {
+    stepVector = decodedArgs.at(2);
+    isIntervalYearMonth = args[2]->type()->isIntervalYearMonth();
+  }
+
+  const auto numRows = rows.end();
+  auto pool = context.pool();
+  size_t numElements = 0;
+
+  BufferPtr sizes = allocateSizes(numRows, pool);
+  BufferPtr offsets = allocateOffsets(numRows, pool);
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+  const bool isDate = args[0]->type()->isDate();
+  context.applyToSelectedNoThrow(rows, [&](auto row) {
+    rawSizes[row] = checkArguments(
+        startVector,
+        stopVector,
+        stepVector,
+        row,
+        isDate,
+        isIntervalYearMonth);
+    numElements += rawSizes[row];
+  });
+
+  // We could overflow int32 if total number of elements is too large,
+  // potentially causing a small buffer allocation followed by a large write,
+  // resulting in SIGSEGV.
+  BOLT_USER_CHECK_LE(
+      numElements,
+      std::numeric_limits<vector_size_t>::max(),
+      "SEQUENCE result too large: {} elements exceeds maximum {}",
+      numElements,
+      std::numeric_limits<vector_size_t>::max());
+
+  VectorPtr elements =
+      BaseVector::create(outputType->childAt(0), numElements, pool);
+  auto rawElements = elements->asFlatVector<T>()->mutableRawValues();
+
+  vector_size_t elementsOffset = 0;
+  context.applyToSelectedNoThrow(rows, [&](auto row) {
+    const auto sequenceCount = rawSizes[row];
+    if (sequenceCount) {
+      rawOffsets[row] = elementsOffset;
+      writeToElements(
+          rawElements + elementsOffset,
+          isDate,
+          isIntervalYearMonth,
+          sequenceCount,
+          startVector,
+          stopVector,
+          stepVector,
+          row);
+      elementsOffset += rawSizes[row];
+    }
+  });
+  context.moveOrCopyResult(
+      std::make_shared<ArrayVector>(
+          pool, outputType, nullptr, numRows, offsets, sizes, elements),
+      rows,
+      result);
+}
+
+template <typename T, typename K>
+vector_size_t SequenceFunction<T, K>::checkArguments(
+    DecodedVector* startVector,
+    DecodedVector* stopVector,
+    DecodedVector* stepVector,
+    vector_size_t row,
+    bool isDate,
+    bool isYearMonth) {
+  T start = startVector->valueAt<T>(row);
+  T stop = stopVector->valueAt<T>(row);
+  auto step = getStep(
+      toInt64(start), toInt64(stop), stepVector, row, isDate, isYearMonth);
+  BOLT_USER_CHECK_NE(step, 0, "step must not be zero");
+  BOLT_USER_CHECK(
+      step > 0 ? stop >= start : stop <= start,
+      "sequence stop value should be greater than or equal to start value if "
+      "step is greater than zero otherwise stop should be less than or equal to start");
+  int128_t sequenceCount;
+  if (isYearMonth) {
+    sequenceCount = getStepCount(start, stop, step);
+  } else {
+    sequenceCount = (static_cast<int128_t>(toInt64(stop)) -
+                     static_cast<int128_t>(toInt64(start))) /
+            step +
+        1; // prevent overflow
+  }
+
+  BOLT_USER_CHECK_LE(
+      sequenceCount,
+      kMaxResultEntries,
+      "result of sequence function must not have more than {} entries",
+      kMaxResultEntries);
+  return sequenceCount;
+}
+
+template <typename T, typename K>
+void SequenceFunction<T, K>::writeToElements(
+    T* elements,
+    bool isDate,
+    bool isYearMonth,
+    vector_size_t sequenceCount,
+    DecodedVector* startVector,
+    DecodedVector* stopVector,
+    DecodedVector* stepVector,
+    vector_size_t row) {
+  auto start = startVector->valueAt<T>(row);
+  auto stop = stopVector->valueAt<T>(row);
+  auto step = getStep(
+      toInt64(start), toInt64(stop), stepVector, row, isDate, isYearMonth);
+  for (auto sequence = 0; sequence < sequenceCount; ++sequence) {
+    elements[sequence] = add(start, step, sequence);
+  }
+}
+
+template <typename T, typename K>
+K SequenceFunction<T, K>::getStep(
+    int64_t start,
+    int64_t stop,
+    DecodedVector* stepVector,
+    vector_size_t row,
+    bool isDate,
+    bool isYearMonth) {
+  if (!stepVector) {
+    return (stop >= start ? 1 : -1);
+  }
+  // When element type T differs from step type K (e.g., integer sequence
+  // using T=int32_t, K=int64_t to avoid conflicting with date
+  // specializations), read step as T and cast to K.
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, K>) {
+    if (!isDate) {
+      return static_cast<K>(stepVector->valueAt<T>(row));
+    }
+  }
+  auto step = stepVector->valueAt<K>(row);
+  if (!isDate || isYearMonth) {
+    return step;
+  }
+  // Handle Date
+  BOLT_USER_CHECK(
+      step % kMillisInDay == 0,
+      "sequence step must be a day interval if start and end values are dates");
+  return step / kMillisInDay;
+}
+
+// Explicit instantiations for all supported types.
+// Presto types:
+template class SequenceFunction<int64_t, int64_t>;
+template class SequenceFunction<int32_t, int64_t>;
+template class SequenceFunction<int32_t, int32_t>;
+template class SequenceFunction<Timestamp, int64_t>;
+template class SequenceFunction<Timestamp, int32_t>;
+// Spark-specific types:
+template class SequenceFunction<int8_t, int8_t>;
+template class SequenceFunction<int16_t, int16_t>;
+
+} // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/Sequence.h
+++ b/bolt/functions/lib/Sequence.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/expression/VectorFunction.h"
+
+namespace bytedance::bolt::functions {
+
+/// Sequence function that generates an array of values from start to stop
+/// (inclusive) with an optional step. Supports integer types (tinyint,
+/// smallint, integer, bigint), date, and timestamp.
+template <typename T, typename K>
+class SequenceFunction : public exec::VectorFunction {
+ public:
+  static constexpr int32_t kMaxResultEntries = 10'000;
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override;
+
+ private:
+  static vector_size_t checkArguments(
+      DecodedVector* startVector,
+      DecodedVector* stopVector,
+      DecodedVector* stepVector,
+      vector_size_t row,
+      bool isDate,
+      bool isYearMonth);
+
+  static void writeToElements(
+      T* elements,
+      bool isDate,
+      bool isYearMonth,
+      vector_size_t sequenceCount,
+      DecodedVector* startVector,
+      DecodedVector* stopVector,
+      DecodedVector* stepVector,
+      vector_size_t row);
+
+  static K getStep(
+      int64_t start,
+      int64_t stop,
+      DecodedVector* stepVector,
+      vector_size_t row,
+      bool isDate,
+      bool isYearMonth);
+};
+
+} // namespace bytedance::bolt::functions

--- a/bolt/functions/sparksql/CMakeLists.txt
+++ b/bolt/functions/sparksql/CMakeLists.txt
@@ -50,6 +50,7 @@ bolt_add_library(
   # Register.cpp
   # RegisterArithmetic.cpp
   # RegisterCompare.cpp
+  SequenceFunction.cpp
   SplitFunctions.cpp
   String.cpp
   UnscaledValueFunction.cpp

--- a/bolt/functions/sparksql/SequenceFunction.cpp
+++ b/bolt/functions/sparksql/SequenceFunction.cpp
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * This file has been modified by ByteDance Ltd. and/or its affiliates on
- * 2025-11-11.
+ * 2026-06-16.
  *
  * Original file was released under the Apache License 2.0,
  * with the full license text available at:
@@ -30,12 +30,12 @@
 
 #include "bolt/functions/lib/Sequence.h"
 
-namespace bytedance::bolt::functions {
+namespace bytedance::bolt::functions::sparksql {
 namespace {
 
-std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
-  signatures = {
+std::vector<std::shared_ptr<exec::FunctionSignature>> sequenceSignatures() {
+  // Integer types: 2-arg (start, stop) and 3-arg (start, stop, step).
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures = {
       exec::FunctionSignatureBuilder()
           .returnType("array(bigint)")
           .argumentType("bigint")
@@ -59,63 +59,60 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
           .argumentType("integer")
           .build(),
       exec::FunctionSignatureBuilder()
-          .returnType("array(date)")
-          .argumentType("date")
-          .argumentType("date")
+          .returnType("array(smallint)")
+          .argumentType("smallint")
+          .argumentType("smallint")
           .build(),
       exec::FunctionSignatureBuilder()
-          .returnType("array(date)")
-          .argumentType("date")
-          .argumentType("date")
-          .argumentType("interval day to second")
+          .returnType("array(smallint)")
+          .argumentType("smallint")
+          .argumentType("smallint")
+          .argumentType("smallint")
           .build(),
       exec::FunctionSignatureBuilder()
-          .returnType("array(date)")
-          .argumentType("date")
-          .argumentType("date")
-          .argumentType("interval year to month")
+          .returnType("array(tinyint)")
+          .argumentType("tinyint")
+          .argumentType("tinyint")
           .build(),
       exec::FunctionSignatureBuilder()
-          .returnType("array(timestamp)")
-          .argumentType("timestamp")
-          .argumentType("timestamp")
-          .argumentType("interval day to second")
+          .returnType("array(tinyint)")
+          .argumentType("tinyint")
+          .argumentType("tinyint")
+          .argumentType("tinyint")
           .build(),
-      exec::FunctionSignatureBuilder()
-          .returnType("array(timestamp)")
-          .argumentType("timestamp")
-          .argumentType("timestamp")
-          .argumentType("interval year to month")
-          .build()};
+  };
   return signatures;
 }
 
-std::shared_ptr<exec::VectorFunction> create(
+std::shared_ptr<exec::VectorFunction> makeSequence(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& /*config*/) {
-  if (inputArgs[0].type->isDate()) {
-    if (inputArgs.size() > 2 && inputArgs[2].type->isIntervalYearMonth()) {
-      return std::make_shared<SequenceFunction<int32_t, int32_t>>();
-    }
-    return std::make_shared<SequenceFunction<int32_t, int64_t>>();
-  }
-
+    const core::QueryConfig& /* config */) {
   switch (inputArgs[0].type->kind()) {
     case TypeKind::BIGINT:
       return std::make_shared<SequenceFunction<int64_t, int64_t>>();
+    // Use K=int64_t for INTEGER to avoid conflicting with the
+    // add<int32_t, int32_t> specialization used for date year-to-month
+    // intervals. getStep handles reading the step vector as int32_t when
+    // isDate is false.
     case TypeKind::INTEGER:
-      return std::make_shared<SequenceFunction<int32_t, int32_t>>();
-    case TypeKind::TIMESTAMP:
-      if (inputArgs.size() > 2 && inputArgs[2].type->isIntervalYearMonth()) {
-        return std::make_shared<SequenceFunction<Timestamp, int32_t>>();
-      }
-      return std::make_shared<SequenceFunction<Timestamp, int64_t>>();
+      return std::make_shared<SequenceFunction<int32_t, int64_t>>();
+    case TypeKind::SMALLINT:
+      return std::make_shared<SequenceFunction<int16_t, int16_t>>();
+    case TypeKind::TINYINT:
+      return std::make_shared<SequenceFunction<int8_t, int8_t>>();
     default:
-      BOLT_UNREACHABLE();
+      BOLT_UNREACHABLE(
+          "Unexpected type for Spark sequence: {}",
+          inputArgs[0].type->toString());
   }
 }
+
 } // namespace
 
-BOLT_DECLARE_STATEFUL_VECTOR_FUNCTION(udf_sequence, signatures(), create);
-} // namespace bytedance::bolt::functions
+BOLT_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_spark_sequence,
+    sequenceSignatures(),
+    makeSequence);
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/registration/RegisterArray.cpp
+++ b/bolt/functions/sparksql/registration/RegisterArray.cpp
@@ -210,6 +210,8 @@ void registerArrayFunctions(const std::string& prefix) {
 
   registerIntegerSliceFunction(prefix);
 
+  BOLT_REGISTER_VECTOR_FUNCTION(udf_spark_sequence, prefix + "sequence");
+
   // for now, register ArrayRemoveFunctionString that takes String input and
   // output is enough for our use cases. In future, if need to support more
   // input/output types, will register generic ArrayRemoveFunction

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
   RaiseErrorTest.cpp
   RandTest.cpp
   RegexFunctionsTest.cpp
+  SequenceTest.cpp
   SliceTest.cpp
   SizeTest.cpp
   SortArrayTest.cpp

--- a/bolt/functions/sparksql/tests/SequenceTest.cpp
+++ b/bolt/functions/sparksql/tests/SequenceTest.cpp
@@ -35,6 +35,8 @@
 
 namespace bytedance::bolt::functions::sparksql::test {
 
+using bytedance::bolt::test::assertEqualVectors;
+
 class SequenceTest : public SparkFunctionBaseTest {};
 
 TEST_F(SequenceTest, ascending) {

--- a/bolt/functions/sparksql/tests/SequenceTest.cpp
+++ b/bolt/functions/sparksql/tests/SequenceTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-06-16.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+
+class SequenceTest : public SparkFunctionBaseTest {};
+
+TEST_F(SequenceTest, ascending) {
+  auto result = evaluate(
+      "sequence(c0, c1)",
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 3}),
+          makeFlatVector<int64_t>({5, 6}),
+      }));
+  auto expected = makeArrayVector<int64_t>({{1, 2, 3, 4, 5}, {3, 4, 5, 6}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, descending) {
+  auto result = evaluate(
+      "sequence(c0, c1)",
+      makeRowVector({
+          makeFlatVector<int64_t>({5}),
+          makeFlatVector<int64_t>({1}),
+      }));
+  auto expected = makeArrayVector<int64_t>({{5, 4, 3, 2, 1}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, withStep) {
+  auto result = evaluate(
+      "sequence(c0, c1, c2)",
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 5}),
+          makeFlatVector<int64_t>({10, 1}),
+          makeFlatVector<int64_t>({3, -2}),
+      }));
+  auto expected = makeArrayVector<int64_t>({{1, 4, 7, 10}, {5, 3, 1}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, singleElement) {
+  auto result = evaluate(
+      "sequence(c0, c1)",
+      makeRowVector({
+          makeFlatVector<int64_t>({5}),
+          makeFlatVector<int64_t>({5}),
+      }));
+  auto expected = makeArrayVector<int64_t>({{5}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, integerType) {
+  auto result = evaluate(
+      "sequence(c0, c1)",
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 5}),
+          makeFlatVector<int32_t>({5, 1}),
+      }));
+  auto expected = makeArrayVector<int32_t>({{1, 2, 3, 4, 5}, {5, 4, 3, 2, 1}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, integerWithStep) {
+  auto result = evaluate(
+      "sequence(c0, c1, c2)",
+      makeRowVector({
+          makeFlatVector<int32_t>({1}),
+          makeFlatVector<int32_t>({9}),
+          makeFlatVector<int32_t>({2}),
+      }));
+  auto expected = makeArrayVector<int32_t>({{1, 3, 5, 7, 9}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, smallintType) {
+  auto result = evaluate(
+      "sequence(c0, c1)",
+      makeRowVector({
+          makeFlatVector<int16_t>({1, 5}),
+          makeFlatVector<int16_t>({5, 1}),
+      }));
+  auto expected = makeArrayVector<int16_t>({{1, 2, 3, 4, 5}, {5, 4, 3, 2, 1}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, tinyintType) {
+  auto result = evaluate(
+      "sequence(c0, c1)",
+      makeRowVector({
+          makeFlatVector<int8_t>({1, 5}),
+          makeFlatVector<int8_t>({5, 1}),
+      }));
+  auto expected = makeArrayVector<int8_t>({{1, 2, 3, 4, 5}, {5, 4, 3, 2, 1}});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, nullInputs) {
+  auto start = makeNullableFlatVector<int64_t>({std::nullopt, 1, 1});
+  auto stop = makeNullableFlatVector<int64_t>({5, std::nullopt, 3});
+  auto result = evaluate("sequence(c0, c1)", makeRowVector({start, stop}));
+
+  auto expected = makeNullableArrayVector<int64_t>(
+      {std::nullopt,
+       std::nullopt,
+       std::optional<std::vector<std::optional<int64_t>>>({{1, 2, 3}})});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, nullStep) {
+  auto start = makeNullableFlatVector<int64_t>({1});
+  auto stop = makeNullableFlatVector<int64_t>({5});
+  auto step = makeNullableFlatVector<int64_t>({std::nullopt});
+  auto result =
+      evaluate("sequence(c0, c1, c2)", makeRowVector({start, stop, step}));
+
+  auto expected = makeNullableArrayVector<int64_t>(
+      {std::optional<std::vector<std::optional<int64_t>>>(std::nullopt)});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SequenceTest, stepZeroError) {
+  BOLT_ASSERT_THROW(
+      evaluate(
+          "sequence(c0, c1, c2)",
+          makeRowVector({
+              makeFlatVector<int64_t>({1}),
+              makeFlatVector<int64_t>({5}),
+              makeFlatVector<int64_t>({0}),
+          })),
+      "step must not be zero");
+}
+
+TEST_F(SequenceTest, wrongDirectionError) {
+  BOLT_ASSERT_THROW(
+      evaluate(
+          "sequence(c0, c1, c2)",
+          makeRowVector({
+              makeFlatVector<int64_t>({1}),
+              makeFlatVector<int64_t>({5}),
+              makeFlatVector<int64_t>({-1}),
+          })),
+      "sequence stop value should be greater than or equal to start value if "
+      "step is greater than zero otherwise stop should be less than or equal "
+      "to start");
+}
+
+} // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
Add Spark `sequence` function support for all integer types (tinyint, smallint, integer, bigint) by extracting the shared `SequenceFunction<T, K>` template into `bolt/functions/lib/` for reuse across dialects.

- Extract `SequenceFunction` template into `lib/Sequence.h` (declaration) and `lib/Sequence.cpp` for reuse across dialects.
- Add `sparksql/SequenceFunction.cpp` with Spark signatures and explicit instantiations for `int8_t` and `int16_t` types.
- Keep Presto-specific signatures and registration in `prestosql/Sequence.cpp`.
- Add Spark-specific tests covering all integer types, null handling, and error cases.

Reference:
https://github.com/facebookincubator/velox/commit/23b491ec0e4df2bcb9b93fcfc7378b0e176985d0

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ✅ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ✅] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [✅ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
