### PR TITLE
feat(sparksql): add format_number function

### DIFF
--- a/bolt/functions/sparksql/CMakeLists.txt
+++ b/bolt/functions/sparksql/CMakeLists.txt
@@ -35,6 +35,7 @@ bolt_add_library(
   DecimalArithmetic.cpp
   DecimalCompare.cpp
   DecimalVectorFunctions.cpp
+  FormatNumber.cpp
   Hash.cpp
   ICURegexFunctions.cpp
   In.cpp

--- a/bolt/functions/sparksql/FormatNumber.cpp
+++ b/bolt/functions/sparksql/FormatNumber.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/sparksql/FormatNumber.h"
+
+#include <fmt/format.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <locale>
+
+namespace bytedance::bolt::functions::sparksql::detail {
+
+namespace {
+
+// Java DecimalFormat internally caps fraction digits at 340.
+constexpr int32_t kMaxFractionDigits = 340;
+
+// Custom numpunct that provides US-style thousands grouping without
+// depending on system locale availability.
+struct UsNumpunct : std::numpunct<char> {
+  char do_thousands_sep() const override {
+    return ',';
+  }
+  std::string do_grouping() const override {
+    return "\3";
+  }
+  char do_decimal_point() const override {
+    return '.';
+  }
+};
+
+// Locale with US-style thousands grouping for fmt.
+const std::locale& usLocale() {
+  static const std::locale loc(std::locale::classic(), new UsNumpunct());
+  return loc;
+}
+
+} // namespace
+
+void formatInteger(
+    int64_t value,
+    int32_t decimalPlaces,
+    exec::StringWriter<false>& out) {
+  int32_t cappedPlaces = std::min(decimalPlaces, kMaxFractionDigits);
+
+  // Use fmt::memory_buffer (stack-allocated for typical sizes) to avoid
+  // per-row heap allocation.
+  fmt::memory_buffer buf;
+  fmt::format_to(std::back_inserter(buf), usLocale(), "{:Ld}", value);
+
+  if (cappedPlaces > 0) {
+    buf.push_back('.');
+    for (int32_t i = 0; i < cappedPlaces; ++i) {
+      buf.push_back('0');
+    }
+  }
+
+  out.append(std::string_view(buf.data(), buf.size()));
+}
+
+void formatFloatingPoint(
+    double value,
+    int32_t decimalPlaces,
+    exec::StringWriter<false>& out) {
+  if (std::isnan(value)) {
+    out.append(std::string_view("NaN"));
+    return;
+  }
+  if (std::isinf(value)) {
+    // Java DecimalFormat with US locale uses the infinity symbol (U+221E).
+    if (value < 0) {
+      out.append(std::string_view("-\xE2\x88\x9E"));
+    } else {
+      out.append(std::string_view("\xE2\x88\x9E"));
+    }
+    return;
+  }
+
+  int32_t cappedPlaces = std::min(decimalPlaces, kMaxFractionDigits);
+
+  // Use fmt::memory_buffer (stack-allocated for typical sizes) to avoid
+  // per-row heap allocation.
+  fmt::memory_buffer buf;
+  fmt::format_to(
+      std::back_inserter(buf), usLocale(), "{:.{}Lf}", value, cappedPlaces);
+  out.append(std::string_view(buf.data(), buf.size()));
+}
+
+} // namespace bytedance::bolt::functions::sparksql::detail

--- a/bolt/functions/sparksql/FormatNumber.h
+++ b/bolt/functions/sparksql/FormatNumber.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <type_traits>
+
+#include "bolt/expression/StringWriter.h"
+#include "bolt/functions/Macros.h"
+
+namespace bytedance::bolt::functions::sparksql {
+
+namespace detail {
+
+// Formats a number with US locale (comma thousands separator, dot decimal
+// separator) and d decimal places. Writes the result directly into 'out'.
+// Uses the default format pattern "#,###,###,###,###,###,##0" with d
+// fractional digits appended, matching Java DecimalFormat with Locale.US.
+void formatInteger(
+    int64_t value,
+    int32_t decimalPlaces,
+    exec::StringWriter<false>& out);
+
+void formatFloatingPoint(
+    double value,
+    int32_t decimalPlaces,
+    exec::StringWriter<false>& out);
+
+} // namespace detail
+
+/// format_number(x, d) -> varchar
+///
+/// Formats number x with d decimal places using US locale formatting (comma
+/// as thousands separator, dot as decimal separator), matching Java
+/// DecimalFormat with the default pattern "#,###,###,###,###,###,##0" and
+/// Locale.US. Returns null if d < 0.
+///
+/// Currently only supports the integer second argument (number of decimal
+/// places). Spark also supports a string format argument, which is not yet
+/// implemented.
+// TODO: Support string format argument (user-specified format pattern).
+///
+/// Unlike CAST(x AS VARCHAR), this adds thousands separators and fixed decimal
+/// places with HALF_EVEN (banker's) rounding.
+template <typename TExec>
+struct FormatNumberFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename T>
+  bool call(out_type<Varchar>& result, const T& value, int32_t decimalPlaces) {
+    if (decimalPlaces < 0) {
+      return false;
+    }
+    if constexpr (std::is_floating_point_v<T>) {
+      detail::formatFloatingPoint(
+          static_cast<double>(value), decimalPlaces, result);
+    } else {
+      detail::formatInteger(static_cast<int64_t>(value), decimalPlaces, result);
+    }
+    return true;
+  }
+};
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/registration/RegisterString.cpp
+++ b/bolt/functions/sparksql/registration/RegisterString.cpp
@@ -31,6 +31,7 @@
 #include "bolt/functions/lib/Re2Functions.h"
 #include "bolt/functions/prestosql/StringFunctions.h"
 #include "bolt/functions/sparksql/Base64Function.h"
+#include "bolt/functions/sparksql/FormatNumber.h"
 #include "bolt/functions/sparksql/LuhnCheckFunction.h"
 #include "bolt/functions/sparksql/MaskFunction.h"
 #include "bolt/functions/sparksql/String.h"
@@ -68,6 +69,19 @@ void registerStringFunctions(const std::string& prefix) {
 
   registerFunction<ToTitleFunction, Varchar, Varchar>(
       {prefix + "to_title", prefix + "initcap"});
+
+  registerFunction<FormatNumberFunction, Varchar, int8_t, int32_t>(
+      {prefix + "format_number"});
+  registerFunction<FormatNumberFunction, Varchar, int16_t, int32_t>(
+      {prefix + "format_number"});
+  registerFunction<FormatNumberFunction, Varchar, int32_t, int32_t>(
+      {prefix + "format_number"});
+  registerFunction<FormatNumberFunction, Varchar, int64_t, int32_t>(
+      {prefix + "format_number"});
+  registerFunction<FormatNumberFunction, Varchar, float, int32_t>(
+      {prefix + "format_number"});
+  registerFunction<FormatNumberFunction, Varchar, double, int32_t>(
+      {prefix + "format_number"});
 
   registerFunction<TrimSpaceFunction, Varchar, Varchar>({prefix + "trim"});
   registerFunction<TrimFunction, Varchar, Varchar, Varchar>({prefix + "trim"});

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(
   DecimalVectorFunctionsTest.cpp
   ElementAtTest.cpp
   FactorialTest.cpp
+  FormatNumberTest.cpp
   FromJsonTest.cpp
   FromJsonTest.cpp
   FromToJsonRoundTripTest.cpp

--- a/bolt/functions/sparksql/tests/FormatNumberTest.cpp
+++ b/bolt/functions/sparksql/tests/FormatNumberTest.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cmath>
+#include <limits>
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+
+class FormatNumberTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  std::optional<std::string> formatNumber(T value, int32_t decimalPlaces) {
+    return evaluateOnce<std::string>(
+        "format_number(c0, c1)",
+        std::optional<T>(value),
+        std::optional<int32_t>(decimalPlaces));
+  }
+
+  std::optional<std::string> formatInt32(int32_t value, int32_t d) {
+    return formatNumber<int32_t>(value, d);
+  }
+
+  std::optional<std::string> formatInt64(int64_t value, int32_t d) {
+    return formatNumber<int64_t>(value, d);
+  }
+
+  std::optional<std::string> formatDouble(double value, int32_t d) {
+    return formatNumber<double>(value, d);
+  }
+
+  std::optional<std::string> formatFloat(float value, int32_t d) {
+    return formatNumber<float>(value, d);
+  }
+};
+
+TEST_F(FormatNumberTest, integers) {
+  EXPECT_EQ(formatInt32(12345, 0), "12,345");
+  EXPECT_EQ(formatInt32(12345, 2), "12,345.00");
+  EXPECT_EQ(formatInt32(0, 0), "0");
+  EXPECT_EQ(formatInt32(0, 3), "0.000");
+  EXPECT_EQ(formatInt32(-12345, 0), "-12,345");
+  EXPECT_EQ(formatInt32(-12345, 2), "-12,345.00");
+  EXPECT_EQ(formatInt32(5, 2), "5.00");
+
+  EXPECT_EQ(formatInt64(1234567890, 0), "1,234,567,890");
+  EXPECT_EQ(formatInt64(1234567890, 4), "1,234,567,890.0000");
+  EXPECT_EQ(formatInt64(-9876543210LL, 0), "-9,876,543,210");
+
+  EXPECT_EQ(formatNumber<int8_t>(127, 0), "127");
+  EXPECT_EQ(formatNumber<int8_t>(-128, 0), "-128");
+  EXPECT_EQ(formatNumber<int8_t>(42, 1), "42.0");
+
+  EXPECT_EQ(formatNumber<int16_t>(1234, 0), "1,234");
+  EXPECT_EQ(formatNumber<int16_t>(-1234, 2), "-1,234.00");
+}
+
+TEST_F(FormatNumberTest, bigintPrecision) {
+  // Values above 2^53 are formatted exactly without double conversion.
+  EXPECT_EQ(formatInt64(9007199254740993LL, 0), "9,007,199,254,740,993");
+  EXPECT_EQ(
+      formatInt64(std::numeric_limits<int64_t>::max(), 0),
+      "9,223,372,036,854,775,807");
+  EXPECT_EQ(
+      formatInt64(std::numeric_limits<int64_t>::min(), 0),
+      "-9,223,372,036,854,775,808");
+  EXPECT_EQ(formatInt64(9007199254740993LL, 2), "9,007,199,254,740,993.00");
+}
+
+TEST_F(FormatNumberTest, floatingPoint) {
+  EXPECT_EQ(formatDouble(12345.678, 2), "12,345.68");
+  EXPECT_EQ(formatDouble(12345.678, 0), "12,346");
+  EXPECT_EQ(formatDouble(0.123, 3), "0.123");
+  EXPECT_EQ(formatDouble(-1234.5, 1), "-1,234.5");
+  EXPECT_EQ(formatDouble(12831273.234, 3), "12,831,273.234");
+
+  EXPECT_EQ(formatFloat(1234.5f, 1), "1,234.5");
+  EXPECT_EQ(formatFloat(0.0f, 2), "0.00");
+  EXPECT_EQ(formatFloat(-99.99f, 1), "-100.0");
+}
+
+TEST_F(FormatNumberTest, halfEvenRounding) {
+  // HALF_EVEN (banker's rounding) matches Java DecimalFormat default.
+  EXPECT_EQ(formatDouble(0.5, 0), "0");
+  EXPECT_EQ(formatDouble(1.5, 0), "2");
+  EXPECT_EQ(formatDouble(2.5, 0), "2");
+  EXPECT_EQ(formatDouble(3.5, 0), "4");
+  EXPECT_EQ(formatDouble(5.5, 0), "6");
+  EXPECT_EQ(formatDouble(5.4, 0), "5");
+  EXPECT_EQ(formatDouble(5.6, 0), "6");
+  EXPECT_EQ(formatDouble(-0.5, 0), "-0");
+  EXPECT_EQ(formatDouble(-1.5, 0), "-2");
+  EXPECT_EQ(formatDouble(-2.5, 0), "-2");
+}
+
+TEST_F(FormatNumberTest, binaryTieRounding) {
+  // These lock fmt's HALF_EVEN contract for double-representable tie cases.
+  // Verified against vanilla Spark (sha 12b25952).
+  EXPECT_EQ(formatDouble(1.225, 2), "1.23");
+  EXPECT_EQ(formatDouble(2.675, 2), "2.67");
+  EXPECT_EQ(formatDouble(1.15, 1), "1.1");
+  EXPECT_EQ(formatDouble(1.25, 1), "1.2");
+  EXPECT_EQ(formatDouble(-1.225, 2), "-1.23");
+  EXPECT_EQ(formatDouble(-2.675, 2), "-2.67");
+}
+
+TEST_F(FormatNumberTest, negativeDecimalPlaces) {
+  // d < 0 returns null per Spark semantics.
+  EXPECT_EQ(
+      (evaluateOnce<std::string, int32_t, int32_t>(
+          "format_number(c0, c1)", 12345, -1)),
+      std::nullopt);
+  EXPECT_EQ(
+      (evaluateOnce<std::string, double, int32_t>(
+          "format_number(c0, c1)", 12345.6, -2)),
+      std::nullopt);
+}
+
+TEST_F(FormatNumberTest, boundaryValues) {
+  EXPECT_EQ(formatInt32(0, 0), "0");
+  EXPECT_EQ(formatInt32(1, 0), "1");
+  EXPECT_EQ(formatInt32(-1, 0), "-1");
+  EXPECT_EQ(formatInt32(999, 0), "999");
+  EXPECT_EQ(formatInt32(1000, 0), "1,000");
+  EXPECT_EQ(formatInt32(999999, 0), "999,999");
+  EXPECT_EQ(formatInt32(1000000, 0), "1,000,000");
+}
+
+TEST_F(FormatNumberTest, nanAndInfinity) {
+  // Verified against Spark's FormatNumber which passes directly to
+  // DecimalFormat.format(). DecimalFormat uses DecimalFormatSymbols for
+  // NaN ("NaN") and infinity ("\u221E") in US locale.
+  EXPECT_EQ(formatDouble(std::numeric_limits<double>::quiet_NaN(), 2), "NaN");
+  EXPECT_EQ(formatDouble(std::numeric_limits<double>::infinity(), 2), "\u221E");
+  EXPECT_EQ(
+      formatDouble(-std::numeric_limits<double>::infinity(), 2), "-\u221E");
+  EXPECT_EQ(formatFloat(std::numeric_limits<float>::quiet_NaN(), 0), "NaN");
+  EXPECT_EQ(formatFloat(std::numeric_limits<float>::infinity(), 0), "\u221E");
+}
+
+TEST_F(FormatNumberTest, largeValues) {
+  EXPECT_EQ(
+      formatInt32(std::numeric_limits<int32_t>::max(), 0), "2,147,483,647");
+  EXPECT_EQ(
+      formatInt32(std::numeric_limits<int32_t>::min(), 0), "-2,147,483,648");
+}
+
+TEST_F(FormatNumberTest, negativeZero) {
+  // Java DecimalFormat preserves the sign for -0.0.
+  // Verified against Spark: SELECT format_number(-0.0d, 0) -> "-0".
+  EXPECT_EQ(formatDouble(-0.0, 0), "-0");
+  EXPECT_EQ(formatDouble(-0.0, 2), "-0.00");
+  EXPECT_EQ(formatDouble(-0.0, 5), "-0.00000");
+  // Negative values that round to zero also preserve the sign.
+  EXPECT_EQ(formatDouble(-0.4, 0), "-0");
+  EXPECT_EQ(formatDouble(-0.0000001, 0), "-0");
+  EXPECT_EQ(formatDouble(-0.0000001, 3), "-0.000");
+}
+
+TEST_F(FormatNumberTest, roundingCarry) {
+  EXPECT_EQ(formatDouble(999.9, 0), "1,000");
+  EXPECT_EQ(formatDouble(999.95, 1), "1,000.0");
+  EXPECT_EQ(formatDouble(999999.9, 0), "1,000,000");
+  EXPECT_EQ(formatDouble(-999.9, 0), "-1,000");
+}
+
+TEST_F(FormatNumberTest, largeFractionDigits) {
+  // Java DecimalFormat caps fraction digits at 340.
+  auto result = formatDouble(1.0, 340);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->size(), 342u);
+
+  // d > 340 is capped at 340.
+  auto resultCapped = formatDouble(1.0, 400);
+  ASSERT_TRUE(resultCapped.has_value());
+  EXPECT_EQ(resultCapped->size(), 342u);
+
+  auto intResult = formatInt64(1, 400);
+  ASSERT_TRUE(intResult.has_value());
+  EXPECT_EQ(intResult->size(), 342u);
+}
+
+} // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
Port format_number from Velox commit ee367988 to Bolt. Formats numeric values with US locale (comma thousands separator, dot decimal separator) matching Java DecimalFormat with the default pattern and Locale.US. Supports tinyint, smallint, integer, bigint, float, and double; returns NULL when decimal places are negative.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
