### PR TITLE
fix: preserve decimal element type in percentile_approx partial state

### DIFF
--- a/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.h
+++ b/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.h
@@ -192,6 +192,12 @@ class PercentileApproxAggregate : public exec::Aggregate {
     auto rowResult = (*result)->as<RowVector>();
     BOLT_USER_CHECK(rowResult);
     auto pool = rowResult->pool();
+    // Carry the declared element type (e.g. DECIMAL) for the type-placeholder
+    // field. CppToType<T> would yield the physical native type (e.g. HUGEINT)
+    // and drop decimal precision/scale, producing a vector whose runtime type
+    // disagrees with the intermediate schema.
+    const auto& placeholderType =
+        rowResult->type()->asRow().childAt(kTypePalceHolder);
 
     // percentiles_ can be uninitialized during an intermediate aggregation step
     // when all input intermediate states are nulls. Result should be nulls in
@@ -206,8 +212,8 @@ class PercentileApproxAggregate : public exec::Aggregate {
           BaseVector::createNullConstant(BOOLEAN(), numGroups, pool);
       rowResult->childAt(kAccuracy) =
           BaseVector::createNullConstant(INTEGER(), numGroups, pool);
-      rowResult->childAt(kTypePalceHolder) = BaseVector::createNullConstant(
-          CppToType<T>::create(), numGroups, pool);
+      rowResult->childAt(kTypePalceHolder) =
+          BaseVector::createNullConstant(placeholderType, numGroups, pool);
       auto rawNulls = rowResult->mutableRawNulls();
       bits::fillBits(rawNulls, 0, rowResult->size(), bits::kNull);
       return;
@@ -233,7 +239,7 @@ class PercentileApproxAggregate : public exec::Aggregate {
     rowResult->childAt(kAccuracy) = std::make_shared<ConstantVector<int32_t>>(
         pool, numGroups, accuracy_ <= 0, INTEGER(), int32_t(accuracy_));
     rowResult->childAt(kTypePalceHolder) = std::make_shared<ConstantVector<T>>(
-        pool, numGroups, false, CppToType<T>::create(), T());
+        pool, numGroups, false, placeholderType, T());
     auto serializedSummary =
         rowResult->childAt(kSerialized)->asFlatVector<StringView>();
 

--- a/bolt/functions/sparksql/aggregates/tests/PercentileApproxTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/PercentileApproxTest.cpp
@@ -22,6 +22,7 @@
 #include "bolt/common/base/RandomUtil.h"
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
+#include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
 #include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "bolt/functions/sparksql/aggregates/Register.h"
@@ -480,6 +481,48 @@ TEST_F(PercentileApproxTest, nullPercentile) {
       testAggregations(
           {rows}, {}, {"percentile_approx(c0, c1)"}, "SELECT NULL"),
       "Percentage value must not be null");
+}
+
+// For a decimal input, the intermediate (partial) state of percentile_approx is
+// a ROW whose type-placeholder field carries the input element type. That field
+// must keep the logical decimal type; building it from the C++ native type
+// would make it a physical HUGEINT, leaving a vector whose runtime type
+// disagrees with its declared type. Downstream type-aware consumers (e.g. the
+// shuffle writer) then reject it as an unsupported type.
+TEST_F(PercentileApproxTest, decimalPartialPreservesElementType) {
+  const auto decimalType = DECIMAL(32, 3);
+  auto values =
+      makeFlatVector<int128_t>({1000, 2000, 3000, 4000, 5000}, decimalType);
+  auto rows = makeRowVector({values});
+
+  auto plan = exec::test::PlanBuilder()
+                  .values({rows})
+                  .partialAggregation({}, {"percentile_approx(c0, 0.5)"})
+                  .planNode();
+
+  // Read the raw intermediate output; copyResult would re-materialize children
+  // with the declared row type and hide the mismatch.
+  exec::test::CursorParameters params;
+  params.planNode = plan;
+  params.serialExecution = true;
+  params.copyResult = false;
+  auto cursor = exec::test::TaskCursor::create(params);
+  ASSERT_TRUE(cursor->moveNext());
+  auto output = cursor->current();
+
+  auto intermediate = output->childAt(0)->as<RowVector>();
+  ASSERT_NE(intermediate, nullptr);
+  // Intermediate ROW layout: {percentiles, isArray, accuracy, typePlaceholder,
+  // serialized}; index 3 is the element-type placeholder.
+  constexpr int32_t kTypePlaceholder = 3;
+  auto placeholderType = intermediate->childAt(kTypePlaceholder)->type();
+  EXPECT_TRUE(placeholderType->isDecimal())
+      << "type-placeholder field type is " << placeholderType->toString()
+      << ", expected a decimal";
+  EXPECT_TRUE(placeholderType->equivalent(*decimalType));
+
+  while (cursor->moveNext()) {
+  }
 }
 
 } // namespace

--- a/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
@@ -80,7 +80,10 @@ void SparkShuffleWriter::addInput(RowVectorPtr input) {
           << ", pool reserved: " << pool()->reservedBytes()
           << ", total free: " << freeMem.value();
   auto status = shuffleWriter_->split(input, memLimit);
-  BOLT_CHECK(status.ok(), "Native split: shuffle writer split failed");
+  BOLT_CHECK(
+      status.ok(),
+      "Native split: shuffle writer split failed: {}",
+      status.ToString());
 }
 
 void SparkShuffleWriter::noMoreInput() {


### PR DESCRIPTION
### What problem does this PR solve?

Queries running `percentile_approx` over a `decimal` column fail deterministically in the
Bolt native shuffle-write stage:

```
org.apache.gluten.exception.GlutenException: BoltRuntimeError
Error Code: INVALID_STATE
Reason: Native split: shuffle writer split failed,
        Invalid: Column type decimal128(32, 3) is not supported.
Context: Operator: SparkShuffleWriter[10], Function: addInput
File: bolt/shuffle/sparksql/ShuffleWriterNode.cpp:83
```

The failure is fast, deterministic, retries on other executors don't help, and the JVM heap
is healthy (not an OOM).

Issue Number: close #648 

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

**Root cause.** For a decimal input, `percentile_approx`'s partial (intermediate) state is a
`ROW(array<double>, boolean, integer, <inputType>, varbinary)`, where the 4th field
(`inputTypePlaceHolder`) is meant to carry the input element type.
`PercentileApproxAggregate<T>::extractAccumulators` built that field with
`CppToType<T>::create()`. For `decimal128` (precision > 18), `T = int128_t` and
`CppToType<int128_t>::create()` is **`HUGEINT`** — the physical type, with precision/scale
dropped. So the child vector's runtime `type()` is `HUGEINT`, while the enclosing ROW / plan
declares `DECIMAL`: a logical/physical type mismatch.

**Why it surfaces now.** Previously the percentile-like `TypedImperativeAggregate` rewrite
folded the partial buffer into a single struct attribute, so the whole ROW was shuffled as one
complex column (Presto serialization is purely physical-layout based and type-agnostic — the
HUGEINT placeholder serialized fine). That rewrite was removed (aligning with upstream), so the
aggregate now exposes its raw multi-field buffer; `extractStructNeeded` then unpacks the ROW
into top-level columns, and the placeholder becomes a top-level fixed-width decimal column. The
shuffle writer's `splitFixedWidthValueBuffer` 128-bit branch keys the copy width on
`isShortDecimal()/isLongDecimal()` (a `dynamic_cast` to `*DecimalType`), both false for a bare
`HUGEINT`, so it returns `Invalid: ... is not supported.`, reported as `INVALID_STATE`.

**Fix.** Build the placeholder field from the declared intermediate child type
(`rowResult->type()->asRow().childAt(kTypePalceHolder)`) instead of `CppToType<T>::create()`,
so it keeps the logical decimal type for every downstream consumer. Applied to both the null
and the normal branch.

Additionally, surface the underlying arrow `Status` in the shuffle split check
(`ShuffleWriterNode.cpp`) so future type mismatches are diagnosable rather than hidden behind a
generic "split failed" message.

### Performance Impact
- [x] **No Impact**: This change does not affect the critical path (constructs an intermediate
  placeholder vector with the correct type; same allocation, just the right `TypePtr`).

### Release Note

```text
Release Note:
- Fixed "Native split: shuffle writer split failed (Column type decimal128 is not supported)"
  when shuffling the partial state of percentile_approx over a decimal column.
```

### Checklist (For Author)
- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
- [x] No
