### PR TITLE
bugfix: first/last value agg functions overwirte memory

### DIFF
--- a/bolt/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -81,7 +81,7 @@ class FirstLastAggregateBase
       std::vector<VectorPtr>& args,
       VectorPtr& result) const override {
     const auto& input = args[0];
-    result->resize(rows.size());
+    result->resize(input->size());
     copyToIntermediate(rows, args, result->as<RowVector>()->childAt(0));
     auto rawNulls = result->mutableRawNulls();
     // set all rows to null


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #653

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

Root cause

In FirstLastAggregateBase::toIntermediate , result was resized to rows.size() while bits::setAllNull(rawNulls, input->size()) wrote input->size() bits. When the aggregate has a filter/mask, GroupingSet::toIntermediate passes a masked SelectivityVector whose rows.size() can be smaller than input->size() . The nulls buffer was allocated via ensureNullsCapacity(length_=rows.size(), …) , but setAllNull then wrote past its end → ASan heap-buffer-overflow.

Fix

Resize result to input->size() (consistent with assignToIntermediate , copyToIntermediate , countToIntermediate , and AverageAggregateBase::toIntermediate in the same fix series — commit 583d708be3d ). This ensures the nulls buffer is sized to match the setAllNull(..., input->size()) write.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [x] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
