### PR TITLE
fix(paimon): keep batch readers alive for output vectors

### DIFF
--- a/bolt/connectors/paimon/PaimonDataSource.cpp
+++ b/bolt/connectors/paimon/PaimonDataSource.cpp
@@ -207,12 +207,12 @@ std::optional<RowVectorPtr> PaimonDataSource::next(
     ContinueFuture& /* future */) {
   // If we've already encountered EOF (inputSplits_ are cleared and no reader),
   // don't try to do anything else
-  if (inputSplits_.empty() && !reader_) {
+  if (inputSplits_.empty() && !currentReader_) {
     return nullptr;
   }
 
   // Lazily create the BatchReader using accumulated splits.
-  if (!reader_ && !inputSplits_.empty()) {
+  if (!currentReader_ && !inputSplits_.empty()) {
     VLOG(1) << "PaimonDataSource::next(): Creating reader with "
             << inputSplits_.size() << " split(s)";
     auto&& readerCreateStatus = tableRead_->CreateReader(inputSplits_);
@@ -222,23 +222,23 @@ std::optional<RowVectorPtr> PaimonDataSource::next(
       BOLT_FAIL(
           "create reader error: {}", readerCreateStatus.status().ToString());
     }
-    reader_ = std::move(readerCreateStatus).value();
+    currentReader_ = std::move(readerCreateStatus).value();
   }
 
-  if (!reader_) {
+  if (!currentReader_) {
     VLOG(1)
         << "PaimonDataSource::next(): No reader available, returning nullopt";
     return nullptr;
   }
 
   VLOG(1) << "PaimonDataSource::next(): Calling reader->NextBatch() at "
-          << reader_.get();
-  auto batchRes = reader_->NextBatch();
+          << currentReader_.get();
+  auto batchRes = currentReader_->NextBatch();
   if (!batchRes.ok()) {
     VLOG(1) << "PaimonDataSource::next(): NextBatch NOT ok: "
             << batchRes.status().ToString();
-    reader_->Close();
-    reader_.reset();
+    currentReader_->Close();
+    holdReader_.push_back(std::move(currentReader_));
     inputSplits_.clear();
     BOLT_FAIL("failed to get next batch: {}", batchRes.status().ToString());
   }
@@ -254,8 +254,8 @@ std::optional<RowVectorPtr> PaimonDataSource::next(
     if (pair.second && pair.second->release) {
       pair.second->release(pair.second.get());
     }
-    reader_->Close();
-    reader_.reset();
+    currentReader_->Close();
+    holdReader_.push_back(std::move(currentReader_));
     inputSplits_.clear();
     return nullptr;
   }

--- a/bolt/connectors/paimon/PaimonDataSource.h
+++ b/bolt/connectors/paimon/PaimonDataSource.h
@@ -68,11 +68,11 @@ class PaimonDataSource : public DataSource {
   std::shared_ptr<PaimonTableHandle> tableHandle_;
   memory::MemoryPool* pool_;
 
-  std::unique_ptr<::paimon::BatchReader> reader_;
+  std::vector<std::unique_ptr<::paimon::BatchReader>> holdReader_;
+  std::unique_ptr<::paimon::BatchReader> currentReader_;
   std::unique_ptr<::paimon::TableRead> tableRead_;
   std::vector<std::shared_ptr<::paimon::Split>> inputSplits_;
   std::shared_ptr<::paimon::MemoryPool> paimonPool_;
-  std::shared_ptr<PaimonConnectorSplit> currentSplit_;
 
   uint64_t completedRows_{0};
   uint64_t completedBytes_{0};

--- a/bolt/connectors/paimon/tests/PaimonConnectorTest.cpp
+++ b/bolt/connectors/paimon/tests/PaimonConnectorTest.cpp
@@ -24,10 +24,12 @@
 #include <paimon/table/source/data_split.h>
 #include <paimon/table/source/plan.h>
 #include <paimon/table/source/table_scan.h>
+#include "bolt/common/config/Config.h"
 #include "bolt/common/memory/Memory.h"
 #include "bolt/connectors/paimon/BoltMemoryPool.h"
 #include "bolt/connectors/paimon/PaimonConfig.h"
 #include "bolt/connectors/paimon/PaimonConnectorSplit.h"
+#include "bolt/connectors/paimon/PaimonDataSource.h"
 #include "bolt/connectors/paimon/PaimonTableHandle.h"
 #include "bolt/exec/tests/utils/OperatorTestBase.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
@@ -95,6 +97,21 @@ class PaimonConnectorTest
 
 std::shared_ptr<exec::test::TempDirectoryPath> PaimonConnectorTest::tempDir_ =
     nullptr;
+
+std::vector<std::shared_ptr<PaimonConnectorSplit>> makeConnectorSplits(
+    const std::shared_ptr<::paimon::Plan>& paimonPlan,
+    const std::shared_ptr<::paimon::MemoryPool>& paimonPool) {
+  std::vector<std::shared_ptr<PaimonConnectorSplit>> paimonConnectorSplits;
+  const auto paimonSplits = paimonPlan->Splits();
+  paimonConnectorSplits.reserve(paimonSplits.size());
+  for (const auto& paimonSplit : paimonSplits) {
+    const auto serialized =
+        ::paimon::Split::Serialize(paimonSplit, paimonPool).value();
+    paimonConnectorSplits.push_back(std::make_shared<PaimonConnectorSplit>(
+        "paimon_test", serialized.data(), serialized.length()));
+  }
+  return paimonConnectorSplits;
+}
 
 TEST_F(PaimonConnectorTest, TestTableScanBasic) {
   // Create Parquet data with unique id
@@ -164,6 +181,73 @@ TEST_F(PaimonConnectorTest, TestTableScanBasic) {
       paimonConnectorSplits.begin(),
       paimonConnectorSplits.end());
   assertQueryOrdered(plan, inputSplits, duckSql, std::vector<uint32_t>{0});
+}
+
+TEST_F(PaimonConnectorTest, ReturnedVectorsCanOutliveReaderEof) {
+  auto rootPool =
+      memory::memoryManager()->addRootPool("PaimonDataSourceLifetimeTest");
+  auto leafPool = rootPool->addLeafChild("leaf");
+  auto connectorPool = rootPool->addAggregateChild("connector");
+  auto paimonPool = std::make_shared<BoltPaimonMemoryPool>(leafPool.get());
+
+  std::string tablePath = "file:" + tempDir_->path + "/test_db.db/basic";
+  ::paimon::ScanContextBuilder contextBuilder(tablePath);
+  auto scanContext =
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+          .Finish()
+          .value();
+  auto tableScan = ::paimon::TableScan::Create(std::move(scanContext)).value();
+  auto paimonPlan = tableScan->CreatePlan().value();
+
+  auto rowType = ROW({"id"}, {BIGINT()});
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+      columnHandles;
+  columnHandles["id"] = std::make_shared<PaimonColumnHandle>("id", BIGINT());
+  auto tableHandle = std::make_shared<PaimonTableHandle>(
+      "paimon_test",
+      "test_table",
+      tablePath,
+      std::unordered_map<std::string, std::string>());
+  auto sessionProperties = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+  auto queryCtx = std::make_shared<connector::ConnectorQueryCtx>(
+      leafPool.get(),
+      connectorPool.get(),
+      sessionProperties.get(),
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      "query.PaimonDataSourceLifetimeTest",
+      "task.PaimonDataSourceLifetimeTest",
+      "planNodeId.PaimonDataSourceLifetimeTest",
+      0);
+
+  PaimonDataSource dataSource(
+      rowType,
+      tableHandle,
+      columnHandles,
+      queryCtx,
+      core::QueryConfig({}),
+      std::make_shared<PaimonConfig>(sessionProperties));
+
+  for (const auto& split : makeConnectorSplits(paimonPlan, paimonPool)) {
+    dataSource.addSplit(split);
+  }
+
+  ContinueFuture future;
+  std::vector<RowVectorPtr> outputs;
+  for (;;) {
+    auto next = dataSource.next(1, future);
+    ASSERT_TRUE(next.has_value());
+    if (!next.value()) {
+      break;
+    }
+    outputs.push_back(std::move(next).value());
+  }
+
+  ASSERT_FALSE(outputs.empty());
+  outputs.clear();
 }
 
 TEST_F(PaimonConnectorTest, TestTableScanAppendOnlyMultipleAppend) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
`PaimonDataSource::next()` destroyed the current batch reader when reaching EOF. However, returned Arrow-backed `RowVector`s may still reference resources owned by that reader.

Releasing these vectors after EOF could therefore cause a core dump.

Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Keep closed batch readers alive until the `PaimonDataSource` is destroyed, ensuring returned vectors do not outlive their backing reader resources.

Add a regression test that:

1. Retains the `RowVector`s returned by `next()`.
2. Continues reading until EOF.
3. Releases the retained vectors after the reader has been closed.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a Paimon connector crash when releasing returned RowVectors after reaching EOF.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
