### PR TITLE
fix: keep spark first/last intermediate struct non-null

### DIFF
--- a/bolt/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -83,14 +83,18 @@ class FirstLastAggregateBase
     const auto& input = args[0];
     result->resize(rows.size());
     copyToIntermediate(rows, args, result->as<RowVector>()->childAt(0));
-    auto rawNulls = result->mutableRawNulls();
-    // set all rows to null
-    bits::setAllNull(rawNulls, input->size());
-    rows.applyToSelected([&](vector_size_t i) {
-      if (!input->isNullAt(i)) {
-        bits::clearNull(rawNulls, i);
-      }
-    });
+    // Keep the struct non-null and mark recorded rows via 'valueSet' (same
+    // invariant as extractAccumulators), so the (value, valueSet) intermediate
+    // survives the split/shuffle/rebuild. (was: null struct, valueSet unset.)
+    bits::clearAllNull(result->mutableRawNulls(), input->size());
+    auto* valueSet = result->as<RowVector>()->childAt(1)->asFlatVector<bool>();
+    valueSet->resize(input->size());
+    for (vector_size_t i = 0; i < input->size(); ++i) {
+      valueSet->set(i, false);
+    }
+    if constexpr (!ignoreNull) {
+      rows.applyToSelected([&](vector_size_t i) { valueSet->set(i, true); });
+    }
   }
 
   FLATTEN void initializeNewGroups(
@@ -145,17 +149,16 @@ class FirstLastAggregateBase
     ignoreNullVector->resize(numGroups);
 
     extractValues(groups, numGroups, &(rowVector->childAt(0)));
+    // Keep every struct non-null; 'valueSet' is the sole "has a value"
+    // indicator -- a null struct does not survive the shuffle round-trip.
+    bits::clearAllNull(rowVector->mutableRawNulls(), numGroups);
     for (auto i = 0; i < numGroups; i++) {
       if constexpr (ignoreNull) {
         ignoreNullVector->set(i, false);
         continue;
       }
-      if (Aggregate::value<TAccumulator>(groups[i])->has_value()) {
-        rowVector->setNull(i, false);
-        ignoreNullVector->set(i, true);
-      } else {
-        ignoreNullVector->set(i, false);
-      }
+      ignoreNullVector->set(
+          i, Aggregate::value<TAccumulator>(groups[i])->has_value());
     }
   }
 

--- a/bolt/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/memory/HashStringAllocator.h"
+#include "bolt/exec/Aggregate.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
@@ -180,6 +182,88 @@ class FirstAggregateTest : public AggregationTestBase {
     }
   }
 };
+
+// A group that recorded no value (e.g. an empty partition) must extract to a
+// non-null struct {value=null, valueSet=false}. The 'valueSet' flag, not the
+// struct's null-ness, signals "no value" -- a null struct would not survive a
+// shuffle and would be mis-merged as a recorded null.
+TEST_F(FirstAggregateTest, extractAccumulatorsKeepsEmptyGroupNonNull) {
+  HashStringAllocator allocator(pool());
+  std::vector<TypePtr> argTypes{VARCHAR()};
+  std::unordered_map<std::string, std::string> emptyConfig;
+  auto func = exec::Aggregate::create(
+      "spark_first",
+      core::AggregationNode::Step::kSingle,
+      argTypes,
+      VARCHAR(),
+      core::QueryConfig{emptyConfig});
+  func->setAllocator(&allocator);
+  func->setOffsets(
+      /*offset*/ 16, /*nullByte*/ 0, /*nullMask*/ 1, /*rowSizeOffset*/ 8);
+
+  // Initialize one group but add no input rows (an empty partition).
+  std::vector<char> group(16 + func->accumulatorFixedWidthSize());
+  std::vector<char*> groups{group.data()};
+  std::vector<vector_size_t> indices{0};
+  func->initializeNewGroups(groups.data(), indices);
+
+  auto intermediateType = func->intermediateType("spark_first", argTypes);
+  auto result = BaseVector::create(intermediateType, 1, pool());
+  func->extractAccumulators(groups.data(), 1, &result);
+
+  auto* row = result->as<RowVector>();
+  // The struct must be non-null so valueSet survives the split/shuffle/rebuild.
+  ASSERT_FALSE(row->isNullAt(0));
+  // No value recorded -> value is null and valueSet is false (merge skips it).
+  ASSERT_TRUE(row->childAt(0)->isNullAt(0));
+  ASSERT_FALSE(row->childAt(1)->asFlatVector<bool>()->valueAt(0));
+
+  func->destroy(folly::Range(groups.data(), 1));
+}
+
+// toIntermediate() is the abandon-partial-aggregation fast path: it maps each
+// raw input row directly to the (value, valueSet) intermediate without
+// accumulating. Every selected row is a recorded value -- even a null one -- so
+// each must extract to a non-null struct with valueSet=true. (A null struct or
+// an unset valueSet would be misread as "no value" once the intermediate is
+// split, shuffled, and rebuilt for the global merge.) This mirrors the
+// non-null-struct + valueSet invariant that extractAccumulators establishes.
+TEST_F(FirstAggregateTest, toIntermediateMarksEveryRowAsValueSet) {
+  HashStringAllocator allocator(pool());
+  std::vector<TypePtr> argTypes{BIGINT()};
+  std::unordered_map<std::string, std::string> emptyConfig;
+  auto func = exec::Aggregate::create(
+      "spark_first",
+      core::AggregationNode::Step::kSingle,
+      argTypes,
+      BIGINT(),
+      core::QueryConfig{emptyConfig});
+  func->setAllocator(&allocator);
+  func->setOffsets(
+      /*offset*/ 16, /*nullByte*/ 0, /*nullMask*/ 1, /*rowSizeOffset*/ 8);
+
+  // Two input rows, one non-null and one null; both are "recorded values".
+  auto input =
+      makeRowVector({makeNullableFlatVector<int64_t>({42, std::nullopt})});
+  std::vector<VectorPtr> args{input->childAt(0)};
+
+  auto intermediateType = func->intermediateType("spark_first", argTypes);
+  auto result = BaseVector::create(intermediateType, 2, pool());
+
+  SelectivityVector rows(2);
+  func->toIntermediate(rows, args, result);
+
+  auto* row = result->as<RowVector>();
+  auto* valueSet = row->childAt(1)->asFlatVector<bool>();
+  for (vector_size_t i = 0; i < 2; ++i) {
+    // Struct non-null and the row marked as a recorded value.
+    ASSERT_FALSE(row->isNullAt(i));
+    ASSERT_TRUE(valueSet->valueAt(i));
+  }
+  // The recorded values round-trip, including the null one.
+  ASSERT_EQ(42, row->childAt(0)->asFlatVector<int64_t>()->valueAt(0));
+  ASSERT_TRUE(row->childAt(0)->isNullAt(1));
+}
 
 TEST_F(FirstAggregateTest, boolean) {
   testAggregate<bool>();

--- a/scripts/launch-spark/test-queries.sql
+++ b/scripts/launch-spark/test-queries.sql
@@ -227,3 +227,23 @@ LIMIT 10;
 SET spark.gluten.enabled;
 SET spark.plugins;
 SET spark.shuffle.manager;
+
+-- =========================================================================
+-- 21. first()/last() with empty partitions (200 partitions, ~198 empty after
+--     the filter). Constant value makes it deterministic: expect '20260531',
+--     not NULL. NULL means an empty partition's partial polluted the merge.
+-- =========================================================================
+SELECT first(v) AS first_v,
+       last(v)  AS last_v,
+       first(v, true) AS first_v_ignore_nulls,
+       count(*) AS n
+FROM (SELECT id, id % 100 AS k, '20260531' AS v FROM range(0, 200, 1, 200))
+WHERE k = 7;
+EXPLAIN
+SELECT first(v) FROM (SELECT id, id % 100 AS k, '20260531' AS v
+                      FROM range(0, 200, 1, 200))
+WHERE k = 7;
+
+-- A genuinely-recorded NULL must still return NULL (expect NULL).
+SELECT first(c) AS genuine_null
+FROM (SELECT CAST(NULL AS INT) AS c FROM range(0, 100, 1, 8));


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #663

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

`spark_first`/`spark_last`'s partial result is `(value, valueSet)`:
- `(value, valueSet = true)` → valid input
- `(value, valueSet = false)` → input is empty
- `null ROW()` → treated as null input

Since the latest Gluten splits the ROW after partial aggregation and uses `row_constructor_with_null` to reconstruct it in the final aggregation, `(NULL, valueSet = false)` will be reconstructed as a null ROW in the final aggregation. The final aggregation then treats it as a null input and may use this as the final result.

Enforce one invariant in both producers: the intermediate struct is never null and 'valueSet' is the sole "has a value" indicator.
- extractAccumulators: force the struct non-null for every group, with valueSet = has_value().
- toIntermediate (abandon-partial fast path): keep the struct non-null and set valueSet=true for each recorded row (it previously left valueSet unset). The merge (addIntermediateResults) already honors valueSet given a non-null struct, so it is unchanged. The matching gluten-side change has first/last use row_constructor_with_all_null (like min_by/max_by) so the struct stays non-null through the rebuild.


After fix:
**ignoreNull=true** (valueSet always false; the value field's null-ness is the indicator):

| State | value | valueSet |
|---|---|---|
| Has a value | v (non-null) | false |
| No value | null | false |

**ignoreNull=false** (valueSet distinguishes the three states):

| State | value | valueSet |
|---|---|---|
| Recorded a non-null value | v | true |
| Recorded a null value | null | true |
| No value | null | false |

Tests: extractAccumulators emits a non-null {value=null, valueSet=false} for an empty group; toIntermediate marks every recorded row valueSet=true (incl. a null value); plus a test-queries.sql case for the multi-partition empty-partition scenario.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
