### PR TITLE
fix(sparksql): align json_to_map with Hive jsoniter — control chars, number precision, non-object scalars

### DIFF
--- a/bolt/functions/sparksql/JsonToMap.cpp
+++ b/bolt/functions/sparksql/JsonToMap.cpp
@@ -24,6 +24,70 @@
 #include "sonic/dom/parser.h"
 namespace bytedance::bolt::functions::sparksql {
 namespace {
+// Escape raw (unescaped) control chars (\x00 ~ \x1f) that appear *inside*
+// string literals (keys or values), producing strictly valid JSON whose
+// decoded contents are unchanged. Control chars outside strings are valid
+// JSON whitespace and are left untouched. Both parser backends fall back to
+// this so they accept the same inputs as the reference Hive UDF
+// (com.jsoniter), which tolerates raw control chars and keeps them verbatim.
+std::string escapeUnescapedControlChars(std::string_view in) {
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(in.size());
+  bool inString = false;
+  bool escaped = false;
+  for (unsigned char c : in) {
+    if (!inString) {
+      if (c == '"') {
+        inString = true;
+      }
+      out.push_back(c);
+      continue;
+    }
+    if (escaped) {
+      out.push_back(c);
+      escaped = false;
+      continue;
+    }
+    if (c == '\\') {
+      out.push_back(c);
+      escaped = true;
+      continue;
+    }
+    if (c == '"') {
+      out.push_back(c);
+      inString = false;
+      continue;
+    }
+    if (c < 0x20) {
+      switch (c) {
+        case '\n':
+          out += "\\n";
+          break;
+        case '\r':
+          out += "\\r";
+          break;
+        case '\t':
+          out += "\\t";
+          break;
+        case '\b':
+          out += "\\b";
+          break;
+        case '\f':
+          out += "\\f";
+          break;
+        default:
+          out += "\\u00";
+          out.push_back(kHex[(c >> 4) & 0xf]);
+          out.push_back(kHex[c & 0xf]);
+      }
+      continue;
+    }
+    out.push_back(c);
+  }
+  return out;
+}
+
 class JsonToMapFunction : public exec::VectorFunction {
  public:
   bool isDefaultNullBehavior() const override {
@@ -70,41 +134,65 @@ class JsonToMapFunction : public exec::VectorFunction {
         folly::F14FastMap<std::string_view, std::string_view> keyValues;
         auto sv = input->valueAt<StringView>(row);
         const std::string_view current = std::string_view(sv.data(), sv.size());
-        padded_data = current;
-        if (padded_data.capacity() < sv.size() + simdjson::SIMDJSON_PADDING) {
-          padded_data.reserve(std::max(
-              sv.size() + simdjson::SIMDJSON_PADDING,
-              padded_data.capacity() + padded_data.capacity() / 2));
-        }
-        try {
-          simdjson::ondemand::document doc = parser.iterate(padded_data);
-          simdjson::ondemand::value val = doc;
-          if (val.type() != simdjson::ondemand::json_type::object) {
-            // hiveudf returns empty map for valid non-object JSON
-            // (null, number, boolean, string, array), not SQL NULL.
-            resultWriter.commit();
-            return;
+
+        // Parse the given buffer into keyValues. Returns true on success
+        // (including valid non-object JSON, which yields an empty map);
+        // returns false if the JSON could not be parsed. The string_views
+        // stored in keyValues remain valid as long as `buffer` and `parser`
+        // are not mutated/reused, so the caller writes them out before any
+        // subsequent parse attempt.
+        auto parseInto = [&](std::string& buffer) -> bool {
+          keyValues.clear();
+          if (buffer.capacity() < buffer.size() + simdjson::SIMDJSON_PADDING) {
+            buffer.reserve(std::max(
+                buffer.size() + simdjson::SIMDJSON_PADDING,
+                buffer.capacity() + buffer.capacity() / 2));
           }
-          for (auto field : val.get_object()) {
-            std::string_view key = field.unescaped_key(true);
-            simdjson::ondemand::value value = field.value();
-            std::string_view view;
-            if (value.type() == simdjson::ondemand::json_type::string) {
-              view = value.get_string(true);
-            } else {
-              view = simdjson::to_json_string(value);
+          try {
+            simdjson::ondemand::document doc = parser.iterate(buffer);
+            simdjson::ondemand::value val = doc;
+            if (val.type() != simdjson::ondemand::json_type::object) {
+              // hiveudf returns empty map for valid non-object JSON
+              // (null, number, boolean, string, array), not SQL NULL.
+              return true;
             }
-            keyValues.insert_or_assign(key, view);
+            for (auto field : val.get_object()) {
+              std::string_view key = field.unescaped_key(true);
+              simdjson::ondemand::value value = field.value();
+              std::string_view view;
+              if (value.type() == simdjson::ondemand::json_type::string) {
+                view = value.get_string(true);
+              } else {
+                view = simdjson::to_json_string(value);
+              }
+              keyValues.insert_or_assign(key, view);
+            }
+            return true;
+          } catch (std::exception& e) {
+            return false;
           }
-          for (const auto& [key, value] : keyValues) {
-            auto [keyWriter, valueWriter] = mapWriter.add_item();
-            keyWriter.append(StringView(key));
-            valueWriter.append(StringView(value));
-          }
-          resultWriter.commit();
-        } catch (std::exception& e) {
-          resultWriter.commitNull();
+        };
+
+        padded_data = current;
+        bool ok = parseInto(padded_data);
+        if (!ok) {
+          // simdjson, unlike the reference Hive UDF (com.jsoniter), rejects
+          // raw control chars inside strings. Escape them and retry so both
+          // backends behave identically; this only runs on the (rare) failure
+          // path, so valid JSON pays no extra cost.
+          padded_data = escapeUnescapedControlChars(current);
+          ok = parseInto(padded_data);
         }
+        if (!ok) {
+          resultWriter.commitNull();
+          return;
+        }
+        for (const auto& [key, value] : keyValues) {
+          auto [keyWriter, valueWriter] = mapWriter.add_item();
+          keyWriter.append(StringView(key));
+          valueWriter.append(StringView(value));
+        }
+        resultWriter.commit();
       }
     });
     resultWriter.finish();
@@ -132,6 +220,16 @@ class JsonToMapFunction : public exec::VectorFunction {
         const std::string_view current = std::string_view(sv.data(), sv.size());
         sonic_json::Document doc;
         doc.Parse(current);
+        std::string escaped;
+        if (doc.HasParseError()) {
+          // The reference Hive UDF (com.jsoniter) accepts raw (unescaped)
+          // control chars inside keys/values, while strict parsers reject
+          // them. Escape such chars and retry so both behave the same and the
+          // control chars are preserved in the result; `escaped` must outlive
+          // the member iteration below.
+          escaped = escapeUnescapedControlChars(current);
+          doc.Parse(escaped);
+        }
         if (doc.HasParseError()) {
           resultWriter.commitNull();
           return;

--- a/bolt/functions/sparksql/JsonToMap.cpp
+++ b/bolt/functions/sparksql/JsonToMap.cpp
@@ -24,12 +24,11 @@
 #include "sonic/dom/parser.h"
 namespace bytedance::bolt::functions::sparksql {
 namespace {
-// Escape raw (unescaped) control chars (\x00 ~ \x1f) that appear *inside*
-// string literals (keys or values), producing strictly valid JSON whose
-// decoded contents are unchanged. Control chars outside strings are valid
-// JSON whitespace and are left untouched. Both parser backends fall back to
-// this so they accept the same inputs as the reference Hive UDF
-// (com.jsoniter), which tolerates raw control chars and keeps them verbatim.
+// Escape raw control chars (U+0000-U+001F) inside JSON string literals, leaving
+// the decoded value unchanged, so a strict parser accepts them. RFC 8259 sec.7
+// requires these to be escaped inside strings (outside, they are only
+// whitespace, so we leave them). Lets both backends match the Hive reference
+// UDF (com.jsoniter), which tolerates raw control chars.
 std::string escapeUnescapedControlChars(std::string_view in) {
   static constexpr char kHex[] = "0123456789abcdef";
   std::string out;
@@ -37,53 +36,22 @@ std::string escapeUnescapedControlChars(std::string_view in) {
   bool inString = false;
   bool escaped = false;
   for (unsigned char c : in) {
-    if (!inString) {
-      if (c == '"') {
-        inString = true;
-      }
-      out.push_back(c);
-      continue;
-    }
-    if (escaped) {
-      out.push_back(c);
-      escaped = false;
-      continue;
-    }
-    if (c == '\\') {
-      out.push_back(c);
-      escaped = true;
-      continue;
-    }
-    if (c == '"') {
-      out.push_back(c);
-      inString = false;
-      continue;
-    }
-    if (c < 0x20) {
-      switch (c) {
-        case '\n':
-          out += "\\n";
-          break;
-        case '\r':
-          out += "\\r";
-          break;
-        case '\t':
-          out += "\\t";
-          break;
-        case '\b':
-          out += "\\b";
-          break;
-        case '\f':
-          out += "\\f";
-          break;
-        default:
-          out += "\\u00";
-          out.push_back(kHex[(c >> 4) & 0xf]);
-          out.push_back(kHex[c & 0xf]);
-      }
+    // \u00XX covers the whole range (RFC 8259 sec.7) and decodes to the same
+    // byte, so the \n/\t/... two-char forms are not needed.
+    if (inString && !escaped && c < 0x20) {
+      out += "\\u00";
+      out.push_back(kHex[c >> 4]);
+      out.push_back(kHex[c & 0xf]);
       continue;
     }
     out.push_back(c);
+    if (escaped) {
+      escaped = false; // this char was consumed by the preceding backslash
+    } else if (c == '\\' && inString) {
+      escaped = true;
+    } else if (c == '"') {
+      inString = !inString;
+    }
   }
   return out;
 }
@@ -135,12 +103,10 @@ class JsonToMapFunction : public exec::VectorFunction {
         auto sv = input->valueAt<StringView>(row);
         const std::string_view current = std::string_view(sv.data(), sv.size());
 
-        // Parse the given buffer into keyValues. Returns true on success
-        // (including valid non-object JSON, which yields an empty map);
-        // returns false if the JSON could not be parsed. The string_views
-        // stored in keyValues remain valid as long as `buffer` and `parser`
-        // are not mutated/reused, so the caller writes them out before any
-        // subsequent parse attempt.
+        // Parse `buffer` into keyValues; true on success (valid non-object JSON
+        // yields an empty map), false if unparsable. The stored string_views
+        // point into `buffer`/`parser`, so the caller must write them out
+        // before the next parse attempt.
         auto parseInto = [&](std::string& buffer) -> bool {
           keyValues.clear();
           if (buffer.capacity() < buffer.size() + simdjson::SIMDJSON_PADDING) {
@@ -150,13 +116,13 @@ class JsonToMapFunction : public exec::VectorFunction {
           }
           try {
             simdjson::ondemand::document doc = parser.iterate(buffer);
-            simdjson::ondemand::value val = doc;
-            if (val.type() != simdjson::ondemand::json_type::object) {
-              // hiveudf returns empty map for valid non-object JSON
-              // (null, number, boolean, string, array), not SQL NULL.
+            // Check the document type instead of coercing to a value: a
+            // top-level scalar throws SCALAR_DOCUMENT_AS_VALUE, but is still
+            // valid non-object JSON -> empty map (like hiveudf), not NULL.
+            if (doc.type() != simdjson::ondemand::json_type::object) {
               return true;
             }
-            for (auto field : val.get_object()) {
+            for (auto field : doc.get_object()) {
               std::string_view key = field.unescaped_key(true);
               simdjson::ondemand::value value = field.value();
               std::string_view view;
@@ -176,10 +142,8 @@ class JsonToMapFunction : public exec::VectorFunction {
         padded_data = current;
         bool ok = parseInto(padded_data);
         if (!ok) {
-          // simdjson, unlike the reference Hive UDF (com.jsoniter), rejects
-          // raw control chars inside strings. Escape them and retry so both
-          // backends behave identically; this only runs on the (rare) failure
-          // path, so valid JSON pays no extra cost.
+          // On failure, escape raw control chars and retry (only the rare
+          // failure path; valid JSON is unaffected).
           padded_data = escapeUnescapedControlChars(current);
           ok = parseInto(padded_data);
         }
@@ -219,16 +183,19 @@ class JsonToMapFunction : public exec::VectorFunction {
         auto sv = input->valueAt<StringView>(row);
         const std::string_view current = std::string_view(sv.data(), sv.size());
         sonic_json::Document doc;
-        doc.Parse(current);
+        // Keep numeric values as their original source text rather than
+        // round-tripping through a double (which loses precision and reformats,
+        // e.g. 1e10 -> 10000000000.0) or failing on out-of-range exponents
+        // (e.g. 1e400). Matches the Hive reference UDF (com.jsoniter).
+        constexpr unsigned kParseFlags =
+            kParseIntegerAsRaw | kParseOverflowNumAsNumStr;
+        doc.Parse<kParseFlags>(current);
         std::string escaped;
         if (doc.HasParseError()) {
-          // The reference Hive UDF (com.jsoniter) accepts raw (unescaped)
-          // control chars inside keys/values, while strict parsers reject
-          // them. Escape such chars and retry so both behave the same and the
-          // control chars are preserved in the result; `escaped` must outlive
-          // the member iteration below.
+          // On failure, escape raw control chars and retry (matching jsoniter);
+          // `escaped` must outlive the member iteration below.
           escaped = escapeUnescapedControlChars(current);
-          doc.Parse(escaped);
+          doc.Parse<kParseFlags>(escaped);
         }
         if (doc.HasParseError()) {
           resultWriter.commitNull();

--- a/bolt/functions/sparksql/tests/JsonToMapTest.cpp
+++ b/bolt/functions/sparksql/tests/JsonToMapTest.cpp
@@ -142,6 +142,35 @@ TEST_F(JsonToMapTest, basic) {
   }
 }
 
+TEST_F(JsonToMapTest, unescapedControlChars) {
+  // Strict JSON requires control chars (\x00-\x1f) inside strings to be
+  // escaped, but the reference Hive UDF (backed by com.jsoniter) accepts raw
+  // control chars and keeps them verbatim in the values. json_to_map must
+  // match that lenient behavior instead of returning SQL NULL.
+  {
+    // Raw newlines embedded in several values; they must be preserved.
+    StringView json =
+        StringView("{\"a\":\"x\ny\",\"b\":\"plain\",\"c\":\"end\n\"}");
+    testJsonToMap(
+        {json},
+        {{"a", StringView("x\ny")},
+         {"b", "plain"},
+         {"c", StringView("end\n")}});
+  }
+
+  {
+    // Other raw control chars (tab, carriage return) are likewise preserved.
+    StringView json = StringView("{\"k\":\"a\tb\rc\"}");
+    testJsonToMap({json}, {{"k", StringView("a\tb\rc")}});
+  }
+
+  {
+    // A raw control char in the key is also accepted.
+    StringView json = StringView("{\"key\nname\":\"v\"}");
+    testJsonToMap({json}, {{StringView("key\nname"), "v"}});
+  }
+}
+
 TEST_F(JsonToMapTest, DISABLED_spaceAfterColon) {
   // int, double, [], {} keep the blank spaces after ':'
   {

--- a/bolt/functions/sparksql/tests/JsonToMapTest.cpp
+++ b/bolt/functions/sparksql/tests/JsonToMapTest.cpp
@@ -165,9 +165,42 @@ TEST_F(JsonToMapTest, unescapedControlChars) {
   }
 
   {
+    // Backspace/form-feed and a generic control char (no named escape) are all
+    // accepted and preserved verbatim.
+    StringView json = StringView("{\"k\":\"\b\f\x01\x1f\"}");
+    testJsonToMap({json}, {{"k", StringView("\b\f\x01\x1f")}});
+  }
+
+  {
     // A raw control char in the key is also accepted.
     StringView json = StringView("{\"key\nname\":\"v\"}");
     testJsonToMap({json}, {{StringView("key\nname"), "v"}});
+  }
+}
+
+TEST_F(JsonToMapTest, numericValuesPreserveOriginalText) {
+  // Numeric values must be returned as their original JSON token, matching the
+  // Hive reference UDF (com.jsoniter). They must NOT be round-tripped through a
+  // double (which loses precision and reformats) nor rejected when the value is
+  // out of double range.
+  {
+    // Large integer that does not fit in a double: must keep all digits.
+    testJsonToMap(
+        {R"({"v":6222000000000000000001125652734})"},
+        {{"v", "6222000000000000000001125652734"}});
+  }
+  {
+    // High-precision decimal: must not be rounded to the nearest double.
+    testJsonToMap(
+        {R"({"v":221.5222225222225222})"}, {{"v", "221.5222225222225222"}});
+  }
+  {
+    // Exponent form must be preserved, not expanded.
+    testJsonToMap({R"({"v":1e10})"}, {{"v", "1e10"}});
+  }
+  {
+    // Out-of-double-range exponent must not fail the whole parse.
+    testJsonToMap({R"({"v":1e400})"}, {{"v", "1e400"}});
   }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

`json_to_map` diverged from the online Hive reference UDF (backed by
`com.jsoniter`) in several ways found by coverage-guided differential fuzzing
(tracking issue #666). This PR fixes the cleanly-fixable divergences.

Issue Number: close #672, close #667, close #670, close #673

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

**#672 — raw control characters (both backends).** Both parsers rejected JSON
with raw (unescaped) control chars (`\x00`–`\x1f`) inside string keys/values,
returning NULL, while jsoniter accepts and preserves them (real payloads have
e.g. a trailing newline in a value). On strict-parse failure both backends now
escape unescaped control chars inside string literals and retry, preserving the
decoded bytes. The fallback only runs on the failure path, so valid JSON is
unaffected.

**#667 (numbers) + #670 — number values (sonic).** The sonic backend parsed
numbers through a `double` and re-serialized them, losing precision
(`6222000000000000000001125652734` → `6.222e+30`), reformatting (`1e10` →
`10000000000.0`), and failing outright on out-of-range exponents (`1e400`).
Parsing with `kParseIntegerAsRaw | kParseOverflowNumAsNumStr` keeps numeric
values as their original source text, matching jsoniter and the simdjson backend.

**#673 — non-object scalar (simdjson).** A top-level scalar threw
`SCALAR_DOCUMENT_AS_VALUE` when coerced to a value and returned NULL; detecting
the type via `doc.type()` makes valid non-object JSON yield an empty map, like
the sonic backend and the reference.

Not addressed (documented in #666): sonic in-range float reformatting and nested
whitespace/escaping (the DOM API has no raw-source access); #671 simdjson
leniency on malformed non-object input; #669 lone surrogates.

### Performance Impact

- [x] **No Impact**: The control-char escape-and-retry runs only on parse
  failure; valid-JSON parsing takes the original path unchanged.

### Release Note

```text
Release Note:
- json_to_map now matches the Hive reference for: raw control characters in
  string keys/values (preserved instead of returning NULL); numeric values
  (original text preserved, no precision loss or reformatting, out-of-range
  exponents accepted); and valid non-object scalar JSON on the simdjson backend
  (empty map instead of NULL).
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No

https://claude.ai/code/session_011UjCuHq6S6yCn7gyLo8deo
