### PR TITLE
fix(flinksql): return false for invalid regex in rlike

### DIFF
--- a/bolt/functions/flinksql/CMakeLists.txt
+++ b/bolt/functions/flinksql/CMakeLists.txt
@@ -17,6 +17,7 @@ bolt_add_library(
   bolt_functions_flink_impl
   HashCodeFunction.cpp
   JsonFunctions.cpp
+  RegexFunctions.cpp
   ElementAt.cpp
   specialforms/FlinkCastExpr.cpp
 )

--- a/bolt/functions/flinksql/RegexFunctions.cpp
+++ b/bolt/functions/flinksql/RegexFunctions.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/RegexFunctions.h"
+
+#include "bolt/functions/lib/Re2Functions.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+std::shared_ptr<exec::VectorFunction> makeRLike(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config) {
+  return makeRe2SearchWithPolicy(
+      name, inputArgs, config, InvalidRegexPolicy::kReturnFalse);
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> rlikeSignatures() {
+  return re2SearchSignatures();
+}
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/RegexFunctions.h
+++ b/bolt/functions/flinksql/RegexFunctions.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "bolt/expression/Expr.h"
+#include "bolt/vector/BaseVector.h"
+
+namespace bytedance::bolt::functions::flinksql {
+
+// Flink rlike reuses the shared RE2 vector-function implementation in
+// lib/Re2Functions.h, but chooses an invalid-regex policy that returns false
+// instead of failing the task.
+std::shared_ptr<exec::VectorFunction> makeRLike(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> rlikeSignatures();
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -22,6 +22,7 @@
 #include "bolt/functions/flinksql/DateTimeFunctions.h"
 #include "bolt/functions/flinksql/HashCodeFunction.h"
 #include "bolt/functions/flinksql/Rand.h"
+#include "bolt/functions/flinksql/RegexFunctions.h"
 #include "bolt/functions/flinksql/String.h"
 #include "bolt/functions/flinksql/ToTimestampFunction.h"
 #include "bolt/functions/flinksql/specialforms/FlinkCastExpr.h"
@@ -43,6 +44,8 @@ static void registerStringFunctions(const std::string& prefix) {
   registerFunction<IsAlphaFunction, bool, Varchar>({prefix + "is_alpha"});
   registerFunction<IsDecimalFunction, bool, Varchar>({prefix + "is_decimal"});
   registerFunction<IsDigitFunction, bool, Varchar>({prefix + "is_digit"});
+  exec::registerStatefulVectorFunction(
+      prefix + "rlike", rlikeSignatures(), makeRLike);
   registerFunction<SplitIndex, Varchar, Varchar, Varchar, int64_t>(
       {prefix + "split_index"});
   registerFunction<SplitIndex, Varchar, Varchar, int32_t, int64_t>(

--- a/bolt/functions/flinksql/tests/CMakeLists.txt
+++ b/bolt/functions/flinksql/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   FlinkCastExprTest.cpp
   FlinkSqlDataTimeFunctionsTest.cpp
   JsonFunctionsTest.cpp
+  RegexFunctionsTest.cpp
   RandTest.cpp
   StringFunctionsTest.cpp
 )

--- a/bolt/functions/flinksql/tests/RegexFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/RegexFunctionsTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/tests/FlinkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::flinksql::test {
+namespace {
+
+class FlinkRegexFunctionsTest : public FlinkFunctionBaseTest {};
+
+TEST_F(FlinkRegexFunctionsTest, invalidRegexReturnsFalse) {
+  EXPECT_EQ(
+      false,
+      evaluateOnce<bool>(
+          "rlike(c0, c1)",
+          makeRowVector({
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"abc"}),
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"**"}),
+          })));
+
+  EXPECT_EQ(
+      false,
+      evaluateOnce<bool>(
+          "rlike(c0, '**')",
+          makeRowVector({makeNullableFlatVector(
+              std::vector<std::optional<std::string>>{"abc"})})));
+}
+
+TEST_F(FlinkRegexFunctionsTest, validRegexStillWorks) {
+  EXPECT_EQ(
+      true,
+      evaluateOnce<bool>(
+          "rlike(c0, c1)",
+          makeRowVector({
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"abc123"}),
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"[0-9]+"}),
+          })));
+
+  EXPECT_EQ(
+      false,
+      evaluateOnce<bool>(
+          "rlike(c0, c1)",
+          makeRowVector({
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"abc"}),
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"[0-9]+"}),
+          })));
+
+  EXPECT_EQ(
+      true,
+      evaluateOnce<bool>(
+          "rlike(c0, '[0-9]+')",
+          makeRowVector({makeNullableFlatVector(
+              std::vector<std::optional<std::string>>{"abc123"})})));
+}
+
+TEST_F(FlinkRegexFunctionsTest, nullInputPreservesNullSemantics) {
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<bool>(
+          "rlike(c0, c1)",
+          makeRowVector({
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{std::nullopt}),
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"[0-9]+"}),
+          })));
+
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<bool>(
+          "rlike(c0, c1)",
+          makeRowVector({
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{"abc"}),
+              makeNullableFlatVector(
+                  std::vector<std::optional<std::string>>{std::nullopt}),
+          })));
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::flinksql::test

--- a/bolt/functions/lib/Re2Functions.cpp
+++ b/bolt/functions/lib/Re2Functions.cpp
@@ -33,6 +33,7 @@
 #include "folly/container/EvictingCacheMap.h"
 
 #include <re2/re2.h>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -105,6 +106,21 @@ bool re2FullMatch(StringView str, const RE2& re) {
 
 bool re2PartialMatch(StringView str, const RE2& re) {
   return RE2::PartialMatch(toStringPiece(str), re);
+}
+
+bool handleInvalidRegex(
+    const RE2& re,
+    InvalidRegexPolicy invalidRegexPolicy,
+    std::function<void()> returnFalse) {
+  if (LIKELY(re.ok())) {
+    return true;
+  }
+  if (invalidRegexPolicy == InvalidRegexPolicy::kReturnFalse) {
+    returnFalse();
+    return false;
+  }
+  BOLT_USER_FAIL("invalid regular expression: {}", re.error());
+  return false;
 }
 
 bool re2Extract(
@@ -197,8 +213,11 @@ std::string likePatternToRe2(
 template <bool (*Fn)(StringView, const RE2&)>
 class Re2MatchConstantPattern final : public VectorFunction {
  public:
-  explicit Re2MatchConstantPattern(StringView pattern)
-      : re_(toStringPiece(pattern), RE2::Quiet) {}
+  explicit Re2MatchConstantPattern(
+      StringView pattern,
+      InvalidRegexPolicy invalidRegexPolicy)
+      : re_(toStringPiece(pattern), RE2::Quiet),
+        invalidRegexPolicy_(invalidRegexPolicy) {}
 
   void apply(
       const SelectivityVector& rows,
@@ -210,7 +229,17 @@ class Re2MatchConstantPattern final : public VectorFunction {
     FlatVector<bool>& result = ensureWritableBool(rows, context, resultRef);
     exec::LocalDecodedVector toSearch(context, *args[0], rows);
     try {
-      checkForBadPattern(re_);
+      if (!handleInvalidRegex(re_, invalidRegexPolicy_, [&]() {
+            context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
+              if (UNLIKELY(toSearch->isNullAt(i))) {
+                result.setNull(i, true);
+              } else {
+                result.set(i, false);
+              }
+            });
+          })) {
+        return;
+      }
     } catch (const std::exception& e) {
       context.setErrors(rows, std::current_exception());
       return;
@@ -223,12 +252,15 @@ class Re2MatchConstantPattern final : public VectorFunction {
 
  private:
   RE2 re_;
+  const InvalidRegexPolicy invalidRegexPolicy_;
 };
 
 template <bool (*Fn)(StringView, const RE2&)>
 class Re2Match final : public VectorFunction {
  public:
-  Re2Match() : compiledRegularExpressions_(kMaxCompiledRegexes) {}
+  explicit Re2Match(InvalidRegexPolicy invalidRegexPolicy)
+      : compiledRegularExpressions_(kMaxCompiledRegexes),
+        invalidRegexPolicy_(invalidRegexPolicy) {}
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -238,8 +270,8 @@ class Re2Match final : public VectorFunction {
     BOLT_CHECK_EQ(args.size(), 2);
 
     if (auto pattern = getIfConstant<StringView>(*args[1])) {
-      Re2MatchConstantPattern<Fn>(*pattern).apply(
-          rows, args, outputType, context, resultRef);
+      Re2MatchConstantPattern<Fn>(*pattern, invalidRegexPolicy_)
+          .apply(rows, args, outputType, context, resultRef);
       return;
     }
     // General case.
@@ -260,7 +292,8 @@ class Re2Match final : public VectorFunction {
           } else {
             auto regex =
                 std::make_shared<RE2>(toStringPiece(pattern), RE2::Quiet);
-            if (UNLIKELY(!regex->ok())) {
+            if (UNLIKELY(!regex->ok()) &&
+                invalidRegexPolicy_ == InvalidRegexPolicy::kThrow) {
               BOLT_USER_FAIL("invalid regular expression: {}", regex->error());
             }
             auto regexResult =
@@ -270,6 +303,13 @@ class Re2Match final : public VectorFunction {
           }
         }
         BOLT_CHECK_NOT_NULL(impl);
+        if (UNLIKELY(!impl->ok())) {
+          if (invalidRegexPolicy_ == InvalidRegexPolicy::kReturnFalse) {
+            result.set(row, false);
+            return;
+          }
+          BOLT_USER_FAIL("invalid regular expression: {}", impl->error());
+        }
         result.set(row, Fn(toSearch->valueAt<StringView>(row), *impl));
       }
     });
@@ -280,6 +320,7 @@ class Re2Match final : public VectorFunction {
   mutable folly::EvictingCacheMap<std::string, std::shared_ptr<RE2>>
       compiledRegularExpressions_;
   mutable std::mutex mutex_;
+  const InvalidRegexPolicy invalidRegexPolicy_;
 }; // namespace
 
 void checkForBadGroupId(int64_t groupId, const RE2& re) {
@@ -950,7 +991,8 @@ class Re2ExtractAll final : public VectorFunction {
 template <bool (*Fn)(StringView, const RE2&)>
 std::shared_ptr<VectorFunction> makeRe2MatchImpl(
     const std::string& name,
-    const std::vector<VectorFunctionArg>& inputArgs) {
+    const std::vector<VectorFunctionArg>& inputArgs,
+    InvalidRegexPolicy invalidRegexPolicy) {
   if (inputArgs.size() != 2 || !inputArgs[0].type->isVarchar() ||
       !inputArgs[1].type->isVarchar()) {
     BOLT_UNSUPPORTED(
@@ -963,11 +1005,10 @@ std::shared_ptr<VectorFunction> makeRe2MatchImpl(
 
   if (constantPattern != nullptr && !constantPattern->isNullAt(0)) {
     return std::make_shared<Re2MatchConstantPattern<Fn>>(
-        constantPattern->as<ConstantVector<StringView>>()->valueAt(0));
+        constantPattern->as<ConstantVector<StringView>>()->valueAt(0),
+        invalidRegexPolicy);
   }
-  static std::shared_ptr<Re2Match<Fn>> kMatchExpr =
-      std::make_shared<Re2Match<Fn>>();
-  return kMatchExpr;
+  return std::make_shared<Re2Match<Fn>>(invalidRegexPolicy);
 }
 
 } // namespace
@@ -976,7 +1017,8 @@ std::shared_ptr<VectorFunction> makeRe2Match(
     const std::string& name,
     const std::vector<VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  return makeRe2MatchImpl<re2FullMatch>(name, inputArgs);
+  return makeRe2MatchImpl<re2FullMatch>(
+      name, inputArgs, InvalidRegexPolicy::kThrow);
 }
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2MatchSignatures() {
@@ -991,8 +1033,17 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2MatchSignatures() {
 std::shared_ptr<VectorFunction> makeRe2Search(
     const std::string& name,
     const std::vector<VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& /*config*/) {
-  return makeRe2MatchImpl<re2PartialMatch>(name, inputArgs);
+    const core::QueryConfig& config) {
+  return makeRe2SearchWithPolicy(
+      name, inputArgs, config, InvalidRegexPolicy::kThrow);
+}
+
+std::shared_ptr<VectorFunction> makeRe2SearchWithPolicy(
+    const std::string& name,
+    const std::vector<VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/,
+    InvalidRegexPolicy invalidRegexPolicy) {
+  return makeRe2MatchImpl<re2PartialMatch>(name, inputArgs, invalidRegexPolicy);
 }
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2SearchSignatures() {

--- a/bolt/functions/lib/Re2Functions.h
+++ b/bolt/functions/lib/Re2Functions.h
@@ -41,6 +41,11 @@
 #include "bolt/vector/BaseVector.h"
 namespace bytedance::bolt::functions {
 
+enum class InvalidRegexPolicy {
+  kThrow,
+  kReturnFalse,
+};
+
 /// Representation of different kinds of patterns.
 enum class PatternKind {
   /// Pattern containing wildcard character '_' only, such as _, __, ____.
@@ -100,6 +105,12 @@ std::shared_ptr<exec::VectorFunction> makeRe2Search(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
+
+std::shared_ptr<exec::VectorFunction> makeRe2SearchWithPolicy(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config,
+    InvalidRegexPolicy invalidRegexPolicy);
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2SearchSignatures();
 


### PR DESCRIPTION
Use InvalidRegexPolicy to make Flink rlike return false instead of throwing on invalid RE2 patterns.

### What problem does this PR solve?
Flink `rlike` currently reuses the shared RE2 search implementation, which throws an exception when the supplied RE2 pattern is invalid. This behavior can fail the whole task, but Flink expects `rlike` to return `false` for invalid regex patterns instead of throwing. This PR introduces an `InvalidRegexPolicy` in the shared RE2 path so different callers can choose how invalid patterns are handled. Flink `rlike` is then registered with a `return false` policy, aligning its behavior with Flink semantics while keeping the default behavior for other RE2-based functions unchanged.

Issue Number: close #657 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This change adds policy-based handling for invalid RE2 patterns in the shared regex implementation and applies it to Flink `rlike`.

#### What changed
- Added `InvalidRegexPolicy` to the shared RE2 function layer so callers can choose whether invalid patterns should throw or return `false`.
- Added `makeRe2SearchWithPolicy(...)` and kept the default `re2Search` behavior unchanged.
- Introduced a dedicated Flink `rlike` wrapper that uses `InvalidRegexPolicy::kReturnFalse`.
- Registered Flink `rlike` as a stateful vector function using the new wrapper.
- Added unit tests covering:
  - invalid regex returns `false`
  - valid regex behavior remains unchanged
  - null input still preserves null semantics

#### Why
Flink expects `rlike` to be tolerant of invalid RE2 patterns and return `false` rather than fail the query. The previous shared implementation threw on invalid patterns, which made Flink behavior inconsistent with user expectations.

#### How
The shared RE2 matching path now accepts an invalid-regex policy. For Flink `rlike`, invalid constant and non-constant patterns are handled by returning `false` for non-null rows, while null inputs still return null. Other RE2-based functions continue using the existing throw-on-invalid behavior.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
- Fixed Flink `rlike` so invalid RE2 patterns return false instead of throwing an exception.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
