### PR TITLE
fix: RowBaseSpill used the cached jit function

### DIFF
--- a/bolt/exec/tests/AggregationTest.cpp
+++ b/bolt/exec/tests/AggregationTest.cpp
@@ -4902,6 +4902,76 @@ TEST_P(AggregationTest, rowBasedSpillNull) {
   }
 }
 
+TEST_F(AggregationTest, rowBasedSpillJoinAggregationOrderByWithJit) {
+  constexpr vector_size_t kSize = 100;
+  std::vector<RowVectorPtr> tmp1;
+  std::vector<RowVectorPtr> tmp2;
+  std::vector<RowVectorPtr> duckTmp2;
+  for (auto batch = 0; batch < 5; ++batch) {
+    tmp1.push_back(makeRowVector(
+        {"id"}, {makeFlatVector<int32_t>(kSize, [batch](auto row) {
+          return (batch * kSize + row) % 16;
+        })}));
+    tmp2.push_back(makeRowVector(
+        {"build_id", "amount"},
+        {makeFlatVector<int32_t>(
+             kSize, [batch](auto row) { return (batch * kSize + row) % 16; }),
+         makeFlatVector<int32_t>(
+             kSize, [batch](auto row) { return batch * kSize + row; })}));
+    duckTmp2.push_back(makeRowVector(
+        {"id", "amount"},
+        {makeFlatVector<int32_t>(
+             kSize, [batch](auto row) { return (batch * kSize + row) % 16; }),
+         makeFlatVector<int32_t>(
+             kSize, [batch](auto row) { return batch * kSize + row; })}));
+  }
+
+  createDuckDbTable("tmp1", tmp1);
+  createDuckDbTable("tmp2", duckTmp2);
+
+  core::PlanNodeId aggrNodeId;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                  .values(tmp1)
+                  .hashJoin(
+                      {"id"},
+                      {"build_id"},
+                      PlanBuilder(planNodeIdGenerator).values(tmp2).planNode(),
+                      "",
+                      {"id", "amount"})
+                  .singleAggregation({"id"}, {"sum(amount) AS amount_sum"}, {})
+                  .capturePlanNodeId(aggrNodeId)
+                  .orderBy({"id", "amount_sum DESC"}, false)
+                  .planNode();
+
+  const auto* const sql = R"(
+      SELECT id, amount_sum FROM
+       (
+        SELECT id, sum(amount) as amount_sum FROM
+          (SELECT tmp1.id, tmp2.amount FROM
+            tmp1 join tmp2 on tmp1.id = tmp2.id
+          )
+        GROUP BY id
+       )
+       ORDER BY id, amount_sum DESC)";
+
+  auto spillDirectory = exec::test::TempDirectoryPath::create();
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .spillDirectory(spillDirectory->path)
+                  .config(QueryConfig::kTestingSpillPct, "100")
+                  .config(QueryConfig::kSpillEnabled, "true")
+                  .config(QueryConfig::kAggregationSpillEnabled, "true")
+                  .config(QueryConfig::kRowBasedSpillMode, "compression")
+                  .config(QueryConfig::kJitLevel, "-1")
+                  .assertResults(sql);
+
+  auto taskStats = exec::toPlanStats(task->taskStats());
+  auto& stats = taskStats.at(aggrNodeId);
+  checkSpillStats(stats, true);
+  checkRowBasedSpillStats(stats, true);
+  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+}
+
 INSTANTIATE_GPU_TEST_SUITE_P(AggregationTestOnCPUOrGPU, AggregationTest);
 
 } // namespace bytedance::bolt::exec::test

--- a/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
+++ b/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
@@ -157,9 +157,21 @@ CompiledModuleSP RowContainerCodeGenerator::codegen() {
 
 /// util functions
 std::string RowContainerCodeGenerator::GetCmpFuncName() {
-  std::string fn = isEqualOp() ? "jit_rr_eq"
-      : isCmp()                ? "jit_rr_cmp"
-                               : "jit_rr_less";
+  std::string fn = "jit_rr_";
+  switch (cmpType) {
+    case CmpType::SORT_LESS:
+      fn.append("sort_less");
+      break;
+    case CmpType::EQUAL:
+      fn.append("eq");
+      break;
+    case CmpType::CMP:
+      fn.append("cmp");
+      break;
+    case CmpType::CMP_SPILL:
+      fn.append("cmp_spill");
+      break;
+  }
   fn.append(hasNullKeys ? "N" : "");
   for (auto i = 0; i < keysTypes.size(); ++i) {
     fn.append(keysTypes[i]->jitName());


### PR DESCRIPTION
StringView in RowBaseSpill is different from StringView in RowContainer

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #676

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
