### PR TITLE
fix: disable element_at cache for string map keys

### DIFF
--- a/bolt/functions/lib/SubscriptUtil.cpp
+++ b/bolt/functions/lib/SubscriptUtil.cpp
@@ -78,8 +78,6 @@ VectorPtr applyMapTyped(
     }
   }
 
-  auto& typedLookupTable = cachedLookupTablePtr->typedTable<kind>();
-
   auto* pool = context.pool();
   BufferPtr indices = allocateIndices(rows.end(), pool);
   auto rawIndices = indices->asMutable<vector_size_t>();
@@ -117,6 +115,8 @@ VectorPtr applyMapTyped(
     bool found = false;
 
     if (triggeCaching && size >= kMinCachedMapSize) {
+      BOLT_DCHECK_NOT_NULL(cachedLookupTablePtr);
+      auto& typedLookupTable = cachedLookupTablePtr->typedTable<kind>();
       // Create map for mapIndex if not created.
       if (!typedLookupTable.containsMapAtIndex(mapIndex)) {
         typedLookupTable.ensureMapAtIndex(mapIndex);

--- a/bolt/functions/lib/SubscriptUtil.h
+++ b/bolt/functions/lib/SubscriptUtil.h
@@ -139,9 +139,11 @@ class MapSubscript {
       return false;
     }
 
-    if (!mapArg->type()->childAt(0)->isPrimitiveType() &&
-        !!mapArg->type()->childAt(0)->isBoolean()) {
-      // Disable caching if the key type is not primitive or is boolean.
+    const auto& keyType = mapArg->type()->childAt(0);
+    if (!keyType->isPrimitiveType() || keyType->isBoolean() ||
+        keyType->isUseStringView()) {
+      // Disable caching if the key type is not primitive, is boolean, or uses
+      // StringView.
       allowCaching_ = false;
       return false;
     }

--- a/bolt/functions/prestosql/tests/ElementAtTest.cpp
+++ b/bolt/functions/prestosql/tests/ElementAtTest.cpp
@@ -1074,3 +1074,73 @@ TEST_F(ElementAtTest, testCachingOptimzation) {
     test::assertEqualVectors(result, result1);
   }
 }
+
+TEST_F(ElementAtTest, varcharMapCacheWithReusedMapVector) {
+  constexpr int32_t kLargeMapSize = 128;
+  const std::string kNeedle = "needle_key_long_enough";
+  const std::string kExpectedValue = "expected_value_long_enough";
+
+  auto makeEntries = [&](const std::string& prefix,
+                         bool includeNeedle,
+                         std::vector<std::string>& storage) {
+    storage.clear();
+    storage.reserve(kLargeMapSize * 2 + 2);
+
+    std::vector<std::pair<StringView, std::optional<StringView>>> entries;
+    entries.reserve(kLargeMapSize);
+    for (int32_t i = 0; i < kLargeMapSize; ++i) {
+      storage.push_back(fmt::format("{}key{:03d}", prefix, i));
+      storage.push_back(fmt::format("{}val{:03d}", prefix, i));
+      entries.push_back(
+          {StringView(storage[storage.size() - 2]),
+           StringView(storage[storage.size() - 1])});
+    }
+
+    if (includeNeedle) {
+      storage.push_back(kNeedle);
+      storage.push_back(kExpectedValue);
+      entries[kLargeMapSize / 2] = {
+          StringView(storage[storage.size() - 2]),
+          StringView(storage[storage.size() - 1])};
+    }
+    return entries;
+  };
+
+  std::vector<std::string> oldStorage;
+  std::vector<std::string> newStorage;
+  auto oldEntries = makeEntries("old", false, oldStorage);
+  auto newEntries = makeEntries("new", true, newStorage);
+
+  auto reusedMap = makeMapVector<StringView, StringView>({oldEntries});
+  auto lookupKeys = makeFlatVector<StringView>({StringView(kNeedle)});
+  std::vector<VectorPtr> args = {reusedMap, lookupKeys};
+
+  exec::ExprSet exprSet({}, &execCtx_);
+  auto inputs = makeRowVector({});
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, inputs.get());
+  SelectivityVector rows(1);
+
+  bytedance::bolt::functions::MapSubscript mapSubscriptWithCaching(true);
+
+  auto oldResult1 = mapSubscriptWithCaching.applyMap(rows, args, evalCtx);
+  auto oldResult2 = mapSubscriptWithCaching.applyMap(rows, args, evalCtx);
+  auto expectedOld = makeNullableFlatVector<StringView>({std::nullopt});
+  test::assertEqualVectors(expectedOld, oldResult1);
+  test::assertEqualVectors(expectedOld, oldResult2);
+
+  auto replacementMap = makeMapVector<StringView, StringView>({newEntries});
+  reusedMap->setOffsetAndSize(
+      0, replacementMap->offsetAt(0), replacementMap->sizeAt(0));
+  reusedMap->setKeysAndValues(
+      replacementMap->mapKeys(), replacementMap->mapValues());
+
+  auto expectedNew = makeFlatVector<StringView>({StringView(kExpectedValue)});
+
+  bytedance::bolt::functions::MapSubscript mapSubscriptWithoutCaching(false);
+  auto uncachedResult =
+      mapSubscriptWithoutCaching.applyMap(rows, args, evalCtx);
+  test::assertEqualVectors(expectedNew, uncachedResult);
+
+  auto cachedResult = mapSubscriptWithCaching.applyMap(rows, args, evalCtx);
+  test::assertEqualVectors(expectedNew, cachedResult);
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #692

`element_at` can return a stale null or value for `MAP(VARCHAR(), VARCHAR())` when map subscript caching is enabled and a `MapVector` is reused with new key and value children. The cached lookup table is built from `StringView` keys, so it can keep using entries tied to the previous string buffers.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This change skips map subscript caching when the map key type is backed by `StringView`. Boolean keys were already excluded from this cache path; varchar keys need the same treatment because the cached lookup can outlive the key buffers it was built from.

A regression test reuses one `MapVector`, swaps in new key/value children, and checks that the cached path returns the same value as an uncached lookup.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [x] **Negative Impact**: String-key map subscript lookups no longer use this cache path. This trades that optimization for correct results when keys are backed by reused string buffers.

### Release Note

```text
Release Note:
- Fixed stale `element_at` results for varchar map keys when a reused MapVector hits the map subscript cache.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

### Validation

```text
cmake --build --preset conan-release --target bolt_functions_test
./_build/Release/bolt/functions/prestosql/tests/bolt_functions_test --gtest_filter=ElementAtTest.varcharMapCacheWithReusedMapVector
./_build/Release/bolt/functions/prestosql/tests/bolt_functions_test
ctest --test-dir _build/Release -R '^bolt_functions_test$' --output-on-failure
```

The full `bolt_functions_test` run reported 902 passed and 3 skipped tests. The targeted regression test failed before the fix with `expected expected_value, but got null`, then passed after the cache guard change.
