### PR TITLE
docs: add Bolt operator fusion blog

### DIFF
--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -119,9 +119,21 @@ representation.
 
 ## 3. Sort + Window
 
-Window functions have a different pattern. They are order-sensitive: `partition by` and `order by` define the input order required by the Window operator. In a conventional plan, sorting and window evaluation may be separated by an operator boundary. The sort operator first converts input into rows, sorts those rows in a row-oriented structure, and then converts the sorted result back into a columnar output batch before passing it to the next Window operator. Window then converts the data back into rows again for evaluation. The intermediate `RowVector` is therefore materialized only to satisfy the columnar representation expected at operator boundaries.
+Window functions have a different pattern. They are order-sensitive: `partition
+by` and `order by` define the input order required by the Window operator. In a
+conventional plan, sorting and window evaluation may be separated by an operator
+boundary. The sort operator first converts input into rows, sorts those rows in a
+row-oriented structure, and then converts the sorted result back into a columnar
+output batch before passing it to the next Window operator. Window then converts
+the data back into rows again for evaluation. The intermediate `RowVector` is
+therefore materialized only to satisfy the columnar representation expected at
+operator boundaries.
 
-This is where Sort + Window fusion applies. Instead of converting sorted rows back into a normal columnar batch just to cross an operator boundary, sort and window evaluation can be fused into a single Window operator. Both ordering and window computation then happen inside that operator, avoiding the intermediate `RowVector` materialization and improving execution efficiency.
+This is where Sort + Window fusion applies. Instead of converting sorted rows
+back into a normal columnar batch just to cross an operator boundary, sort and
+window evaluation can be fused into a single Window operator. Both ordering and
+window computation then happen inside that operator, avoiding the intermediate
+`RowVector` materialization and improving execution efficiency.
 
 ### 3.1 Motivation
 
@@ -232,11 +244,15 @@ increase is within an acceptable range.
 We benchmarked Sort + Window with window query shapes observed in production,
 comparing the old `OrderBy -> Window` shape with the fused `sortWindow`
 shape under the same partition keys, sort keys, spill setting, and window
-function. The benchmark results showed consistent improvement, with an average of about 20% and the best cases reaching roughly 50%. These results match the optimization target: once Window can consume row-oriented sorted data directly, Bolt avoids the extra rows -> RowVector -> rows round trip between standalone sort and window evaluation.
+function. The benchmark results showed consistent improvement, with an average
+of about 20% and the best cases reaching roughly 50%. These results match the
+optimization target: once Window can consume row-oriented sorted data directly,
+Bolt avoids the extra rows -> RowVector -> rows round trip between standalone
+sort and window evaluation.
 
-The production results showed the same trend. Across 62 real online tasks, the
-median performance improvement was about 17.95%, P90 improvement was about
-28.11%, and the best task improved by about 40.35%. 
+The production results showed the same trend. Across a broad set of real online
+tasks, the median performance improvement was about 17.95%, P90 improvement was
+about 28.11%, and the best task improved by about 40.35%.
 
 Overall, Sort + Window fusion significantly improves both the performance and
 stability of workloads where sorting and window evaluation appear together.

--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -7,13 +7,15 @@ parent: Blog
 nav_order: 2
 ---
 
-Bolt's operator fusion work removes data reorganization that exists only because
-two physical operators meet at a boundary. Aggregation + Shuffle reduces the
+Bolt's operator fusion optimizations reduce the format-conversion and
+intermediate-materialization overhead introduced at physical operator
+boundaries. Aggregation + Shuffle fusion avoids the
 `RowContainer -> RowVector -> CompactRow` round trip before row-based shuffle
-write. Sort + Window keeps sorting inside Window when the input is not already
-sorted. On representative production-style double-run tests, Aggregation +
-Shuffle fusion reduced the overall agg + shuffle stage time by roughly 18% to
-25%, with shuffle size ranging from roughly unchanged to about 6% larger.
+write. Sort + Window fusion keeps sorting inside the Window operator when the
+input is not already ordered. In representative production-style double-run
+tests, Aggregation + Shuffle fusion reduced the overall agg + shuffle stage
+time by roughly 18% to 25%, while shuffle size ranged from roughly unchanged to
+about 6% larger.
 {: .note }
 
 ## 1. Background

--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -1,0 +1,207 @@
+---
+layout: post
+title: "Operator Fusion: Reducing Data Layout Conversion Across Operators"
+date: 2026-07-01
+author: "Haiyan Gu, Jinyuan Zhang"
+parent: Blog
+nav_order: 2
+---
+
+Bolt's operator fusion work removes data reorganization that exists only because
+two physical operators meet at a boundary. Aggregation + Shuffle reduces the
+`RowContainer -> RowVector -> CompactRow` round trip before row-based shuffle
+write. Sort + Window keeps sorting inside Window when the input is not already
+sorted. On representative production-style double-run tests, Aggregation +
+Shuffle fusion reduced the overall agg + shuffle stage time by roughly 18% to
+25%, with shuffle size ranging from roughly unchanged to about 6% larger.
+{: .note }
+
+## 1. Background
+
+Bolt's execution engine is primarily columnar at operator boundaries. This
+representation works well for vectorized execution, projection, filtering, and
+many downstream consumers. However, not every operator is naturally columnar
+internally.
+
+Hash aggregation is a typical example. During aggregation, grouping keys and
+accumulator states are maintained in hash-table-backed row-oriented structures.
+When aggregation output is immediately consumed by row-based shuffle, forcing
+the data through a normal columnar output batch introduces an avoidable round
+trip:
+
+```text
+RowContainer -> RowVector -> CompactRow
+```
+
+The `RowVector` in the middle is useful for a generic columnar boundary, but in
+this path it is not the representation that the next operator ultimately needs.
+The shuffle writer will rebuild a row-oriented payload again.
+
+Operator fusion in Bolt targets this kind of boundary cost. It keeps the
+physical plan semantics unchanged, while allowing adjacent operators to share a
+more suitable intermediate representation.
+
+![Aggregation and Shuffle before and after fusion]({{ site.baseurl }}/assets/images/operator-fusion-before-after.svg)
+
+## 2. Aggregation + Shuffle
+
+Consider a common distributed aggregation path:
+
+```text
+partial aggregation -> exchange -> final aggregation
+```
+
+In Bolt, partial aggregation maintains grouping keys and accumulator states in
+`RowContainer`. When the next stage is row-based shuffle, the conventional path
+first emits a normal `RowVector`, and the shuffle writer then serializes that
+data back into row format.
+
+This is where Aggregation + Shuffle fusion applies. Instead of eagerly
+flattening the aggregation state into a normal columnar batch, partial
+aggregation can emit a `CompositeRowVector`.
+
+### 2.1 CompositeRowVector
+
+`CompositeRowVector` separates two parts of the output:
+
+- Grouping keys remain accessible as columns.
+- Accumulator state is kept as row payload.
+
+This design matters because shuffle still needs column access to grouping keys
+for projection and partition hashing. At the same time, the accumulator payload
+does not need to be reconstructed from columns before row-based shuffle write.
+
+![CompositeRowVector layout]({{ site.baseurl }}/assets/images/operator-fusion-composite-vector.svg)
+
+`CompositeRowVector` does not make the whole output row-based. It keeps the key
+columns visible to the vectorized path, while preserving the aggregation state
+in a format that can be copied into shuffle frames more directly.
+
+The composite output path is intentionally constrained. It is used only for
+partial aggregation, requires the row-based spill layout to be available,
+excludes global and distinct aggregation shapes, requires compatible row
+alignment, and is enabled only when the accumulator side is large enough
+compared with the grouping-key side. These conditions keep the optimization
+focused on cases where the saved conversion cost is likely to matter.
+
+### 2.2 Execution Path
+
+With fusion enabled, the main change happens between partial aggregation and
+shuffle write:
+
+1. Partial aggregation builds its state in `RowContainer`.
+2. Instead of materializing all aggregation output as a normal `RowVector`, it
+   emits `CompositeRowVector`.
+3. Projection and partitioning continue to read grouping keys as columns.
+4. The row-based shuffle writer splits the composite vector by partition and
+   writes the accumulator payload into shuffle frames.
+5. The shuffle reader still produces a normal columnar batch for final
+   aggregation.
+
+The last step is intentionally unchanged. Final aggregation continues to consume
+columnar input. The optimization mainly removes the
+`RowContainer -> RowVector -> CompactRow` round trip before shuffle write.
+
+There is also an important compatibility detail. Partial aggregation may
+abandon the optimized path in some cases. Therefore, shuffle writer and shuffle
+reader need to handle both ordinary `RowVector` and `CompositeRowVector`. Bolt
+records layout information in shuffle frame metadata, so the reader can parse
+each frame according to its actual layout.
+
+![Adaptive shuffle layout]({{ site.baseurl }}/assets/images/operator-fusion-adaptive-shuffle.svg)
+
+This makes the optimization adaptive rather than invasive. The external
+exchange semantics remain unchanged, while the optimized path avoids unnecessary
+reconstruction when the producer and consumer can share a better physical
+representation.
+
+## 3. Sort + Window
+
+Window functions have a different pattern. They are sensitive to ordering:
+`partition by` and `order by` define the input order required by the window
+operator. In a conventional plan, sorting and window evaluation may be separated
+by an operator boundary. The sort operator materializes ordered intermediate
+data, and the window operator consumes it later.
+
+Bolt fuses this boundary by making sorting an internal capability of the Window
+operator when the input is not already sorted.
+
+At runtime, Window checks whether the plan marks its input as already sorted:
+
+```cpp
+needSort_ = !(windowNode->inputsSorted());
+```
+
+If the input already satisfies the ordering requirement, Window uses a streaming
+path and evaluates window functions directly. Otherwise, sorting is performed
+inside the Window operator through the sort-window build path, and the sorted
+rows are consumed by the same operator to compute window results.
+
+![Sort and Window fusion]({{ site.baseurl }}/assets/images/operator-fusion-sort-window.svg)
+
+This is also operator fusion, but it is different from Aggregation + Shuffle
+fusion. It does not rely on `CompositeRowVector`, and it is not controlled by
+the composite aggregation configuration. Its goal is to avoid a separate
+Sort-to-Window boundary and keep sorting, buffering, and window evaluation
+within one physical operator when sorting is required.
+
+The benefit is that ordered data does not need to be handed off through an
+additional materialized boundary before window evaluation. For large partitions
+or complex window functions, reducing that boundary can lower memory movement
+and simplify the execution path.
+
+## 4. Performance Results
+
+In representative production-style double-run tests, Aggregation + Shuffle
+fusion showed stable improvement on the overall agg + shuffle stage. End-to-end
+stage time for the agg + shuffle portion decreased by roughly 18% to 25%.
+
+The largest gain was concentrated between partial aggregation and shuffle write,
+where elapsed time decreased by roughly 28% to 38%. The shuffle read + final
+aggregation side also improved to different degrees, with reductions of roughly
+4% to 22%. This matches the optimization target: once the
+`RowContainer -> RowVector -> CompactRow` round trip is reduced, the most direct
+benefit appears on the data reorganization path before shuffle write.
+
+The main cost is reflected in shuffle size. In the tests, shuffle size ranged
+from roughly unchanged to about 6% larger, mainly due to differences in
+row-payload layout. Compared with the reduction in stage time, this size
+increase is within an acceptable range.
+
+## 5. Configuration and Observability
+
+Aggregation + Shuffle composite output is controlled by the following
+configuration items:
+
+| Configuration | Default | Scope | Description |
+| --- | --- | --- | --- |
+| `hashaggregation_composite_output_enabled` | `false` | Aggregation + Shuffle | Master switch for composite aggregation output. |
+| `hashaggregation_composite_output_accumulator_ratio` | `5` | Aggregation + Shuffle | Trigger threshold based on the ratio between accumulator count and grouping-key count. |
+
+Whether the composite path is actually used can be observed through the runtime
+statistic `aggregationOutputCompositeVector`.
+
+Sort + Window does not use `CompositeRowVector`, and it does not have a
+corresponding composite switch. Whether sorting is needed is determined by
+`WindowNode::inputsSorted()`: if the input already satisfies the required
+ordering, Window runs in the streaming path; otherwise, sorting is performed
+inside the Window operator.
+
+## 6. Summary
+
+Operator fusion in Bolt is not a single implementation technique. It is a design
+principle for removing unnecessary work across adjacent physical operators.
+
+Aggregation + Shuffle fusion focuses on data representation. It lets partial
+aggregation pass row-oriented accumulator payloads to row-based shuffle without
+first rebuilding them as ordinary columnar output and then converting them back
+to row format.
+
+Sort + Window fusion focuses on operator boundaries. It moves sorting into
+Window when the input is not already sorted, so that sorting and window
+evaluation can share the same physical execution context.
+
+The common point is the same: do not materialize an intermediate representation
+only because an operator boundary exists. When adjacent operators naturally
+agree on part of the data organization, Bolt keeps that agreement in the
+execution path and removes the redundant conversion around it.

--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Operator Fusion: Reducing Data Layout Conversion Across Operators"
+title: "Operator Fusion: Reducing Data Layout Conversions"
 date: 2026-07-01
 author: "Haiyan Gu, Jinyuan Zhang"
 parent: Blog

--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -181,7 +181,6 @@ already provide sorted input. `Window` reads one planner flag to choose the path
 needSort_ = !(windowNode->inputsSorted());
 ```
 
-
 If `inputsSorted()` returns true, `Window` keeps the streaming-style path. If it
 returns false, `Window` routes input through a shared sort preparation path before
 the selected build implementation handles partition loading and output:
@@ -212,7 +211,6 @@ The same fused path supports `SortWindowBuild`, `RowsStreamingWindowBuild`, and
 `SpillableWindowBuild`. The common `WindowBuild` path owns the sorted row input;
 each concrete build still controls how it loads partitions and produces output.
 The rest of the engine still sees normal `Window` output.
-
 
 The fused operator also keeps the sort cost visible. Operator stats report sort
 output, column-to-row time, in-sort time, window input, partition loading, window

--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -119,40 +119,97 @@ representation.
 
 ## 3. Sort + Window
 
-Window functions have a different pattern. They are sensitive to ordering:
-`partition by` and `order by` define the input order required by the window
-operator. In a conventional plan, sorting and window evaluation may be separated
-by an operator boundary. The sort operator materializes ordered intermediate
-data, and the window operator consumes it later.
+Window functions have a different pattern. They are order-sensitive: `partition by` and `order by` define the input order required by the Window operator. In a conventional plan, sorting and window evaluation may be separated by an operator boundary. The sort operator first converts input into rows, sorts those rows in a row-oriented structure, and then converts the sorted result back into a columnar output batch before passing it to the next Window operator. Window then converts the data back into rows again for evaluation. The intermediate `RowVector` is therefore materialized only to satisfy the columnar representation expected at operator boundaries.
 
-Bolt fuses this boundary by making sorting an internal capability of the Window
-operator when the input is not already sorted.
+This is where Sort + Window fusion applies. Instead of converting sorted rows back into a normal columnar batch just to cross an operator boundary, sort and window evaluation can be fused into a single Window operator. Both ordering and window computation then happen inside that operator, avoiding the intermediate `RowVector` materialization and improving execution efficiency.
 
-At runtime, Window checks whether the plan marks its input as already sorted:
+### 3.1 Motivation
+
+Consider a running total:
+
+```sql
+SELECT
+  user_id,
+  event_time,
+  SUM(amount) OVER (
+    PARTITION BY user_id
+    ORDER BY event_time
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  ) AS running_amount
+FROM events;
+```
+
+The query needs all rows for the same `user_id` to stay together, and it needs
+rows inside each user partition to follow `event_time`. A conventional plan often
+builds that order with a standalone sort:
+
+```text
+TableScan -> OrderBy(user_id, event_time) -> Window
+```
+
+That plan gives `OrderBy` and `Window` a clean contract, but it also creates this
+data-shape path:
+
+```text
+RowVector input -> OrderBy row storage -> RowVector output -> Window row storage
+```
+
+`OrderBy` needs row-oriented storage to sort. After sorting, it emits a normal
+columnar `RowVector` because operator boundaries are columnar. `Window` then
+builds row-oriented state again to find user boundaries, peer groups, and frame
+ranges. The SQL semantics do not require this `rows -> columns -> rows` middle
+step; the physical boundary does.
+
+### 3.2 Fused Execution Path
+
+Sort + Window fusion moves the ordering work into `Window` when the plan does not
+already provide sorted input. `Window` reads one planner flag to choose the path:
 
 ```cpp
 needSort_ = !(windowNode->inputsSorted());
 ```
 
-If the input already satisfies the ordering requirement, Window uses a streaming
-path and evaluates window functions directly. Otherwise, sorting is performed
-inside the Window operator through the sort-window build path, and the sorted
-rows are consumed by the same operator to compute window results.
+
+If `inputsSorted()` returns true, `Window` keeps the streaming-style path. If it
+returns false, `Window` routes input through a shared sort preparation path before
+the selected build implementation handles partition loading and output:
+
+```cpp
+if (needSort_) {
+  windowBuild_->addInputCommon(input);
+}
+windowBuild_->addInput(input);
+
+if (needSort_) {
+  windowBuild_->noMoreInputCommon();
+}
+windowBuild_->noMoreInput();
+```
+
+`addInputCommon()` decodes the incoming columnar batches once into
+`WindowBuild`'s `RowContainer`. The constructor reorders channels as partition
+keys, sort keys, then payload columns. On `noMoreInput()`,
+`noMoreInputCommon()` sorts row pointers in memory or finishes sort spill and
+creates an ordered spill reader. After that step, equal partition keys form
+contiguous ranges, and the order keys inside each range drive peer and frame
+computation.
 
 ![Sort and Window fusion]({{ site.baseurl }}/assets/images/operator-fusion-sort-window.svg)
 
-This is also operator fusion, but it is different from Aggregation + Shuffle
-fusion. It does not rely on `CompositeRowVector`, and it is not controlled by
-the composite aggregation configuration. Its goal is to avoid a separate
-Sort-to-Window boundary and keep sorting, buffering, and window evaluation
-within one physical operator when sorting is required.
+The same fused path supports `SortWindowBuild`, `RowsStreamingWindowBuild`, and
+`SpillableWindowBuild`. The common `WindowBuild` path owns the sorted row input;
+each concrete build still controls how it loads partitions and produces output.
+The rest of the engine still sees normal `Window` output.
 
-The benefit is that ordered data does not need to be handed off through an
-additional materialized boundary before window evaluation. For large partitions
-or complex window functions, reducing that boundary can lower memory movement
-and simplify the execution path.
+
+The fused operator also keeps the sort cost visible. Operator stats report sort
+output, column-to-row time, in-sort time, window input, partition loading, window
+function computation, output, and spill work. `SortWindowBenchmark` compares
+`OrderBy -> streamingWindow` with `sortWindow` under the same workload.
 
 ## 4. Performance Results
+
+### 4.1 Aggregation + Shuffle
 
 In representative production-style double-run tests, Aggregation + Shuffle
 fusion showed stable improvement on the overall agg + shuffle stage. End-to-end
@@ -169,6 +226,20 @@ The main cost is reflected in shuffle size. In the tests, shuffle size ranged
 from roughly unchanged to about 6% larger, mainly due to differences in
 row-payload layout. Compared with the reduction in stage time, this size
 increase is within an acceptable range.
+
+### 4.2 Sort + Window
+
+We benchmarked Sort + Window with window query shapes observed in production,
+comparing the old `OrderBy -> Window` shape with the fused `sortWindow`
+shape under the same partition keys, sort keys, spill setting, and window
+function. The benchmark results showed consistent improvement, with an average of about 20% and the best cases reaching roughly 50%. These results match the optimization target: once Window can consume row-oriented sorted data directly, Bolt avoids the extra rows -> RowVector -> rows round trip between standalone sort and window evaluation.
+
+The production results showed the same trend. Across 62 real online tasks, the
+median performance improvement was about 17.95%, P90 improvement was about
+28.11%, and the best task improved by about 40.35%. 
+
+Overall, Sort + Window fusion significantly improves both the performance and
+stability of workloads where sorting and window evaluation appear together.
 
 ## 5. Configuration and Observability
 

--- a/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
+++ b/doc/blog/_posts/2026-07-01-operator-fusion-eliminating-row-column-conversion.md
@@ -4,7 +4,7 @@ title: "Operator Fusion: Reducing Data Layout Conversions"
 date: 2026-07-01
 author: "Haiyan Gu, Jinyuan Zhang"
 parent: Blog
-nav_order: 2
+nav_order: 4
 ---
 
 Bolt's operator fusion optimizations reduce the format-conversion and

--- a/doc/blog/assets/images/operator-fusion-adaptive-shuffle.svg
+++ b/doc/blog/assets/images/operator-fusion-adaptive-shuffle.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 360" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+  <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#64748b"/></marker></defs>
+  <rect width="900" height="360" fill="#fff"/>
+  <style>.title{font-size:18px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.blue{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.orange{fill:#fff7ed;stroke:#ea580c;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.note{font-size:12px;fill:#475569}</style>
+  <text x="32" y="42" class="title">Adaptive shuffle layout</text>
+  <text x="32" y="66" class="note">Partial aggregation may fall back to ordinary RowVector, so writer and reader must handle mixed frames.</text>
+  <g transform="translate(70,112)">
+    <rect class="blue" x="0" y="0" width="190" height="78" rx="8"/><text class="label" x="95" y="31">Composite frame</text><text class="small" x="95" y="53">layout tag + row payload</text>
+    <rect class="box" x="285" y="0" width="190" height="78" rx="8"/><text class="label" x="380" y="31">Columnar frame</text><text class="small" x="380" y="53">ordinary RowVector path</text>
+    <rect class="orange" x="570" y="0" width="190" height="78" rx="8"/><text class="label" x="665" y="31">Shuffle reader</text><text class="small" x="665" y="53">parse by frame tag</text>
+    <line x1="190" y1="39" x2="280" y2="39" stroke="#64748b" stroke-width="1.3" marker-end="url(#a)"/>
+    <line x1="475" y1="39" x2="565" y2="39" stroke="#64748b" stroke-width="1.3" marker-end="url(#a)"/>
+  </g>
+  <g transform="translate(145,232)">
+    <rect class="box" x="0" y="0" width="610" height="58" rx="8"/>
+    <text class="label" x="305" y="24">reader output</text>
+    <text class="small" x="305" y="43">a normal columnar batch consumed by final aggregation</text>
+  </g>
+  <text x="450" y="330" class="note" text-anchor="middle">The external interface stays compatible while the optimized path reduces reconstruction before shuffle write.</text>
+</svg>

--- a/doc/blog/assets/images/operator-fusion-before-after.svg
+++ b/doc/blog/assets/images/operator-fusion-before-after.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 370" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+  <defs><marker id="ag" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#94a3b8"/></marker><marker id="ab" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#2563eb"/></marker></defs>
+  <rect width="960" height="370" fill="#fff"/>
+  <style>.title{font-size:16px;font-weight:600;fill:#334155}.nt{font-size:12.5px;font-weight:600;text-anchor:middle}.ns{font-size:10.5px;text-anchor:middle}.op{fill:#f8fafc;stroke:#94a3b8;stroke-width:1.2}.rm{fill:#fdf2f2;stroke:#d99a9a;stroke-width:1.2}.ok{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.keep{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.dark{fill:#1f2937}.sub{fill:#64748b}.red{fill:#9b2c2c}.blue{fill:#1d4ed8}.gray{fill:#475569}</style>
+  <text x="30" y="38" class="title">Before fusion · redundant row / column conversion before row-based shuffle</text>
+  <g transform="translate(30,62)">
+    <rect class="op" x="0" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="62.5" y="26">Partial Agg</text><text class="ns sub" x="62.5" y="45">RowContainer</text>
+    <rect class="rm" x="145" y="0" width="125" height="62" rx="8"/><text class="nt red" x="207.5" y="25">row → column</text><text class="ns red" x="207.5" y="43">emit RowVector</text>
+    <rect class="rm" x="290" y="0" width="125" height="62" rx="8"/><text class="nt red" x="352.5" y="25">column → row</text><text class="ns red" x="352.5" y="43">write CompactRow</text>
+    <rect class="op" x="435" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="497.5" y="26">Shuffle</text><text class="ns sub" x="497.5" y="45">row format</text>
+    <rect class="keep" x="580" y="0" width="125" height="62" rx="8"/><text class="nt gray" x="642.5" y="25">row → column</text><text class="ns sub" x="642.5" y="43">reader output</text>
+    <rect class="op" x="725" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="787.5" y="26">Final Agg</text><text class="ns sub" x="787.5" y="45">columnar batch</text>
+    <g stroke="#94a3b8" stroke-width="1.3" fill="none"><line x1="125" y1="31" x2="143" y2="31" marker-end="url(#ag)"/><line x1="270" y1="31" x2="288" y2="31" marker-end="url(#ag)"/><line x1="415" y1="31" x2="433" y2="31" marker-end="url(#ag)"/><line x1="560" y1="31" x2="578" y2="31" marker-end="url(#ag)"/><line x1="705" y1="31" x2="723" y2="31" marker-end="url(#ag)"/></g>
+  </g>
+  <text x="455" y="154" font-size="11.5" fill="#64748b" text-anchor="middle">Red nodes are the redundant conversions primarily removed by fusion; reader output after shuffle remains columnar.</text>
+  <line x1="30" y1="188" x2="930" y2="188" stroke="#e5e7eb"/>
+  <text x="30" y="232" class="title">After fusion · keep row payload until shuffle write</text>
+  <g transform="translate(30,256)">
+    <rect class="ok" x="0" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="62.5" y="24">Partial Agg</text><text class="ns blue" x="62.5" y="42">CompositeRowVector</text>
+    <rect class="ok" x="145" y="0" width="125" height="62" rx="8"/><text class="nt blue" x="207.5" y="24">keep row</text><text class="ns blue" x="207.5" y="42">accumulator payload</text>
+    <rect class="ok" x="290" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="352.5" y="24">Project</text><text class="ns sub" x="352.5" y="42">key columns only</text>
+    <rect class="ok" x="435" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="497.5" y="24">Shuffle</text><text class="ns blue" x="497.5" y="42">memcpy</text>
+    <rect class="keep" x="580" y="0" width="125" height="62" rx="8"/><text class="nt gray" x="642.5" y="25">row → column</text><text class="ns sub" x="642.5" y="43">reader output</text>
+    <rect class="op" x="725" y="0" width="125" height="62" rx="8"/><text class="nt dark" x="787.5" y="26">Final Agg</text><text class="ns sub" x="787.5" y="45">columnar batch</text>
+    <g stroke="#2563eb" stroke-width="1.4" fill="none"><line x1="125" y1="31" x2="143" y2="31" marker-end="url(#ab)"/><line x1="270" y1="31" x2="288" y2="31" marker-end="url(#ab)"/><line x1="415" y1="31" x2="433" y2="31" marker-end="url(#ab)"/><line x1="560" y1="31" x2="578" y2="31" marker-end="url(#ab)"/><line x1="705" y1="31" x2="723" y2="31" marker-end="url(#ab)"/></g>
+  </g>
+  <text x="455" y="348" font-size="11.5" fill="#64748b" text-anchor="middle">The row-to-column output between Shuffle and Final Agg remains; fusion removes the round trip before shuffle write.</text>
+</svg>

--- a/doc/blog/assets/images/operator-fusion-composite-vector.svg
+++ b/doc/blog/assets/images/operator-fusion-composite-vector.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 360" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+  <rect width="900" height="360" fill="#fff"/>
+  <style>.title{font-size:18px;font-weight:600;fill:#334155}.label{font-size:13px;font-weight:600;fill:#1f2937}.small{font-size:11px;fill:#64748b}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.key{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.payload{fill:#fff7ed;stroke:#ea580c;stroke-width:1.2}.note{font-size:12px;fill:#475569}</style>
+  <text x="32" y="42" class="title">CompositeRowVector layout</text>
+  <text x="32" y="66" class="small">Grouping keys remain column-accessible; accumulator state is kept as row payload.</text>
+  <rect x="70" y="105" width="760" height="190" rx="12" class="box"/>
+  <text x="450" y="130" class="label" text-anchor="middle">CompositeRowVector</text>
+  <g transform="translate(110,158)">
+    <rect class="key" x="0" y="0" width="150" height="82" rx="8"/><text class="label" x="75" y="32" text-anchor="middle">Key column 1</text><text class="small" x="75" y="54" text-anchor="middle">partition / hash</text>
+    <rect class="key" x="175" y="0" width="150" height="82" rx="8"/><text class="label" x="250" y="32" text-anchor="middle">Key column 2</text><text class="small" x="250" y="54" text-anchor="middle">projectable</text>
+    <rect class="payload" x="365" y="0" width="340" height="82" rx="8"/><text class="label" x="535" y="30" text-anchor="middle">Accumulator row payload</text><text class="small" x="535" y="54" text-anchor="middle">serialized state from RowContainer</text>
+  </g>
+  <line x1="450" y1="247" x2="450" y2="275" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="450" y="320" class="note" text-anchor="middle">Project and partitioning read key columns; row-based shuffle writer copies the payload without rebuilding it.</text>
+</svg>

--- a/doc/blog/assets/images/operator-fusion-sort-window.svg
+++ b/doc/blog/assets/images/operator-fusion-sort-window.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 360" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+  <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#94a3b8"/></marker><marker id="b" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#2563eb"/></marker></defs>
+  <rect width="900" height="360" fill="#fff"/>
+  <style>.title{font-size:17px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.red{fill:#fdf2f2;stroke:#d99a9a;stroke-width:1.2}.blue{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.note{font-size:12px;fill:#475569}</style>
+  <text x="32" y="42" class="title">Before fusion · Sort and Window separated by an operator boundary</text>
+  <g transform="translate(80,78)">
+    <rect class="box" x="0" y="0" width="160" height="64" rx="8"/><text class="label" x="80" y="25">Input</text><text class="small" x="80" y="44">columnar batches</text>
+    <rect class="red" x="240" y="0" width="160" height="64" rx="8"/><text class="label" x="320" y="25">Sort</text><text class="small" x="320" y="44">materialize order</text>
+    <rect class="red" x="480" y="0" width="160" height="64" rx="8"/><text class="label" x="560" y="25">Window</text><text class="small" x="560" y="44">consume sorted rows</text>
+    <line x1="160" y1="32" x2="235" y2="32" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#a)"/><line x1="400" y1="32" x2="475" y2="32" stroke="#94a3b8" stroke-width="1.3" marker-end="url(#a)"/>
+  </g>
+  <line x1="32" y1="176" x2="868" y2="176" stroke="#e5e7eb"/>
+  <text x="32" y="218" class="title">After fusion · sorting is internal to Window when required</text>
+  <g transform="translate(80,254)">
+    <rect class="box" x="0" y="0" width="160" height="64" rx="8"/><text class="label" x="80" y="25">Input</text><text class="small" x="80" y="44">planned order checked</text>
+    <rect class="blue" x="240" y="0" width="210" height="64" rx="8"/><text class="label" x="345" y="24">Window</text><text class="small" x="345" y="43">SortWindowBuild or streaming</text>
+    <rect class="box" x="530" y="0" width="160" height="64" rx="8"/><text class="label" x="610" y="25">Output</text><text class="small" x="610" y="44">window results</text>
+    <line x1="160" y1="32" x2="235" y2="32" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/><line x1="450" y1="32" x2="525" y2="32" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
+  </g>
+  <text x="450" y="344" class="note" text-anchor="middle">If inputsSorted() is true, Window uses the streaming path; otherwise it sorts within the Window operator.</text>
+</svg>


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #695 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [x] 📝 Documentation only

### Description

Add a GitHub Pages blog post introducing Operator Fusion in Bolt.

The post covers two implemented optimization paths:

- Aggregation + Shuffle fusion, which reduces the `RowContainer -> RowVector -> CompactRow` round trip before row-based shuffle write.
- Sort + Window fusion, which keeps sorting inside the Window operator when the input is not already sorted.

It also includes diagrams, configuration notes, observability guidance, and summarized performance results.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- docs: add Bolt operator fusion blog
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
