### PR TITLE
docs: add adaptive task parallelism blog post

### DIFF
--- a/doc/blog/_posts/2026-07-02-adaptive-task-parallelism.md
+++ b/doc/blog/_posts/2026-07-02-adaptive-task-parallelism.md
@@ -1,0 +1,185 @@
+---
+layout: post
+title: "Adaptive Task Parallelism in Bolt"
+date: 2026-07-02
+author: "Haiyan Gu, Guangxin Wang"
+parent: Blog
+nav_order: 3
+---
+
+Bolt's adaptive task parallelism adjusts task concurrency at stage granularity
+based on measured CPU utilization, memory pressure, and input throughput. The
+mechanism keeps Spark as the task scheduler and moves the concurrency decision
+into the Bolt executor, where task-level runtime statistics are already
+available. On a sample of more than 1,000 production Spark on Bolt tasks, the
+feature delivered an average end-to-end speedup of 1.27x.
+{: .note }
+
+## 1. Background
+
+Spark on Bolt workloads often run with CPU utilization in the 50%-55% range.
+The main limiter is usually not compute itself, but time spent outside CPU,
+primarily in I/O and memory access. Increasing task concurrency is a direct way
+to raise CPU utilization, but a single static concurrency value is a poor fit
+across stages and queries: some stages are memory-bound, some are I/O-bound,
+and only some benefit from higher concurrency at all.
+
+Adaptive task parallelism addresses this by deciding concurrency during stage
+execution, using signals that the executor can observe locally at low cost. The
+design keeps two constraints from the existing execution model:
+
+- Spark remains responsible for task scheduling. Bolt does not take over Spark
+  scheduling semantics.
+- Stages that are not safe to adjust, such as memory-tight or spill-prone
+  stages, stay at the default concurrency.
+
+## 2. Design Choice
+
+Two directions were considered.
+
+The first was Bolt-side self-scheduling. Spark would hand Bolt more tasks than
+the configured concurrency, and Bolt would hold the excess tasks in a local
+queue, starting them based on runtime feedback.
+
+The second was to let Bolt decide concurrency while Spark continues to schedule
+tasks. Bolt reports the current target concurrency back through task metrics,
+and the Spark driver adjusts subsequent task dispatch accordingly.
+
+The current implementation takes the second path. This avoids changing Spark
+ task lifecycle semantics, including task timing, speculative execution, and UI
+metrics, while still allowing the concurrency decision to use fine-grained
+runtime statistics inside the Bolt executor. Bolt-side self-scheduling remains
+available as an experimental option, but it is not the default path.
+
+![Bolt decides concurrency, Spark schedules tasks]({{ site.baseurl }}/assets/images/adaptive-task-parallelism-flow.svg)
+
+## 3. Execution Path
+
+The core logic lives in `ExecutorTaskScheduler`, implemented in
+`bolt/exec/ExecutorTaskScheduler.{h,cpp}`. It is a process-scope singleton:
+one instance per Bolt executor process, shared by tasks running concurrently in
+that executor. It owns the state machine, the sampling window, and the
+concurrency decision.
+
+Bolt tasks connect to the scheduler through two points:
+
+- `Task::create` reads the current target concurrency when dynamic concurrency
+  adjustment is enabled.
+- `Task::terminate` reports runtime statistics to the scheduler and triggers
+  `scheduleNewTasksIfAny`, which may call `decideConcurrencyLocked()` when a
+  decision is due.
+
+### 3.1 State Machine
+
+The scheduler maintains four states per stage:
+
+- `kInit`: the initial state, before any task has been observed for decision
+  making.
+- `kSampling`: finished-task statistics are collected. Once the number of
+  tracked tasks reaches `numTrackingTaskThreshold_`, the scheduler computes a
+  candidate concurrency.
+- `kRevising`: the candidate concurrency has been applied, and subsequent task
+  results are observed to confirm that throughput does not regress.
+- `kCompleted`: the concurrency decision for the current stage is stable, and
+  later task completions no longer change it.
+
+```cpp
+enum SchedulerState { kInit, kSampling, kRevising, kCompleted };
+```
+
+![ExecutorTaskScheduler state machine]({{ site.baseurl }}/assets/images/adaptive-task-parallelism-state.svg)
+
+Before the scheduler reaches `kCompleted`, two conditions send the stage back to
+a safe baseline:
+
+- Memory reclaim was observed during sampling. The scheduler treats the stage
+  as close to a memory limit and falls back to `defaultConcurrency_`.
+- Throughput regressed after the adjustment. The scheduler also falls back to
+  `defaultConcurrency_` in that case.
+
+### 3.2 Concurrency Decision
+
+`decideConcurrencyLocked()` uses three signals: CPU utilization, memory
+headroom, and input throughput. The core estimate considers both CPU headroom
+and memory headroom, and applies a cap to keep a single adjustment from being
+too aggressive:
+
+```cpp
+double estimatedResourceMul = estimatedMulOnResource();
+int32_t newConcurrency = std::min(
+    (int32_t)std::round(estimatedResourceMul * defaultConcurrency_),
+    3 * defaultConcurrency_);
+```
+
+`estimatedMulOnResource()` takes the more conservative value between a
+CPU-target-to-current-utilization ratio and a memory-headroom ratio, so the
+final adjustment is bounded by whichever resource is tighter. In the current
+implementation, the cap is `3 * defaultConcurrency_`. When task concurrency is
+adjusted, the scheduler also resizes the I/O executor thread pool through
+`ioExecutor_->setNumThreads`, so I/O parallelism stays aligned with task
+concurrency.
+
+### 3.3 Task Lifecycle Integration
+
+On task creation, the scheduler exposes the current target concurrency. On task
+termination, `Task::terminate` calls
+`ExecutorTaskScheduler::scheduleNewTasksIfAny`, which updates runtime
+statistics, advances the state machine, and invokes
+`decideConcurrencyLocked()` when required.
+
+The current concurrency and a monotonically increasing version are returned to
+Spark through task metrics. The version exists to handle out-of-order reports:
+if metrics from different tasks reach the driver in different orders, the driver
+can ignore stale values and avoid switching concurrency based on old decisions.
+
+## 4. Configuration and Observability
+
+The feature is mainly controlled by two configuration items:
+
+| Configuration | Default | Description |
+| --- | --- | --- |
+| `spark.gluten.sql.columnar.backend.bolt.dynamicConcurrencyAdjustment.enabled` | `false` | Master switch for adaptive task parallelism. |
+| `spark.gluten.sql.columnar.backend.bolt.boltTaskScheduling.enabled` | `false` | Switch for Bolt-side self-scheduling. When enabled, Bolt maintains a local task queue. Default is off. |
+
+Another option,
+`spark.gluten.sql.columnar.backend.bolt.dynamicDefaultConcurrency`, supplies the
+initial default concurrency used as the baseline for later adjustment.
+
+The scheduler reports current concurrency as a runtime stat named
+`dynamicConcurrency`. It is currently attached to source operators such as
+`TableScan` and `ValueStream`:
+
+```cpp
+lockedStats->addRuntimeStat(
+    "dynamicConcurrency", RuntimeCounter(this->getConcurrency()));
+```
+
+A companion adjustment counter is used as a version indicator rather than a
+duration or data-size metric. In practice, both the current concurrency and its
+version need to be read together: the former shows what the executor is using,
+and the latter shows whether that value comes from the latest decision.
+
+## 5. Performance Results
+
+Adaptive task parallelism was evaluated on a set of production Spark on Bolt
+tasks. The sample was filtered by CPU and memory headroom criteria and covered
+more than 1,000 online tasks, with an average end-to-end speedup of 1.27x.
+
+This result matches the intended behavior. Concurrency is raised only when the
+executor's runtime signals indicate remaining headroom. For stages with higher
+memory pressure, stages that observed memory reclaim during sampling, or stages
+where throughput did not improve after adjustment, the scheduler keeps or
+returns to the default concurrency.
+
+## 6. Summary
+
+Adaptive task parallelism does not change Spark's scheduling model. It moves the
+concurrency decision into the Bolt executor, where task-level runtime
+statistics are already available. `ExecutorTaskScheduler` samples, decides, and
+revises at stage granularity; once memory pressure or throughput regression is
+observed, it returns to the default concurrency. The reported concurrency is
+versioned so that the Spark driver can adopt updates safely.
+
+The goal is straightforward: raise concurrency for stages with low CPU
+utilization and remaining memory headroom, and stay with the default behavior
+for stages where the gain is uncertain or the memory risk is higher.

--- a/doc/blog/assets/images/adaptive-task-parallelism-flow.svg
+++ b/doc/blog/assets/images/adaptive-task-parallelism-flow.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 340" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+  <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#64748b"/></marker><marker id="b" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#2563eb"/></marker></defs>
+  <rect width="960" height="340" fill="#fff"/>
+  <style>.title{font-size:16px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.act{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.note{font-size:12px;fill:#475569}.edge{font-size:11px;fill:#475569}</style>
+  <text x="30" y="38" class="title">Bolt decides concurrency, Spark schedules tasks</text>
+  <g transform="translate(30,66)">
+    <rect class="box" x="0" y="0" width="200" height="72" rx="10"/><text class="label" x="100" y="30">Spark Driver</text><text class="small" x="100" y="50">dispatches tasks at default</text><text class="small" x="100" y="64">concurrency to executors</text>
+    <rect class="act" x="260" y="0" width="360" height="72" rx="10"/><text class="label" x="440" y="28">Bolt Executor · ExecutorTaskScheduler</text><text class="small" x="440" y="48">collect runtime stats per task</text><text class="small" x="440" y="62">decideConcurrencyLocked on Task::terminate</text>
+    <rect class="box" x="650" y="0" width="280" height="72" rx="10"/><text class="label" x="790" y="28">Source operator runtime stats</text><text class="small" x="790" y="48">dynamicConcurrency</text><text class="small" x="790" y="62">version-tagged for each adjustment</text>
+    <g stroke="#64748b" stroke-width="1.3" fill="none"><line x1="200" y1="36" x2="258" y2="36" marker-end="url(#a)"/><line x1="620" y1="36" x2="648" y2="36" marker-end="url(#a)"/></g>
+  </g>
+  <g transform="translate(30,180)">
+    <rect class="act" x="70" y="0" width="820" height="80" rx="10"/>
+    <text class="label" x="480" y="28">Feedback loop</text>
+    <text class="small" x="480" y="50">Task metrics carry current concurrency and a monotonic version back to Spark Driver;</text>
+    <text class="small" x="480" y="66">Driver adjusts per-executor task dispatch to match the reported value on subsequent tasks.</text>
+    <line x1="480" y1="0" x2="480" y2="-40" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
+    <line x1="480" y1="80" x2="130" y2="140" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
+  </g>
+  <text x="30" y="316" class="note">Feature switches: dynamicConcurrencyAdjustment.enabled (main) and boltTaskScheduling.enabled (Bolt-side self-scheduling; off by default).</text>
+</svg>

--- a/doc/blog/assets/images/adaptive-task-parallelism-flow.svg
+++ b/doc/blog/assets/images/adaptive-task-parallelism-flow.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 340" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 290" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
   <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#64748b"/></marker><marker id="b" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#2563eb"/></marker></defs>
-  <rect width="960" height="340" fill="#fff"/>
+  <rect width="960" height="290" fill="#fff"/>
   <style>.title{font-size:16px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.act{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.note{font-size:12px;fill:#475569}.edge{font-size:11px;fill:#475569}</style>
-  <text x="30" y="38" class="title">Bolt decides concurrency, Spark schedules tasks</text>
+  <text x="480" y="38" class="title" text-anchor="middle">Bolt decides concurrency, Spark schedules tasks</text>
   <g transform="translate(30,66)">
     <rect class="box" x="0" y="0" width="200" height="72" rx="10"/><text class="label" x="100" y="30">Spark Driver</text><text class="small" x="100" y="50">dispatches tasks at default</text><text class="small" x="100" y="64">concurrency to executors</text>
     <rect class="act" x="260" y="0" width="360" height="72" rx="10"/><text class="label" x="440" y="28">Bolt Executor · ExecutorTaskScheduler</text><text class="small" x="440" y="48">collect runtime stats per task</text><text class="small" x="440" y="62">decideConcurrencyLocked on Task::terminate</text>
@@ -14,8 +14,9 @@
     <text class="label" x="480" y="28">Feedback loop</text>
     <text class="small" x="480" y="50">Task metrics carry current concurrency and a monotonic version back to Spark Driver;</text>
     <text class="small" x="480" y="66">Driver adjusts per-executor task dispatch to match the reported value on subsequent tasks.</text>
-    <line x1="480" y1="0" x2="480" y2="-40" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
-    <line x1="480" y1="80" x2="130" y2="140" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
+    <line x1="760" y1="-40" x2="760" y2="-2" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
+    <line x1="100" y1="0" x2="100" y2="-40" stroke="#2563eb" stroke-width="1.4" marker-end="url(#b)"/>
+    <text class="edge" x="748" y="-14" text-anchor="end">metrics</text>
+    <text class="edge" x="112" y="-14" text-anchor="start">adjust</text>
   </g>
-  <text x="30" y="316" class="note">Feature switches: dynamicConcurrencyAdjustment.enabled (main) and boltTaskScheduling.enabled (Bolt-side self-scheduling; off by default).</text>
 </svg>

--- a/doc/blog/assets/images/adaptive-task-parallelism-state.svg
+++ b/doc/blog/assets/images/adaptive-task-parallelism-state.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 260" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
   <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#64748b"/></marker><marker id="b" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#b45309"/></marker></defs>
-  <rect width="960" height="260" fill="#fff"/>
-  <style>.title{font-size:16px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.act{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.rev{fill:#fff7ed;stroke:#ea580c;stroke-width:1.2}.done{fill:#ecfdf5;stroke:#059669;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.edge{font-size:11px;fill:#475569;text-anchor:middle}.note{font-size:12px;fill:#475569}</style>
-  <text x="30" y="38" class="title">ExecutorTaskScheduler state machine</text>
+  <rect width="960" height="240" fill="#fff"/>
+  <style>.title{font-size:16px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.act{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.rev{fill:#fff7ed;stroke:#ea580c;stroke-width:1.2}.done{fill:#ecfdf5;stroke:#059669;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.edge{font-size:11px;fill:#475569;text-anchor:middle}</style>
+  <text x="480" y="38" class="title" text-anchor="middle">ExecutorTaskScheduler state machine</text>
   <g transform="translate(30,72)">
     <rect class="box" x="0" y="0" width="170" height="70" rx="10"/><text class="label" x="85" y="30">kInit</text><text class="small" x="85" y="50">process-scope singleton</text>
     <rect class="act" x="230" y="0" width="200" height="70" rx="10"/><text class="label" x="330" y="30">kSampling</text><text class="small" x="330" y="50">collect runtime stats per task</text>
@@ -16,9 +16,7 @@
     <text class="edge" x="199" y="27">new stage</text>
     <text class="edge" x="444" y="27">decide</text>
     <text class="edge" x="694" y="27">stable</text>
-    <path d="M570 70 C 480 140, 320 140, 250 90" fill="none" stroke="#b45309" stroke-width="1.4" marker-end="url(#b)"/>
-    <text class="edge" x="400" y="140" fill="#b45309">throughput drop or memory reclaim · revert to default</text>
+    <path d="M570 70 C 525 120, 360 126, 265 90" fill="none" stroke="#b45309" stroke-width="1.4" marker-end="url(#b)"/>
+    <text class="edge" x="420" y="154" fill="#b45309">regression or memory reclaim · fallback to default concurrency</text>
   </g>
-  <text x="30" y="220" class="note">Sampling ends after numTrackingTaskThreshold_ tasks complete; decideConcurrencyLocked runs on Task::terminate.</text>
-  <text x="30" y="240" class="note">Revising confirms the new concurrency; a regression falls back to defaultConcurrency_.</text>
 </svg>

--- a/doc/blog/assets/images/adaptive-task-parallelism-state.svg
+++ b/doc/blog/assets/images/adaptive-task-parallelism-state.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 260" font-family="'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif">
+  <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#64748b"/></marker><marker id="b" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#b45309"/></marker></defs>
+  <rect width="960" height="260" fill="#fff"/>
+  <style>.title{font-size:16px;font-weight:600;fill:#334155}.box{fill:#f8fafc;stroke:#cbd5e1;stroke-width:1.2}.act{fill:#eef4ff;stroke:#2563eb;stroke-width:1.2}.rev{fill:#fff7ed;stroke:#ea580c;stroke-width:1.2}.done{fill:#ecfdf5;stroke:#059669;stroke-width:1.2}.label{font-size:13px;font-weight:600;fill:#1f2937;text-anchor:middle}.small{font-size:11px;fill:#64748b;text-anchor:middle}.edge{font-size:11px;fill:#475569;text-anchor:middle}.note{font-size:12px;fill:#475569}</style>
+  <text x="30" y="38" class="title">ExecutorTaskScheduler state machine</text>
+  <g transform="translate(30,72)">
+    <rect class="box" x="0" y="0" width="170" height="70" rx="10"/><text class="label" x="85" y="30">kInit</text><text class="small" x="85" y="50">process-scope singleton</text>
+    <rect class="act" x="230" y="0" width="200" height="70" rx="10"/><text class="label" x="330" y="30">kSampling</text><text class="small" x="330" y="50">collect runtime stats per task</text>
+    <rect class="rev" x="460" y="0" width="220" height="70" rx="10"/><text class="label" x="570" y="30">kRevising</text><text class="small" x="570" y="50">observe throughput after change</text>
+    <rect class="done" x="710" y="0" width="220" height="70" rx="10"/><text class="label" x="820" y="30">kCompleted</text><text class="small" x="820" y="50">stage concurrency locked</text>
+    <g stroke="#64748b" stroke-width="1.3" fill="none">
+      <line x1="170" y1="35" x2="228" y2="35" marker-end="url(#a)"/>
+      <line x1="430" y1="35" x2="458" y2="35" marker-end="url(#a)"/>
+      <line x1="680" y1="35" x2="708" y2="35" marker-end="url(#a)"/>
+    </g>
+    <text class="edge" x="199" y="27">new stage</text>
+    <text class="edge" x="444" y="27">decide</text>
+    <text class="edge" x="694" y="27">stable</text>
+    <path d="M570 70 C 480 140, 320 140, 250 90" fill="none" stroke="#b45309" stroke-width="1.4" marker-end="url(#b)"/>
+    <text class="edge" x="400" y="140" fill="#b45309">throughput drop or memory reclaim · revert to default</text>
+  </g>
+  <text x="30" y="220" class="note">Sampling ends after numTrackingTaskThreshold_ tasks complete; decideConcurrencyLocked runs on Task::terminate.</text>
+  <text x="30" y="240" class="note">Revising confirms the new concurrency; a regression falls back to defaultConcurrency_.</text>
+</svg>


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #695 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [x] 📝 Documentation only

### Description

Add a blog post about adaptive task parallelism in Bolt, covering how task concurrency is adjusted at stage granularity based on runtime CPU, memory, and throughput signals.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- docs: add adaptive task parallelism blog post
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
