### PR TITLE
fix(sparksql): align array_repeat count limit with Spark semantics (#…

### DIFF
--- a/bolt/functions/lib/Repeat.cpp
+++ b/bolt/functions/lib/Repeat.cpp
@@ -30,6 +30,9 @@
 
 #include "bolt/expression/DecodedArgs.h"
 #include "bolt/expression/VectorFunction.h"
+
+#include <limits>
+#include <optional>
 namespace bytedance::bolt::functions {
 namespace {
 // See documentation at https://prestodb.io/docs/current/functions/array.html
@@ -37,8 +40,10 @@ class RepeatFunction : public exec::VectorFunction {
  public:
   // @param allowNegativeCount If true, negative 'count' is allowed
   // and treated the same as zero (Spark's behavior).
-  explicit RepeatFunction(bool allowNegativeCount)
-      : allowNegativeCount_(allowNegativeCount) {}
+  explicit RepeatFunction(
+      bool allowNegativeCount,
+      std::optional<int32_t> maxCount)
+      : allowNegativeCount_(allowNegativeCount), maxCount_(maxCount) {}
 
   static constexpr int32_t kMaxResultEntries = 10'000;
 
@@ -67,7 +72,10 @@ class RepeatFunction : public exec::VectorFunction {
 
  private:
   // Check count to make sure it is in valid range.
-  static int32_t checkCount(int32_t count, bool allowNegativeCount) {
+  static int32_t checkCount(
+      int32_t count,
+      bool allowNegativeCount,
+      const std::optional<int32_t>& maxCount) {
     if (count < 0) {
       if (allowNegativeCount) {
         return 0;
@@ -77,10 +85,13 @@ class RepeatFunction : public exec::VectorFunction {
           count,
           0);
     }
-    BOLT_USER_CHECK_LE(
-        count,
-        kMaxResultEntries,
-        "Count argument of repeat function must be less than or equal to 10000");
+    if (maxCount.has_value()) {
+      BOLT_USER_CHECK_LE(
+          count,
+          maxCount.value(),
+          "Count argument of repeat function must be less than or equal to {}",
+          maxCount.value());
+    }
     return count;
   }
 
@@ -100,15 +111,21 @@ class RepeatFunction : public exec::VectorFunction {
 
     auto count = constantCount->valueAt(0);
     try {
-      count = checkCount(count, allowNegativeCount_);
+      count = checkCount(count, allowNegativeCount_, maxCount_);
     } catch (const BoltUserError&) {
       context.setErrors(rows, std::current_exception());
       return nullptr;
     }
-    const auto totalCount = count * numRows;
+    const int64_t totalCount = static_cast<int64_t>(count) * numRows;
+    BOLT_USER_CHECK_LE(
+        totalCount,
+        std::numeric_limits<int32_t>::max(),
+        "Total entries in repeat function result must be less than or equal to {}",
+        std::numeric_limits<int32_t>::max());
 
     // Allocate new vectors for indices, lengths and offsets.
-    BufferPtr indices = allocateIndices(totalCount, pool);
+    BufferPtr indices =
+        allocateIndices(static_cast<vector_size_t>(totalCount), pool);
     BufferPtr sizes = allocateSizes(numRows, pool);
     BufferPtr offsets = allocateOffsets(numRows, pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
@@ -130,7 +147,8 @@ class RepeatFunction : public exec::VectorFunction {
         numRows,
         offsets,
         sizes,
-        BaseVector::wrapInDictionary(nullptr, indices, totalCount, args[0]));
+        BaseVector::wrapInDictionary(
+            nullptr, indices, static_cast<vector_size_t>(totalCount), args[0]));
   }
 
   VectorPtr applyNonConstantCount(
@@ -140,13 +158,18 @@ class RepeatFunction : public exec::VectorFunction {
       exec::EvalCtx& context) const {
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto countDecoded = decodedArgs.at(1);
-    int32_t totalCount = 0;
+    int64_t totalCount = 0;
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       auto count =
           countDecoded->isNullAt(row) ? 0 : countDecoded->valueAt<int32_t>(row);
-      count = checkCount(count, allowNegativeCount_);
+      count = checkCount(count, allowNegativeCount_, maxCount_);
       totalCount += count;
     });
+    BOLT_USER_CHECK_LE(
+        totalCount,
+        std::numeric_limits<int32_t>::max(),
+        "Total entries in repeat function result must be less than or equal to {}",
+        std::numeric_limits<int32_t>::max());
 
     const auto numRows = rows.end();
     auto pool = context.pool();
@@ -160,7 +183,8 @@ class RepeatFunction : public exec::VectorFunction {
     }
 
     // Allocate new vectors for indices, lengths and offsets.
-    BufferPtr indices = allocateIndices(totalCount, pool);
+    BufferPtr indices =
+        allocateIndices(static_cast<vector_size_t>(totalCount), pool);
     BufferPtr sizes = allocateSizes(numRows, pool);
     BufferPtr offsets = allocateOffsets(numRows, pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
@@ -196,10 +220,12 @@ class RepeatFunction : public exec::VectorFunction {
         numRows,
         offsets,
         sizes,
-        BaseVector::wrapInDictionary(nullptr, indices, totalCount, args[0]));
+        BaseVector::wrapInDictionary(
+            nullptr, indices, static_cast<vector_size_t>(totalCount), args[0]));
   }
 
   const bool allowNegativeCount_;
+  const std::optional<int32_t> maxCount_;
 };
 } // namespace
 
@@ -217,14 +243,23 @@ std::shared_ptr<exec::VectorFunction> makeRepeat(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& /* inputArgs */,
     const core::QueryConfig& /*config*/) {
-  return std::make_unique<RepeatFunction>(false);
+  return std::make_unique<RepeatFunction>(
+      false, RepeatFunction::kMaxResultEntries);
 }
 
 std::shared_ptr<exec::VectorFunction> makeRepeatAllowNegativeCount(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& /* inputArgs */,
     const core::QueryConfig& /*config*/) {
-  return std::make_unique<RepeatFunction>(true);
+  return std::make_unique<RepeatFunction>(
+      true, RepeatFunction::kMaxResultEntries);
+}
+
+std::shared_ptr<exec::VectorFunction> makeRepeatAllowNegativeCountNoLimit(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& /* inputArgs */,
+    const core::QueryConfig& /*config*/) {
+  return std::make_unique<RepeatFunction>(true, std::nullopt);
 }
 
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/Repeat.h
+++ b/bolt/functions/lib/Repeat.h
@@ -48,4 +48,10 @@ std::shared_ptr<exec::VectorFunction> makeRepeatAllowNegativeCount(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
+
+// Allows negative count and doesn't enforce a hard per-row count limit.
+std::shared_ptr<exec::VectorFunction> makeRepeatAllowNegativeCountNoLimit(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/sparksql/registration/RegisterArray.cpp
+++ b/bolt/functions/sparksql/registration/RegisterArray.cpp
@@ -206,7 +206,7 @@ void registerArrayFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "array_repeat",
       repeatSignatures(),
-      makeRepeatAllowNegativeCount);
+      makeRepeatAllowNegativeCountNoLimit);
 
   registerIntegerSliceFunction(prefix);
 

--- a/bolt/functions/sparksql/tests/ArrayRepeatTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayRepeatTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace bytedance::bolt::test;
+
+namespace bytedance::bolt::functions::sparksql::test {
+
+class ArrayRepeatTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(ArrayRepeatTest, supportsLargeRepeatCount) {
+  const auto elementVector = makeFlatVector<int32_t>({1});
+  const auto countVector = makeFlatVector<int32_t>({15'000});
+
+  VectorPtr expected =
+      makeArrayVector<int32_t>({std::vector<int32_t>(15'000, 1)});
+  testExpression(
+      "array_repeat(c0, c1)", {elementVector, countVector}, expected);
+}
+
+TEST_F(ArrayRepeatTest, nullAndNegativeCount) {
+  const auto elementVector =
+      makeNullableFlatVector<int32_t>({1, 2, 3, std::nullopt, 5});
+  const auto countVector =
+      makeNullableFlatVector<int32_t>({2, -1, std::nullopt, 3, 0});
+
+  VectorPtr expected = makeNullableArrayVector<int32_t>({
+      {{1, 1}},
+      emptyArray,
+      std::nullopt,
+      {{std::nullopt, std::nullopt, std::nullopt}},
+      emptyArray,
+  });
+
+  testExpression(
+      "array_repeat(c0, c1)", {elementVector, countVector}, expected);
+}
+
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
   ArrayPrependTest.cpp
+  ArrayRepeatTest.cpp
   ArrayShuffleTest.cpp
   ArraySliceSumTest.cpp
   ArrayUnionTest.cpp


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #652

Spark `array_repeat` should not enforce the Presto per-row limit (10,000).

Before this change, Bolt reused the same repeat check for both engines and failed on valid Spark queries such as:

```sql
SELECT array_repeat(1, CAST(rand() * 10000 + 15000 AS INT)) FROM range(1)
```

with an error like:

```text
Count argument of repeat function must be less than or equal to 10000
```

This PR separates Spark and Presto behavior.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR updates repeat handling for `array_repeat`:

1. Keep Presto behavior unchanged:
  - still enforces per-row count limit 10,000.

2. Apply Spark behavior for `array_repeat`:
  - allows negative count to become 0,
  - removes the fixed 10,000 per-row cap.

3. Keep safety guard for output size:
  - check total repeated entries against `int32` max,
  - use `int64_t` accumulation for total count.

The Spark registration now uses a no-limit factory:

```cpp
exec::registerStatefulVectorFunction(
    prefix + "array_repeat",
    repeatSignatures(),
    makeRepeatAllowNegativeCountNoLimit);
```

This PR also adds regression tests:

1. Spark `ArrayRepeatTest` for large count (15,000).
2. Spark `ArrayRepeatTest` for null and negative count behavior.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed Spark array_repeat to remove an incorrect hard per-row limit of 10,000 while keeping Presto repeat behavior unchanged.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
