### PR TITLE
fix(functions): avoid array_sort StringViewStats DCHECK for varchar n…

### DIFF
--- a/bolt/functions/lib/ArraySort.cpp
+++ b/bolt/functions/lib/ArraySort.cpp
@@ -133,9 +133,10 @@ inline void swapWithNull(
     vector_size_t index,
     vector_size_t nullIndex) {
   // Values are already present in vector stringBuffers. Don't create additional
-  // copy.
+  // copy. Moving StringViews within the same vector keeps StringViewStats
+  // valid because total bytes and max length do not change.
   if constexpr (std::is_same_v<T, StringView>) {
-    vector->setNoCopy(nullIndex, vector->valueAt(index));
+    vector->setNoCopyUnsafe(nullIndex, vector->valueAt(index));
   } else {
     vector->set(nullIndex, vector->valueAt(index));
   }

--- a/bolt/functions/prestosql/tests/ArraySortTest.cpp
+++ b/bolt/functions/prestosql/tests/ArraySortTest.cpp
@@ -432,6 +432,35 @@ TEST_F(ArraySortTest, dictionaryEncodedElements) {
           {{4, std::nullopt}, {1, std::nullopt, std::nullopt}}));
 }
 
+TEST_F(ArraySortTest, varcharElementsWithStringStats) {
+  auto inputPool = rootPool_->addLeafChild("array-sort-varchar-input");
+  VectorMaker inputVectorMaker(inputPool.get());
+  auto elementVector = inputVectorMaker.flatVectorNullable<std::string>({
+      "banana",
+      std::nullopt,
+      "apple",
+      "kiwi fruit with enough characters",
+      "grape",
+  });
+
+  auto arrayVector = makeArrayVector({0}, elementVector);
+  auto result = evaluate("array_sort(c0)", makeRowVector({arrayVector}));
+
+  auto expected = makeNullableArrayVector<std::string>({
+      {"apple",
+       "banana",
+       "grape",
+       "kiwi fruit with enough characters",
+       std::nullopt},
+  });
+  assertEqualVectors(expected, result);
+
+  auto resultElements = result->asUnchecked<ArrayVector>()
+                            ->elements()
+                            ->asFlatVector<StringView>();
+  ASSERT_TRUE(resultElements->stringStats().has_value());
+}
+
 // Test arrays with dictionary-encoded elements of complex type.
 TEST_P(ArraySortTest, encodedElements) {
   // Base vector: [0, 10, 20, 30, 40, 50].


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->

`array_sort` can fail in DCHECK-enabled builds when sorting `VARCHAR` arrays
with null elements after the copied result elements vector has
`StringViewStats`.

The failure is reproducible with:

```bash
_build/Debug/bolt/functions/prestosql/tests/bolt_functions_test \
  --gtest_filter=ArraySortTest.varcharElementsWithStringStats
```

The key error is:

```text
Exception: BoltRuntimeError
Error Code: INVALID_STATE
Expression: !stringStats_.has_value()
Context: Top-level Expression: array_sort(c0)
Function: setNoCopy
Mutating FlatVector with StringViewStats set. StringViewStats may become stale.
```

The scalar `array_sort` path sorts a copied flat elements vector in place. While
moving nulls to the end, it moves an existing non-null `StringView` into a null
slot. The old code used `FlatVector<StringView>::setNoCopy()` for this move,
which trips the stats guard above.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR changes the `StringView` branch of `swapWithNull()` to use
`setNoCopyUnsafe()` for the null-position move.

This keeps the existing zero-copy behavior and avoids the generic
`setNoCopy()` DCHECK, which is too broad for a move inside the same flat result
vector.

Regression coverage is added in
`ArraySortTest.varcharElementsWithStringStats`. The test builds a `VARCHAR`
array with a null element, forces `StringViewStats` to be materialized on the
copied result elements, and verifies the sorted output.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: The fix keeps the existing zero-copy move and does not add
  allocation, copying, or extra sorting work.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Release Note:

```text
Release Note:
- Fixed a DCHECK-enabled `array_sort` failure for VARCHAR arrays with nulls and StringViewStats.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
