### PR TITLE
metrics(sparksql) : add some spark shuffle read metrics

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -402,6 +402,7 @@ std::unique_ptr<InMemoryPayload> BoltColumnarBatchDeserializer::drainSaved() {
 
   auto payload = std::make_unique<InMemoryPayload>(
       0, isValidityBuffer_, std::move(arrowBuffers));
+
   for (auto& savedPayload : savedPayloads_.payloads) {
     auto result = InMemoryPayload::merge(
         std::move(payload),

--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -389,6 +389,7 @@ std::unique_ptr<InMemoryPayload> BoltColumnarBatchDeserializer::drainSaved() {
       bufferSizes[i] += payload->bufferSizeAt(i);
     }
   }
+  NanosecondTimer timer(&mergeTime_);
   std::vector<std::shared_ptr<arrow::Buffer>> arrowBuffers;
   for (int i = 0; i < numBuffers; ++i) {
     auto buffer = arrow::AllocateResizableBuffer(bufferSizes[i], memoryPool_);
@@ -401,7 +402,6 @@ std::unique_ptr<InMemoryPayload> BoltColumnarBatchDeserializer::drainSaved() {
 
   auto payload = std::make_unique<InMemoryPayload>(
       0, isValidityBuffer_, std::move(arrowBuffers));
-  NanosecondTimer timer(&mergeTime_);
   for (auto& savedPayload : savedPayloads_.payloads) {
     auto result = InMemoryPayload::merge(
         std::move(payload),

--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -401,7 +401,7 @@ std::unique_ptr<InMemoryPayload> BoltColumnarBatchDeserializer::drainSaved() {
 
   auto payload = std::make_unique<InMemoryPayload>(
       0, isValidityBuffer_, std::move(arrowBuffers));
-
+  NanosecondTimer timer(&mergeTime_);
   for (auto& savedPayload : savedPayloads_.payloads) {
     auto result = InMemoryPayload::merge(
         std::move(payload),
@@ -430,6 +430,7 @@ BoltColumnarBatchDeserializer::BoltColumnarBatchDeserializer(
     bool hasComplexType,
     uint64_t& deserializeTime,
     uint64_t& decompressTime,
+    uint64_t& mergeTime,
     bool isRowFormat,
     AdaptiveParallelZstdCodec* zstdCodec,
     RowBufferPool* rowBufferPool,
@@ -445,6 +446,7 @@ BoltColumnarBatchDeserializer::BoltColumnarBatchDeserializer(
       hasComplexType_(hasComplexType),
       deserializeTime_(deserializeTime),
       decompressTime_(decompressTime),
+      mergeTime_(mergeTime),
       isRowFormat_(isRowFormat),
       zstdCodec_(zstdCodec),
       rowBufferPool_(rowBufferPool),
@@ -782,6 +784,7 @@ BoltColumnarBatchDeserializerFactory::createDeserializer(
       hasComplexType_,
       deserializeTime_,
       decompressTime_,
+      mergeTime_,
       isRowBased,
       zstdCodec_.get(),
       rowBufferPool_.get(),
@@ -798,6 +801,10 @@ int64_t BoltColumnarBatchDeserializerFactory::getDecompressTime() {
 
 int64_t BoltColumnarBatchDeserializerFactory::getDeserializeTime() {
   return deserializeTime_;
+}
+
+int64_t BoltColumnarBatchDeserializerFactory::getMergeTime() {
+  return mergeTime_;
 }
 
 void BoltColumnarBatchDeserializerFactory::initFromSchema() {

--- a/bolt/shuffle/sparksql/BoltShuffleReader.h
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.h
@@ -202,6 +202,7 @@ class BoltColumnarBatchDeserializer {
       bool hasComplexType,
       uint64_t& deserializeTime,
       uint64_t& decompressTime,
+      uint64_t& mergeTime,
       bool isRowFormat = false,
       AdaptiveParallelZstdCodec* zstdCodec = nullptr,
       RowBufferPool* rowBufferPool = nullptr,
@@ -228,6 +229,7 @@ class BoltColumnarBatchDeserializer {
 
   uint64_t& deserializeTime_;
   uint64_t& decompressTime_;
+  uint64_t& mergeTime_;
 
   struct SavedPayload {
     uint64_t size{0};
@@ -278,6 +280,8 @@ class BoltColumnarBatchDeserializerFactory {
   int64_t getDecompressTime();
 
   int64_t getDeserializeTime();
+
+  int64_t getMergeTime();
 
   void setNumPartitions(int32_t numPartitions) {
     numPartitions_ = numPartitions;
@@ -331,6 +335,7 @@ class BoltColumnarBatchDeserializerFactory {
 
   uint64_t deserializeTime_{0};
   uint64_t decompressTime_{0};
+  uint64_t mergeTime_{0};
 
   void initFromSchema();
   // for rowbased shuffle
@@ -370,6 +375,10 @@ class BoltShuffleReader {
 
   int64_t getDeserializeTime() const {
     return factory_->getDeserializeTime();
+  }
+
+  int64_t getMergeTime() const {
+    return factory_->getMergeTime();
   }
 
   arrow::MemoryPool* getPool() const {

--- a/bolt/shuffle/sparksql/CelebornReaderStreamIterator.cpp
+++ b/bolt/shuffle/sparksql/CelebornReaderStreamIterator.cpp
@@ -153,12 +153,18 @@ void CelebornReaderStreamIterator::updateMetrics(
     int64_t numBatches,
     int64_t decompressTime,
     int64_t deserializeTime,
+    int64_t deserializerCreateTime,
+    int64_t deserializerDestroyTime,
+    int64_t mergeTime,
     int64_t totalReadTime) {
   // TODO: align Celeborn read metrics reporting with Gluten implementation.
   (void)numRows;
   (void)numBatches;
   (void)decompressTime;
   (void)deserializeTime;
+  (void)deserializerCreateTime;
+  (void)deserializerDestroyTime;
+  (void)mergeTime;
   (void)totalReadTime;
 }
 

--- a/bolt/shuffle/sparksql/CelebornReaderStreamIterator.h
+++ b/bolt/shuffle/sparksql/CelebornReaderStreamIterator.h
@@ -48,6 +48,9 @@ class CelebornReaderStreamIterator : public ReaderStreamIterator {
       int64_t numBatches,
       int64_t decompressTime,
       int64_t deserializeTime,
+      int64_t deserializerCreateTime,
+      int64_t deserializerDestroyTime,
+      int64_t mergeTime,
       int64_t totalReadTime) override;
 
  private:

--- a/bolt/shuffle/sparksql/ReaderStreamIterator.h
+++ b/bolt/shuffle/sparksql/ReaderStreamIterator.h
@@ -47,6 +47,9 @@ class ReaderStreamIterator {
       int64_t numBatches,
       int64_t decompressTime,
       int64_t deserializeTime,
+      int64_t deserializerCreateTime,
+      int64_t deserializerDestroyTime,
+      int64_t mergeTime,
       int64_t totalReadTime) = 0;
 };
 

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "bolt/shuffle/sparksql/ShuffleReaderNode.h"
+#include "bolt/common/base/RuntimeMetrics.h"
+#include "bolt/common/time/Timer.h"
 #include "bolt/shuffle/sparksql/compression/Compression.h"
 using namespace bytedance::bolt::shuffle::sparksql;
 
@@ -94,6 +96,7 @@ void SparkShuffleReader::init() {
 }
 
 bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
+  NanosecondTimer timerRead(&totalReadTime_);
   std::call_once(initFlag_, &SparkShuffleReader::init, this);
   if (finished_) {
     return nullptr;
@@ -103,6 +106,7 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
     // Reuse a single BufferedInputStream by chaining all reader streams into
     // one continuous stream behind a single deserializer.
     if (!columnarBatchDeserializer_) {
+      NanosecondTimer timer(&deserializerCreateTime_);
       auto chainedStream = std::make_shared<ChainedReaderStream>(
           readerStreamIterator_, arrowPool_.get());
       columnarBatchDeserializer_ =
@@ -120,6 +124,7 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
               hasComplexType_,
               deserializeTime_,
               decompressTime_,
+              mergeTime_,
               isRowBased_,
               zstdCodec_.get(),
               rowBufferPool_.get(),
@@ -139,6 +144,7 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
     if (!columnarBatchDeserializer_) {
       auto in = readerStreamIterator_->nextStream(arrowPool_.get());
       if (in) {
+        NanosecondTimer timer(&deserializerCreateTime_);
         columnarBatchDeserializer_ =
             std::make_unique<BoltColumnarBatchDeserializer>(
                 std::move(in),
@@ -154,6 +160,7 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
                 hasComplexType_,
                 deserializeTime_,
                 decompressTime_,
+                mergeTime_,
                 isRowBased_,
                 zstdCodec_.get(),
                 rowBufferPool_.get(),
@@ -168,19 +175,33 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
     if (output) {
       return output;
     } else {
+      NanosecondTimer timer(&deserializerDestroyTime_);
       columnarBatchDeserializer_ = nullptr;
     }
   }
 }
 
 void SparkShuffleReader::close() {
-  auto stats = this->stats().rlock();
-  readerStreamIterator_->updateMetrics(
-      stats->outputPositions,
-      stats->outputVectors,
-      decompressTime_,
-      deserializeTime_,
-      stats->getOutputTiming.wallNanos);
+  // Account for the destroy overhead of the last deserializer that is still
+  // alive (e.g. the single reused deserializer in the reuse path).
+  if (columnarBatchDeserializer_) {
+    NanosecondTimer timer(&deserializerDestroyTime_);
+    columnarBatchDeserializer_ = nullptr;
+  }
+
+  {
+    auto stats = this->stats().rlock();
+    readerStreamIterator_->updateMetrics(
+        stats->outputPositions,
+        stats->outputVectors,
+        decompressTime_,
+        deserializeTime_,
+        deserializerCreateTime_,
+        deserializerDestroyTime_,
+        mergeTime_,
+        totalReadTime_);
+  }
+
   if (readerStreamIterator_) {
     readerStreamIterator_->close();
     readerStreamIterator_ = nullptr;

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "bolt/shuffle/sparksql/ShuffleReaderNode.h"
-#include "bolt/common/base/RuntimeMetrics.h"
 #include "bolt/common/time/Timer.h"
 #include "bolt/shuffle/sparksql/compression/Compression.h"
 using namespace bytedance::bolt::shuffle::sparksql;

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.h
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.h
@@ -130,6 +130,13 @@ class SparkShuffleReader : public bytedance::bolt::exec::SourceOperator {
 
   uint64_t deserializeTime_{0};
   uint64_t decompressTime_{0};
+  uint64_t mergeTime_{0};
+
+  // Metrics for BoltColumnarBatchDeserializer create/destroy overhead.
+  uint64_t deserializerCreateTime_{0};
+  uint64_t deserializerDestroyTime_{0};
+
+  uint64_t totalReadTime_{0};
 
   // for rowbased shuffle
   std::shared_ptr<AdaptiveParallelZstdCodec> zstdCodec_{nullptr};

--- a/bolt/shuffle/sparksql/tests/CelebornClientTest.cpp
+++ b/bolt/shuffle/sparksql/tests/CelebornClientTest.cpp
@@ -405,7 +405,7 @@ TEST(CelebornReaderStreamIteratorTest, appendsMultiplePushesPerMap) {
 TEST(CelebornReaderStreamIteratorTest, updateMetricsNoop) {
   auto client = std::make_shared<FakeShuffleClient>();
   CelebornReaderStreamIterator iterator(client, 1, {1}, 0, 0, 0, false);
-  EXPECT_NO_THROW(iterator.updateMetrics(0, 0, 0, 0, 0));
+  EXPECT_NO_THROW(iterator.updateMetrics(0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 TEST(CelebornE2ESmokeTest, nativeClientPushAndReadBack) {

--- a/bolt/shuffle/sparksql/tests/LocalFileReaderStreamIterator.h
+++ b/bolt/shuffle/sparksql/tests/LocalFileReaderStreamIterator.h
@@ -66,6 +66,9 @@ class LocalFileReaderStreamIterator : public ReaderStreamIterator {
       int64_t numBatches,
       int64_t decompressTime,
       int64_t deserializeTime,
+      int64_t deserializerCreateTime,
+      int64_t deserializerDestroyTime,
+      int64_t mergeTime,
       int64_t totalReadTime) override {
     // no-op for test
   }

--- a/bolt/shuffle/sparksql/tests/MemoryReaderStreamIterator.h
+++ b/bolt/shuffle/sparksql/tests/MemoryReaderStreamIterator.h
@@ -49,6 +49,9 @@ class MemoryReaderStreamIterator : public ReaderStreamIterator {
       int64_t numBatches,
       int64_t decompressTime,
       int64_t deserializeTime,
+      int64_t deserializerCreateTime,
+      int64_t deserializerDestroyTime,
+      int64_t mergeTime,
       int64_t totalReadTime) override {}
 
  private:


### PR DESCRIPTION
### What problem does this PR solve?


### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

add mergeTime、deserializerCreateTime and deserializerDestroyTime for spark shuffle read.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
