### PR TITLE
fix(parquet): make created_by parseable by parquet-mr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,7 @@ find_package(roaring REQUIRED)
 
 include_directories(${CMAKE_SOURCE_DIR})
 include_directories(${CMAKE_SOURCE_DIR}/bolt)
+include_directories(${CMAKE_BINARY_DIR}/gen_cpp)
 
 if(NOT BOLT_DISABLE_GOOGLETEST)
   find_package(GTest CONFIG REQUIRED)

--- a/bolt/dwio/parquet/arrow/Properties.h
+++ b/bolt/dwio/parquet/arrow/Properties.h
@@ -47,14 +47,21 @@
 #include "bolt/dwio/parquet/arrow/Schema.h"
 #include "bolt/dwio/parquet/arrow/Types.h"
 #include "bolt/dwio/parquet/arrow/util/Compression.h"
+#include "bolt/version/version.h"
 
-// Define the parquet created by version.
+// Define the parquet created_by value. Keep this compatible with parquet-mr's
+// VersionParser because Java readers use it to validate binary statistics.
 
 #ifdef CREATED_BY_VERSION
 #undef CREATED_BY_VERSION
 #endif
 
-#define CREATED_BY_VERSION "parquet-cpp-bolt"
+#ifndef BOLT_PARQUET_CREATED_BY_VERSION
+#define BOLT_PARQUET_CREATED_BY_VERSION "1.0.0"
+#endif
+
+#define CREATED_BY_VERSION \
+  "parquet-cpp-bolt version " BOLT_PARQUET_CREATED_BY_VERSION
 namespace bytedance::bolt::parquet::arrow {
 
 using bytedance::bolt::parquet::arrow::util::CodecOptions;
@@ -239,7 +246,10 @@ static constexpr int64_t DEFAULT_MAX_ROW_GROUP_LENGTH = 1024 * 1024;
 static constexpr bool DEFAULT_ARE_STATISTICS_ENABLED = true;
 static constexpr int64_t DEFAULT_MAX_STATISTICS_SIZE = 4096;
 static constexpr Encoding::type DEFAULT_ENCODING = Encoding::UNKNOWN;
-static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
+static const std::string CREATED_BY_BUILD =
+    std::string(" (build ") + ::bytedance::bolt::BuildInfo::shortHash + ")";
+static const std::string DEFAULT_CREATED_BY =
+    std::string(CREATED_BY_VERSION) + CREATED_BY_BUILD;
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE =
     Compression::UNCOMPRESSED;
 static constexpr bool DEFAULT_IS_PAGE_INDEX_ENABLED = false;

--- a/bolt/dwio/parquet/arrow/tests/MetadataTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/MetadataTest.cpp
@@ -621,6 +621,18 @@ TEST(ApplicationVersion, Basics) {
       Type::BYTE_ARRAY, stats_int, SortOrder::UNSIGNED));
 }
 
+TEST(ApplicationVersion, DefaultCreatedBy) {
+  ApplicationVersion version(DEFAULT_CREATED_BY);
+
+  ASSERT_EQ(
+      std::string("parquet-cpp-bolt version ") +
+          BOLT_PARQUET_CREATED_BY_VERSION + " (build " +
+          ::bytedance::bolt::BuildInfo::shortHash + ")",
+      DEFAULT_CREATED_BY);
+  ASSERT_EQ("parquet-cpp-bolt", version.application_);
+  ASSERT_EQ(::bytedance::bolt::BuildInfo::shortHash, version.build_);
+}
+
 TEST(ApplicationVersion, Empty) {
   ApplicationVersion version("");
 

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -41,10 +41,12 @@
 #include "bolt/dwio/common/tests/utils/BatchMaker.h"
 #include "bolt/dwio/parquet/RegisterParquetWriter.h"
 #include "bolt/dwio/parquet/arrow/Encoding.h"
+#include "bolt/dwio/parquet/arrow/tests/FileReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 #include "bolt/type/fbhive/HiveTypeParser.h"
 #include "bolt/vector/BaseVector.h"
 #include "bolt/vector/arrow/Bridge.h"
+#include "bolt/version/version.h"
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::common;
 using namespace bytedance::bolt::dwio::common;
@@ -285,6 +287,34 @@ TEST_F(ParquetWriterTest, compression) {
   auto rowReader = createRowReaderWithSchema(std::move(reader), schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 };
+
+TEST_F(ParquetWriterTest, defaultCreatedBy) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  const int64_t kRows = 10;
+  const auto data = makeRowVector(
+      {makeFlatVector<int32_t>(kRows, [](auto row) { return row; })});
+
+  std::string parquetPath = tempPath_->path + "/defaultCreatedBy.parquet";
+  vp::WriterOptions writerOptions{};
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  auto fileReader =
+      bytedance::bolt::parquet::arrow::ParquetFileReader::OpenFile(
+          parquetPath, false);
+  const auto& createdBy = fileReader->metadata()->created_by();
+
+  ASSERT_EQ(
+      std::string("parquet-cpp-bolt version ") +
+          BOLT_PARQUET_CREATED_BY_VERSION + " (build " +
+          ::bytedance::bolt::BuildInfo::shortHash + ")",
+      createdBy);
+
+  bytedance::bolt::parquet::arrow::ApplicationVersion version(createdBy);
+  EXPECT_EQ("parquet-cpp-bolt", version.application_);
+  EXPECT_EQ(::bytedance::bolt::BuildInfo::shortHash, version.build_);
+}
 
 TEST_F(ParquetWriterTest, lz4Hadoop) {
   const int64_t kRows = 10'000'000;


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #728

Bolt currently writes Parquet metadata with `created_by = parquet-cpp-bolt`.

parquet-mr's `VersionParser` expects the writer metadata to include a `version` section. Java readers such as Apache Paimon/Flink fail to parse the current value and log:

```text
Ignoring statistics because created_by could not be parsed (see PARQUET-251): parquet-cpp-bolt
```

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR changes the default Parquet `created_by` value from:

```text
parquet-cpp-bolt
```

to a parquet-mr compatible format:

```text
parquet-cpp-bolt version 1.0.0 (build <short_hash>)
```

Changes included:

- Add `BOLT_PARQUET_CREATED_BY_VERSION`, defaulting to `1.0.0`.
- Include Bolt build metadata in the default Parquet `created_by` string.
- Add a regression test for parsing the default `created_by` value.
- Add the generated header directory to CMake include paths so `bolt/version/version.h` is available to targets including the public Parquet properties header.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed Bolt Parquet `created_by` metadata so parquet-mr based Java readers can parse it and keep statistics enabled.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
