### PR TITLE
bugfix: check thread name when async threads begin to work

### DIFF
--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -480,6 +480,7 @@ class AsyncThreadCtx {
       if (ctx_) {
         if (!isAsyncPreloadThread() || !ctx_->in(bytes_)) { // be in order
           ctx_ = nullptr;
+          bytes_ = 0;
         }
       }
     }

--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -405,9 +405,7 @@ class IndexSource {
 class AsyncThreadCtx {
  public:
   explicit AsyncThreadCtx(int64_t memLimit, bool adaptive)
-      : preloadBytesLimit_(memLimit), adaptive_(adaptive) {
-    BOLT_CHECK_GT(preloadBytesLimit_, 0);
-  }
+      : preloadBytesLimit_(memLimit), adaptive_(adaptive) {}
 
   enum class State { kActive, kClosed };
 
@@ -468,7 +466,7 @@ class AsyncThreadCtx {
   }
 
   bool allowPreload() {
-    if (adaptive_ && allowPreload_.load()) {
+    if (adaptive_ && allowPreload_.load() && preloadBytesLimit_ > 0) {
       std::scoped_lock lock(mutex_);
       return inPreloadingBytes_ < preloadBytesLimit_;
     }

--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -478,7 +478,7 @@ class AsyncThreadCtx {
     explicit Guard(AsyncThreadCtx* ctx, int64_t bytes = 0)
         : ctx_(ctx), bytes_(bytes) {
       if (ctx_) {
-        if (!ctx_->in(bytes_) || !isAsyncPreloadThread()) {
+        if (!isAsyncPreloadThread() || !ctx_->in(bytes_)) { // be in order
           ctx_ = nullptr;
         }
       }

--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -480,7 +480,7 @@ class AsyncThreadCtx {
     explicit Guard(AsyncThreadCtx* ctx, int64_t bytes = 0)
         : ctx_(ctx), bytes_(bytes) {
       if (ctx_) {
-        if (!ctx_->in(bytes_)) {
+        if (!ctx_->in(bytes_) || !isAsyncPreloadThread()) {
           ctx_ = nullptr;
         }
       }


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

thread name may not be set sucessfully, so should check it before doing work.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
