### PR TITLE
perf(build): parallelize aggregate compilation and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,6 +642,27 @@ find_package(date REQUIRED)
 
 include(CTest) # include after project() but before add_subdirectory()
 
+function(bolt_add_sharded_gtest TEST_TARGET NUM_SHARDS)
+  math(EXPR LAST_SHARD "${NUM_SHARDS} - 1")
+  foreach(SHARD_INDEX RANGE ${LAST_SHARD})
+    set(TEST_NAME "${TEST_TARGET}_shard_${SHARD_INDEX}")
+    add_test(
+      NAME ${TEST_NAME}
+      COMMAND ${TEST_TARGET}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_tests_properties(
+      ${TEST_NAME}
+      PROPERTIES COST 1
+                 ENVIRONMENT
+                 "GTEST_TOTAL_SHARDS=${NUM_SHARDS};GTEST_SHARD_INDEX=${SHARD_INDEX}"
+    )
+    if(ARGC GREATER 2)
+      set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT ${ARGV2})
+    endif()
+  endforeach()
+endfunction()
+
 # Adding this down here prevents warnings in dependencies from stopping the build
 if("${TREAT_WARNINGS_AS_ERRORS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/bolt/common/memory/tests/SharedArbitratorTest.cpp
+++ b/bolt/common/memory/tests/SharedArbitratorTest.cpp
@@ -292,10 +292,11 @@ class SharedArbitrationTest : public testing::WithParamInterface<TestParam>,
 
   void setupMemory(
       int64_t memoryCapacity = 0,
-      uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity) {
+      uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
+      uint64_t maxArbitrationTimeMs = 5 * 60 * 1'000) {
     memoryCapacity = (memoryCapacity != 0) ? memoryCapacity : kMemoryCapacity;
-    memoryManager_ =
-        createMemoryManager(memoryCapacity, memoryPoolInitCapacity);
+    memoryManager_ = createMemoryManager(
+        memoryCapacity, memoryPoolInitCapacity, maxArbitrationTimeMs);
     ASSERT_EQ(memoryManager_->arbitrator()->kind(), "SHARED");
     arbitrator_ = static_cast<SharedArbitrator*>(memoryManager_->arbitrator());
   }
@@ -1308,7 +1309,7 @@ TEST_P(
     SCOPED_TRACE(testData.debugString());
     const auto totalCapacity = testData.totalCapacity;
     const auto queryCapacity = testData.queryCapacity;
-    setupMemory(totalCapacity);
+    setupMemory(totalCapacity, kMemoryPoolInitCapacity, 10'000);
 
     std::mutex mutex;
     std::vector<std::shared_ptr<core::QueryCtx>> queries;

--- a/bolt/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/reader/CMakeLists.txt
@@ -52,7 +52,7 @@ add_executable(bolt_parquet_filter_test
   ParquetRowGroupFilterTest.cpp
 )
 
-add_test(bolt_parquet_filter_test bolt_parquet_filter_test)
+bolt_add_sharded_gtest(bolt_parquet_filter_test 4)
 target_link_libraries(
   bolt_parquet_filter_test
   bolt_e2e_filter_test_base

--- a/bolt/exec/tests/CMakeLists.txt
+++ b/bolt/exec/tests/CMakeLists.txt
@@ -69,7 +69,6 @@ add_executable(
   MergeTest.cpp
   MergerTest.cpp
   MorselDrivenTest.cpp
-  MultiFragmentTest.cpp
   OneWayStatusFlagTest.cpp
   OperatorTraceTest.cpp
   OrderByTest.cpp
@@ -86,8 +85,6 @@ add_executable(
   SortAndWindowTest.cpp
   SortBufferTest.cpp
   SortWindowTest.cpp
-  SpillableWindowTest.cpp
-  SpillerTest.cpp
   SpillOperatorGroupTest.cpp
   SpillTest.cpp
   SplitToStringTest.cpp
@@ -111,6 +108,12 @@ if(KERNEL_SUPPORTS_IO_URING)
 endif()
 
 add_executable(bolt_exec_aggregation_test AggregationTest.cpp Main.cpp)
+
+add_executable(bolt_exec_spiller_test Main.cpp SpillerTest.cpp)
+
+add_executable(
+  bolt_exec_multifragment_window_test Main.cpp MultiFragmentTest.cpp SpillableWindowTest.cpp
+)
 
 add_executable(
   bolt_exec_hash_join_test HashBitRangeTest.cpp HashJoinBridgeTest.cpp HashJoinTest.cpp
@@ -145,6 +148,7 @@ add_test(
   COMMAND bolt_exec_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+set_tests_properties(bolt_exec_test PROPERTIES COST 1 TIMEOUT 3000)
 
 add_test(
   NAME row_based_spill_test
@@ -158,9 +162,8 @@ if(KERNEL_SUPPORTS_IO_URING)
     COMMAND iouring_spill_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
+  set_tests_properties(iouring_spill_test PROPERTIES COST 1)
 endif()
-
-set_tests_properties(bolt_exec_test PROPERTIES TIMEOUT 3000)
 
 add_test(
   NAME bolt_exec_infra_test
@@ -175,16 +178,24 @@ add_test(
 )
 
 add_test(
-  NAME bolt_exec_hash_join_test
-  COMMAND bolt_exec_hash_join_test
+  NAME bolt_exec_spiller_test
+  COMMAND bolt_exec_spiller_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+set_tests_properties(bolt_exec_spiller_test PROPERTIES COST 1 TIMEOUT 3000)
 
 add_test(
-  NAME bolt_exec_scan_test
-  COMMAND bolt_exec_scan_test
+  NAME bolt_exec_multifragment_window_test
+  COMMAND bolt_exec_multifragment_window_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+set_tests_properties(
+  bolt_exec_multifragment_window_test PROPERTIES COST 1 TIMEOUT 3000
+)
+
+bolt_add_sharded_gtest(bolt_exec_hash_join_test 5)
+
+bolt_add_sharded_gtest(bolt_exec_scan_test 4)
 
 add_test(
   NAME bolt_exec_merge_join_test
@@ -220,6 +231,12 @@ target_link_libraries(
 target_link_libraries(row_based_spill_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
 
 target_link_libraries(bolt_exec_aggregation_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+
+target_link_libraries(bolt_exec_spiller_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+
+target_link_libraries(
+  bolt_exec_multifragment_window_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
 
 target_link_libraries(bolt_exec_hash_join_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
 

--- a/bolt/exec/tests/HashJoinTest.cpp
+++ b/bolt/exec/tests/HashJoinTest.cpp
@@ -1141,11 +1141,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbeWithSpillMemoryThreshold) {
       .run();
 }
 
-TEST_P(MultiThreadedHashJoinTest, emptyProbeWithReclaimWatermark) {
-  if (numDrivers_ != 1) {
-    GTEST_SKIP() << "Covers single-driver finishHashBuild admission path only";
-  }
-
+TEST_F(HashJoinTest, emptyProbeWithReclaimWatermark) {
   std::atomic<bool> injectOnce{true};
   SCOPED_TESTVALUE_SET(
       "bytedance::bolt::exec::HashBuild::finishHashBuild",
@@ -1161,7 +1157,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbeWithReclaimWatermark) {
   auto queryPool = memory::memoryManager()->addRootPool(
       "", 8 << 20, memory::MemoryReclaimer::create());
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-      .numDrivers(numDrivers_)
+      .numDrivers(1)
       .keyTypes({BIGINT()})
       .probeVectors(0, 5)
       .buildVectors(1500, 5)
@@ -1271,7 +1267,7 @@ TEST_P(MultiThreadedHashJoinTest, normalizedKey) {
       .run();
 }
 
-TEST_P(MultiThreadedHashJoinTest, normalizedKeyOverflow) {
+TEST_F(HashJoinTest, normalizedKeyOverflow) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .keyTypes({BIGINT(), VARCHAR(), BIGINT(), BIGINT(), BIGINT(), BIGINT()})
       .probeVectors(1600, 5)
@@ -1341,7 +1337,7 @@ DEBUG_ONLY_TEST_P(
       "Aborted for external error");
 }
 
-TEST_P(MultiThreadedHashJoinTest, allTypes) {
+TEST_F(HashJoinTest, allTypes) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .keyTypes(
           {BIGINT(),
@@ -1944,7 +1940,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
   }
 }
 
-TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
+TEST_F(HashJoinTest, semiFilterOverLazyVectors) {
   auto probeVectors = makeBatches(1, [&](auto /*unused*/) {
     return makeRowVector(
         {"t0", "t1"},
@@ -3414,7 +3410,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithNoMatch) {
       .run();
 }
 
-TEST_P(MultiThreadedHashJoinTest, fullJoinWithNoMatchRangePartition) {
+TEST_F(HashJoinTest, fullJoinWithNoMatchRangePartition) {
   // Left side keys are [0, 1, 2,..10].
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(

--- a/bolt/exec/tests/MultiFragmentTest.cpp
+++ b/bolt/exec/tests/MultiFragmentTest.cpp
@@ -1999,7 +1999,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
 }
 
 TEST_F(MultiFragmentTest, taskTerminateWithProblematicRemainingRemoteSplits) {
-  // Start the task with 2 drivers.
+  // Start the task with one driver.
   auto probeData =
       makeRowVector({"p_c0"}, {makeFlatVector<int64_t>({1, 2, 3})});
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -2019,32 +2019,66 @@ TEST_F(MultiFragmentTest, taskTerminateWithProblematicRemainingRemoteSplits) {
                   .planNode();
   auto taskId = makeTaskId("final", 0);
   auto task = makeTask(taskId, plan, 0);
-  task->start(2);
 
-  // Wait for all drivers to be blocked, so that the promises will be made.
-  bool allDriversBlocked = false;
-  while (!allDriversBlocked) {
-    allDriversBlocked = true;
-    task->testingVisitDrivers([&](Driver* driver) {
-      if (driver->isOnThread() ||
-          (driver->blockingReason() != BlockingReason::kWaitForSplit &&
-           driver->blockingReason() != BlockingReason::kWaitForProducer &&
-           driver->blockingReason() != BlockingReason::kWaitForJoinBuild)) {
-        allDriversBlocked = false;
-      }
-    });
+  struct BadSplitFactoryState {
+    std::atomic_bool firstSplitEntered{false};
+    std::atomic_bool releaseFirstSplit{false};
+    std::atomic_int secondSplitAttempts{0};
+    folly::EventCount firstSplitBarrier;
+  };
+
+  const auto firstBadTaskId = makeBadTaskId("leaf", 0);
+  const auto secondBadTaskId = makeBadTaskId("leaf", 1);
+  auto factoryState = std::make_shared<BadSplitFactoryState>();
+  auto& exchangeSourceFactories = ExchangeSource::factories();
+  exchangeSourceFactories.insert(
+      exchangeSourceFactories.begin(),
+      [factoryState, firstBadTaskId, secondBadTaskId](
+          const std::string& remoteTaskId,
+          int /*destination*/,
+          std::shared_ptr<ExchangeQueue> /*queue*/,
+          memory::MemoryPool* /*pool*/) -> std::shared_ptr<ExchangeSource> {
+        if (remoteTaskId == firstBadTaskId) {
+          factoryState->firstSplitEntered = true;
+          factoryState->firstSplitBarrier.notifyAll();
+          factoryState->firstSplitBarrier.await(
+              [&]() { return factoryState->releaseFirstSplit.load(); });
+          throw std::runtime_error("Testing error");
+        }
+        if (remoteTaskId == secondBadTaskId) {
+          ++factoryState->secondSplitAttempts;
+          throw std::runtime_error("Testing error");
+        }
+        return nullptr;
+      });
+  auto cleanup = folly::makeGuard([&]() {
+    factoryState->releaseFirstSplit = true;
+    factoryState->firstSplitBarrier.notifyAll();
+    task->requestAbort().wait();
+    exchangeSourceFactories.erase(exchangeSourceFactories.begin());
+  });
+  task->start(1);
+
+  // Block the only driver while it creates the first bad ExchangeSource.
+  task->addSplit(exchangeNodeId, remoteSplit(firstBadTaskId));
+  const auto waitDeadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (!factoryState->firstSplitEntered.load() &&
+         std::chrono::steady_clock::now() < waitDeadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+  ASSERT_TRUE(factoryState->firstSplitEntered.load());
 
-  // Add one bad remote split and trigger Task::terminate.
-  task->addSplit(exchangeNodeId, remoteSplit(makeBadTaskId("leaf", 0)));
-
-  // Add one more bad split, making sure `remainingRemoteSplits` is not empty
-  // and processing it would cause an exception.
-  task->addSplit(exchangeNodeId, remoteSplit(makeBadTaskId("leaf", 1)));
+  // With the only driver blocked, this split remains queued and must be
+  // processed by Task::terminate after the first factory attempt fails.
+  task->addSplit(exchangeNodeId, remoteSplit(secondBadTaskId));
+  factoryState->releaseFirstSplit = true;
+  factoryState->firstSplitBarrier.notifyAll();
 
   // Wait for the task to fail, and make sure the task has been deleted instead
   // of hanging as a zombie task.
   ASSERT_TRUE(waitForTaskFailure(task.get(), 30'000'000)) << task->taskId();
+  EXPECT_EQ(factoryState->secondSplitAttempts.load(), 1);
 }
 
 TEST_F(

--- a/bolt/functions/prestosql/aggregates/CMakeLists.txt
+++ b/bolt/functions/prestosql/aggregates/CMakeLists.txt
@@ -28,26 +28,38 @@
 set(APAGG_TYPES "int8_t" "int16_t" "int32_t" "int64_t" "float" "double")
 specialize_template(APAGG_GENERATED_FILES ApproxPercentileAggregate.cpp.in ${APAGG_TYPES})
 
-set(MIN_MAX_BY_TYPES
+set(MIN_MAX_BY_VALUE_TYPES
     "bool"
     "int8_t"
     "int16_t"
     "int32_t"
     "int64_t"
+    "int128_t"
     "float"
     "double"
     "StringView"
     "Timestamp"
     "ComplexType"
 )
-specialize_template(MAX_BY_NARG_GENERATED_FILES MaxByAggregatesNArg.cpp.in ${MIN_MAX_BY_TYPES})
-specialize_template(MIN_BY_NARG_GENERATED_FILES MinByAggregatesNArg.cpp.in ${MIN_MAX_BY_TYPES})
+set(MIN_MAX_BY_NARG_VALUE_TYPES ${MIN_MAX_BY_VALUE_TYPES})
+list(REMOVE_ITEM MIN_MAX_BY_NARG_VALUE_TYPES "int128_t")
+specialize_template(
+  MAX_BY_NARG_GENERATED_FILES MaxByAggregatesNArg.cpp.in ${MIN_MAX_BY_NARG_VALUE_TYPES}
+)
+specialize_template(
+  MIN_BY_NARG_GENERATED_FILES MinByAggregatesNArg.cpp.in ${MIN_MAX_BY_NARG_VALUE_TYPES}
+)
+
+specialize_template(
+  MIN_MAX_BY_FACTORY_GENERATED_FILES MinMaxByAggregate.cpp.in ${MIN_MAX_BY_VALUE_TYPES}
+)
 
 bolt_add_library(
   bolt_aggregates
   ${APAGG_GENERATED_FILES}
   ${MAX_BY_NARG_GENERATED_FILES}
   ${MIN_BY_NARG_GENERATED_FILES}
+  ${MIN_MAX_BY_FACTORY_GENERATED_FILES}
   ApproxDistinctAggregate.cpp
   ApproxMostFrequentAggregate.cpp
   ApproxPercentileAggregate.cpp

--- a/bolt/functions/prestosql/aggregates/MinByAggregatesNArg.cpp.in
+++ b/bolt/functions/prestosql/aggregates/MinByAggregatesNArg.cpp.in
@@ -15,6 +15,7 @@
  */
 
 #include "bolt/functions/prestosql/aggregates/MinMaxByAggregates.h"
+
 namespace bytedance::bolt::aggregate::prestosql {
 template std::unique_ptr<exec::Aggregate>
 createNArg<MinByNAggregate, @type@>(TypePtr, TypePtr, const std::string&);

--- a/bolt/functions/prestosql/aggregates/MinMaxByAggregate.cpp.in
+++ b/bolt/functions/prestosql/aggregates/MinMaxByAggregate.cpp.in
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h"
+
+namespace bytedance::bolt::aggregate::prestosql::detail {
+
+template <bool IsMaxFunc, typename ValueType>
+std::unique_ptr<exec::Aggregate>
+MinMaxByAggregateFactory<IsMaxFunc, ValueType>::create(
+    TypePtr resultType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  return functions::aggregate::create<
+      functions::aggregate::MinMaxByAggregateBase,
+      IsMaxFunc,
+      Comparator,
+      ValueType>(resultType, compareType, errorMessage, true);
+}
+
+template struct MinMaxByAggregateFactory<true, @type@>;
+template struct MinMaxByAggregateFactory<false, @type@>;
+
+} // namespace bytedance::bolt::aggregate::prestosql::detail

--- a/bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h
+++ b/bolt/functions/prestosql/aggregates/MinMaxByAggregateRegistration.h
@@ -33,6 +33,97 @@ inline std::string toString(const std::vector<TypePtr>& types) {
   return out.str();
 }
 
+template <bool IsMaxFunc, typename V>
+struct MinMaxByAggregateFactory {
+  static std::unique_ptr<exec::Aggregate> create(
+      TypePtr resultType,
+      TypePtr compareType,
+      const std::string& errorMessage);
+};
+
+extern template struct MinMaxByAggregateFactory<true, bool>;
+extern template struct MinMaxByAggregateFactory<true, int8_t>;
+extern template struct MinMaxByAggregateFactory<true, int16_t>;
+extern template struct MinMaxByAggregateFactory<true, int32_t>;
+extern template struct MinMaxByAggregateFactory<true, int64_t>;
+extern template struct MinMaxByAggregateFactory<true, int128_t>;
+extern template struct MinMaxByAggregateFactory<true, float>;
+extern template struct MinMaxByAggregateFactory<true, double>;
+extern template struct MinMaxByAggregateFactory<true, StringView>;
+extern template struct MinMaxByAggregateFactory<true, Timestamp>;
+extern template struct MinMaxByAggregateFactory<true, ComplexType>;
+extern template struct MinMaxByAggregateFactory<false, bool>;
+extern template struct MinMaxByAggregateFactory<false, int8_t>;
+extern template struct MinMaxByAggregateFactory<false, int16_t>;
+extern template struct MinMaxByAggregateFactory<false, int32_t>;
+extern template struct MinMaxByAggregateFactory<false, int64_t>;
+extern template struct MinMaxByAggregateFactory<false, int128_t>;
+extern template struct MinMaxByAggregateFactory<false, float>;
+extern template struct MinMaxByAggregateFactory<false, double>;
+extern template struct MinMaxByAggregateFactory<false, StringView>;
+extern template struct MinMaxByAggregateFactory<false, Timestamp>;
+extern template struct MinMaxByAggregateFactory<false, ComplexType>;
+
+template <bool IsMaxFunc, typename V>
+std::unique_ptr<exec::Aggregate> createMinMaxByAggregateForValueType(
+    TypePtr resultType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  return MinMaxByAggregateFactory<IsMaxFunc, V>::create(
+      resultType, compareType, errorMessage);
+}
+
+template <bool IsMaxFunc>
+std::unique_ptr<exec::Aggregate> createMinMaxByAggregate(
+    TypePtr resultType,
+    TypePtr valueType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  switch (valueType->kind()) {
+    case TypeKind::BOOLEAN:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, bool>(
+          resultType, compareType, errorMessage);
+    case TypeKind::TINYINT:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, int8_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::SMALLINT:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, int16_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::INTEGER:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, int32_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::BIGINT:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, int64_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::HUGEINT:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, int128_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::REAL:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, float>(
+          resultType, compareType, errorMessage);
+    case TypeKind::DOUBLE:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, double>(
+          resultType, compareType, errorMessage);
+    case TypeKind::VARCHAR:
+      [[fallthrough]];
+    case TypeKind::VARBINARY:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, StringView>(
+          resultType, compareType, errorMessage);
+    case TypeKind::TIMESTAMP:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, Timestamp>(
+          resultType, compareType, errorMessage);
+    case TypeKind::ARRAY:
+      [[fallthrough]];
+    case TypeKind::MAP:
+      [[fallthrough]];
+    case TypeKind::ROW:
+      return createMinMaxByAggregateForValueType<IsMaxFunc, ComplexType>(
+          resultType, compareType, errorMessage);
+    default:
+      BOLT_FAIL(errorMessage);
+  }
+}
+
 template <
     template <
         typename U,
@@ -100,8 +191,8 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
           return createNArg<NAggregate>(
               resultType, argTypes[0], argTypes[1], errorMessage);
         }
-        return functions::aggregate::create<Aggregate, Comparator, IsMaxFunc>(
-            resultType, argTypes[0], argTypes[1], errorMessage, true);
+        return createMinMaxByAggregate<IsMaxFunc>(
+            resultType, argTypes[0], argTypes[1], errorMessage);
       });
 }
 

--- a/bolt/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/bolt/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(AGGREGATES_TEST_SRC
     Main.cpp
     MapAccumulatorTest.cpp
     MapSumAggregateTest.cpp
+    MinMaxByAggregationTest.cpp
     MinMaxTest.cpp
     MultiMapAggTest.cpp
     PrestoHasherTest.cpp
@@ -75,19 +76,7 @@ endif()
 
 add_executable(bolt_aggregates_test ${AGGREGATES_TEST_SRC})
 
-add_executable(bolt_minmaxby_aggregates_test Main.cpp MinMaxByAggregationTest.cpp)
-
-add_test(
-  NAME bolt_aggregates_test
-  COMMAND bolt_aggregates_test
-  WORKING_DIRECTORY .
-)
-
-add_test(
-  NAME bolt_minmaxby_aggregates_test
-  COMMAND bolt_minmaxby_aggregates_test
-  WORKING_DIRECTORY .
-)
+bolt_add_sharded_gtest(bolt_aggregates_test 6)
 
 set(BOLT_AGGREGATES_TEST_DEPENDENCIES
     bolt_aggregates
@@ -112,5 +101,3 @@ set(BOLT_AGGREGATES_TEST_DEPENDENCIES
 )
 
 target_link_libraries(bolt_aggregates_test ${BOLT_AGGREGATES_TEST_DEPENDENCIES})
-
-target_link_libraries(bolt_minmaxby_aggregates_test ${BOLT_AGGREGATES_TEST_DEPENDENCIES})

--- a/bolt/functions/sparksql/aggregates/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/CMakeLists.txt
@@ -37,9 +37,42 @@ set(PAAGG_TYPES
 )
 specialize_template(PAAGG_GENERATED_FILES PercentileApproxAggregate.cpp.in ${PAAGG_TYPES})
 
+set(PERCENTILE_TYPES
+    "TypeKind::TINYINT"
+    "TypeKind::SMALLINT"
+    "TypeKind::INTEGER"
+    "TypeKind::BIGINT"
+    "TypeKind::HUGEINT"
+    "TypeKind::REAL"
+    "TypeKind::DOUBLE"
+    "TypeKind::VARCHAR"
+)
+specialize_template(
+  PERCENTILE_GENERATED_FILES PercentileAggregate.cpp.in ${PERCENTILE_TYPES}
+)
+
+set(MIN_MAX_BY_TYPES
+    "bool"
+    "int8_t"
+    "int16_t"
+    "int32_t"
+    "int64_t"
+    "int128_t"
+    "float"
+    "double"
+    "StringView"
+    "Timestamp"
+    "ComplexType"
+)
+specialize_template(
+  MIN_MAX_BY_GENERATED_FILES MinMaxByAggregate.cpp.in ${MIN_MAX_BY_TYPES}
+)
+
 bolt_add_library(
   bolt_functions_spark_aggregates
   ${PAAGG_GENERATED_FILES}
+  ${PERCENTILE_GENERATED_FILES}
+  ${MIN_MAX_BY_GENERATED_FILES}
   AverageAggregate.cpp
   BitwiseXorAggregate.cpp
   BloomFilterAggAggregate.cpp
@@ -50,6 +83,7 @@ bolt_add_library(
   MinMaxByAggregate.cpp
   ModeAggregate.cpp
   PercentileApproxAggregate.cpp
+  PercentileAggregate.cpp
   Register.cpp
   RegrReplacementAggregate.cpp
   SumAggregate.cpp

--- a/bolt/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -28,57 +28,12 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/functions/lib/aggregates/MinMaxByAggregatesBase.h"
+#include "bolt/functions/sparksql/aggregates/MinMaxByAggregateInternal.h"
+
 using namespace bytedance::bolt::functions::aggregate;
 namespace bytedance::bolt::functions::aggregate::sparksql {
 
 namespace {
-
-/// Returns compare result align with Spark's specific behavior,
-/// which returns true if the value in 'index' row of 'newComparisons' is
-/// greater than/equal or less than/equal the value in the 'accumulator'.
-template <bool sparkGreaterThan, typename T, typename TAccumulator>
-struct SparkComparator {
-  static bool compare(
-      TAccumulator* accumulator,
-      const DecodedVector& newComparisons,
-      vector_size_t index,
-      bool isFirstValue) {
-    if constexpr (isNumeric<T>()) {
-      if (isFirstValue) {
-        return true;
-      }
-      if constexpr (sparkGreaterThan) {
-        return SimpleVector<T>::comparePrimitiveAsc(
-                   newComparisons.valueAt<T>(index), *accumulator) >= 0;
-      } else {
-        return SimpleVector<T>::comparePrimitiveAsc(
-                   newComparisons.valueAt<T>(index), *accumulator) <= 0;
-      }
-    } else {
-      if constexpr (sparkGreaterThan) {
-        return !accumulator->hasValue() ||
-            compare(accumulator, newComparisons, index) <= 0;
-      } else {
-        return !accumulator->hasValue() ||
-            compare(accumulator, newComparisons, index) >= 0;
-      }
-    }
-  }
-
-  FOLLY_ALWAYS_INLINE static int32_t compare(
-      const SingleValueAccumulator* accumulator,
-      const DecodedVector& decoded,
-      vector_size_t index) {
-    static const CompareFlags kCompareFlags{
-        true, // nullsFirst
-        true, // ascending
-        false, // equalsOnly
-        CompareFlags::NullHandlingMode::kNullAsValue};
-    auto result = accumulator->compare(decoded, index, kCompareFlags);
-    return result.value();
-  }
-};
 
 std::string toString(const std::vector<TypePtr>& types) {
   std::ostringstream out;
@@ -91,15 +46,7 @@ std::string toString(const std::vector<TypePtr>& types) {
   return out.str();
 }
 
-template <
-    template <
-        typename U,
-        typename V,
-        bool B1,
-        template <bool B2, typename C1, typename C2>
-        class C>
-    class Aggregate,
-    bool isMaxFunc>
+template <bool isMaxFunc>
 exec::AggregateRegistrationResult registerMinMaxBy(
     const std::string& name,
     bool withCompanionFunctions,
@@ -133,14 +80,14 @@ exec::AggregateRegistrationResult registerMinMaxBy(
 
         if (isRawInput) {
           // Input is: V, C.
-          return create<Aggregate, SparkComparator, isMaxFunc>(
+          return createMinMaxByAggregate<isMaxFunc>(
               resultType, argTypes[0], argTypes[1], errorMessage);
         } else {
           // Input is: ROW(V, C).
           const auto& rowType = argTypes[0];
           const auto& valueType = rowType->childAt(0);
           const auto& compareType = rowType->childAt(1);
-          return create<Aggregate, SparkComparator, isMaxFunc>(
+          return createMinMaxByAggregate<isMaxFunc>(
               resultType, valueType, compareType, errorMessage);
         }
       },
@@ -154,10 +101,8 @@ void registerMinMaxByAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerMinMaxBy<MinMaxByAggregateBase, true>(
-      prefix + "max_by", withCompanionFunctions, overwrite);
-  registerMinMaxBy<MinMaxByAggregateBase, false>(
-      prefix + "min_by", withCompanionFunctions, overwrite);
+  registerMinMaxBy<true>(prefix + "max_by", withCompanionFunctions, overwrite);
+  registerMinMaxBy<false>(prefix + "min_by", withCompanionFunctions, overwrite);
 }
 
 } // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/MinMaxByAggregate.cpp.in
+++ b/bolt/functions/sparksql/aggregates/MinMaxByAggregate.cpp.in
@@ -14,19 +14,30 @@
  * limitations under the License.
  */
 
-#include "bolt/functions/sparksql/aggregates/PercentileApproxAggregate.h"
+#include "bolt/functions/sparksql/aggregates/MinMaxByAggregateInternal.h"
 
 namespace bytedance::bolt::functions::aggregate::sparksql {
 
-template <typename T>
+template <typename ValueType>
 std::unique_ptr<exec::Aggregate>
-PercentileApproxAggregateFactory<T>::create(
-    bool hasAccuracy,
-    const TypePtr& resultType) {
-  return std::make_unique<PercentileApproxAggregate<T>>(
-      hasAccuracy, resultType);
+MinMaxByAggregateFactory<ValueType>::createMax(
+    TypePtr resultType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  return create<MinMaxByAggregateBase, true, SparkComparator, ValueType>(
+      resultType, compareType, errorMessage);
 }
 
-template struct PercentileApproxAggregateFactory<@type@>;
+template <typename ValueType>
+std::unique_ptr<exec::Aggregate>
+MinMaxByAggregateFactory<ValueType>::createMin(
+    TypePtr resultType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  return create<MinMaxByAggregateBase, false, SparkComparator, ValueType>(
+      resultType, compareType, errorMessage);
+}
+
+template struct MinMaxByAggregateFactory<@type@>;
 
 } // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/MinMaxByAggregateInternal.h
+++ b/bolt/functions/sparksql/aggregates/MinMaxByAggregateInternal.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/functions/lib/aggregates/MinMaxByAggregatesBase.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+/// Returns compare result align with Spark's specific behavior,
+/// which returns true if the value in 'index' row of 'newComparisons' is
+/// greater than/equal or less than/equal the value in the 'accumulator'.
+template <bool sparkGreaterThan, typename T, typename TAccumulator>
+struct SparkComparator {
+  static bool compare(
+      TAccumulator* accumulator,
+      const DecodedVector& newComparisons,
+      vector_size_t index,
+      bool isFirstValue) {
+    if constexpr (isNumeric<T>()) {
+      if (isFirstValue) {
+        return true;
+      }
+      if constexpr (sparkGreaterThan) {
+        return SimpleVector<T>::comparePrimitiveAsc(
+                   newComparisons.valueAt<T>(index), *accumulator) >= 0;
+      } else {
+        return SimpleVector<T>::comparePrimitiveAsc(
+                   newComparisons.valueAt<T>(index), *accumulator) <= 0;
+      }
+    } else {
+      if constexpr (sparkGreaterThan) {
+        return !accumulator->hasValue() ||
+            compare(accumulator, newComparisons, index) <= 0;
+      } else {
+        return !accumulator->hasValue() ||
+            compare(accumulator, newComparisons, index) >= 0;
+      }
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE static int32_t compare(
+      const SingleValueAccumulator* accumulator,
+      const DecodedVector& decoded,
+      vector_size_t index) {
+    static const CompareFlags kCompareFlags{
+        true, // nullsFirst
+        true, // ascending
+        false, // equalsOnly
+        CompareFlags::NullHandlingMode::kNullAsValue};
+    auto result = accumulator->compare(decoded, index, kCompareFlags);
+    return result.value();
+  }
+};
+
+template <typename ValueType>
+struct MinMaxByAggregateFactory {
+  static std::unique_ptr<exec::Aggregate> createMax(
+      TypePtr resultType,
+      TypePtr compareType,
+      const std::string& errorMessage);
+
+  static std::unique_ptr<exec::Aggregate> createMin(
+      TypePtr resultType,
+      TypePtr compareType,
+      const std::string& errorMessage);
+};
+
+extern template struct MinMaxByAggregateFactory<bool>;
+extern template struct MinMaxByAggregateFactory<int8_t>;
+extern template struct MinMaxByAggregateFactory<int16_t>;
+extern template struct MinMaxByAggregateFactory<int32_t>;
+extern template struct MinMaxByAggregateFactory<int64_t>;
+extern template struct MinMaxByAggregateFactory<int128_t>;
+extern template struct MinMaxByAggregateFactory<float>;
+extern template struct MinMaxByAggregateFactory<double>;
+extern template struct MinMaxByAggregateFactory<StringView>;
+extern template struct MinMaxByAggregateFactory<Timestamp>;
+extern template struct MinMaxByAggregateFactory<ComplexType>;
+
+template <typename ValueType, bool isMaxFunc>
+std::unique_ptr<exec::Aggregate> createMinMaxByAggregateForValueType(
+    TypePtr resultType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  if constexpr (isMaxFunc) {
+    return MinMaxByAggregateFactory<ValueType>::createMax(
+        resultType, compareType, errorMessage);
+  } else {
+    return MinMaxByAggregateFactory<ValueType>::createMin(
+        resultType, compareType, errorMessage);
+  }
+}
+
+template <bool isMaxFunc>
+std::unique_ptr<exec::Aggregate> createMinMaxByAggregate(
+    TypePtr resultType,
+    TypePtr valueType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  switch (valueType->kind()) {
+    case TypeKind::BOOLEAN:
+      return createMinMaxByAggregateForValueType<bool, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::TINYINT:
+      return createMinMaxByAggregateForValueType<int8_t, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::SMALLINT:
+      return createMinMaxByAggregateForValueType<int16_t, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::INTEGER:
+      return createMinMaxByAggregateForValueType<int32_t, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::BIGINT:
+      return createMinMaxByAggregateForValueType<int64_t, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::HUGEINT:
+      return createMinMaxByAggregateForValueType<int128_t, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::REAL:
+      return createMinMaxByAggregateForValueType<float, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::DOUBLE:
+      return createMinMaxByAggregateForValueType<double, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::VARCHAR:
+      [[fallthrough]];
+    case TypeKind::VARBINARY:
+      return createMinMaxByAggregateForValueType<StringView, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::TIMESTAMP:
+      return createMinMaxByAggregateForValueType<Timestamp, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    case TypeKind::ARRAY:
+      [[fallthrough]];
+    case TypeKind::MAP:
+      [[fallthrough]];
+    case TypeKind::ROW:
+      return createMinMaxByAggregateForValueType<ComplexType, isMaxFunc>(
+          resultType, compareType, errorMessage);
+    default:
+      BOLT_FAIL(errorMessage);
+  }
+}
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/PercentileAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/PercentileAggregate.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/sparksql/aggregates/PercentileAggregate.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+namespace {
+
+bool validPercentileType(const Type& type) {
+  if (type.kind() == TypeKind::DOUBLE) {
+    return true;
+  }
+  if (type.kind() != TypeKind::ARRAY) {
+    return false;
+  }
+  return type.as<TypeKind::ARRAY>().elementType()->kind() == TypeKind::DOUBLE;
+}
+
+void addDecimalSignatures(
+    std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
+        signatures) {
+  auto intermediateType =
+      "row(array(double), boolean, array(DECIMAL(a_precision, a_scale)), array(bigint))";
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .integerVariable("a_precision")
+                           .integerVariable("a_scale")
+                           .returnType("double")
+                           .intermediateType(intermediateType)
+                           .argumentType("DECIMAL(a_precision, a_scale)")
+                           .argumentType("double")
+                           .build());
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .integerVariable("a_precision")
+                           .integerVariable("a_scale")
+                           .returnType("array(double)")
+                           .intermediateType(intermediateType)
+                           .argumentType("DECIMAL(a_precision, a_scale)")
+                           .argumentType("array(double)")
+                           .build());
+  for (const auto& weightType : {"tinyint", "smallint", "integer", "bigint"}) {
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("double")
+                             .intermediateType(intermediateType)
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType("double")
+                             .argumentType(weightType)
+                             .build());
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("array(double)")
+                             .intermediateType(intermediateType)
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType("array(double)")
+                             .argumentType(weightType)
+                             .build());
+  }
+}
+
+void addSignatures(
+    const std::string& inputType,
+    const std::string& percentileType,
+    const std::string& returnType,
+    std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
+        signatures) {
+  auto intermediateType = fmt::format(
+      "row(array(double), boolean, array({0}), array(bigint))", inputType);
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType(returnType)
+                           .intermediateType(intermediateType)
+                           .argumentType(inputType)
+                           .argumentType(percentileType)
+                           .build());
+  for (const auto& weightType : {"tinyint", "smallint", "integer", "bigint"}) {
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .returnType(returnType)
+                             .intermediateType(intermediateType)
+                             .argumentType(inputType)
+                             .argumentType(percentileType)
+                             .argumentType(weightType)
+                             .build());
+  }
+}
+
+exec::AggregateRegistrationResult registerPercentile(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  for (const auto& inputType :
+       {"tinyint",
+        "smallint",
+        "integer",
+        "bigint",
+        "hugeint",
+        "real",
+        "double",
+        "varchar"}) {
+    addSignatures(inputType, "double", "double", signatures);
+    addSignatures(inputType, "array(double)", "array(double)", signatures);
+  }
+  addDecimalSignatures(signatures);
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig&
+          /*config*/) -> std::unique_ptr<exec::Aggregate> {
+        auto isRawInput = exec::isRawInput(step);
+        TypeKind weightType = TypeKind::BIGINT;
+        auto hasWeight = argTypes.size() >= 3;
+
+        if (isRawInput) {
+          BOLT_USER_CHECK_EQ(
+              argTypes.size(),
+              2 + hasWeight,
+              "Wrong number of arguments passed to {}",
+              name);
+          if (hasWeight) {
+            if (argTypes[2]->kind() != TypeKind::BIGINT &&
+                argTypes[2]->kind() != TypeKind::INTEGER &&
+                argTypes[2]->kind() != TypeKind::SMALLINT &&
+                argTypes[2]->kind() != TypeKind::TINYINT) {
+              BOLT_USER_FAIL(
+                  "The type of the weight argument of {} must be integer type",
+                  name);
+            }
+            weightType = argTypes[2]->kind();
+          }
+          BOLT_USER_CHECK(
+              validPercentileType(*argTypes[1]),
+              "The type of the percentile argument of {} must be DOUBLE or ARRAY(DOUBLE)",
+              name);
+        } else {
+          BOLT_USER_CHECK_EQ(
+              argTypes.size(),
+              1,
+              "The type of partial result for {} must be ROW",
+              name);
+        }
+
+        TypePtr type;
+        if (isRawInput) {
+          type = argTypes[0];
+        } else {
+          type = argTypes[0]->asRow().childAt(detail::kItems);
+          type = type->as<TypeKind::ARRAY>().elementType();
+        }
+
+        int scale = 0;
+        if (type->isLongDecimal() || type->isShortDecimal()) {
+          scale = getDecimalPrecisionScale(*type).second;
+        }
+        auto powerOfScale = DecimalUtil::kPowersOfTen[scale];
+
+        switch (type->kind()) {
+          case TypeKind::TINYINT:
+            return detail::PercentileAggregateFactory<TypeKind::TINYINT>::
+                create(weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::SMALLINT:
+            return detail::PercentileAggregateFactory<TypeKind::SMALLINT>::
+                create(weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::INTEGER:
+            return detail::PercentileAggregateFactory<TypeKind::INTEGER>::
+                create(weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::BIGINT:
+            return detail::PercentileAggregateFactory<TypeKind::BIGINT>::create(
+                weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::HUGEINT:
+            return detail::PercentileAggregateFactory<TypeKind::HUGEINT>::
+                create(weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::REAL:
+            return detail::PercentileAggregateFactory<TypeKind::REAL>::create(
+                weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::DOUBLE:
+            return detail::PercentileAggregateFactory<TypeKind::DOUBLE>::create(
+                weightType, hasWeight, resultType, powerOfScale);
+          case TypeKind::VARCHAR:
+            return detail::PercentileAggregateFactory<TypeKind::VARCHAR>::
+                create(weightType, hasWeight, resultType, powerOfScale);
+          default:
+            BOLT_USER_FAIL(
+                "Unsupported input type for percentile aggregation {}",
+                type->toString());
+        }
+      },
+      /*registerCompanionFunctions*/ true);
+}
+
+} // namespace
+
+void registerPercentileAggregate(const std::string& prefix) {
+  registerPercentile(prefix + "percentile");
+}
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/PercentileAggregate.cpp.in
+++ b/bolt/functions/sparksql/aggregates/PercentileAggregate.cpp.in
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-#include "bolt/functions/prestosql/aggregates/MinMaxByAggregates.h"
+#include "bolt/functions/sparksql/aggregates/PercentileAggregate.h"
 
-namespace bytedance::bolt::aggregate::prestosql {
-template std::unique_ptr<exec::Aggregate>
-createNArg<MaxByNAggregate, @type@>(TypePtr, TypePtr, const std::string&);
-} // namespace bytedance::bolt::aggregate::prestosql
+namespace bytedance::bolt::functions::aggregate::sparksql::detail {
+
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> PercentileAggregateFactory<Kind>::create(
+    const TypeKind& weightType,
+    bool hasWeight,
+    const TypePtr& resultType,
+    int128_t powerOfScale) {
+  return getPercentileFuncPtr<Kind>(
+      weightType, hasWeight, resultType, powerOfScale);
+}
+
+template struct PercentileAggregateFactory<@type@>;
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql::detail

--- a/bolt/functions/sparksql/aggregates/PercentileAggregate.h
+++ b/bolt/functions/sparksql/aggregates/PercentileAggregate.h
@@ -35,7 +35,7 @@
 #include "bolt/vector/VectorEncoding.h"
 namespace bytedance::bolt::functions::aggregate::sparksql {
 
-namespace {
+namespace detail {
 
 template <typename T>
 struct custom_equal_to {
@@ -957,84 +957,6 @@ class PercentileAggregate : public exec::Aggregate {
   }
 };
 
-bool validPercentileType(const Type& type) {
-  if (type.kind() == TypeKind::DOUBLE) {
-    return true;
-  }
-  if (type.kind() != TypeKind::ARRAY) {
-    return false;
-  }
-  return type.as<TypeKind::ARRAY>().elementType()->kind() == TypeKind::DOUBLE;
-}
-
-void addDecimalSignatures(
-    std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
-        signatures) {
-  auto intermediateType =
-      "row(array(double), boolean, array(DECIMAL(a_precision, a_scale)), array(bigint))";
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .integerVariable("a_precision")
-                           .integerVariable("a_scale")
-                           .returnType("double")
-                           .intermediateType(intermediateType)
-                           .argumentType("DECIMAL(a_precision, a_scale)")
-                           .argumentType("double")
-                           .build());
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .integerVariable("a_precision")
-                           .integerVariable("a_scale")
-                           .returnType("array(double)")
-                           .intermediateType(intermediateType)
-                           .argumentType("DECIMAL(a_precision, a_scale)")
-                           .argumentType("array(double)")
-                           .build());
-  for (const auto& weightType : {"tinyint", "smallint", "integer", "bigint"}) {
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .integerVariable("a_precision")
-                             .integerVariable("a_scale")
-                             .returnType("double")
-                             .intermediateType(intermediateType)
-                             .argumentType("DECIMAL(a_precision, a_scale)")
-                             .argumentType("double")
-                             .argumentType(weightType)
-                             .build());
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .integerVariable("a_precision")
-                             .integerVariable("a_scale")
-                             .returnType("array(double)")
-                             .intermediateType(intermediateType)
-                             .argumentType("DECIMAL(a_precision, a_scale)")
-                             .argumentType("array(double)")
-                             .argumentType(weightType)
-                             .build());
-  }
-}
-
-void addSignatures(
-    const std::string& inputType,
-    const std::string& percentileType,
-    const std::string& returnType,
-    std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
-        signatures) {
-  auto intermediateType = fmt::format(
-      "row(array(double), boolean, array({0}), array(bigint))", inputType);
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .returnType(returnType)
-                           .intermediateType(intermediateType)
-                           .argumentType(inputType)
-                           .argumentType(percentileType)
-                           .build());
-  for (const auto& weightType : {"tinyint", "smallint", "integer", "bigint"}) {
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .returnType(returnType)
-                             .intermediateType(intermediateType)
-                             .argumentType(inputType)
-                             .argumentType(percentileType)
-                             .argumentType(weightType)
-                             .build());
-  }
-}
-
 template <TypeKind Kind>
 std::unique_ptr<exec::Aggregate> getPercentileFuncPtr(
     const TypeKind& weightType,
@@ -1064,115 +986,26 @@ std::unique_ptr<exec::Aggregate> getPercentileFuncPtr(
   }
 }
 
-exec::AggregateRegistrationResult registerPercentile(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  for (const auto& inputType :
-       {"tinyint",
-        "smallint",
-        "integer",
-        "bigint",
-        "hugeint",
-        "real",
-        "double",
-        "varchar"}) {
-    addSignatures(inputType, "double", "double", signatures);
-    addSignatures(inputType, "array(double)", "array(double)", signatures);
-  }
-  addDecimalSignatures(signatures);
-  return exec::registerAggregateFunction(
-      name,
-      std::move(signatures),
-      [name](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig&
-          /*config*/) -> std::unique_ptr<exec::Aggregate> {
-        auto isRawInput = exec::isRawInput(step);
-        TypeKind weightType = TypeKind::BIGINT;
-        auto hasWeight = argTypes.size() >= 3;
+template <TypeKind Kind>
+struct PercentileAggregateFactory {
+  static std::unique_ptr<exec::Aggregate> create(
+      const TypeKind& weightType,
+      bool hasWeight,
+      const TypePtr& resultType,
+      int128_t powerOfScale);
+};
 
-        if (isRawInput) {
-          BOLT_USER_CHECK_EQ(
-              argTypes.size(),
-              2 + hasWeight,
-              "Wrong number of arguments passed to {}",
-              name);
-          if (hasWeight) {
-            if (argTypes[2]->kind() != TypeKind::BIGINT &&
-                argTypes[2]->kind() != TypeKind::INTEGER &&
-                argTypes[2]->kind() != TypeKind::SMALLINT &&
-                argTypes[2]->kind() != TypeKind::TINYINT) {
-              BOLT_USER_FAIL(
-                  "The type of the weight argument of {} must be integer type",
-                  name);
-            }
-            weightType = argTypes[2]->kind();
-          }
-          BOLT_USER_CHECK(
-              validPercentileType(*argTypes[1]),
-              "The type of the percentile argument of {} must be DOUBLE or ARRAY(DOUBLE)",
-              name);
-        } else {
-          BOLT_USER_CHECK_EQ(
-              argTypes.size(),
-              1,
-              "The type of partial result for {} must be ROW",
-              name);
-        }
+extern template struct PercentileAggregateFactory<TypeKind::TINYINT>;
+extern template struct PercentileAggregateFactory<TypeKind::SMALLINT>;
+extern template struct PercentileAggregateFactory<TypeKind::INTEGER>;
+extern template struct PercentileAggregateFactory<TypeKind::BIGINT>;
+extern template struct PercentileAggregateFactory<TypeKind::HUGEINT>;
+extern template struct PercentileAggregateFactory<TypeKind::REAL>;
+extern template struct PercentileAggregateFactory<TypeKind::DOUBLE>;
+extern template struct PercentileAggregateFactory<TypeKind::VARCHAR>;
 
-        TypePtr type;
-        if (isRawInput) {
-          type = argTypes[0];
-        } else {
-          type = argTypes[0]->asRow().childAt(kItems);
-          type = type->as<TypeKind::ARRAY>().elementType();
-        }
+} // namespace detail
 
-        int scale = 0;
-        if (type->isLongDecimal() || type->isShortDecimal()) {
-          scale = getDecimalPrecisionScale(*type).second;
-        }
-        auto powerOfScale = DecimalUtil::kPowersOfTen[scale];
-
-        switch (type->kind()) {
-          case TypeKind::TINYINT:
-            return getPercentileFuncPtr<TypeKind::TINYINT>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::SMALLINT:
-            return getPercentileFuncPtr<TypeKind::SMALLINT>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::INTEGER:
-            return getPercentileFuncPtr<TypeKind::INTEGER>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::BIGINT:
-            return getPercentileFuncPtr<TypeKind::BIGINT>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::HUGEINT:
-            return getPercentileFuncPtr<TypeKind::HUGEINT>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::REAL:
-            return getPercentileFuncPtr<TypeKind::REAL>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::DOUBLE:
-            return getPercentileFuncPtr<TypeKind::DOUBLE>(
-                weightType, hasWeight, resultType, powerOfScale);
-          case TypeKind::VARCHAR:
-            return getPercentileFuncPtr<TypeKind::VARCHAR>(
-                weightType, hasWeight, resultType, powerOfScale);
-          default:
-            BOLT_USER_FAIL(
-                "Unsupported input type for percentile aggregation {}",
-                type->toString());
-        }
-      },
-      /*registerCompanionFunctions*/ true);
-}
-
-} // namespace
-
-void registerPercentileAggregate(const std::string& prefix) {
-  registerPercentile(prefix + "percentile");
-}
+void registerPercentileAggregate(const std::string& prefix);
 
 } // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.cpp
@@ -17,6 +17,143 @@
 #include "bolt/functions/sparksql/aggregates/PercentileApproxAggregate.h"
 namespace bytedance::bolt::functions::aggregate::sparksql {
 
+PercentileApproxAggregateBase::PercentileApproxAggregateBase(
+    bool hasAccuracy,
+    const TypePtr& resultType)
+    : exec::Aggregate(resultType), hasAccuracy_(hasAccuracy) {}
+
+void PercentileApproxAggregateBase::decodePercentileAndAccuracy(
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    size_t& argIndex) {
+  checkSetPercentile(rows, *args[argIndex++]);
+  if (hasAccuracy_) {
+    decodedAccuracy_.decode(*args[argIndex++], rows, true);
+    checkSetAccuracy();
+  }
+}
+
+void PercentileApproxAggregateBase::extractPercentiles(
+    const ArrayVector* arrays,
+    vector_size_t indexInBaseVector,
+    const double*& data,
+    vector_size_t& len,
+    std::vector<bool>& isNull) {
+  auto elements = arrays->elements()->asFlatVector<double>();
+  auto offset = arrays->offsetAt(indexInBaseVector);
+  data = elements->rawValues() + offset;
+  len = arrays->sizeAt(indexInBaseVector);
+  isNull.resize(len);
+  for (auto index = offset; index < offset + len; index++) {
+    isNull[index - offset] = elements->isNullAt(index);
+  }
+}
+
+void PercentileApproxAggregateBase::checkSetPercentile(
+    const SelectivityVector& rows,
+    const BaseVector& vec) {
+  DecodedVector decoded(vec, rows);
+  BOLT_USER_CHECK(
+      decoded.isConstantMapping(),
+      "Percentile argument must be constant for all input rows");
+  bool isArray;
+  const double* data;
+  vector_size_t len;
+  std::vector<bool> isNull;
+  auto indexInBaseVector = decoded.index(0);
+  if (decoded.base()->typeKind() == TypeKind::DOUBLE) {
+    isArray = false;
+    auto baseVector = decoded.base();
+    data = baseVector->asUnchecked<ConstantVector<double>>()->rawValues() +
+        indexInBaseVector;
+    len = 1;
+    isNull = {baseVector->isNullAt(indexInBaseVector)};
+  } else if (decoded.base()->typeKind() == TypeKind::ARRAY) {
+    isArray = true;
+    auto arrays = decoded.base()->asUnchecked<ArrayVector>();
+    BOLT_USER_CHECK(
+        arrays->elements()->isFlatEncoding(),
+        "Only flat encoding is allowed for percentile array elements");
+    extractPercentiles(arrays, indexInBaseVector, data, len, isNull);
+  } else {
+    BOLT_USER_FAIL(
+        "Incorrect type for percentile: {}", decoded.base()->typeKind());
+  }
+  checkSetPercentile(isArray, data, len, isNull);
+}
+
+void PercentileApproxAggregateBase::checkSetPercentile(
+    bool isArray,
+    const double* data,
+    vector_size_t len,
+    const std::vector<bool>& isNull) {
+  if (!percentiles_) {
+    BOLT_USER_CHECK_GT(len, 0, "Percentile cannot be empty");
+    percentiles_ = {
+        .values = std::vector<double>(len),
+        .isArray = isArray,
+    };
+    for (vector_size_t i = 0; i < len; ++i) {
+      BOLT_USER_CHECK(!isNull[i], "Percentage value must not be null");
+      BOLT_USER_CHECK(
+          data[i] >= 0.0 && data[i] <= 1.0,
+          "All percentage values must be between 0.0 and 1.0 (current = {})",
+          data[i]);
+      percentiles_->values[i] = data[i];
+    }
+  } else {
+    BOLT_USER_CHECK_EQ(
+        isArray,
+        percentiles_->isArray,
+        "The percentage provided must be a constant literal");
+    BOLT_USER_CHECK_EQ(
+        len,
+        percentiles_->values.size(),
+        "Percentile argument must be constant for all input rows");
+    for (vector_size_t i = 0; i < len; ++i) {
+      BOLT_USER_CHECK_EQ(
+          data[i],
+          percentiles_->values[i],
+          "Percentile argument must be constant for all input rows");
+    }
+  }
+}
+
+void PercentileApproxAggregateBase::checkSetAccuracy() {
+  if (!hasAccuracy_) {
+    return;
+  }
+  BOLT_USER_CHECK(
+      decodedAccuracy_.isConstantMapping(),
+      "The accuracy provided must be a constant literal");
+  TypeKind accuracyType = decodedAccuracy_.base()->type()->kind();
+  BOLT_USER_CHECK(
+      accuracyType == TypeKind::BIGINT || accuracyType == TypeKind::INTEGER,
+      "The accuracy provided must be a literal of integer or bigint (current value = {})",
+      decodedAccuracy_.base()->type()->toString());
+  if (accuracyType == TypeKind::INTEGER) {
+    checkSetAccuracy(decodedAccuracy_.valueAt<int32_t>(0));
+  } else {
+    checkSetAccuracy(decodedAccuracy_.valueAt<int64_t>(0));
+  }
+}
+
+void PercentileApproxAggregateBase::checkSetAccuracy(int64_t accuracy) {
+  BOLT_USER_CHECK(
+      accuracy > 0 && accuracy <= 2147483647,
+      "The accuracy provided must be a literal between (0, 2147483647] (current value = {})",
+      accuracy);
+  const auto checkedAccuracy = static_cast<int32_t>(accuracy);
+  if (accuracy_ == kDefaultAccuracy) {
+    accuracy_ = checkedAccuracy;
+  } else {
+    BOLT_USER_CHECK_EQ(
+        checkedAccuracy,
+        accuracy_,
+        "Accuracy argument must be constant for all input rows");
+  }
+}
+
 bool validPercentileType(const Type& type) {
   if (type.kind() == TypeKind::DOUBLE) {
     return true;
@@ -196,37 +333,34 @@ void registerPercentileApproxAggregate(
         }
         switch (type->kind()) {
           case TypeKind::TINYINT:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::TINYINT>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<
+                TypeTraits<TypeKind::TINYINT>::NativeType>::
+                create(hasAccuracy, resultType);
           case TypeKind::SMALLINT:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::SMALLINT>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<
+                TypeTraits<TypeKind::SMALLINT>::NativeType>::
+                create(hasAccuracy, resultType);
           case TypeKind::INTEGER:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::INTEGER>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<
+                TypeTraits<TypeKind::INTEGER>::NativeType>::
+                create(hasAccuracy, resultType);
           case TypeKind::BIGINT:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::BIGINT>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<TypeTraits<
+                TypeKind::BIGINT>::NativeType>::create(hasAccuracy, resultType);
           case TypeKind::HUGEINT:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::HUGEINT>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<
+                TypeTraits<TypeKind::HUGEINT>::NativeType>::
+                create(hasAccuracy, resultType);
           case TypeKind::REAL:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::REAL>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<TypeTraits<
+                TypeKind::REAL>::NativeType>::create(hasAccuracy, resultType);
           case TypeKind::DOUBLE:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::DOUBLE>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<TypeTraits<
+                TypeKind::DOUBLE>::NativeType>::create(hasAccuracy, resultType);
           case TypeKind::TIMESTAMP:
-            return std::make_unique<PercentileApproxAggregate<
-                TypeTraits<TypeKind::TIMESTAMP>::NativeType>>(
-                hasAccuracy, resultType);
+            return PercentileApproxAggregateFactory<
+                TypeTraits<TypeKind::TIMESTAMP>::NativeType>::
+                create(hasAccuracy, resultType);
           default:
             BOLT_USER_FAIL(
                 "Unsupported input type for {} aggregation {}, isRawInput: {}, setp: {}, result type: {}",

--- a/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.h
+++ b/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.h
@@ -95,11 +95,55 @@ enum IntermediateTypeChildIndex {
   kSerialized = 4,
 };
 
+class PercentileApproxAggregateBase : public exec::Aggregate {
+ public:
+  PercentileApproxAggregateBase(bool hasAccuracy, const TypePtr& resultType);
+
+ protected:
+  struct Percentiles {
+    std::vector<double> values;
+    bool isArray;
+  };
+
+  void decodePercentileAndAccuracy(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      size_t& argIndex);
+
+  static void extractPercentiles(
+      const ArrayVector* arrays,
+      vector_size_t indexInBaseVector,
+      const double*& data,
+      vector_size_t& len,
+      std::vector<bool>& isNull);
+
+  void checkSetPercentile(const SelectivityVector& rows, const BaseVector& vec);
+
+  void checkSetPercentile(
+      bool isArray,
+      const double* data,
+      vector_size_t len,
+      const std::vector<bool>& isNull);
+
+  void checkSetAccuracy();
+
+  void checkSetAccuracy(int64_t accuracy);
+
+  const bool hasAccuracy_;
+  std::optional<Percentiles> percentiles_;
+  int32_t accuracy_{kDefaultAccuracy};
+
+ private:
+  DecodedVector decodedAccuracy_;
+};
+
 template <typename T>
-class PercentileApproxAggregate : public exec::Aggregate {
+class PercentileApproxAggregate : public PercentileApproxAggregateBase {
  public:
   PercentileApproxAggregate(bool hasAccuracy, const TypePtr& resultType)
-      : exec::Aggregate(resultType), hasAccuracy_(hasAccuracy) {}
+      : PercentileApproxAggregateBase(hasAccuracy, resultType) {}
+
+  ~PercentileApproxAggregate() override = default;
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(GKAccumulator<T>);
@@ -390,134 +434,8 @@ class PercentileApproxAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args) {
     size_t argIndex = 0;
     decodedValue_.decode(*args[argIndex++], rows, true);
-    checkSetPercentile(rows, *args[argIndex++]);
-    if (hasAccuracy_) {
-      decodedAccuracy_.decode(*args[argIndex++], rows, true);
-      checkSetAccuracy();
-    }
+    decodePercentileAndAccuracy(rows, args, argIndex);
     BOLT_USER_CHECK_EQ(argIndex, args.size());
-  }
-
-  /// Extract percentile info: the raw data, the length and the null-ness from
-  /// top-level ArrayVector.
-  static void extractPercentiles(
-      const ArrayVector* arrays,
-      vector_size_t indexInBaseVector,
-      const double*& data,
-      vector_size_t& len,
-      std::vector<bool>& isNull) {
-    auto elements = arrays->elements()->asFlatVector<double>();
-    auto offset = arrays->offsetAt(indexInBaseVector);
-    data = elements->rawValues() + offset;
-    len = arrays->sizeAt(indexInBaseVector);
-    isNull.resize(len);
-    for (auto index = offset; index < offset + len; index++) {
-      isNull[index - offset] = elements->isNullAt(index);
-    }
-  }
-
-  void checkSetPercentile(
-      const SelectivityVector& rows,
-      const BaseVector& vec) {
-    DecodedVector decoded(vec, rows);
-    BOLT_USER_CHECK(
-        decoded.isConstantMapping(),
-        "Percentile argument must be constant for all input rows");
-    bool isArray;
-    const double* data;
-    vector_size_t len;
-    std::vector<bool> isNull;
-    auto indexInBaseVector = decoded.index(0);
-    if (decoded.base()->typeKind() == TypeKind::DOUBLE) {
-      isArray = false;
-      auto baseVector = decoded.base();
-      data = baseVector->asUnchecked<ConstantVector<double>>()->rawValues() +
-          indexInBaseVector;
-      len = 1;
-      isNull = {baseVector->isNullAt(indexInBaseVector)};
-    } else if (decoded.base()->typeKind() == TypeKind::ARRAY) {
-      isArray = true;
-      auto arrays = decoded.base()->asUnchecked<ArrayVector>();
-      BOLT_USER_CHECK(
-          arrays->elements()->isFlatEncoding(),
-          "Only flat encoding is allowed for percentile array elements");
-      extractPercentiles(arrays, indexInBaseVector, data, len, isNull);
-    } else {
-      BOLT_USER_FAIL(
-          "Incorrect type for percentile: {}", decoded.base()->typeKind());
-    }
-    checkSetPercentile(isArray, data, len, isNull);
-  }
-
-  void checkSetPercentile(
-      bool isArray,
-      const double* data,
-      vector_size_t len,
-      const std::vector<bool>& isNull) {
-    if (!percentiles_) {
-      BOLT_USER_CHECK_GT(len, 0, "Percentile cannot be empty");
-      percentiles_ = {
-          .values = std::vector<double>(len),
-          .isArray = isArray,
-      };
-      for (vector_size_t i = 0; i < len; ++i) {
-        BOLT_USER_CHECK(!isNull[i], "Percentage value must not be null");
-        BOLT_USER_CHECK(
-            data[i] >= 0.0 && data[i] <= 1.0,
-            "All percentage values must be between 0.0 and 1.0 (current = {})",
-            data[i]);
-        percentiles_->values[i] = data[i];
-      }
-    } else {
-      BOLT_USER_CHECK_EQ(
-          isArray,
-          percentiles_->isArray,
-          "The percentage provided must be a constant literal");
-      BOLT_USER_CHECK_EQ(
-          len,
-          percentiles_->values.size(),
-          "Percentile argument must be constant for all input rows");
-      for (vector_size_t i = 0; i < len; ++i) {
-        BOLT_USER_CHECK_EQ(
-            data[i],
-            percentiles_->values[i],
-            "Percentile argument must be constant for all input rows");
-      }
-    }
-  }
-
-  void checkSetAccuracy() {
-    if (!hasAccuracy_) {
-      return;
-    }
-    BOLT_USER_CHECK(
-        decodedAccuracy_.isConstantMapping(),
-        "The accuracy provided must be a constant literal");
-    TypeKind accuracyType = decodedAccuracy_.base()->type()->kind();
-    BOLT_USER_CHECK(
-        accuracyType == TypeKind::BIGINT || accuracyType == TypeKind::INTEGER,
-        "The accuracy provided must be a literal of integer or bigint (current value = {})",
-        decodedAccuracy_.base()->type()->toString());
-    if (accuracyType == TypeKind::INTEGER) {
-      checkSetAccuracy(decodedAccuracy_.valueAt<int32_t>(0));
-    } else {
-      checkSetAccuracy(decodedAccuracy_.valueAt<int64_t>(0));
-    }
-  }
-
-  void checkSetAccuracy(int32_t accuracy) {
-    BOLT_USER_CHECK(
-        accuracy > 0 && accuracy <= 2147483647,
-        "The accuracy provided must be a literal between (0, 2147483647] (current value = {}})",
-        accuracy);
-    if (accuracy_ == kDefaultAccuracy) {
-      accuracy_ = accuracy;
-    } else {
-      BOLT_USER_CHECK_EQ(
-          accuracy,
-          accuracy_,
-          "Accuracy argument must be constant for all input rows");
-    }
   }
 
   GKAccumulator<T>* initRawAccumulator(char* group) {
@@ -538,17 +456,7 @@ class PercentileApproxAggregate : public exec::Aggregate {
     addIntermediateImpl<kSingleGroup, false>(group, rows, args);
   }
 
-  struct Percentiles {
-    std::vector<double> values;
-    bool isArray;
-  };
-
-  const bool hasAccuracy_;
-  std::optional<Percentiles> percentiles_;
-  int32_t accuracy_{kDefaultAccuracy};
   DecodedVector decodedValue_;
-  DecodedVector decodedAccuracy_;
-  DecodedVector decodedDigest_;
 
  private:
   template <bool kSingleGroup, bool checkIntermediateInputs>
@@ -662,12 +570,20 @@ class PercentileApproxAggregate : public exec::Aggregate {
   }
 };
 
-extern template class PercentileApproxAggregate<int8_t>;
-extern template class PercentileApproxAggregate<int16_t>;
-extern template class PercentileApproxAggregate<int32_t>;
-extern template class PercentileApproxAggregate<int64_t>;
-extern template class PercentileApproxAggregate<int128_t>;
-extern template class PercentileApproxAggregate<float>;
-extern template class PercentileApproxAggregate<double>;
-extern template class PercentileApproxAggregate<Timestamp>;
+template <typename T>
+struct PercentileApproxAggregateFactory {
+  static std::unique_ptr<exec::Aggregate> create(
+      bool hasAccuracy,
+      const TypePtr& resultType);
+};
+
+extern template struct PercentileApproxAggregateFactory<int8_t>;
+extern template struct PercentileApproxAggregateFactory<int16_t>;
+extern template struct PercentileApproxAggregateFactory<int32_t>;
+extern template struct PercentileApproxAggregateFactory<int64_t>;
+extern template struct PercentileApproxAggregateFactory<int128_t>;
+extern template struct PercentileApproxAggregateFactory<float>;
+extern template struct PercentileApproxAggregateFactory<double>;
+extern template struct PercentileApproxAggregateFactory<Timestamp>;
+
 } // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/Register.cpp
+++ b/bolt/functions/sparksql/aggregates/Register.cpp
@@ -39,7 +39,6 @@
 #include "bolt/functions/sparksql/aggregates/CollectListAggregate.h"
 #include "bolt/functions/sparksql/aggregates/CovarianceAggregate.h"
 #include "bolt/functions/sparksql/aggregates/DecimalSumAggregate.h"
-#include "bolt/functions/sparksql/aggregates/PercentileAggregate.h"
 #include "bolt/functions/sparksql/aggregates/RegrReplacementAggregate.h"
 #include "bolt/functions/sparksql/aggregates/SumAggregate.h"
 namespace bytedance::bolt::aggregate::prestosql {
@@ -66,6 +65,7 @@ extern void registerModeAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
+void registerPercentileAggregate(const std::string& prefix);
 
 void registerAggregateFunctions(
     const std::string& prefix,

--- a/bolt/functions/sparksql/aggregates/tests/PercentileApproxTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/PercentileApproxTest.cpp
@@ -365,6 +365,23 @@ TEST_F(PercentileApproxTest, finalAggregateAccuracy) {
   assertQuery(op, "SELECT 4");
 }
 
+TEST_F(PercentileApproxTest, accuracyOutOfRange) {
+  constexpr int64_t kAccuracy = (1LL << 32) + 1;
+  auto rows = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeConstant<int64_t>(kAccuracy, 3),
+  });
+  auto plan = PlanBuilder()
+                  .values({rows})
+                  .singleAggregation({}, {"percentile_approx(c0, 0.5, c1)"})
+                  .planNode();
+  AssertQueryBuilder query(plan);
+  BOLT_ASSERT_THROW(
+      query.copyResults(pool()),
+      "The accuracy provided must be a literal between (0, 2147483647] "
+      "(current value = 4294967297)");
+}
+
 TEST_F(PercentileApproxTest, invalidEncoding) {
   auto indices = AlignedBuffer::allocate<vector_size_t>(3, pool());
   auto rawIndices = indices->asMutable<vector_size_t>();

--- a/bolt/jit/tests/CMakeLists.txt
+++ b/bolt/jit/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ if(${ENABLE_BOLT_JIT})
     GTest::gtest_main
     Folly::follybenchmark
   )
-  add_test(bolt_row_row_cmp_test bolt_row_row_cmp_test)
+  bolt_add_sharded_gtest(bolt_row_row_cmp_test 3)
 
   add_executable(bolt_row_vec_cmp_test
     RowEqVectorsIRTest.cpp


### PR DESCRIPTION
### What problem does this PR solve?
Split the heavy aggregate instantiations into generated per-type sources.

Shard the slow CTest targets, move the longest exec tests into separate binaries, and shorten the arbitration timeout used by the concurrent stress test.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [c] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Split the heavy aggregate instantiations into generated per-type sources.

Shard the slow CTest targets, move the longest exec tests into separate binaries, and shorten the arbitration timeout used by the concurrent stress test.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Split the heavy aggregate instantiations into generated per-type sources.

Shard the slow CTest targets, move the longest exec tests into separate binaries, and shorten the arbitration timeout used by the concurrent stress test.

Release Note:

```text
Release Note:
- Split the heavy aggregate instantiations into generated per-type sources.
- Shard the slow CTest targets, move the longest exec tests into separate binaries, and shorten the arbitration timeout used by the concurrent stress test.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
