### PR TITLE
Support bigint index for Spark get

### DIFF
--- a/bolt/functions/sparksql/ArrayGetFunction.cpp
+++ b/bolt/functions/sparksql/ArrayGetFunction.cpp
@@ -50,13 +50,16 @@ class ArrayGetFunction : public SubscriptImpl<
   explicit ArrayGetFunction() : SubscriptImpl(false) {}
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    return {// array(T), integer -> T
-            exec::FunctionSignatureBuilder()
-                .typeVariable("T")
-                .returnType("T")
-                .argumentType("array(T)")
-                .argumentType("integer")
-                .build()};
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+    for (const auto& indexType : {"integer", "bigint"}) {
+      signatures.push_back(exec::FunctionSignatureBuilder()
+                               .typeVariable("T")
+                               .returnType("T")
+                               .argumentType("array(T)")
+                               .argumentType(indexType)
+                               .build());
+    }
+    return signatures;
   }
 };
 } // namespace

--- a/bolt/functions/sparksql/tests/ArrayGetTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayGetTest.cpp
@@ -28,6 +28,7 @@
  * --------------------------------------------------------------------------
  */
 
+#include <limits>
 #include <optional>
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
@@ -48,6 +49,15 @@ class ArrayGetTest : public SparkFunctionBaseTest {
         makeRowVector({arrayVector, makeConstant(index, arrayVector->size())});
     return evaluateOnce<T>("get(c0, c1)", input);
   }
+
+  template <typename T>
+  std::optional<T> arrayGetBigint(
+      const ArrayVectorPtr& arrayVector,
+      const std::optional<int64_t>& index) {
+    auto input =
+        makeRowVector({arrayVector, makeConstant(index, arrayVector->size())});
+    return evaluateOnce<T>("get(c0, c1)", input);
+  }
 };
 
 TEST_F(ArrayGetTest, basic) {
@@ -58,6 +68,38 @@ TEST_F(ArrayGetTest, basic) {
   EXPECT_EQ(arrayGet<int32_t>(arrayVector, 2), std::nullopt);
   EXPECT_EQ(arrayGet<int32_t>(arrayVector, 3), std::nullopt);
   EXPECT_EQ(arrayGet<int32_t>(arrayVector, std::nullopt), std::nullopt);
+}
+
+TEST_F(ArrayGetTest, bigintIndex) {
+  auto arrayVector = makeNullableArrayVector<int32_t>({{1, 2, std::nullopt}});
+  EXPECT_EQ(arrayGetBigint<int32_t>(arrayVector, -1), std::nullopt);
+  EXPECT_EQ(arrayGetBigint<int32_t>(arrayVector, 0), 1);
+  EXPECT_EQ(arrayGetBigint<int32_t>(arrayVector, 1), 2);
+  EXPECT_EQ(arrayGetBigint<int32_t>(arrayVector, 2), std::nullopt);
+  EXPECT_EQ(arrayGetBigint<int32_t>(arrayVector, 3), std::nullopt);
+  EXPECT_EQ(
+      arrayGetBigint<int32_t>(
+          arrayVector, int64_t{std::numeric_limits<int32_t>::max()} + 1),
+      std::nullopt);
+  EXPECT_EQ(arrayGetBigint<int32_t>(arrayVector, std::nullopt), std::nullopt);
+}
+
+TEST_F(ArrayGetTest, bigintIndexVector) {
+  auto arrayVector = makeNullableArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+      {std::nullopt},
+      {6},
+  });
+  auto input = makeRowVector({
+      arrayVector,
+      makeFlatVector<int64_t>(
+          {0, 1, 0, int64_t{std::numeric_limits<int32_t>::max()} + 1}),
+  });
+  auto expected =
+      makeNullableFlatVector<int32_t>({1, 5, std::nullopt, std::nullopt});
+  auto result = evaluate("get(c0, c1)", input);
+  assertEqualVectors(expected, result);
 }
 } // namespace
 } // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
Support bigint index for Spark get


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
