### PR TITLE
[feat] Implement Spark char/varchar helpers

### DIFF
--- a/bolt/functions/sparksql/CharVarchar.h
+++ b/bolt/functions/sparksql/CharVarchar.h
@@ -80,7 +80,7 @@ writeSideCheck(TOutString& output, const TInString& input, int32_t limit) {
     }
 
     if (numChars - numSpacesTrimmed > limit) {
-      BOLT_USER_FAIL("Exceeds allowed length limitation: {}", limit);
+      BOLT_USER_FAIL("Exceeds char/varchar type length limitation: {}", limit);
     }
     output.setNoCopy(StringView(input.data(), static_cast<size_t>(endIdx + 1)));
   }

--- a/bolt/functions/sparksql/CharVarchar.h
+++ b/bolt/functions/sparksql/CharVarchar.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/functions/Macros.h"
+#include "bolt/functions/lib/string/StringCore.h"
+
+#include <cstring>
+
+namespace bytedance::bolt::functions::sparksql {
+namespace detail {
+
+static constexpr char kSpace = ' ';
+
+template <bool isAscii, typename TString>
+FOLLY_ALWAYS_INLINE int64_t charLength(const TString& input) {
+  if constexpr (isAscii) {
+    return input.size();
+  } else {
+    return stringCore::lengthUnicode(input.data(), input.size());
+  }
+}
+
+template <typename TOutString, typename TInString>
+FOLLY_ALWAYS_INLINE void copyWithPadding(
+    TOutString& output,
+    const TInString& input,
+    int64_t numPaddingSpaces) {
+  output.resize(input.size() + static_cast<size_t>(numPaddingSpaces));
+  if (input.size() > 0) {
+    std::memcpy(output.data(), input.data(), input.size());
+  }
+  std::memset(
+      output.data() + input.size(),
+      kSpace,
+      static_cast<size_t>(numPaddingSpaces));
+}
+
+template <
+    bool isAscii,
+    bool padIfShort,
+    typename TOutString,
+    typename TInString>
+FOLLY_ALWAYS_INLINE void
+writeSideCheck(TOutString& output, const TInString& input, int32_t limit) {
+  const auto numChars = charLength<isAscii>(input);
+  if (numChars <= limit) {
+    if constexpr (padIfShort) {
+      if (numChars < limit) {
+        copyWithPadding(output, input, limit - numChars);
+        return;
+      }
+    }
+    output.setNoCopy(StringView(input.data(), input.size()));
+  } else {
+    const auto numTailSpacesToTrim = numChars - limit;
+    auto endIdx = static_cast<int64_t>(input.size()) - 1;
+    const auto trimTo =
+        static_cast<int64_t>(input.size()) - numTailSpacesToTrim;
+    int64_t numSpacesTrimmed = 0;
+
+    while (endIdx >= trimTo && input.data()[endIdx] == kSpace) {
+      --endIdx;
+      ++numSpacesTrimmed;
+    }
+
+    if (numChars - numSpacesTrimmed > limit) {
+      BOLT_USER_FAIL("Exceeds allowed length limitation: {}", limit);
+    }
+    output.setNoCopy(StringView(input.data(), static_cast<size_t>(endIdx + 1)));
+  }
+}
+
+template <bool isAscii, typename TOutString, typename TInString>
+FOLLY_ALWAYS_INLINE void
+readSidePadding(TOutString& output, const TInString& input, int32_t limit) {
+  const auto numChars = charLength<isAscii>(input);
+  if (numChars < limit) {
+    copyWithPadding(output, input, limit - numChars);
+  } else {
+    output.setNoCopy(StringView(input.data(), input.size()));
+  }
+}
+
+} // namespace detail
+
+template <typename T>
+struct CharTypeWriteSideCheckFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    detail::writeSideCheck<false, true>(result, input, limit);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    detail::writeSideCheck<true, true>(result, input, limit);
+  }
+};
+
+template <typename T>
+struct VarcharTypeWriteSideCheckFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    detail::writeSideCheck<false, false>(result, input, limit);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    detail::writeSideCheck<true, false>(result, input, limit);
+  }
+};
+
+template <typename T>
+struct ReadSidePaddingFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    detail::readSidePadding<false>(result, input, limit);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    detail::readSidePadding<true>(result, input, limit);
+  }
+};
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/registration/CMakeLists.txt
+++ b/bolt/functions/sparksql/registration/CMakeLists.txt
@@ -33,6 +33,7 @@ bolt_add_library(
   RegisterArray.cpp
   RegisterBinary.cpp
   RegisterBitwise.cpp
+  RegisterCharVarchar.cpp
   RegisterComparison.cpp
   RegisterDatetime.cpp
   RegisterJson.cpp

--- a/bolt/functions/sparksql/registration/Register.cpp
+++ b/bolt/functions/sparksql/registration/Register.cpp
@@ -37,6 +37,7 @@ namespace bytedance::bolt::functions::sparksql {
 extern void registerArrayFunctions(const std::string& prefix);
 extern void registerBinaryFunctions(const std::string& prefix);
 extern void registerBitwiseFunctions(const std::string& prefix);
+extern void registerCharVarcharFunctions(const std::string& prefix);
 extern void registerCompareFunctions(const std::string& prefix);
 extern void registerDatetimeFunctions(const std::string& prefix);
 extern void registerJsonFunctions(const std::string& prefix);
@@ -54,6 +55,7 @@ void registerFunctions(const std::string& prefix) {
   registerArrayFunctions(prefix);
   registerBinaryFunctions(prefix);
   registerBitwiseFunctions(prefix);
+  registerCharVarcharFunctions(prefix);
   registerCompareFunctions(prefix);
   registerDatetimeFunctions(prefix);
   registerJsonFunctions(prefix);

--- a/bolt/functions/sparksql/registration/RegisterCharVarchar.cpp
+++ b/bolt/functions/sparksql/registration/RegisterCharVarchar.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/lib/RegistrationHelpers.h"
+#include "bolt/functions/sparksql/CharVarchar.h"
+
+namespace bytedance::bolt::functions::sparksql {
+
+void registerCharVarcharFunctions(const std::string& prefix) {
+  registerFunction<CharTypeWriteSideCheckFunction, Varchar, Varchar, int32_t>(
+      {prefix + "char_type_write_side_check"});
+  registerFunction<
+      VarcharTypeWriteSideCheckFunction,
+      Varchar,
+      Varchar,
+      int32_t>({prefix + "varchar_type_write_side_check"});
+  registerFunction<ReadSidePaddingFunction, Varchar, Varchar, int32_t>(
+      {prefix + "read_side_padding"});
+}
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
   BitwiseTest.cpp
+  CharVarcharTest.cpp
   ComparisonsTest.cpp
   DecimalArithmeticFuncTest.cpp
   DecimalArithmeticTest.cpp

--- a/bolt/functions/sparksql/tests/CharVarcharTest.cpp
+++ b/bolt/functions/sparksql/tests/CharVarcharTest.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+#include <optional>
+#include <string>
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class CharVarcharTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<std::string> charWrite(
+      std::optional<std::string> input,
+      int32_t limit) {
+    return evaluateOnce<std::string>(
+        "char_type_write_side_check(c0, c1)",
+        input,
+        std::optional<int32_t>{limit});
+  }
+
+  std::optional<std::string> charWrite(
+      const std::string& input,
+      int32_t limit) {
+    return charWrite(std::optional<std::string>{input}, limit);
+  }
+
+  std::optional<std::string> charWrite(const char* input, int32_t limit) {
+    return charWrite(std::optional<std::string>{input}, limit);
+  }
+
+  std::optional<std::string> varcharWrite(
+      std::optional<std::string> input,
+      int32_t limit) {
+    return evaluateOnce<std::string>(
+        "varchar_type_write_side_check(c0, c1)",
+        input,
+        std::optional<int32_t>{limit});
+  }
+
+  std::optional<std::string> varcharWrite(
+      const std::string& input,
+      int32_t limit) {
+    return varcharWrite(std::optional<std::string>{input}, limit);
+  }
+
+  std::optional<std::string> varcharWrite(const char* input, int32_t limit) {
+    return varcharWrite(std::optional<std::string>{input}, limit);
+  }
+
+  std::optional<std::string> readPadding(
+      std::optional<std::string> input,
+      int32_t limit) {
+    return evaluateOnce<std::string>(
+        "read_side_padding(c0, c1)", input, std::optional<int32_t>{limit});
+  }
+
+  std::optional<std::string> readPadding(
+      const std::string& input,
+      int32_t limit) {
+    return readPadding(std::optional<std::string>{input}, limit);
+  }
+
+  std::optional<std::string> readPadding(const char* input, int32_t limit) {
+    return readPadding(std::optional<std::string>{input}, limit);
+  }
+};
+
+TEST_F(CharVarcharTest, charTypeWriteSideCheck) {
+  EXPECT_EQ("abcde", charWrite("abcde", 5).value());
+  EXPECT_EQ("abc  ", charWrite("abc", 5).value());
+  EXPECT_EQ("abcde", charWrite("abcde ", 5).value());
+  EXPECT_EQ("abcd ", charWrite("abcd  ", 5).value());
+
+  BOLT_ASSERT_USER_THROW(
+      charWrite("abcdef", 5), "Exceeds allowed length limitation: 5");
+  BOLT_ASSERT_USER_THROW(
+      charWrite("abcdef ", 5), "Exceeds allowed length limitation: 5");
+}
+
+TEST_F(CharVarcharTest, varcharTypeWriteSideCheck) {
+  EXPECT_EQ("abc", varcharWrite("abc", 5).value());
+  EXPECT_EQ("abcde", varcharWrite("abcde", 5).value());
+  EXPECT_EQ("abcde", varcharWrite("abcde ", 5).value());
+  EXPECT_EQ("abcd ", varcharWrite("abcd  ", 5).value());
+
+  BOLT_ASSERT_USER_THROW(
+      varcharWrite("abcdef", 5), "Exceeds allowed length limitation: 5");
+  BOLT_ASSERT_USER_THROW(
+      varcharWrite("abcdef ", 5), "Exceeds allowed length limitation: 5");
+}
+
+TEST_F(CharVarcharTest, readSidePadding) {
+  EXPECT_EQ("abc  ", readPadding("abc", 5).value());
+  EXPECT_EQ("abcde", readPadding("abcde", 5).value());
+  EXPECT_EQ("abcdef", readPadding("abcdef", 5).value());
+}
+
+TEST_F(CharVarcharTest, unicodeCharactersCountByCodePoint) {
+  const std::string hello = "\xE4\xBD\xA0\xE5\xA5\xBD";
+  const std::string face = "\xF0\x9F\x98\x80";
+  const std::string pound = "\xC2\xA3";
+  const std::string ideographicSpace = "\xE3\x80\x80";
+
+  EXPECT_EQ(hello + " ", charWrite(hello, 3).value());
+  EXPECT_EQ(hello, charWrite(hello + " ", 2).value());
+  EXPECT_EQ(hello + "x", charWrite(hello + "x ", 3).value());
+  EXPECT_EQ(hello + " ", readPadding(hello, 3).value());
+  EXPECT_EQ(hello + "  ", readPadding(hello, 4).value());
+  EXPECT_EQ(face + " ", charWrite(face, 2).value());
+  EXPECT_EQ(face, varcharWrite(face + " ", 1).value());
+  EXPECT_EQ(pound + "ab", varcharWrite(pound + "ab ", 3).value());
+
+  BOLT_ASSERT_USER_THROW(
+      charWrite(hello + "x", 2), "Exceeds allowed length limitation: 2");
+  BOLT_ASSERT_USER_THROW(
+      varcharWrite(hello + ideographicSpace, 2),
+      "Exceeds allowed length limitation: 2");
+}
+
+TEST_F(CharVarcharTest, nullInput) {
+  EXPECT_EQ(std::nullopt, charWrite(std::optional<std::string>{}, 5));
+  EXPECT_EQ(std::nullopt, varcharWrite(std::optional<std::string>{}, 5));
+  EXPECT_EQ(std::nullopt, readPadding(std::optional<std::string>{}, 5));
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/CharVarcharTest.cpp
+++ b/bolt/functions/sparksql/tests/CharVarcharTest.cpp
@@ -88,9 +88,10 @@ TEST_F(CharVarcharTest, charTypeWriteSideCheck) {
   EXPECT_EQ("abcd ", charWrite("abcd  ", 5).value());
 
   BOLT_ASSERT_USER_THROW(
-      charWrite("abcdef", 5), "Exceeds allowed length limitation: 5");
+      charWrite("abcdef", 5), "Exceeds char/varchar type length limitation: 5");
   BOLT_ASSERT_USER_THROW(
-      charWrite("abcdef ", 5), "Exceeds allowed length limitation: 5");
+      charWrite("abcdef ", 5),
+      "Exceeds char/varchar type length limitation: 5");
 }
 
 TEST_F(CharVarcharTest, varcharTypeWriteSideCheck) {
@@ -100,9 +101,11 @@ TEST_F(CharVarcharTest, varcharTypeWriteSideCheck) {
   EXPECT_EQ("abcd ", varcharWrite("abcd  ", 5).value());
 
   BOLT_ASSERT_USER_THROW(
-      varcharWrite("abcdef", 5), "Exceeds allowed length limitation: 5");
+      varcharWrite("abcdef", 5),
+      "Exceeds char/varchar type length limitation: 5");
   BOLT_ASSERT_USER_THROW(
-      varcharWrite("abcdef ", 5), "Exceeds allowed length limitation: 5");
+      varcharWrite("abcdef ", 5),
+      "Exceeds char/varchar type length limitation: 5");
 }
 
 TEST_F(CharVarcharTest, readSidePadding) {
@@ -127,10 +130,11 @@ TEST_F(CharVarcharTest, unicodeCharactersCountByCodePoint) {
   EXPECT_EQ(pound + "ab", varcharWrite(pound + "ab ", 3).value());
 
   BOLT_ASSERT_USER_THROW(
-      charWrite(hello + "x", 2), "Exceeds allowed length limitation: 2");
+      charWrite(hello + "x", 2),
+      "Exceeds char/varchar type length limitation: 2");
   BOLT_ASSERT_USER_THROW(
       varcharWrite(hello + ideographicSpace, 2),
-      "Exceeds allowed length limitation: 2");
+      "Exceeds char/varchar type length limitation: 2");
 }
 
 TEST_F(CharVarcharTest, nullInput) {


### PR DESCRIPTION
### What problem does this PR solve?

Spark/Gluten emits native helper calls for char/varchar table read and write paths, but Bolt did not register Spark-compatible implementations for them. This caused Spark char/varchar suites to fail when write-side length checks or read-side padding reached native execution.

Issue Number: close #741

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds Spark-compatible native implementations for:

- `char_type_write_side_check(varchar, integer) -> varchar`
- `varchar_type_write_side_check(varchar, integer) -> varchar`
- `read_side_padding(varchar, integer) -> varchar`

The implementation follows Spark 3.5 semantics:

- `char_type_write_side_check` pads short values with ASCII spaces, returns equal-length values unchanged, and trims only excess trailing ASCII spaces for oversized values.
- `varchar_type_write_side_check` returns short/equal values unchanged and trims only excess trailing ASCII spaces for oversized values.
- `read_side_padding` pads short char values and leaves equal or oversized values unchanged.
- UTF-8 strings are measured by character count; trimming only recognizes ASCII space `0x20`, not other Unicode whitespace.
- Unchanged or trimmed results use shallow copy through `StringView`; only padding allocates and copies into a new output buffer.

The helpers are registered in a dedicated SparkSQL registration file, and focused unit tests cover ASCII behavior, UTF-8 behavior, trimming, padding, error paths, and null propagation.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Added Spark-compatible char/varchar write-side checks and read-side padding helper functions.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation notes:

- Commit hooks passed: clang-format, CMake format, license header check, C++ lint, and spell check.
- `git diff --check` passed locally.
- Local build/test was not run in the Codex environment because `conan` is not installed, so CMake presets could not be generated.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>