### PR TITLE
fix: prevent ExecutionMemoryPool logging crash on concurrent toString

### DIFF
--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
@@ -204,7 +204,7 @@ int64_t ExecutionMemoryPool::acquireMemory(
                 << ")"
                 << ", internalMemoryUsed=" << internalMemoryUsed()
                 << ", internalMemoryFree=" << internalMemoryFree()
-                << ", ExecutionPool detail is: " << this;
+                << ", ExecutionPool detail is: " << toStringLocked();
       // In Spark's implementation, there is no timeout, but in Gluten's
       // practice, we found that some deadlock issues occurred, so we added a
       // timeout here. deadlock scenario:
@@ -423,19 +423,7 @@ uint64_t ExecutionMemoryPool::getConfiguredMemoryPerTask() {
 }
 
 std::ostream& operator<<(std::ostream& os, const ExecutionMemoryPool& pool) {
-  os << "ExecutionMemoryPool(poolSize=" << pool.poolSize_.value_or(0)
-     << ", poolExtendSize=" << pool.poolExtendSize_.value_or(0)
-     << ", memIncreaseSize=" << pool.memIncreaseSize_ << " memoryForTask={";
-  for (const auto& pair : pool.memoryForTask_) {
-    os << "[taskAttemptId=" << pair.first << ", memoryUsed=" << pair.second
-       << "]";
-  }
-  if (pool.statistics_.extendCount > 0) {
-    os << ", DynamicMemoryQuotaManagerStatistics="
-       << pool.statistics_.toString();
-  }
-  os << ", DynamicMemoryQuotaManagerOption=" << pool.option_.toString();
-  return os << "}";
+  return os << pool.toString();
 }
 
 std::ostream& operator<<(std::ostream& os, const ExecutionMemoryPool* pool) {
@@ -447,8 +435,23 @@ std::ostream& operator<<(std::ostream& os, const ExecutionMemoryPool* pool) {
 }
 
 std::string ExecutionMemoryPool::toString() const {
+  MemoryMutexGuard guard(lock_);
+  return toStringLocked();
+}
+
+std::string ExecutionMemoryPool::toStringLocked() const {
   std::stringstream ss;
-  ss << this;
+  ss << "ExecutionMemoryPool(poolSize=" << poolSize_.value_or(0)
+     << ", poolExtendSize=" << poolExtendSize_.value_or(0)
+     << ", memIncreaseSize=" << memIncreaseSize_ << " memoryForTask={";
+  for (const auto& pair : memoryForTask_) {
+    ss << "[taskAttemptId=" << pair.first << ", memoryUsed=" << pair.second
+       << "]";
+  }
+  if (statistics_.extendCount > 0) {
+    ss << ", DynamicMemoryQuotaManagerStatistics=" << statistics_.toString();
+  }
+  ss << ", DynamicMemoryQuotaManagerOption=" << option_.toString() << "}";
   return ss.str();
 }
 
@@ -533,7 +536,7 @@ bool ExecutionMemoryPool::triggerDynamicMemoryQuotaManager(
                     << ", reachThreshold="
                     << (reachThreshold ? "true" : "false") << ", statistics is "
                     << statistics_.toString() << ", pool details is "
-                    << this->toString();
+                    << toStringLocked();
         }
       }
       return true;

--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.h
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.h
@@ -147,6 +147,8 @@ class ExecutionMemoryPool final
 
   void enableDynamicMemoryQuotaManagerForTask(int64_t taskAttemptId);
 
+  std::string toStringLocked() const;
+
   int64_t internalMemoryUsed() const;
 
   int64_t internalPoolSize() const;

--- a/bolt/common/memory/sparksql/tests/MemoryConsumerTest.cpp
+++ b/bolt/common/memory/sparksql/tests/MemoryConsumerTest.cpp
@@ -428,4 +428,110 @@ TEST_F(
   EXPECT_EQ(memoryPool->acquireMemory(1, kTaskAttemptId), 1);
 }
 
+TEST_F(MemoryConsumerTest, toStringRacesWithConcurrentMemoryUpdates) {
+  constexpr int64_t kCapacity = 1 << 20;
+  constexpr int64_t kWorkerThreads = 8;
+  constexpr int64_t kWriterIterations = 20'000;
+  constexpr int64_t kStringifierThreads = 4;
+  constexpr int64_t kStringifyIterations = 20'000;
+
+  auto memoryPool = std::make_shared<ExecutionMemoryPool>();
+  memoryPool->setPoolSize(kCapacity);
+
+  std::vector<TaskMemoryManagerPtr> managers(kWorkerThreads);
+  std::vector<std::shared_ptr<TestMemoryConsumer>> consumers(kWorkerThreads);
+  for (int64_t i = 0; i < kWorkerThreads; ++i) {
+    managers[i] = std::make_shared<TaskMemoryManager>(memoryPool, i);
+    consumers[i] = std::make_shared<TestMemoryConsumer>(managers[i]);
+  }
+
+  std::atomic_bool start{false};
+  std::atomic_bool stop{false};
+  std::atomic<int64_t> stringifyCalls{0};
+  std::exception_ptr backgroundFailure{nullptr};
+  std::mutex failureLock;
+
+  auto recordFailure = [&](std::exception_ptr error) {
+    std::lock_guard<std::mutex> guard(failureLock);
+    if (backgroundFailure == nullptr) {
+      backgroundFailure = error;
+    }
+    stop.store(true, std::memory_order_release);
+  };
+
+  std::vector<std::thread> writers;
+  writers.reserve(kWorkerThreads);
+  for (int64_t i = 0; i < kWorkerThreads; ++i) {
+    writers.emplace_back([&, i]() {
+      try {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+
+        auto& consumer = consumers[i];
+        for (int64_t iter = 0;
+             iter < kWriterIterations && !stop.load(std::memory_order_acquire);
+             ++iter) {
+          const auto request = 1 + ((iter + i * 17) % 127);
+          if ((iter & 1) == 0) {
+            consumer->acquireMemory(request);
+          } else {
+            const auto toFree = std::min<int64_t>(consumer->getUsed(), request);
+            if (toFree > 0) {
+              consumer->freeMemory(toFree);
+            }
+          }
+        }
+
+        const auto remaining = consumer->getUsed();
+        if (remaining > 0) {
+          consumer->freeMemory(remaining);
+        }
+      } catch (...) {
+        recordFailure(std::current_exception());
+      }
+    });
+  }
+
+  std::vector<std::thread> stringifiers;
+  stringifiers.reserve(kStringifierThreads);
+  for (int64_t i = 0; i < kStringifierThreads; ++i) {
+    stringifiers.emplace_back([&]() {
+      try {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+
+        for (int64_t iter = 0; iter < kStringifyIterations &&
+             !stop.load(std::memory_order_acquire);
+             ++iter) {
+          const auto detail = memoryPool->toString();
+          if (detail.empty()) {
+            throw std::runtime_error(
+                "ExecutionMemoryPool::toString returned empty");
+          }
+          stringifyCalls.fetch_add(1, std::memory_order_relaxed);
+        }
+      } catch (...) {
+        recordFailure(std::current_exception());
+      }
+    });
+  }
+
+  start.store(true, std::memory_order_release);
+
+  for (auto& writer : writers) {
+    writer.join();
+  }
+  stop.store(true, std::memory_order_release);
+  for (auto& stringifier : stringifiers) {
+    stringifier.join();
+  }
+
+  if (backgroundFailure != nullptr) {
+    std::rethrow_exception(backgroundFailure);
+  }
+
+  EXPECT_GT(stringifyCalls.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(memoryPool->memoryUsed(), 0);
+}
+
 } // namespace bytedance::bolt::memory::sparksql


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The crash stack points to ExecutionMemoryPool::operator<< at +0xe0 while Spark tasks are still running through BoltColumnarToRowExec/nativeHasNext. The root cause is that toString() formats memoryForTask_ without synchronization while acquireMemory()/releaseMemory() mutate the same unordered_map under lock_.
```
Stack: [0x00007fa5d1700000,0x00007fa5d1800000],  sp=0x00007fa5d17fd1f0,  free space=1012k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libbolt_backend.amd64.so+0x5508bf0]  bytedance::bolt::memory::sparksql::operator<<(std::ostream&, bytedance::bolt::memory::sparksql::ExecutionMemoryPool const&)+0xe0
C  [libstdc++.so.6+0x2114f8]  vtable for std::__cxx11::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >+0x10

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 40530  org.apache.gluten.vectorized.ColumnarBatchOutIterator.nativeHasNext(J)Z (0 bytes) @ 0x00007faaad092588 [0x00007faaad092540+0x48]
J 68445 C2 org.apache.gluten.iterator.ClosableIterator.hasNext()Z (65 bytes) @ 0x00007faab188a124 [0x00007faab188a0e0+0x44]
J 5425 C2 scala.collection.convert.Wrappers$JIteratorWrapper.hasNext()Z (10 bytes) @ 0x00007faaaa2995e8 [0x00007faaaa2995a0+0x48]
J 59655 C2 org.apache.gluten.iterator.IteratorsV1$InvocationFlowProtection.hasNext()Z (129 bytes) @ 0x00007faab22ac6ec [0x00007faab22ac4a0+0x24c]
J 87025 C2 org.apache.gluten.iterator.IteratorsV1$IteratorCompleter.hasNext()Z (23 bytes) @ 0x00007faaaca9bd4c [0x00007faaaca9bd00+0x4c]
J 60237 C2 org.apache.gluten.iterator.IteratorsV1$LifeTimeAccumulator.hasNext()Z (23 bytes) @ 0x00007faab25cbaf0 [0x00007faab25cba80+0x70]
J 68431 C2 org.apache.gluten.execution.BoltColumnarToRowExec$.toRowIterator(Lscala/collection/Iterator;Lorg/apache/spark/sql/execution/metric/SQLMetric;Lorg/apache/spark/sql/execution/metric/SQLMetric;Lorg/apache/spark/sql/execution/metric/SQLMetric;)Lscala/collection/Iterator; (90 bytes) @ 0x00007faab2ff47f0 [0x00007faab2ff4780+0x70]
J 68433 C2 org.apache.gluten.execution.BoltColumnarToRowExec$$Lambda$9441.apply(Ljava/lang/Object;)Ljava/lang/Object; (20 bytes) @ 0x00007faaab0a8728 [0x00007faaab0a86a0+0x88]
J 60317 C2 org.apache.spark.rdd.RDD$$Lambda$9439.apply(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (17 bytes) @ 0x00007faaad4dfc1c [0x00007faaad4dfb80+0x9c]
J 98089 C2 org.apache.spark.rdd.MapPartitionsRDD.compute(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (36 bytes) @ 0x00007faab0bd72ec [0x00007faab0bd6f60+0x38c]
J 98087 C2 org.apache.spark.rdd.RDD.iterator(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (46 bytes) @ 0x00007faaabe340e4 [0x00007faaabe33f60+0x184]
J 98089 C2 org.apache.spark.rdd.MapPartitionsRDD.compute(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (36 bytes) @ 0x00007faab0bd72c4 [0x00007faab0bd6f60+0x364]
J 94196 C2 org.apache.spark.sql.execution.SQLExecutionRDD$$Lambda$11910.apply()Ljava/lang/Object; (16 bytes) @ 0x00007faab16cf8e4 [0x00007faab16cf600+0x2e4]
J 99408 C2 org.apache.spark.sql.internal.SQLConf$.withExistingConf(Lorg/apache/spark/sql/internal/SQLConf;Lscala/Function0;)Ljava/lang/Object; (78 bytes) @ 0x00007faaadc71928 [0x00007faaadc71600+0x328]
J 79208 C2 org.apache.spark.sql.execution.SQLExecutionRDD.compute(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (55 bytes) @ 0x00007faab3192e3c [0x00007faab3192b00+0x33c]
J 98087 C2 org.apache.spark.rdd.RDD.iterator(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (46 bytes) @ 0x00007faaabe340e4 [0x00007faaabe33f60+0x184]
J 98089 C2 org.apache.spark.rdd.MapPartitionsRDD.compute(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (36 bytes) @ 0x00007faab0bd72c4 [0x00007faab0bd6f60+0x364]
J 98087 C2 org.apache.spark.rdd.RDD.iterator(Lorg/apache/spark/Partition;Lorg/apache/spark/TaskContext;)Lscala/collection/Iterator; (46 bytes) @ 0x00007faaabe340e4 [0x00007faaabe33f60+0x184]
J 98169 C2 org.apache.spark.scheduler.ResultTask.runTask(Lorg/apache/spark/TaskContext;)Ljava/lang/Object; (212 bytes) @ 0x00007faab1ab3558 [0x00007faab1ab2e40+0x718]
J 96039 C2 org.apache.spark.scheduler.Task.run(JILorg/apache/spark/metrics/MetricsSystem;Lscala/collection/immutable/Map;Lscala/Option;)Ljava/lang/Object; (495 bytes) @ 0x00007faab4402594 [0x00007faab4401900+0xc94]
J 96937 C2 org.apache.spark.executor.Executor$TaskRunner.run()V (3071 bytes) @ 0x00007faab55921b0 [0x00007faab5590c20+0x1590]
J 86453 C2 java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V (225 bytes) @ 0x00007faab2078540 [0x00007faab20783e0+0x160]
J 64567 C2 java.util.concurrent.ThreadPoolExecutor$Worker.run()V (9 bytes) @ 0x00007faaad362724 [0x00007faaad3626e0+0x44]
J 61318 C2 java.lang.Thread.run()V (17 bytes) @ 0x00007faaaf28ea6c [0x00007faaaf28ea20+0x4c]
v  ~StubRoutines::call_stub
```

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Fix this by guarding public toString() with the pool mutex and routing already-locked logging paths through toStringLocked() to avoid self-deadlock. Add a concurrent stress test that reproduces the pre-fix SIGSEGV when toString() races with memory updates.

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
