### PR TITLE
[fix] shuffle min memory limit is too large

### DIFF
--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -105,11 +105,10 @@ arrow::Status BoltRowBasedSortShuffleWriter::split(
       RETURN_NOT_OK(partitioner_->compute(
           pidArr, batch->size(), row2Partition_, partition2RowCount_));
     }
-    if (!boltPool_->maybeReserve(stats.getTotalMemorySize())) {
-      if (boltPool_->reservedBytes() >= kMinMemLimit) {
-        RETURN_NOT_OK(tryEvict());
-        requestSpill_ = false;
-      }
+    if (!boltPool_->maybeReserve(stats.getTotalMemorySize()) &&
+        hasEnoughMemoryUsageToSpill()) {
+      RETURN_NOT_OK(tryEvict());
+      requestSpill_ = false;
     }
     // RowVector->UnsafeRow
     {
@@ -187,6 +186,10 @@ arrow::Status BoltRowBasedSortShuffleWriter::reclaimFixedSize(
       (vectorLayout_ == RowVectorLayout::kComposite &&
        !isCompositeInitialized_) ||
       vectorLayout_ == RowVectorLayout::kInvalid) {
+    *actual = 0;
+    return arrow::Status::OK();
+  }
+  if (!hasEnoughMemoryUsageToSpill()) {
     *actual = 0;
     return arrow::Status::OK();
   }

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -51,6 +51,7 @@
 #include "bolt/shuffle/sparksql/BoltShuffleWriterV2.h"
 #include "bolt/vector/arrow/Abi.h"
 #include "bolt/vector/arrow/Bridge.h"
+#include "common/memory/sparksql/ExecutionMemoryPool.h"
 
 #if defined(__x86_64__)
 #include <immintrin.h>
@@ -1671,13 +1672,15 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
         if (buffers[kValidityBufferIndex] != nullptr) {
           auto validityBufferSize = arrow::bit_util::BytesForBits(numRows);
           if (reuseBuffers) {
-            allBuffers.push_back(arrow::SliceBuffer(
-                buffers[kValidityBufferIndex],
-                0,
-                arrow::bit_util::BytesForBits(numRows)));
+            allBuffers.push_back(
+                arrow::SliceBuffer(
+                    buffers[kValidityBufferIndex],
+                    0,
+                    arrow::bit_util::BytesForBits(numRows)));
           } else {
-            RETURN_NOT_OK(buffers[kValidityBufferIndex]->Resize(
-                validityBufferSize, true));
+            RETURN_NOT_OK(
+                buffers[kValidityBufferIndex]->Resize(
+                    validityBufferSize, true));
             allBuffers.push_back(std::move(buffers[kValidityBufferIndex]));
           }
         } else {
@@ -1689,11 +1692,13 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
             !buffers[kBinaryLengthBufferIndex],
             arrow::Status::Invalid("Offset buffer of binary array is null."));
         if (reuseBuffers) {
-          allBuffers.push_back(arrow::SliceBuffer(
-              buffers[kBinaryLengthBufferIndex], 0, lengthBufferSize));
+          allBuffers.push_back(
+              arrow::SliceBuffer(
+                  buffers[kBinaryLengthBufferIndex], 0, lengthBufferSize));
         } else {
-          RETURN_NOT_OK(buffers[kBinaryLengthBufferIndex]->Resize(
-              lengthBufferSize, true));
+          RETURN_NOT_OK(
+              buffers[kBinaryLengthBufferIndex]->Resize(
+                  lengthBufferSize, true));
           allBuffers.push_back(std::move(buffers[kBinaryLengthBufferIndex]));
         }
 
@@ -1703,8 +1708,9 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
             !buffers[kBinaryValueBufferIndex],
             arrow::Status::Invalid("Value buffer of binary array is null."));
         if (reuseBuffers) {
-          allBuffers.push_back(arrow::SliceBuffer(
-              buffers[kBinaryValueBufferIndex], 0, valueBufferSize));
+          allBuffers.push_back(
+              arrow::SliceBuffer(
+                  buffers[kBinaryValueBufferIndex], 0, valueBufferSize));
         } else if (valueBufferSize > 0) {
           RETURN_NOT_OK(
               buffers[kBinaryValueBufferIndex]->Resize(valueBufferSize, true));
@@ -1734,13 +1740,15 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
         if (buffers[kValidityBufferIndex] != nullptr) {
           auto validityBufferSize = arrow::bit_util::BytesForBits(numRows);
           if (reuseBuffers) {
-            allBuffers.push_back(arrow::SliceBuffer(
-                buffers[kValidityBufferIndex],
-                0,
-                arrow::bit_util::BytesForBits(numRows)));
+            allBuffers.push_back(
+                arrow::SliceBuffer(
+                    buffers[kValidityBufferIndex],
+                    0,
+                    arrow::bit_util::BytesForBits(numRows)));
           } else {
-            RETURN_NOT_OK(buffers[kValidityBufferIndex]->Resize(
-                validityBufferSize, true));
+            RETURN_NOT_OK(
+                buffers[kValidityBufferIndex]->Resize(
+                    validityBufferSize, true));
             allBuffers.push_back(std::move(buffers[kValidityBufferIndex]));
           }
         } else {
@@ -1773,8 +1781,9 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
               arrow::SliceBuffer(valueBuffer, 0, valueBufferSize);
           allBuffers.push_back(std::move(slicedValueBuffer));
         } else {
-          RETURN_NOT_OK(buffers[kFixedWidthValueBufferIndex]->Resize(
-              valueBufferSize, true));
+          RETURN_NOT_OK(
+              buffers[kFixedWidthValueBufferIndex]->Resize(
+                  valueBufferSize, true));
           allBuffers.push_back(std::move(buffers[kFixedWidthValueBufferIndex]));
         }
         fixedWidthIdx++;
@@ -1819,6 +1828,11 @@ arrow::Status BoltShuffleWriter::reclaimFixedSize(
       *actual = 0;
       return arrow::Status::OK();
     }
+  }
+
+  if (!hasEnoughMemoryUsageToSpill()) {
+    *actual = 0;
+    return arrow::Status::OK();
   }
 
   EvictGuard evictGuard{evictState_};
@@ -2639,6 +2653,22 @@ arrow::Status BoltShuffleWriter::checkFixedColumnCopyValue(
         funcLine);
   }
   return arrow::Status::OK();
+}
+
+bool BoltShuffleWriter::hasEnoughMemoryUsageToSpill() {
+  int64_t minMemoryUsageThreshold = options_.shuffleBatchSize;
+  int64_t totalUsedMemory = boltPool_->reservedBytes();
+  if (dynamic_cast<BoltArrowMemoryPool*>(pool_) == nullptr) {
+    totalUsedMemory += pool_->bytes_allocated();
+  }
+  if (memory::sparksql::ExecutionMemoryPool::instance() != nullptr) {
+    int64_t taskAverageMemory =
+        memory::sparksql::ExecutionMemoryPool::instance()->poolSize() /
+        memory::sparksql::ExecutionMemoryPool::instance()->maxTaskNumber();
+    minMemoryUsageThreshold =
+        std::min(minMemoryUsageThreshold, taskAverageMemory / 10);
+  }
+  return totalUsedMemory > minMemoryUsageThreshold;
 }
 
 } // namespace bytedance::bolt::shuffle::sparksql

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -1672,15 +1672,13 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
         if (buffers[kValidityBufferIndex] != nullptr) {
           auto validityBufferSize = arrow::bit_util::BytesForBits(numRows);
           if (reuseBuffers) {
-            allBuffers.push_back(
-                arrow::SliceBuffer(
-                    buffers[kValidityBufferIndex],
-                    0,
-                    arrow::bit_util::BytesForBits(numRows)));
+            allBuffers.push_back(arrow::SliceBuffer(
+                buffers[kValidityBufferIndex],
+                0,
+                arrow::bit_util::BytesForBits(numRows)));
           } else {
-            RETURN_NOT_OK(
-                buffers[kValidityBufferIndex]->Resize(
-                    validityBufferSize, true));
+            RETURN_NOT_OK(buffers[kValidityBufferIndex]->Resize(
+                validityBufferSize, true));
             allBuffers.push_back(std::move(buffers[kValidityBufferIndex]));
           }
         } else {
@@ -1692,13 +1690,11 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
             !buffers[kBinaryLengthBufferIndex],
             arrow::Status::Invalid("Offset buffer of binary array is null."));
         if (reuseBuffers) {
-          allBuffers.push_back(
-              arrow::SliceBuffer(
-                  buffers[kBinaryLengthBufferIndex], 0, lengthBufferSize));
+          allBuffers.push_back(arrow::SliceBuffer(
+              buffers[kBinaryLengthBufferIndex], 0, lengthBufferSize));
         } else {
-          RETURN_NOT_OK(
-              buffers[kBinaryLengthBufferIndex]->Resize(
-                  lengthBufferSize, true));
+          RETURN_NOT_OK(buffers[kBinaryLengthBufferIndex]->Resize(
+              lengthBufferSize, true));
           allBuffers.push_back(std::move(buffers[kBinaryLengthBufferIndex]));
         }
 
@@ -1708,9 +1704,8 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
             !buffers[kBinaryValueBufferIndex],
             arrow::Status::Invalid("Value buffer of binary array is null."));
         if (reuseBuffers) {
-          allBuffers.push_back(
-              arrow::SliceBuffer(
-                  buffers[kBinaryValueBufferIndex], 0, valueBufferSize));
+          allBuffers.push_back(arrow::SliceBuffer(
+              buffers[kBinaryValueBufferIndex], 0, valueBufferSize));
         } else if (valueBufferSize > 0) {
           RETURN_NOT_OK(
               buffers[kBinaryValueBufferIndex]->Resize(valueBufferSize, true));
@@ -1740,15 +1735,13 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
         if (buffers[kValidityBufferIndex] != nullptr) {
           auto validityBufferSize = arrow::bit_util::BytesForBits(numRows);
           if (reuseBuffers) {
-            allBuffers.push_back(
-                arrow::SliceBuffer(
-                    buffers[kValidityBufferIndex],
-                    0,
-                    arrow::bit_util::BytesForBits(numRows)));
+            allBuffers.push_back(arrow::SliceBuffer(
+                buffers[kValidityBufferIndex],
+                0,
+                arrow::bit_util::BytesForBits(numRows)));
           } else {
-            RETURN_NOT_OK(
-                buffers[kValidityBufferIndex]->Resize(
-                    validityBufferSize, true));
+            RETURN_NOT_OK(buffers[kValidityBufferIndex]->Resize(
+                validityBufferSize, true));
             allBuffers.push_back(std::move(buffers[kValidityBufferIndex]));
           }
         } else {
@@ -1781,9 +1774,8 @@ BoltShuffleWriter::assembleBuffers(uint32_t partitionId, bool reuseBuffers) {
               arrow::SliceBuffer(valueBuffer, 0, valueBufferSize);
           allBuffers.push_back(std::move(slicedValueBuffer));
         } else {
-          RETURN_NOT_OK(
-              buffers[kFixedWidthValueBufferIndex]->Resize(
-                  valueBufferSize, true));
+          RETURN_NOT_OK(buffers[kFixedWidthValueBufferIndex]->Resize(
+              valueBufferSize, true));
           allBuffers.push_back(std::move(buffers[kFixedWidthValueBufferIndex]));
         }
         fixedWidthIdx++;

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -612,6 +612,8 @@ class BoltShuffleWriter : public ShuffleWriter {
   virtual arrow::Status reclaimFixedSizeInCompositeLayout(int64_t* actual);
   virtual arrow::Status tryEvictComposite();
 
+  bool hasEnoughMemoryUsageToSpill();
+
   SplitState splitState_{kInit};
 
   EvictState evictState_{kEvictable};

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -134,9 +134,8 @@ arrow::Status BoltShuffleWriterV2::splitExtremelyLargeBatch(
   int32_t offset = 0;
   do {
     auto length = std::min(splitedBatchSize, numRows);
-    batches_.push_back(
-        std::dynamic_pointer_cast<bytedance::bolt::RowVector>(
-            rv->slice(offset, length)));
+    batches_.push_back(std::dynamic_pointer_cast<bytedance::bolt::RowVector>(
+        rv->slice(offset, length)));
     LOG(INFO) << __FUNCTION__
               << ": splitExtremelyLargeBatch offset = " << offset
               << ", numRows = " << length;
@@ -830,12 +829,11 @@ BoltShuffleWriterV2::assembleBuffersGeneral(
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthColumnCount_ + binaryIdx]
                                    [partitionId] != nullptr) {
-          allBuffers.push_back(
-              arrow::SliceBuffer(
-                  partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
-                                           [partitionId],
-                  0,
-                  validityBytes));
+          allBuffers.push_back(arrow::SliceBuffer(
+              partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
+                                       [partitionId],
+              0,
+              validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
@@ -900,22 +898,20 @@ BoltShuffleWriterV2::assembleBuffersGeneral(
       default: {
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthIdx][partitionId] != nullptr) {
-          allBuffers.push_back(
-              arrow::SliceBuffer(
-                  partitionValidityBuffers_[fixedWidthIdx][partitionId],
-                  0,
-                  validityBytes));
+          allBuffers.push_back(arrow::SliceBuffer(
+              partitionValidityBuffers_[fixedWidthIdx][partitionId],
+              0,
+              validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
 
         // value buffer
         if (arrowColumnTypes_[i]->id() == arrow::BooleanType::type_id) {
-          allBuffers.push_back(
-              std::make_shared<arrow::Buffer>(
-                  partitionFixedWidthValueAddrsVector_[fixedWidthIdx]
-                                                      [partitionId][0],
-                  validityBytes));
+          allBuffers.push_back(std::make_shared<arrow::Buffer>(
+              partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId]
+                                                  [0],
+              validityBytes));
         } else {
           uint64_t fixedLen = fixedColValueSize_[fixedWidthIdx];
           const auto& fixedValues =
@@ -1001,12 +997,11 @@ BoltShuffleWriterV2::assembleBuffersOneBatch(uint32_t partitionId) {
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthColumnCount_ + binaryIdx]
                                    [partitionId] != nullptr) {
-          allBuffers.push_back(
-              arrow::SliceBuffer(
-                  partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
-                                           [partitionId],
-                  0,
-                  validityBytes));
+          allBuffers.push_back(arrow::SliceBuffer(
+              partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
+                                       [partitionId],
+              0,
+              validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
@@ -1015,15 +1010,13 @@ BoltShuffleWriterV2::assembleBuffersOneBatch(uint32_t partitionId) {
             partitionBinaryAddrsVector_[binaryIdx][partitionId];
         if (binaryBufs.size() == 1) {
           // length buffer
-          allBuffers.push_back(
-              std::make_shared<arrow::Buffer>(
-                  binaryBufs[0].lengthPtr, lengthBytes));
+          allBuffers.push_back(std::make_shared<arrow::Buffer>(
+              binaryBufs[0].lengthPtr, lengthBytes));
 
           // value buffer
           if (binaryBufs[0].valueOffset > 0) {
-            allBuffers.push_back(
-                std::make_shared<arrow::Buffer>(
-                    binaryBufs[0].valuePtr, binaryBufs[0].valueOffset));
+            allBuffers.push_back(std::make_shared<arrow::Buffer>(
+                binaryBufs[0].valuePtr, binaryBufs[0].valueOffset));
           } else {
             allBuffers.push_back(zeroLengthNullBuffer());
           }
@@ -1087,29 +1080,26 @@ BoltShuffleWriterV2::assembleBuffersOneBatch(uint32_t partitionId) {
       default: {
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthIdx][partitionId] != nullptr) {
-          allBuffers.push_back(
-              arrow::SliceBuffer(
-                  partitionValidityBuffers_[fixedWidthIdx][partitionId],
-                  0,
-                  validityBytes));
+          allBuffers.push_back(arrow::SliceBuffer(
+              partitionValidityBuffers_[fixedWidthIdx][partitionId],
+              0,
+              validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
 
         // value buffer
         if (arrowColumnTypes_[i]->id() == arrow::BooleanType::type_id) {
-          allBuffers.push_back(
-              std::make_shared<arrow::Buffer>(
-                  partitionFixedWidthValueAddrsVector_[fixedWidthIdx]
-                                                      [partitionId][0],
-                  validityBytes));
+          allBuffers.push_back(std::make_shared<arrow::Buffer>(
+              partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId]
+                                                  [0],
+              validityBytes));
         } else {
           auto fixedLen = fixedColValueSize_[fixedWidthIdx];
           const auto& fixedValues =
               partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId];
-          allBuffers.push_back(
-              std::make_shared<arrow::Buffer>(
-                  fixedValues[0], fixedLen * numRows));
+          allBuffers.push_back(std::make_shared<arrow::Buffer>(
+              fixedValues[0], fixedLen * numRows));
           partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId]
               .clear();
         }

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -46,9 +46,6 @@ arrow::Status BoltShuffleWriterV2::split(
   bytedance::bolt::NanosecondTimer splitTimer(&totalSplitTime_);
   updateInputMetrics(rv);
   BOLT_DCHECK(options_.partitioning != Partitioning::kSingle);
-  // Floor the budget so a tiny memLimit (e.g. an upstream operator holding most
-  // of the memory) doesn't fragment into small, poorly-compressed splits.
-  memLimit = std::max(memLimit, kMinMemLimit);
   if (bytedance::bolt::RowVector::isComposite(rv)) {
     if (vectorLayout_ == RowVectorLayout::kColumnar) {
       RETURN_NOT_OK(tryEvict());
@@ -71,7 +68,7 @@ arrow::Status BoltShuffleWriterV2::split(
     // computed during flatten for accurate string size estimation.
     auto flatSize = rv->estimateFlatSize();
     // try evict before split if current batch size is larger than memLimit
-    if (flatSize > memLimit) {
+    if (flatSize > memLimit && hasEnoughMemoryUsageToSpill()) {
       requestSpill_ = true;
     }
     RETURN_NOT_OK(tryEvict(memLimit));
@@ -137,8 +134,9 @@ arrow::Status BoltShuffleWriterV2::splitExtremelyLargeBatch(
   int32_t offset = 0;
   do {
     auto length = std::min(splitedBatchSize, numRows);
-    batches_.push_back(std::dynamic_pointer_cast<bytedance::bolt::RowVector>(
-        rv->slice(offset, length)));
+    batches_.push_back(
+        std::dynamic_pointer_cast<bytedance::bolt::RowVector>(
+            rv->slice(offset, length)));
     LOG(INFO) << __FUNCTION__
               << ": splitExtremelyLargeBatch offset = " << offset
               << ", numRows = " << length;
@@ -832,11 +830,12 @@ BoltShuffleWriterV2::assembleBuffersGeneral(
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthColumnCount_ + binaryIdx]
                                    [partitionId] != nullptr) {
-          allBuffers.push_back(arrow::SliceBuffer(
-              partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
-                                       [partitionId],
-              0,
-              validityBytes));
+          allBuffers.push_back(
+              arrow::SliceBuffer(
+                  partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
+                                           [partitionId],
+                  0,
+                  validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
@@ -901,20 +900,22 @@ BoltShuffleWriterV2::assembleBuffersGeneral(
       default: {
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthIdx][partitionId] != nullptr) {
-          allBuffers.push_back(arrow::SliceBuffer(
-              partitionValidityBuffers_[fixedWidthIdx][partitionId],
-              0,
-              validityBytes));
+          allBuffers.push_back(
+              arrow::SliceBuffer(
+                  partitionValidityBuffers_[fixedWidthIdx][partitionId],
+                  0,
+                  validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
 
         // value buffer
         if (arrowColumnTypes_[i]->id() == arrow::BooleanType::type_id) {
-          allBuffers.push_back(std::make_shared<arrow::Buffer>(
-              partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId]
-                                                  [0],
-              validityBytes));
+          allBuffers.push_back(
+              std::make_shared<arrow::Buffer>(
+                  partitionFixedWidthValueAddrsVector_[fixedWidthIdx]
+                                                      [partitionId][0],
+                  validityBytes));
         } else {
           uint64_t fixedLen = fixedColValueSize_[fixedWidthIdx];
           const auto& fixedValues =
@@ -1000,11 +1001,12 @@ BoltShuffleWriterV2::assembleBuffersOneBatch(uint32_t partitionId) {
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthColumnCount_ + binaryIdx]
                                    [partitionId] != nullptr) {
-          allBuffers.push_back(arrow::SliceBuffer(
-              partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
-                                       [partitionId],
-              0,
-              validityBytes));
+          allBuffers.push_back(
+              arrow::SliceBuffer(
+                  partitionValidityBuffers_[fixedWidthColumnCount_ + binaryIdx]
+                                           [partitionId],
+                  0,
+                  validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
@@ -1013,13 +1015,15 @@ BoltShuffleWriterV2::assembleBuffersOneBatch(uint32_t partitionId) {
             partitionBinaryAddrsVector_[binaryIdx][partitionId];
         if (binaryBufs.size() == 1) {
           // length buffer
-          allBuffers.push_back(std::make_shared<arrow::Buffer>(
-              binaryBufs[0].lengthPtr, lengthBytes));
+          allBuffers.push_back(
+              std::make_shared<arrow::Buffer>(
+                  binaryBufs[0].lengthPtr, lengthBytes));
 
           // value buffer
           if (binaryBufs[0].valueOffset > 0) {
-            allBuffers.push_back(std::make_shared<arrow::Buffer>(
-                binaryBufs[0].valuePtr, binaryBufs[0].valueOffset));
+            allBuffers.push_back(
+                std::make_shared<arrow::Buffer>(
+                    binaryBufs[0].valuePtr, binaryBufs[0].valueOffset));
           } else {
             allBuffers.push_back(zeroLengthNullBuffer());
           }
@@ -1083,26 +1087,29 @@ BoltShuffleWriterV2::assembleBuffersOneBatch(uint32_t partitionId) {
       default: {
         // validity buffer
         if (partitionValidityAddrs_[fixedWidthIdx][partitionId] != nullptr) {
-          allBuffers.push_back(arrow::SliceBuffer(
-              partitionValidityBuffers_[fixedWidthIdx][partitionId],
-              0,
-              validityBytes));
+          allBuffers.push_back(
+              arrow::SliceBuffer(
+                  partitionValidityBuffers_[fixedWidthIdx][partitionId],
+                  0,
+                  validityBytes));
         } else {
           allBuffers.push_back(nullptr);
         }
 
         // value buffer
         if (arrowColumnTypes_[i]->id() == arrow::BooleanType::type_id) {
-          allBuffers.push_back(std::make_shared<arrow::Buffer>(
-              partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId]
-                                                  [0],
-              validityBytes));
+          allBuffers.push_back(
+              std::make_shared<arrow::Buffer>(
+                  partitionFixedWidthValueAddrsVector_[fixedWidthIdx]
+                                                      [partitionId][0],
+                  validityBytes));
         } else {
           auto fixedLen = fixedColValueSize_[fixedWidthIdx];
           const auto& fixedValues =
               partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId];
-          allBuffers.push_back(std::make_shared<arrow::Buffer>(
-              fixedValues[0], fixedLen * numRows));
+          allBuffers.push_back(
+              std::make_shared<arrow::Buffer>(
+                  fixedValues[0], fixedLen * numRows));
           partitionFixedWidthValueAddrsVector_[fixedWidthIdx][partitionId]
               .clear();
         }
@@ -1399,6 +1406,10 @@ arrow::Status BoltShuffleWriterV2::reclaimFixedSize(
       splitState_ == SplitState::kStop ||
       (vectorLayout_ == RowVectorLayout::kComposite &&
        !isCompositeInitialized_)) {
+    *actual = 0;
+    return arrow::Status::OK();
+  }
+  if (!hasEnoughMemoryUsageToSpill()) {
     *actual = 0;
     return arrow::Status::OK();
   }

--- a/bolt/shuffle/sparksql/Options.h
+++ b/bolt/shuffle/sparksql/Options.h
@@ -173,6 +173,7 @@ struct ShuffleWriterOptions {
   int32_t accumulateBatchMaxColumns = kDefaultAccumulateBatchMaxColumns;
   int32_t accumulateBatchMaxBatches = kDefaultAccumulateBatchMaxBatches;
   int32_t recommendedColumn2RowSize = 0;
+  int32_t shuffleBatchSize = kDefaultShuffleBatchByteSize;
   double shuffleCheckRatio = 0;
   int32_t shuffleCheckMaxColumns = kDefaultShuffleCheckMaxColumns;
   row::RowFormat rowFormat = row::RowFormat::COMPACT;

--- a/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
@@ -37,8 +37,7 @@ SparkShuffleWriter::SparkShuffleWriter(
           std::string(shuffleWriterNode->name())),
       shuffleWriterOptions_(shuffleWriterNode->getShuffleWriterOptions()),
       // shuffle writer memory limit should at least hold one max shuffle batch
-      minMemLimit_(
-          shuffleWriterOptions_.partitionWriterOptions.shuffleBufferSize),
+      minMemLimit_(shuffleWriterOptions_.shuffleBatchSize),
       reportShuffleStatusCallback_(
           shuffleWriterNode->getReportShuffleStatusCallback()) {}
 

--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -343,8 +343,9 @@ ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(
     batches.push_back(makeRowVector({"pid", "c0"}, {pidVector, dataVector}));
   }
 
-  // 1GB task; the hog holds 979MB, leaving the writer ~45MB free (far below
-  // kMinMemLimit). Demanding that minimum reclaims the held memory.
+  // 1GB task; the hog holds 979MB, leaving the writer ~45MB free. Configure a
+  // larger spill threshold so the writer still reclaims the held memory and
+  // makes large splits.
   const int64_t memoryLimit = 1024LL * 1024 * 1024;
   const int64_t kHeldBytes = 979LL * 1024 * 1024;
   auto memoryManagerHolder = TestMemoryManagerHolder::create(
@@ -364,6 +365,7 @@ ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(
       tempDir->path + "/shuffle_data.bin";
   writerOptions.partitionWriterOptions.configuredDirs = {localDir};
   writerOptions.partitionWriterOptions.numSubDirs = 1;
+  writerOptions.shuffleBatchSize = 128 * 1024 * 1024;
   writerOptions.taskAttemptId = memoryManagerHolder->taskAttemptId();
 
   // MemoryHog -> SparkShuffleWriter: the hog holds kHeldBytes (reclaimable).
@@ -400,9 +402,8 @@ ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(
 
 // Issue #662: an upstream operator holding most of the memory leaves writer V2
 // a tiny budget, so it spills every batch into small splits that compress
-// poorly and bloat the shuffle output. Enforcing a minimum budget
-// (kMinMemLimit) reclaims the upstream and yields large, well-compressed
-// splits.
+// poorly and bloat the shuffle output. A configured large spill threshold
+// reclaims the upstream and yields large, well-compressed splits.
 TEST_F(ShuffleMemoryTest, testMinMemLimitAvoidsSpillingEveryBatch) {
   expectWellCompressed(
       runReclaimableHogScenario(static_cast<int32_t>(ShuffleWriterType::V2)));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #662

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

After PR #664, we found that the shuffle writer’s default `kMinMemLimit` was too large and could cause OOM errors in memory-constrained environments. To address this issue, we now dynamically adjust `minMemLimit` based on the memory available to each task, preventing OOM errors caused by an excessively large minimum memory limit.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
