### PR TITLE
fix: support zero-step single-element sequence in Spark-compatible builds

### DIFF
--- a/bolt/functions/lib/Sequence.cpp
+++ b/bolt/functions/lib/Sequence.cpp
@@ -202,6 +202,11 @@ vector_size_t SequenceFunction<T, K>::checkArguments(
   T stop = stopVector->valueAt<T>(row);
   auto step = getStep(
       toInt64(start), toInt64(stop), stepVector, row, isDate, isYearMonth);
+#ifdef SPARK_COMPATIBLE
+  if (step == 0 && start == stop) {
+    return 1;
+  }
+#endif
   BOLT_USER_CHECK_NE(step, 0, "step must not be zero");
   BOLT_USER_CHECK(
       step > 0 ? stop >= start : stop <= start,

--- a/bolt/functions/lib/Sequence.cpp
+++ b/bolt/functions/lib/Sequence.cpp
@@ -203,6 +203,7 @@ vector_size_t SequenceFunction<T, K>::checkArguments(
   auto step = getStep(
       toInt64(start), toInt64(stop), stepVector, row, isDate, isYearMonth);
 #ifdef SPARK_COMPATIBLE
+  // Unlike Presto, Spark permits a zero step when both bounds are equal.
   if (step == 0 && start == stop) {
     return 1;
   }

--- a/bolt/functions/prestosql/tests/SequenceTest.cpp
+++ b/bolt/functions/prestosql/tests/SequenceTest.cpp
@@ -161,6 +161,18 @@ TEST_F(SequenceTest, invalidStep) {
       expected);
 }
 
+#ifndef SPARK_COMPATIBLE
+TEST_F(SequenceTest, equalBoundsWithZeroStep) {
+  const auto startVector = makeFlatVector<int64_t>({1});
+  const auto stopVector = makeFlatVector<int64_t>({1});
+  const auto stepVector = makeFlatVector<int64_t>({0});
+  testExpressionWithError(
+      "sequence(C0, C1, C2)",
+      {startVector, stopVector, stepVector},
+      "(0 vs. 0) step must not be zero");
+}
+#endif
+
 TEST_F(SequenceTest, dateArguments) {
   const auto startVector = makeFlatVector<int32_t>({1991, 1992, 1992}, DATE());
   const auto stopVector = makeFlatVector<int32_t>({1996, 1988, 1992}, DATE());

--- a/bolt/functions/sparksql/tests/SequenceTest.cpp
+++ b/bolt/functions/sparksql/tests/SequenceTest.cpp
@@ -84,6 +84,26 @@ TEST_F(SequenceTest, singleElement) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(SequenceTest, singleElementWithZeroStep) {
+  auto bigintResult = evaluate(
+      "sequence(c0, c1, c2)",
+      makeRowVector({
+          makeFlatVector<int64_t>({1}),
+          makeFlatVector<int64_t>({1}),
+          makeFlatVector<int64_t>({0}),
+      }));
+  assertEqualVectors(makeArrayVector<int64_t>({{1}}), bigintResult);
+
+  auto integerResult = evaluate(
+      "sequence(c0, c1, c2)",
+      makeRowVector({
+          makeFlatVector<int32_t>({1}),
+          makeFlatVector<int32_t>({1}),
+          makeFlatVector<int32_t>({0}),
+      }));
+  assertEqualVectors(makeArrayVector<int32_t>({{1}}), integerResult);
+}
+
 TEST_F(SequenceTest, integerType) {
   auto result = evaluate(
       "sequence(c0, c1)",

--- a/bolt/functions/sparksql/tests/SequenceTest.cpp
+++ b/bolt/functions/sparksql/tests/SequenceTest.cpp
@@ -84,6 +84,7 @@ TEST_F(SequenceTest, singleElement) {
   assertEqualVectors(expected, result);
 }
 
+#ifdef SPARK_COMPATIBLE
 TEST_F(SequenceTest, singleElementWithZeroStep) {
   auto bigintResult = evaluate(
       "sequence(c0, c1, c2)",
@@ -103,6 +104,7 @@ TEST_F(SequenceTest, singleElementWithZeroStep) {
       }));
   assertEqualVectors(makeArrayVector<int32_t>({{1}}), integerResult);
 }
+#endif
 
 TEST_F(SequenceTest, integerType) {
   auto result = evaluate(


### PR DESCRIPTION
### What problem does this PR solve?

Spark defines `sequence(1, 1, 0)` as a valid single-element sequence, but Bolt currently rejects it with `step must not be zero`.

PrestoDB and Trino intentionally reject every zero step, so changing the shared implementation unconditionally would introduce a compatibility regression. This PR limits the behavior change to Spark-compatible builds.

Issue Number: close #748

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Handle `start == stop && step == 0` before the generic zero-step validation when `SPARK_COMPATIBLE` is defined.
- Keep the default Presto build behavior unchanged: all zero steps still fail.
- Add Spark SQL tests for `BIGINT` and `INTEGER` single-element sequences with a zero step.
- Add a Presto regression test confirming that equal bounds with a zero step still fail when `SPARK_COMPATIBLE` is not defined.

The production change is limited to `bolt/functions/lib/Sequence.cpp`; it does not change the `SequenceFunction` interface or the Spark/Presto registration paths.

#### Validation

```text
Spark-compatible Bolt SequenceTest.*: 13 passed, 0 failed
Default Presto Bolt SequenceTest.*:    23 passed, 0 failed
Gluten Sequence of numbers:             1 passed, 0 failed
GlutenCollectionExpressionsSuite:      54 passed, 0 failed, 3 ignored
```

The Gluten execution plan for `sequence(1, 1, 0)` contains `ProjectExecTransformer`, confirming that the expression executes through Bolt rather than vanilla Spark fallback.

### Performance Impact

- [x] **No Impact**: This is a correctness fix in sequence argument validation. It does not change the sequence-generation algorithm or memory layout.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Not applicable.
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Fixed Spark-compatible `sequence` to return a single-element array when start and stop are equal and step is zero, while preserving Presto zero-step validation.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
