### PR TITLE
fix: preserve null ROW elements in Spark to_json

### DIFF
--- a/bolt/functions/sparksql/ToJson.h
+++ b/bolt/functions/sparksql/ToJson.h
@@ -413,8 +413,6 @@ inline void toJson<TypeKind::ARRAY>(
     bool isMapKey) {
   auto arrayView = input.castTo<Array<Any>>();
   result.append("[");
-  // Determine the array element kind once to guide null rendering.
-  const auto elementKind = input.type()->childAt(0)->kind();
   for (int i = 0; i < arrayView.size(); i++) {
     if (i > 0) {
       result.append(",");
@@ -424,15 +422,7 @@ inline void toJson<TypeKind::ARRAY>(
       BOLT_DYNAMIC_TYPE_DISPATCH_ALL(
           detail::toJson, element.kind(), element, result, options, isMapKey);
     } else {
-      // Spark semantics: an array element of ROW type with all-null fields
-      // renders as an empty object `{}` rather than `null` when serializing
-      // to JSON (with ignoreNullFields=true). Tests expect `[{}]` for a
-      // single empty ROW element.
-      if (!isMapKey && elementKind == TypeKind::ROW) {
-        result.append("{}");
-      } else {
-        result.append("null");
-      }
+      result.append("null");
     }
   }
   result.append("]");

--- a/bolt/functions/sparksql/tests/FromToJsonRoundTripTest.cpp
+++ b/bolt/functions/sparksql/tests/FromToJsonRoundTripTest.cpp
@@ -69,6 +69,13 @@ TEST_F(FromToJsonRoundTripTest, basicArray) {
   testFromToJsonRoundTrip(input, rowType);
 }
 
+TEST_F(FromToJsonRoundTripTest, arrayOfRows) {
+  auto input = makeNullableFlatVector<std::string>(
+      {R"([{"a":1}])", R"([{}])", R"([null])", R"([])", std::nullopt});
+  auto rowType = ARRAY(ROW({"a"}, {INTEGER()}));
+  testFromToJsonRoundTrip(input, rowType);
+}
+
 TEST_F(FromToJsonRoundTripTest, basicMap) {
   auto input = makeFlatVector<std::string>(
       {R"({"a":1})", R"({"b":2})", R"({"c":3})", R"({"3":3})"});

--- a/bolt/functions/sparksql/tests/ToJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/ToJsonTest.cpp
@@ -756,13 +756,23 @@ TEST_F(ToJsonTest, fromSparkParity) {
     testToJson(input, expected);
   }
   {
-    // Array with single empty ROW.
+    // Distinguish a non-null ROW with null fields from a null ROW element.
     auto rowType = ROW({"a", "b"}, {INTEGER(), VARCHAR()});
-    std::vector<std::vector<std::optional<std::tuple<int32_t, std::string>>>>
-        data{{{std::nullopt}}, {{std::nullopt}}, {{std::nullopt}}};
-    auto input = makeArrayOfRowVector(data, rowType);
-    auto expected =
-        makeNullableFlatVector<std::string>({R"([{}])", R"([{}])", R"([{}])"});
+    const variant nullInt(TypeKind::INTEGER);
+    const variant nullString(TypeKind::VARCHAR);
+    const variant nullRow(TypeKind::ROW);
+    std::vector<std::vector<variant>> data{
+        {variant::row({nullInt, nullString})},
+        {nullRow},
+        {variant::row({1, nullString})}};
+    auto input = makeArrayOfRowVector(rowType, data);
+    auto expected = makeNullableFlatVector<std::string>(
+        {R"([{}])", R"([null])", R"([{"a":1}])"});
+    testToJson(input, expected);
+
+    disableJsonIgnoreNullFields();
+    expected = makeNullableFlatVector<std::string>(
+        {R"([{"a":null,"b":null}])", R"([null])", R"([{"a":1,"b":null}])"});
     testToJson(input, expected);
   }
   {


### PR DESCRIPTION
### What problem does this PR solve?

Spark distinguishes a null ROW array element from a non-null ROW whose fields are null:

- null ROW element -> `[null]`
- non-null ROW with null fields -> `[{}]` when `ignoreNullFields=true`

Bolt currently serializes both states as `[{}]`. This breaks `to_json` / `from_json` roundtrips and causes `GlutenJsonFunctionsSuite#roundtrip in to_json and from_json - array` to fail.

Issue Number: close #750

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Remove the ROW-specific substitution that serialized null array elements as `{}`.
- Serialize every null array element as JSON `null`, matching Spark and Velox.
- Preserve existing ROW serialization so a non-null ROW with all-null fields still produces `{}` when `ignoreNullFields=true`.
- Add explicit coverage for null ROW elements, non-null ROWs with null fields, partially populated ROWs, and both values of `spark.sql.jsonGenerator.ignoreNullFields`.
- Add `array<row>` `from_json` / `to_json` roundtrip coverage for populated objects, empty objects, null elements, empty arrays, and null inputs.

#### Root Cause and History

Bolt added Spark `to_json` in [PR #390](https://github.com/bytedance/bolt/pull/390) by cherry-picking the Velox implementation. The initial cherry-pick, [`9ce2c7f`](https://github.com/bytedance/bolt/commit/9ce2c7ff2cde12500ca3cca227909e78949c9c27), retained Velox's behavior of serializing every null array element as JSON `null`.

A follow-up commit, [`d88dfd7`](https://github.com/bytedance/bolt/commit/d88dfd783aaccd6949b78ad9904aef61ec1cd0de), attempted to fix an "Array with single empty ROW" case. Its test constructed the element with `std::nullopt`, which represents a null ROW element rather than a non-null ROW whose fields are null. To satisfy the test's `[{}]` expectation, the commit added a ROW-specific branch that converted every null ROW array element to `{}`.

That follow-up was squash-merged into `main` as [`ab89ad8`](https://github.com/bytedance/bolt/commit/ab89ad8e814104e4c4100a858de8e6b6f474e601). The resulting implementation conflated two distinct states:

- null ROW element: `[null]`
- non-null ROW with null fields: `[{}]` when `ignoreNullFields=true`

This PR removes the Bolt-only special case and restores the original and current Velox behavior.

### Performance Impact

- [x] **No Impact**: This removes an unnecessary element-type branch from null array-element serialization and does not change the algorithm or memory layout.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Not applicable.
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Fixed Spark `to_json` to preserve null ROW elements inside arrays instead of converting them to empty objects.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

#### Validation

```text
Bolt ToJsonTest.* + FromToJsonRoundTripTest.*: 32 passed, 0 failed
Gluten target regression:                         1 passed, 0 failed
GlutenJsonFunctionsSuite:                        82 passed, 0 failed, 6 ignored
```

The Gluten run loaded the rebuilt Bolt native library and did not report a `GlutenSessionExtensions` initialization failure.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
