### PR TITLE
fix: retain intermediate signatures for partial agg companions

### DIFF
--- a/bolt/exec/Aggregate.cpp
+++ b/bolt/exec/Aggregate.cpp
@@ -160,6 +160,9 @@ std::vector<CompanionSignatureEntry> getCompanionSignatures(
     std::string&& name,
     std::vector<AggregateFunctionSignaturePtr>&& signatures) {
   std::vector<CompanionSignatureEntry> entries;
+  if (signatures.empty()) {
+    return entries;
+  }
   entries.push_back(
       {std::move(name),
        std::vector<FunctionSignaturePtr>{
@@ -171,6 +174,9 @@ std::vector<CompanionSignatureEntry> getCompanionSignatures(
     std::string&& name,
     std::vector<FunctionSignaturePtr>&& signatures) {
   std::vector<CompanionSignatureEntry> entries;
+  if (signatures.empty()) {
+    return entries;
+  }
   entries.push_back({std::move(name), std::move(signatures)});
   return entries;
 }

--- a/bolt/exec/AggregateCompanionSignatures.cpp
+++ b/bolt/exec/AggregateCompanionSignatures.cpp
@@ -113,9 +113,6 @@ CompanionSignatures::partialFunctionSignatures(
     const std::vector<AggregateFunctionSignaturePtr>& signatures) {
   std::vector<AggregateFunctionSignaturePtr> partialSignatures;
   for (const auto& signature : signatures) {
-    if (!isResultTypeResolvableGivenIntermediateType(signature)) {
-      continue;
-    }
     std::vector<TypeSignature> usedTypes = signature->argumentTypes();
     usedTypes.push_back(signature->intermediateType());
     auto variables = usedTypeVariables(usedTypes, signature->variables());
@@ -137,10 +134,6 @@ std::string CompanionSignatures::partialFunctionName(const std::string& name) {
 
 AggregateFunctionSignaturePtr CompanionSignatures::mergeFunctionSignature(
     const AggregateFunctionSignaturePtr& signature) {
-  if (!isResultTypeResolvableGivenIntermediateType(signature)) {
-    return nullptr;
-  }
-
   std::vector<TypeSignature> usedTypes = {signature->intermediateType()};
   auto variables = usedTypeVariables(usedTypes, signature->variables());
   return std::make_shared<AggregateFunctionSignature>(

--- a/bolt/exec/tests/AggregateCompanionAdapterTest.cpp
+++ b/bolt/exec/tests/AggregateCompanionAdapterTest.cpp
@@ -427,8 +427,10 @@ TEST_F(
 TEST_F(
     AggregateCompanionRegistryTest,
     resultTypeNotResolvableFromIntermediateType) {
-  // We only register companion functions for original signatures whose result
-  // type can be resolved from its intermediate type.
+  // Partial and merge companion functions only produce intermediate results, so
+  // they do not need the final result type to be resolvable from the
+  // intermediate type. Extract and merge-extract still need a concrete final
+  // result type and are not registered for this signature.
   std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
       AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -438,9 +440,15 @@ TEST_F(
           .build()};
   registerDummyAggregateFunction("aggregateFunc6", signatures);
 
-  checkAggregateSignaturesCount("aggregateFunc6_partial", 0);
+  checkAggregateSignaturesCount("aggregateFunc6_partial", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc6_partial", {BIGINT()}, VARBINARY(), VARBINARY());
+  checkAggregateTypeResolution(
+      "aggregateFunc6_partial", {DOUBLE()}, VARBINARY(), VARBINARY());
 
-  checkAggregateSignaturesCount("aggregateFunc6_merge", 0);
+  checkAggregateSignaturesCount("aggregateFunc6_merge", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc6_merge", {VARBINARY()}, VARBINARY(), VARBINARY());
 
   checkAggregateSignaturesCount("aggregateFunc6_merge_extract", 0);
 

--- a/bolt/exec/tests/AggregateCompanionSignaturesTest.cpp
+++ b/bolt/exec/tests/AggregateCompanionSignaturesTest.cpp
@@ -198,6 +198,30 @@ TEST_F(AggregateCompanionSignaturesTest, templateSignature) {
   assertEqual(*companionSignatures, expected);
 }
 
+TEST_F(
+    AggregateCompanionSignaturesTest,
+    resultTypeNotResolvableFromIntermediateType) {
+  std::vector<AggregateFunctionSignaturePtr> signatures{
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("array(T)")
+          .intermediateType("varbinary")
+          .argumentType("T")
+          .build()};
+  registerDummyAggregateFunction("aggregateFunc4", signatures);
+  auto companionSignatures = getCompanionFunctionSignatures("aggregateFunc4");
+  EXPECT_TRUE(companionSignatures.has_value());
+
+  assertEqual(
+      companionSignatures->partial,
+      {{"aggregateFunc4_partial", {"(T) -> varbinary -> varbinary"}}});
+  assertEqual(
+      companionSignatures->merge,
+      {{"aggregateFunc4_merge", {"(varbinary) -> varbinary -> varbinary"}}});
+  EXPECT_TRUE(companionSignatures->extract.empty());
+  EXPECT_TRUE(companionSignatures->mergeExtract.empty());
+}
+
 } // namespace
 
 } // namespace bytedance::bolt::exec::test

--- a/bolt/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -30,6 +30,7 @@
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
 #include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "bolt/functions/sparksql/aggregates/Register.h"
 using namespace bytedance::bolt::exec::test;
@@ -300,6 +301,78 @@ TEST_F(AverageAggregationTest, rowBasedSpillDecimalAvg) {
       {},
       /*testWithTableScan*/ false);
   disallowInputShuffle();
+}
+
+TEST_F(AverageAggregationTest, rowBasedSpillDecimalAvgPartialOutputType) {
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < 4; ++i) {
+    constexpr vector_size_t rowCount = 1024;
+    vectors.emplace_back(makeRowVector(
+        {makeFlatVector<int32_t>(
+             rowCount, [&](auto row) { return i * rowCount + row; }),
+         makeFlatVector<int128_t>(
+             rowCount,
+             [](auto row) { return HugeInt::build(0, row + 1); },
+             nullptr,
+             DECIMAL(32, 12))}));
+  }
+
+  auto source = PlanBuilder().values(vectors).planNode();
+  auto key =
+      std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c0");
+  auto input =
+      std::make_shared<const core::FieldAccessTypedExpr>(DECIMAL(32, 12), "c1");
+  auto outputType = ROW({DECIMAL(38, 12), BIGINT()});
+  // Match Substrait plans where Spark partial avg exposes an expanded decimal
+  // sum buffer. The companion signature must resolve the same intermediate
+  // type.
+  core::AggregationNode::Aggregate aggregate{
+      std::make_shared<const core::CallTypedExpr>(
+          outputType,
+          std::vector<core::TypedExprPtr>{input},
+          "spark_avg_partial"),
+      {DECIMAL(32, 12)},
+      nullptr,
+      {},
+      {}};
+  auto plan = std::make_shared<core::AggregationNode>(
+      "partial_avg_decimal_repro",
+      core::AggregationNode::Step::kPartial,
+      std::vector<core::FieldAccessTypedExprPtr>{key},
+      std::vector<core::FieldAccessTypedExprPtr>{},
+      std::vector<std::string>{"avg"},
+      std::vector<core::AggregationNode::Aggregate>{aggregate},
+      false,
+      source);
+
+  auto spillDirectory = exec::test::TempDirectoryPath::create();
+  std::shared_ptr<exec::Task> task;
+  auto result =
+      AssertQueryBuilder(plan)
+          .spillDirectory(spillDirectory->path)
+          .config(core::QueryConfig::kSpillEnabled, true)
+          .config(core::QueryConfig::kAggregationSpillEnabled, true)
+          .config(core::QueryConfig::kTestingSpillPct, "100")
+          .config(core::QueryConfig::kRowBasedSpillMode, "compression")
+          .config(core::QueryConfig::kPartialAggregationSpillMaxPct, "100")
+          .config(
+              core::QueryConfig::kAbandonPartialAggregationMinFinalPct, "100")
+          .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "100")
+          .config(core::QueryConfig::kAggregationSpillMemoryThreshold, "1")
+          .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "50")
+          .copyResults(pool(), task);
+
+  ASSERT_EQ(result->size(), 4 * 1024);
+  ASSERT_TRUE(
+      result->type()->equivalent(*ROW({"c0", "avg"}, {INTEGER(), outputType})));
+
+  int64_t spilledBytes = 0;
+  for (const auto& pipeline : task->taskStats().pipelineStats) {
+    for (const auto& op : pipeline.operatorStats) {
+      spilledBytes += op.spilledBytes;
+    }
+  }
+  ASSERT_GT(spilledBytes, 0);
 }
 
 } // namespace


### PR DESCRIPTION

### What problem does this PR solve?
Partial and merge companion aggregate functions only produce intermediate results, but Bolt filtered their signatures with isResultTypeResolvableGivenIntermediateType(). That predicate is only valid for extract/merge-extract companions, where the final result type must be resolved from the intermediate input.

For Spark decimal avg this filtered out the correct widened partial intermediate ROW<DECIMAL(38, scale), BIGINT> and allowed a fallback ROW<DECIMAL(inputPrecision, scale), BIGINT> signature to be selected. Under row-based aggregation spill this made the plan output type disagree with the accumulator spill type and tripped the outputUniqueGroups type-equivalence check.
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Remove the final-result resolvability filter from partial and merge companion signature generation, keep extract and merge-extract filtered, and avoid exposing empty companion signature entries. Add companion signature/registry coverage plus a row-based spill regression for spark_avg_partial(DECIMAL(XX,12)).

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
