### PR TITLE
fix(parquet): support Spark UINT64 as DECIMAL(20,0)

### DIFF
--- a/bolt/dwio/parquet/reader/IntegerColumnReader.h
+++ b/bolt/dwio/parquet/reader/IntegerColumnReader.h
@@ -80,9 +80,24 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
     bool needConvertion = (castExprSet_ && castExprSet_->size() != 0);
     auto& requestedType = needConvertion ? fileType_->type() : requestedType_;
     auto& fileType = static_cast<const ParquetTypeWithId&>(*fileType_);
-    auto logicalType = fileType.logicalType_;
-    if (logicalType.has_value() && logicalType.value().__isset.INTEGER &&
-        !logicalType.value().INTEGER.isSigned) {
+    bool isUnsigned = false;
+    if (fileType.logicalType_.has_value() &&
+        fileType.logicalType_.value().__isset.INTEGER) {
+      isUnsigned = !fileType.logicalType_.value().INTEGER.isSigned;
+    }
+#ifdef SPARK_COMPATIBLE
+    if (!fileType.logicalType_.has_value() &&
+        fileType.convertedType_ == thrift::ConvertedType::UINT_64) {
+      // Legacy Parquet files may carry only the UINT_64 converted type. In
+      // particular, convertType accepts these files as DECIMAL(20, 0). Without
+      // this fallback, getIntValues() would use its HUGEINT path and interpret
+      // each 8-byte physical UINT64 as a 16-byte int128_t. Use the unsigned
+      // path to preserve the UINT64 bits and widen each value correctly.
+      isUnsigned = true;
+    }
+#endif
+
+    if (isUnsigned) {
       getUnsignedIntValues(rows, requestedType, result);
     } else {
       getIntValues(rows, requestedType, result);

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -125,6 +125,20 @@ bool isInt64Compatible(const bytedance::bolt::TypePtr& type) {
   return type->kind() == TK::BIGINT || acceptsIntFileForReaderCast(type);
 }
 
+bool isUInt64Compatible(const bytedance::bolt::TypePtr& type) {
+#ifdef SPARK_COMPATIBLE
+  if (type->isDecimal()) {
+    // Spark maps Parquet UINT64 to DECIMAL(20, 0) because it has no unsigned
+    // 64-bit type. Keep this as a dedicated Spark representation mapping, not
+    // general integer-to-Decimal schema evolution. The unsigned integer reader
+    // already widens the 8-byte value to 128 bits without rescaling.
+    const auto [precision, scale] = getDecimalPrecisionScale(*type);
+    return precision == 20 && scale == 0;
+  }
+#endif
+  return isInt64Compatible(type);
+}
+
 } // namespace
 
 /// Metadata and options for reading Parquet.
@@ -1082,7 +1096,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "UINT_64 converted type can only be set for value of thrift::Type::INT64");
-        checkRequested([](const TypePtr& t) { return isInt64Compatible(t); });
+        checkRequested([](const TypePtr& t) { return isUInt64Compatible(t); });
         return BIGINT();
 
       case thrift::ConvertedType::DATE:
@@ -1178,6 +1192,19 @@ TypePtr ReaderBase::convertType(
           });
           return TIMESTAMP();
         }
+#ifdef SPARK_COMPATIBLE
+        if (schemaElement.__isset.logicalType &&
+            schemaElement.logicalType.__isset.INTEGER &&
+            !schemaElement.logicalType.INTEGER.isSigned) {
+          BOLT_CHECK_EQ(
+              schemaElement.logicalType.INTEGER.bitWidth,
+              64,
+              "Unsigned INTEGER logical type on INT64 must have bit width 64");
+          checkRequested(
+              [](const TypePtr& t) { return isUInt64Compatible(t); });
+          return BIGINT();
+        }
+#endif
         if (schemaElement.__isset.converted_type &&
             (schemaElement.converted_type ==
                  thrift::ConvertedType::TIMESTAMP_MILLIS ||

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -33,6 +33,9 @@
 #include <type/Type.h>
 #include <cstdlib>
 #include <filesystem>
+#ifdef SPARK_COMPATIBLE
+#include "bolt/common/base/tests/GTestUtils.h"
+#endif
 #include "bolt/core/QueryCtx.h"
 #include "bolt/dwio/parquet/reader/RepeatedColumnReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
@@ -597,8 +600,38 @@ TEST_F(ParquetReaderTest, parseUnsignedInt4) {
            {18446744073709551615ULL,
             2000000000000000000ULL,
             3000000000000000000ULL})});
+
+#ifdef SPARK_COMPATIBLE
+  const std::string sample(getExampleFilePath("uint.parquet"));
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileSchema(rowType);
+  auto reader = createReader(sample, readerOptions);
+
+  auto rowReaderOpts = getReaderOpts(rowType);
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  assertReadWithReaderAndExpected(rowType, *rowReader, expected, *pool_);
+#else
   assertReadWithExpected("uint.parquet", rowType, expected);
+#endif
 }
+
+#ifdef SPARK_COMPATIBLE
+TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
+  const std::vector<TypePtr> unsupportedTypes = {
+      DECIMAL(18, 0), DECIMAL(19, 0), DECIMAL(20, 1), DECIMAL(21, 0)};
+  const std::string sample(getExampleFilePath("uint.parquet"));
+
+  for (const auto& uint64Type : unsupportedTypes) {
+    auto rowType =
+        ROW({"uint8", "uint16", "uint32", "uint64"},
+            {SMALLINT(), INTEGER(), INTEGER(), uint64Type});
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    readerOptions.setFileSchema(rowType);
+    BOLT_ASSERT_THROW(createReader(sample, readerOptions), "Schema mismatch");
+  }
+}
+#endif
 
 TEST_F(ParquetReaderTest, parseUnsignedInt5) {
   auto rowType =


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #754

Spark 3.5 represents a Parquet `UINT_64` column as `DECIMAL(20, 0)`. Bolt already has an unsigned `uint64_t -> uint128_t` materialization path, but the schema compatibility check rejects the requested long Decimal before that path can run.

The new compatibility rule is limited to `SPARK_COMPATIBLE` builds. Presto does not infer Parquet UINT64 as `DECIMAL(20, 0)`, so its schema compatibility behavior remains unchanged. General Spark 4 integer/Decimal schema evolution remains out of scope and is tracked in #753.

Spark 3.5 defines the UINT64 mapping in [`ParquetSchemaConverter.scala`](https://github.com/apache/spark/blob/7c29c664cdc9321205a98a14858aaf8daaa19db2/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala#L248-L263):

```scala
case intTypeAnnotation: IntLogicalTypeAnnotation if !intTypeAnnotation.isSigned =>
  intTypeAnnotation.getBitWidth match {
    // The precision to hold the largest unsigned long is:
    // `java.lang.Long.toUnsignedString(-1).length` = 20
    case 64 => DecimalType(20, 0)
    case _ => illegalType()
  }
```

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- In `SPARK_COMPATIBLE` builds, add a dedicated UINT64 compatibility predicate that accepts exactly `DECIMAL(20, 0)` and keeps all other Decimal precision/scale combinations rejected.
- Check `isDecimal()` before `TypeKind` in that Spark-specific path so short Decimals cannot bypass validation through their shared `BIGINT` kind.
- Apply the rule to both modern `INTEGER(64, false)` and legacy `ConvertedType::UINT_64` annotations.
- In `SPARK_COMPATIBLE` builds, route legacy files that have only `ConvertedType::UINT_64` through unsigned materialization, avoiding interpretation of 8-byte values as 16-byte signed HUGEINT values.
- Make the existing UINT64 reader test set `ReaderOptions::setFileSchema()` so it exercises schema compatibility, and add rejection coverage for `DECIMAL(18,0)`, `DECIMAL(19,0)`, `DECIMAL(20,1)`, and `DECIMAL(21,0)`.

### Performance Impact

- [x] **No Impact**: This restores schema acceptance for an existing materialization path and adds no new per-value conversion.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixed Spark-compatible reads of Parquet UINT64 columns as DECIMAL(20,0).
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation:

```text
bolt_dwio_parquet_reader_test: 116 passed
bolt_dwio_parquet_table_scan_test: 37 passed
GlutenParquetIOSuite: 75 succeeded, 0 failed, 4 ignored
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
