### PR TITLE
feat: implement bitmap_construct_agg aggregate for Spark compatibility

### DIFF
--- a/bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.h"
+
+#include <cstring>
+
+#include <xsimd/xsimd.hpp>
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/exec/Aggregate.h"
+#include "bolt/expression/FunctionSignature.h"
+#include "bolt/vector/FlatVector.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+namespace {
+
+// 4096-byte inline bitmap. uint8_t ensures portable unsigned bitwise
+// semantics. Trivially constructible/destructible — safe for Bolt's group
+// reuse where placement-new may be called on previously freed memory.
+struct BitmapAccumulator {
+  uint8_t bitmap_[kBitmapNumBytes] = {};
+
+  void setPosition(int64_t position) {
+    BOLT_USER_CHECK(
+        position >= 0 && position < kBitmapNumBits,
+        "Invalid bitmap position: {} (valid range: [0, {}))",
+        position,
+        static_cast<int64_t>(kBitmapNumBits));
+    int32_t byteIdx = static_cast<int32_t>(position / 8);
+    int32_t bitIdx = static_cast<int32_t>(position % 8);
+    bitmap_[byteIdx] |= static_cast<uint8_t>(1 << bitIdx);
+  }
+
+  // Byte-wise bitwise OR. xsimd vectorizes across 16 (NEON) or 32 (AVX2)
+  // bytes per iteration.
+  void mergeWith(const char* other) {
+    const auto* otherBytes = reinterpret_cast<const uint8_t*>(other);
+    using Batch = xsimd::batch<uint8_t>;
+    static constexpr int32_t kBatchSize = Batch::size;
+    int32_t i = 0;
+    for (; i + kBatchSize <= kBitmapNumBytes; i += kBatchSize) {
+      auto a = Batch::load_unaligned(bitmap_ + i);
+      auto b = Batch::load_unaligned(otherBytes + i);
+      (a | b).store_unaligned(bitmap_ + i);
+    }
+    for (; i < kBitmapNumBytes; ++i) {
+      bitmap_[i] |= otherBytes[i];
+    }
+  }
+};
+
+static_assert(
+    sizeof(BitmapAccumulator) == kBitmapNumBytes,
+    "BitmapAccumulator size must be exactly 4096 bytes");
+
+// Shared raw-input decoding for single-group and multi-group paths.
+template <typename GetAccumulator>
+FOLLY_ALWAYS_INLINE void processRawInput(
+    const DecodedVector& decoded,
+    const SelectivityVector& rows,
+    GetAccumulator&& getAccumulator) {
+  if (decoded.isConstantMapping()) {
+    if (!decoded.isNullAt(0)) {
+      int64_t pos = decoded.valueAt<int64_t>(0);
+      rows.applyToSelected(
+          [&](vector_size_t i) { getAccumulator(i)->setPosition(pos); });
+    }
+  } else if (decoded.mayHaveNulls()) {
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decoded.isNullAt(row)) {
+        return;
+      }
+      getAccumulator(row)->setPosition(decoded.valueAt<int64_t>(row));
+    });
+  } else {
+    rows.applyToSelected([&](vector_size_t i) {
+      getAccumulator(i)->setPosition(decoded.valueAt<int64_t>(i));
+    });
+  }
+}
+
+class BitmapConstructAggAggregate : public exec::Aggregate {
+ public:
+  explicit BitmapConstructAggAggregate(TypePtr resultType)
+      : Aggregate(std::move(resultType)) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(BitmapAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return true;
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      new (value<BitmapAccumulator>(groups[i])) BitmapAccumulator();
+    }
+  }
+
+  // ---- Raw input (BIGINT bit position) ----
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    BOLT_CHECK_EQ(args.size(), 1);
+    DecodedVector decoded(*args[0], rows);
+    processRawInput(decoded, rows, [&](vector_size_t i) {
+      return value<BitmapAccumulator>(groups[i]);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    BOLT_CHECK_EQ(args.size(), 1);
+    DecodedVector decoded(*args[0], rows);
+    auto* accumulator = value<BitmapAccumulator>(group);
+    processRawInput(decoded, rows, [accumulator](vector_size_t /*i*/) {
+      return accumulator;
+    });
+  }
+
+  // ---- Intermediate results (VARBINARY = serialized 4096-byte bitmap) ----
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    BOLT_CHECK_EQ(args.size(), 1);
+    DecodedVector decoded(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decoded.isNullAt(row)) {
+        return;
+      }
+      auto sv = decoded.valueAt<StringView>(row);
+      BOLT_CHECK_EQ(
+          sv.size(), kBitmapNumBytes, "Intermediate bitmap must be 4096 bytes");
+      value<BitmapAccumulator>(groups[row])->mergeWith(sv.data());
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    BOLT_CHECK_EQ(args.size(), 1);
+    DecodedVector decoded(*args[0], rows);
+    auto* accumulator = value<BitmapAccumulator>(group);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decoded.isNullAt(row)) {
+        return;
+      }
+      auto sv = decoded.valueAt<StringView>(row);
+      BOLT_CHECK_EQ(
+          sv.size(), kBitmapNumBytes, "Intermediate bitmap must be 4096 bytes");
+      accumulator->mergeWith(sv.data());
+    });
+  }
+
+  // ---- Extraction ----
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    BOLT_CHECK(result);
+    auto* flatResult = (*result)->asUnchecked<FlatVector<StringView>>();
+    flatResult->resize(numGroups);
+
+    int32_t totalSize = numGroups * kBitmapNumBytes;
+    char* rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+    for (vector_size_t i = 0; i < numGroups; ++i) {
+      auto* accumulator = value<BitmapAccumulator>(groups[i]);
+      memcpy(rawBuffer, accumulator->bitmap_, kBitmapNumBytes);
+      StringView sv(rawBuffer, kBitmapNumBytes);
+      rawBuffer += kBitmapNumBytes;
+      flatResult->setNoCopy(i, sv);
+    }
+  }
+
+  // Identical to extractValues: accumulator format = final result format.
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerBitmapConstructAggAggregate(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .argumentType("bigint")
+          .intermediateType("varbinary")
+          .returnType("varbinary")
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& /*argTypes*/,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<BitmapConstructAggAggregate>(resultType);
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.cpp
@@ -35,7 +35,7 @@ namespace {
 struct BitmapAccumulator {
   uint8_t bitmap_[kBitmapNumBytes] = {};
 
-  void setPosition(int64_t position) {
+  FOLLY_ALWAYS_INLINE void setPosition(int64_t position) {
     BOLT_USER_CHECK(
         position >= 0 && position < kBitmapNumBits,
         "Invalid bitmap position: {} (valid range: [0, {}))",

--- a/bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.h
+++ b/bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "bolt/exec/AggregateUtil.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql {
+
+// Matching Spark's BitmapExpressionUtils.NUM_BYTES (4 KiB, 32768 bits).
+inline constexpr int32_t kBitmapNumBytes = 4096;
+inline constexpr int32_t kBitmapNumBits = kBitmapNumBytes * 8;
+
+exec::AggregateRegistrationResult registerBitmapConstructAggAggregate(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql

--- a/bolt/functions/sparksql/aggregates/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/CMakeLists.txt
@@ -74,6 +74,7 @@ bolt_add_library(
   ${PERCENTILE_GENERATED_FILES}
   ${MIN_MAX_BY_GENERATED_FILES}
   AverageAggregate.cpp
+  BitmapConstructAggAggregate.cpp
   BitwiseXorAggregate.cpp
   BloomFilterAggAggregate.cpp
   CentralMomentsAggregate.cpp

--- a/bolt/functions/sparksql/aggregates/Register.cpp
+++ b/bolt/functions/sparksql/aggregates/Register.cpp
@@ -33,6 +33,7 @@
 #include "bolt/functions/lib/aggregates/BitDaysOrAggregate.h"
 #include "bolt/functions/lib/aggregates/CollectSetAggregate.h"
 #include "bolt/functions/sparksql/aggregates/AverageAggregate.h"
+#include "bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.h"
 #include "bolt/functions/sparksql/aggregates/BitwiseXorAggregate.h"
 #include "bolt/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
 #include "bolt/functions/sparksql/aggregates/CentralMomentsAggregate.h"
@@ -73,6 +74,8 @@ void registerAggregateFunctions(
     bool overwrite) {
   registerFirstLastAggregates(prefix, withCompanionFunctions, overwrite);
   registerMinMaxByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerBitmapConstructAggAggregate(
+      prefix + "bitmap_construct_agg", withCompanionFunctions, overwrite);
   registerBitDaysOrAggregate(
       prefix + "bit_days_or", withCompanionFunctions, overwrite);
   registerBitwiseXorAggregate(prefix, withCompanionFunctions, overwrite);

--- a/bolt/functions/sparksql/aggregates/tests/BitmapConstructAggAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/BitmapConstructAggAggregateTest.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/exec/tests/utils/AssertQueryBuilder.h"
+#include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "bolt/functions/sparksql/aggregates/BitmapConstructAggAggregate.h"
+#include "bolt/functions/sparksql/aggregates/Register.h"
+
+namespace bytedance::bolt::functions::aggregate::sparksql::test {
+
+namespace {
+
+std::string makeBitmap(const std::vector<int64_t>& positions) {
+  std::string bitmap(kBitmapNumBytes, '\0');
+  for (auto pos : positions) {
+    int32_t byteIdx = static_cast<int32_t>(pos / 8);
+    int32_t bitIdx = static_cast<int32_t>(pos % 8);
+    reinterpret_cast<uint8_t*>(bitmap.data())[byteIdx] |=
+        static_cast<uint8_t>(1 << bitIdx);
+  }
+  return bitmap;
+}
+
+class BitmapConstructAggAggregateTest
+    : public aggregate::test::AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    registerAggregateFunctions("");
+    allowInputShuffle();
+  }
+
+  VectorPtr makeBitmapVector(const std::string& bitmap) {
+    return makeConstant(StringView(bitmap), 1, VARBINARY());
+  }
+};
+
+} // namespace
+
+// ---- Basic correctness ----
+
+TEST_F(BitmapConstructAggAggregateTest, singlePosition) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(1, [](vector_size_t) { return 5; })})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({5}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, multiplePositions) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(3, [](vector_size_t row) { return row; })})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({0, 1, 2}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, duplicatePositions) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(3, [](vector_size_t) { return 7; })})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({7}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, emptyInput) {
+  auto vectors = {makeRowVector({makeFlatVector<int64_t>({})})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, nullInputs) {
+  auto vectors = {makeRowVector({makeNullableFlatVector<int64_t>(
+      {1, std::nullopt, 3, std::nullopt, 5})})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({1, 3, 5}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, allNullInputs) {
+  auto vectors = {makeRowVector({makeAllNullFlatVector<int64_t>(5)})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, groupBy) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>({0, 0, 1, 1, 2, 2}),
+       makeFlatVector<int64_t>({1, 3, 1, 5, 7, 7})})};
+  std::vector<std::string> bitmaps = {
+      makeBitmap({1, 3}), makeBitmap({1, 5}), makeBitmap({7})};
+  auto expected = {makeRowVector(
+      {makeFlatVector<int64_t>({0, 1, 2}),
+       makeFlatVector<StringView>(
+           3,
+           [&](vector_size_t row) { return StringView(bitmaps[row]); },
+           nullptr,
+           VARBINARY())})};
+  testAggregations(vectors, {"c0"}, {"bitmap_construct_agg(c1)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, highPosition) {
+  int64_t pos = kBitmapNumBits - 1; // 32767
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(1, [&](vector_size_t) { return pos; })})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({pos}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, positionZero) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>(1, [](vector_size_t) { return 0; })})};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({0}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+// ---- Error cases ----
+
+TEST_F(BitmapConstructAggAggregateTest, invalidNegativePosition) {
+  auto vectors = {makeRowVector({makeFlatVector<int64_t>({0, -1, 2})})};
+  testFailingAggregations(
+      vectors, {}, {"bitmap_construct_agg(c0)"}, "Invalid bitmap position");
+}
+
+TEST_F(BitmapConstructAggAggregateTest, invalidTooLargePosition) {
+  auto vectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, kBitmapNumBits, 2})})};
+  testFailingAggregations(
+      vectors, {}, {"bitmap_construct_agg(c0)"}, "Invalid bitmap position");
+}
+
+// ---- Merge / round-trip ----
+
+TEST_F(BitmapConstructAggAggregateTest, mergePartialBitmaps) {
+  auto batch1 = makeRowVector(
+      {makeFlatVector<int64_t>(2, [](vector_size_t r) { return r; })});
+  auto batch2 = makeRowVector(
+      {makeFlatVector<int64_t>(2, [](vector_size_t r) { return r + 2; })});
+  auto vectors = {batch1, batch2};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({0, 1, 2, 3}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, mergeAcrossSimdBoundaries) {
+  // Positions spanning SIMD batch boundaries (NEON batch = 16 bytes).
+  auto batch1 = makeRowVector({makeFlatVector<int64_t>({7, 127, 2811})});
+  auto batch2 = makeRowVector({makeFlatVector<int64_t>({128, 32767})});
+  auto vectors = {batch1, batch2};
+  auto expected = {makeRowVector(
+      {makeBitmapVector(makeBitmap({7, 127, 128, 2811, 32767}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, roundTripSerializeMerge) {
+  auto rawInput1 = std::vector<VectorPtr>{
+      makeFlatVector<int64_t>(3, [](vector_size_t r) { return r; })};
+  auto rawInput2 = std::vector<VectorPtr>{
+      makeFlatVector<int64_t>(2, [](vector_size_t r) { return r + 7; })};
+  auto result =
+      testStreaming("bitmap_construct_agg", true, rawInput1, rawInput2);
+  ::bytedance::bolt::test::assertEqualVectors(
+      makeBitmapVector(makeBitmap({0, 1, 2, 7, 8})), result);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, emptyInputThenMerge) {
+  auto batch1 = makeRowVector({makeFlatVector<int64_t>({})});
+  auto batch2 = makeRowVector(
+      {makeFlatVector<int64_t>(2, [](vector_size_t r) { return r * 100; })});
+  auto vectors = {batch1, batch2};
+  auto expected = {makeRowVector({makeBitmapVector(makeBitmap({0, 100}))})};
+  testAggregations(vectors, {}, {"bitmap_construct_agg(c0)"}, expected);
+}
+
+} // namespace bytedance::bolt::functions::aggregate::sparksql::test

--- a/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -28,6 +28,7 @@
 add_executable(
   bolt_functions_spark_aggregates_test
   AverageAggregationTest.cpp
+  BitmapConstructAggAggregateTest.cpp
   BitwiseXorAggregationTest.cpp
   BloomFilterAggAggregateTest.cpp
   CentralMomentsAggregationTest.cpp


### PR DESCRIPTION
Add native implementation of Spark 3.5's bitmap_construct_agg — a BIGINT position aggregate that OR's bits into a 4096-byte (32768 bit) fixed-size bitmap, returning BINARY.

Core design:
- BitmapAccumulator: inline uint8_t[4096], trivially constructible for safe group reuse; static_assert guards the 4096-byte size
- mergeWith: xsimd-vectorized byte-wise OR.
- extractValues == extractAccumulators: accumulator format = final result format (raw 4096-byte bitmap, no type conversion needed)
- Null inputs are skipped, empty input returns all-zero bitmap
- BOLT_USER_CHECK validates position in [0, 32768)
- companion functions registered for distributed partial/merge support

15 unit tests: single/multi/duplicate positions, empty input, null handling, group-by, boundary positions (0, 32767), invalid positions (-1, 32768), SIMD-boundary-spanning merge, round-trip serialization via testStreaming, empty-then-merge.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #756 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
