### PR TITLE
fix: avoid skipping project for non-adjacent partial aggregation

### DIFF
--- a/bolt/exec/LocalPlanner.cpp
+++ b/bolt/exec/LocalPlanner.cpp
@@ -665,7 +665,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
             std::dynamic_pointer_cast<const core::ProjectNode>(planNode)) {
 #ifdef SPARK_COMPATIBLE
       // partialagg + project + project
-      if (markSkipProject && (i = markSkipProjectAggIndex + 1)) {
+      if (markSkipProject && (i == markSkipProjectAggIndex + 1)) {
         auto nextProject = std::dynamic_pointer_cast<const core::ProjectNode>(
             planNodes[markSkipProjectAggIndex + 2]);
         if (nextProject && nextProject->projections().size() > 0) {

--- a/bolt/exec/tests/DriverTest.cpp
+++ b/bolt/exec/tests/DriverTest.cpp
@@ -35,6 +35,7 @@
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
 #include "bolt/dwio/common/tests/utils/BatchMaker.h"
+#include "bolt/exec/LocalPlanner.h"
 #include "bolt/exec/PlanNodeStats.h"
 #include "bolt/exec/Values.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
@@ -617,6 +618,60 @@ TEST_F(DriverTest, pause) {
   EXPECT_EQ(operators[0].outputPositions, 10000000);
   EXPECT_EQ(operators[1].inputPositions, 10000000);
   EXPECT_EQ(operators[1].outputPositions, 10 * hits);
+}
+
+TEST_F(DriverTest, skipCompositeProjectRequiresAdjacentPartialAggregation) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({1, 2, 3}), makeFlatVector<int64_t>({4, 5, 6})});
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  PlanBuilder builder(planNodeIdGenerator);
+  auto partialAgg =
+      builder.values({data}).partialAggregation({"c0"}, {"sum(c1)"}).planNode();
+  auto limit = std::make_shared<core::LimitNode>(
+      planNodeIdGenerator->next(), 0, 100, true, partialAgg);
+  auto hashProject = std::make_shared<core::ProjectNode>(
+      planNodeIdGenerator->next(),
+      std::vector<std::string>{"hash"},
+      std::vector<core::TypedExprPtr>{std::make_shared<core::CallTypedExpr>(
+          BIGINT(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(
+                  limit->outputType()->childAt(0),
+                  limit->outputType()->nameOf(0))},
+          "hive_hash")},
+      limit);
+
+  std::vector<std::unique_ptr<DriverFactory>> factories;
+  LocalPlanner::plan(
+      core::PlanFragment{hashProject},
+      ConsumerSupplier{},
+      &factories,
+      core::QueryConfig{{}},
+      1,
+      false);
+  ASSERT_EQ(factories.size(), 1);
+
+  auto task = Task::create(
+      "skipCompositeProjectRequiresAdjacentPartialAggregation",
+      core::PlanFragment{hashProject},
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel,
+      ConsumerSupplier{});
+  auto driver = factories[0]->createDriver(
+      std::make_unique<DriverCtx>(task, 0, 0, 0, 0),
+      nullptr,
+      [](int /*pipelineId*/) { return 1; });
+
+  std::vector<std::string> operatorTypes;
+  for (const auto* op : driver->operators()) {
+    operatorTypes.push_back(op->operatorType());
+  }
+  EXPECT_EQ(
+      operatorTypes,
+      (std::vector<std::string>{
+          "Values", "PartialAggregation", "Limit", "FilterProject"}));
 }
 
 TEST_F(DriverTest, yield) {


### PR DESCRIPTION
### What problem does this PR solve?
Avoid skipping project for non-adjacent partial aggregation.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Fix a typo in the skip-project guard: the condition used assignment (i = markSkipProjectAggIndex + 1) instead of equality comparison (i == markSkipProjectAggIndex + 1). This could incorrectly make the condition evaluate as true and skip Project even when the partial aggregation was not adjacent.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
