### PR TITLE
feat(flinksql): add Flink-compatible parse_url function

### DIFF
--- a/bolt/functions/flinksql/URLFunctions.h
+++ b/bolt/functions/flinksql/URLFunctions.h
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <folly/IPAddressV6.h>
+
+#include "bolt/functions/Macros.h"
+
+namespace bytedance::bolt::functions::flinksql {
+namespace detail {
+
+struct ParsedUrl {
+  std::string protocol;
+  std::string_view host;
+  std::string_view path;
+  std::optional<std::string_view> query;
+  std::optional<std::string_view> ref;
+  std::optional<std::string_view> authority;
+  std::optional<std::string_view> userInfo;
+};
+
+FOLLY_ALWAYS_INLINE bool isProtocolFirstChar(char c) {
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+FOLLY_ALWAYS_INLINE bool isProtocolChar(char c) {
+  return isProtocolFirstChar(c) || (c >= '0' && c <= '9') || c == '+' ||
+      c == '-' || c == '.';
+}
+
+inline std::string_view trimUrl(std::string_view url) {
+  while (!url.empty() && static_cast<unsigned char>(url.front()) <= ' ') {
+    url.remove_prefix(1);
+  }
+  while (!url.empty() && static_cast<unsigned char>(url.back()) <= ' ') {
+    url.remove_suffix(1);
+  }
+  return url;
+}
+
+inline bool isSupportedProtocol(std::string_view protocol) {
+  return protocol == "file" || protocol == "ftp" || protocol == "http" ||
+      protocol == "https" || protocol == "jar" || protocol == "mailto" ||
+      protocol == "netdoc";
+}
+
+inline bool parsePort(std::string_view port) {
+  if (port.empty()) {
+    return true;
+  }
+
+  bool isNegative = false;
+  if (port.front() == '+' || port.front() == '-') {
+    isNegative = port.front() == '-';
+    port.remove_prefix(1);
+  }
+  if (port.empty()) {
+    return false;
+  }
+
+  int64_t value = 0;
+  for (const auto c : port) {
+    if (c < '0' || c > '9') {
+      return false;
+    }
+    value = value * 10 + (c - '0');
+    if (value > std::numeric_limits<int32_t>::max()) {
+      return false;
+    }
+  }
+
+  return !isNegative || value <= 1;
+}
+
+inline bool isValidIpv6Literal(std::string_view address) {
+  const auto scopeStart = address.find('%');
+  if (scopeStart != std::string_view::npos) {
+    if (scopeStart + 1 == address.size()) {
+      return false;
+    }
+    address = address.substr(0, scopeStart);
+  }
+
+  return folly::IPAddressV6::validate(
+      folly::StringPiece(address.data(), address.size()));
+}
+
+inline bool parseAuthority(std::string_view authority, ParsedUrl& parsed) {
+  parsed.authority = authority;
+  parsed.host = std::string_view{};
+
+  auto hostAndPort = authority;
+  const auto userInfoEnd = authority.find('@');
+  if (userInfoEnd != std::string_view::npos) {
+    if (authority.find('@', userInfoEnd + 1) != std::string_view::npos) {
+      return true;
+    }
+    parsed.userInfo = authority.substr(0, userInfoEnd);
+    hostAndPort = authority.substr(userInfoEnd + 1);
+  }
+
+  if (hostAndPort.empty()) {
+    return true;
+  }
+
+  if (hostAndPort.front() == '[') {
+    const auto closingBracket = hostAndPort.find(']');
+    if (closingBracket == std::string_view::npos) {
+      return false;
+    }
+    if (!isValidIpv6Literal(hostAndPort.substr(1, closingBracket - 1))) {
+      return false;
+    }
+    parsed.host = hostAndPort.substr(0, closingBracket + 1);
+    const auto remainder = hostAndPort.substr(closingBracket + 1);
+    if (remainder.empty()) {
+      return true;
+    }
+    return remainder.front() == ':' && parsePort(remainder.substr(1));
+  }
+
+  const auto portStart = hostAndPort.find(':');
+  if (portStart == std::string_view::npos) {
+    parsed.host = hostAndPort;
+    return true;
+  }
+
+  parsed.host = hostAndPort.substr(0, portStart);
+  return parsePort(hostAndPort.substr(portStart + 1));
+}
+
+inline void splitRef(
+    std::string_view& remainder,
+    std::optional<std::string_view>& ref) {
+  const auto refStart = remainder.find('#');
+  if (refStart != std::string_view::npos) {
+    ref = remainder.substr(refStart + 1);
+    remainder = remainder.substr(0, refStart);
+  }
+}
+
+inline void splitQuery(
+    std::string_view& remainder,
+    std::optional<std::string_view>& query,
+    size_t start = 0) {
+  const auto queryStart = remainder.find('?', start);
+  if (queryStart != std::string_view::npos) {
+    query = remainder.substr(queryStart + 1);
+    remainder = remainder.substr(0, queryStart);
+  }
+}
+
+inline bool parseUrl(std::string_view url, ParsedUrl& parsed);
+
+inline bool parseJar(std::string_view remainder, ParsedUrl& parsed) {
+  splitRef(remainder, parsed.ref);
+
+  const auto separator = remainder.find("!/");
+  if (separator == std::string_view::npos) {
+    return false;
+  }
+
+  ParsedUrl nested;
+  if (!parseUrl(remainder.substr(0, separator), nested)) {
+    return false;
+  }
+
+  splitQuery(remainder, parsed.query, separator + 2);
+  parsed.path = remainder;
+  return true;
+}
+
+inline bool parseMailto(std::string_view remainder, ParsedUrl& parsed) {
+  const auto refStart = remainder.find('#');
+  if (refStart != std::string_view::npos) {
+    remainder = remainder.substr(0, refStart);
+  }
+  if (remainder.empty()) {
+    return false;
+  }
+
+  splitQuery(remainder, parsed.query);
+  parsed.path = remainder;
+  return true;
+}
+
+inline bool parseHierarchical(std::string_view remainder, ParsedUrl& parsed) {
+  splitRef(remainder, parsed.ref);
+  splitQuery(remainder, parsed.query);
+
+  const bool isUncName =
+      remainder.size() >= 4 && remainder.substr(0, 4) == "////";
+  if (!isUncName && remainder.size() >= 2 && remainder[0] == '/' &&
+      remainder[1] == '/') {
+    remainder.remove_prefix(2);
+    const auto pathStart = remainder.find('/');
+    const auto authority = remainder.substr(0, pathStart);
+    if (!parseAuthority(authority, parsed)) {
+      return false;
+    }
+    parsed.path = pathStart == std::string_view::npos
+        ? std::string_view{}
+        : remainder.substr(pathStart);
+    return true;
+  }
+
+  parsed.path = remainder;
+  return true;
+}
+
+inline bool parseUrl(std::string_view url, ParsedUrl& parsed) {
+  url = trimUrl(url);
+  if (url.empty() || !isProtocolFirstChar(url.front())) {
+    return false;
+  }
+
+  const auto protocolEnd = url.find(':');
+  if (protocolEnd == std::string_view::npos) {
+    return false;
+  }
+  for (size_t i = 1; i < protocolEnd; ++i) {
+    if (!isProtocolChar(url[i])) {
+      return false;
+    }
+  }
+
+  parsed.protocol.reserve(protocolEnd);
+  for (size_t i = 0; i < protocolEnd; ++i) {
+    const auto c = url[i];
+    parsed.protocol.push_back(
+        c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c);
+  }
+  if (!isSupportedProtocol(parsed.protocol)) {
+    return false;
+  }
+
+  const auto remainder = url.substr(protocolEnd + 1);
+  if (parsed.protocol == "jar") {
+    return parseJar(remainder, parsed);
+  }
+  if (parsed.protocol == "mailto") {
+    return parseMailto(remainder, parsed);
+  }
+  return parseHierarchical(remainder, parsed);
+}
+
+} // namespace detail
+
+template <typename T>
+struct FlinkParseUrlFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& partToExtract) {
+    detail::ParsedUrl parsed;
+    if (!detail::parseUrl(std::string_view(url.data(), url.size()), parsed)) {
+      return false;
+    }
+
+    if (partToExtract == "PROTOCOL") {
+      result = parsed.protocol;
+      return true;
+    }
+    if (partToExtract == "HOST") {
+      result = parsed.host;
+      return true;
+    }
+    if (partToExtract == "PATH") {
+      result = parsed.path;
+      return true;
+    }
+    if (partToExtract == "QUERY") {
+      if (!parsed.query.has_value()) {
+        return false;
+      }
+      result = parsed.query.value();
+      return true;
+    }
+    if (partToExtract == "REF") {
+      if (!parsed.ref.has_value()) {
+        return false;
+      }
+      result = parsed.ref.value();
+      return true;
+    }
+    if (partToExtract == "FILE") {
+      result = parsed.path;
+      if (parsed.query.has_value()) {
+        result += "?";
+        result += parsed.query.value();
+      }
+      return true;
+    }
+    if (partToExtract == "AUTHORITY") {
+      if (!parsed.authority.has_value()) {
+        return false;
+      }
+      result = parsed.authority.value();
+      return true;
+    }
+    if (partToExtract == "USERINFO") {
+      if (!parsed.userInfo.has_value()) {
+        return false;
+      }
+      result = parsed.userInfo.value();
+      return true;
+    }
+    return false;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& partToExtract,
+      const arg_type<Varchar>& key) {
+    if (partToExtract != "QUERY") {
+      return false;
+    }
+
+    detail::ParsedUrl parsed;
+    if (!detail::parseUrl(std::string_view(url.data(), url.size()), parsed) ||
+        !parsed.query.has_value()) {
+      return false;
+    }
+
+    const auto query = parsed.query.value();
+    const auto keyView = std::string_view(key.data(), key.size());
+    size_t start = 0;
+    while (start <= query.size()) {
+      const auto end = query.find('&', start);
+      const auto parameter = query.substr(
+          start,
+          end == std::string_view::npos ? std::string_view::npos : end - start);
+      const auto equals = parameter.find('=');
+      if (equals != std::string_view::npos &&
+          parameter.substr(0, equals) == keyView) {
+        result = parameter.substr(equals + 1);
+        return true;
+      }
+      if (end == std::string_view::npos) {
+        break;
+      }
+      start = end + 1;
+    }
+    return false;
+  }
+};
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -25,6 +25,7 @@
 #include "bolt/functions/flinksql/RegexFunctions.h"
 #include "bolt/functions/flinksql/String.h"
 #include "bolt/functions/flinksql/ToTimestampFunction.h"
+#include "bolt/functions/flinksql/URLFunctions.h"
 #include "bolt/functions/flinksql/specialforms/FlinkCastExpr.h"
 
 namespace bytedance::bolt::functions {
@@ -50,6 +51,10 @@ static void registerStringFunctions(const std::string& prefix) {
       {prefix + "split_index"});
   registerFunction<SplitIndex, Varchar, Varchar, int32_t, int64_t>(
       {prefix + "split_index"});
+  registerFunction<FlinkParseUrlFunction, Varchar, Varchar, Varchar>(
+      {prefix + "flink_parse_url"});
+  registerFunction<FlinkParseUrlFunction, Varchar, Varchar, Varchar, Varchar>(
+      {prefix + "flink_parse_url"});
 }
 
 static void registerDatetimeFunctions(const std::string& prefix) {

--- a/bolt/functions/flinksql/tests/CMakeLists.txt
+++ b/bolt/functions/flinksql/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   RegexFunctionsTest.cpp
   RandTest.cpp
   StringFunctionsTest.cpp
+  URLFunctionsTest.cpp
 )
 
 add_test(

--- a/bolt/functions/flinksql/tests/URLFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/URLFunctionsTest.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/tests/FlinkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::flinksql::test {
+namespace {
+
+class URLFunctionsTest : public FlinkFunctionBaseTest {
+ protected:
+  std::optional<std::string> parseUrl(
+      const std::optional<std::string>& url,
+      const std::optional<std::string>& partToExtract) {
+    return evaluateOnce<std::string>(
+        "flink_parse_url(c0, c1)", url, partToExtract);
+  }
+
+  std::optional<std::string> parseUrl(
+      const std::optional<std::string>& url,
+      const std::optional<std::string>& partToExtract,
+      const std::optional<std::string>& key) {
+    return evaluateOnce<std::string>(
+        "flink_parse_url(c0, c1, c2)", url, partToExtract, key);
+  }
+
+  void validate(
+      const std::string& url,
+      const std::optional<std::string>& expectedHost,
+      const std::optional<std::string>& expectedPath,
+      const std::optional<std::string>& expectedQuery,
+      const std::optional<std::string>& expectedRef,
+      const std::optional<std::string>& expectedProtocol,
+      const std::optional<std::string>& expectedFile,
+      const std::optional<std::string>& expectedAuthority,
+      const std::optional<std::string>& expectedUserInfo) {
+    EXPECT_EQ(parseUrl(url, "HOST"), expectedHost);
+    EXPECT_EQ(parseUrl(url, "PATH"), expectedPath);
+    EXPECT_EQ(parseUrl(url, "QUERY"), expectedQuery);
+    EXPECT_EQ(parseUrl(url, "REF"), expectedRef);
+    EXPECT_EQ(parseUrl(url, "PROTOCOL"), expectedProtocol);
+    EXPECT_EQ(parseUrl(url, "FILE"), expectedFile);
+    EXPECT_EQ(parseUrl(url, "AUTHORITY"), expectedAuthority);
+    EXPECT_EQ(parseUrl(url, "USERINFO"), expectedUserInfo);
+  }
+
+  void validateInvalidUrl(const std::string& url) {
+    SCOPED_TRACE(url);
+    for (const auto* part :
+         {"HOST",
+          "PATH",
+          "QUERY",
+          "REF",
+          "PROTOCOL",
+          "FILE",
+          "AUTHORITY",
+          "USERINFO"}) {
+      EXPECT_EQ(parseUrl(url, part), std::nullopt);
+    }
+    EXPECT_EQ(parseUrl(url, "QUERY", "key"), std::nullopt);
+  }
+};
+
+TEST_F(URLFunctionsTest, flinkCompatibility) {
+  const auto validateWithQuery =
+      [&](const std::string& url,
+          const std::optional<std::string>& expectedHost,
+          const std::optional<std::string>& expectedPath,
+          const std::optional<std::string>& expectedQuery,
+          const std::optional<std::string>& expectedRef,
+          const std::optional<std::string>& expectedProtocol,
+          const std::optional<std::string>& expectedFile,
+          const std::optional<std::string>& expectedAuthority,
+          const std::optional<std::string>& expectedUserInfo,
+          const std::optional<std::string>& expectedQueryValue) {
+        validate(
+            url,
+            expectedHost,
+            expectedPath,
+            expectedQuery,
+            expectedRef,
+            expectedProtocol,
+            expectedFile,
+            expectedAuthority,
+            expectedUserInfo);
+        EXPECT_EQ(parseUrl(url, "QUERY", "query"), expectedQueryValue);
+      };
+
+  validateWithQuery(
+      "http://userinfo@flink.apache.org/path?query=1#Ref",
+      "flink.apache.org",
+      "/path",
+      "query=1",
+      "Ref",
+      "http",
+      "/path?query=1",
+      "userinfo@flink.apache.org",
+      "userinfo",
+      "1");
+
+  validateWithQuery(
+      "https://use%20r:pas%20s@example.com/dir%20/pa%20th.HTML?query=x%20y&"
+      "q2=2#Ref%20two",
+      "example.com",
+      "/dir%20/pa%20th.HTML",
+      "query=x%20y&q2=2",
+      "Ref%20two",
+      "https",
+      "/dir%20/pa%20th.HTML?query=x%20y&q2=2",
+      "use%20r:pas%20s@example.com",
+      "use%20r:pas%20s",
+      "x%20y");
+
+  validateWithQuery(
+      "http://user:pass@host",
+      "host",
+      "",
+      std::nullopt,
+      std::nullopt,
+      "http",
+      "",
+      "user:pass@host",
+      "user:pass",
+      std::nullopt);
+
+  validateWithQuery(
+      "http://user:pass@host/",
+      "host",
+      "/",
+      std::nullopt,
+      std::nullopt,
+      "http",
+      "/",
+      "user:pass@host",
+      "user:pass",
+      std::nullopt);
+
+  validateWithQuery(
+      "http://user:pass@host/?#",
+      "host",
+      "/",
+      "",
+      "",
+      "http",
+      "/?",
+      "user:pass@host",
+      "user:pass",
+      std::nullopt);
+
+  validateWithQuery(
+      "http://user:pass@host/file;param?query;p2",
+      "host",
+      "/file;param",
+      "query;p2",
+      std::nullopt,
+      "http",
+      "/file;param?query;p2",
+      "user:pass@host",
+      "user:pass",
+      std::nullopt);
+
+  validateWithQuery(
+      "invalid://user:pass@host/file;param?query;p2",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, requiresProtocol) {
+  for (const auto* url :
+       {"",
+        "   ",
+        "//image-cdn.tuchong.com/weili/video/ms/1814206798056260889.webp",
+        "path/to/file",
+        "/absolute/path"}) {
+    validateInvalidUrl(url);
+  }
+}
+
+TEST_F(URLFunctionsTest, invalidProtocol) {
+  for (const auto* url :
+       {"http//host/path",
+        "://host/path",
+        "1http://host/path",
+        "ht*tp://host/path",
+        "unknown://host/path"}) {
+    validateInvalidUrl(url);
+  }
+}
+
+TEST_F(URLFunctionsTest, validPort) {
+  validate(
+      "http://host:/path",
+      "host",
+      "/path",
+      std::nullopt,
+      std::nullopt,
+      "http",
+      "/path",
+      "host:",
+      std::nullopt);
+
+  validate(
+      "http://[::1]:/path",
+      "[::1]",
+      "/path",
+      std::nullopt,
+      std::nullopt,
+      "http",
+      "/path",
+      "[::1]:",
+      std::nullopt);
+
+  validate(
+      "http://host:65536/path",
+      "host",
+      "/path",
+      std::nullopt,
+      std::nullopt,
+      "http",
+      "/path",
+      "host:65536",
+      std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, invalidPort) {
+  for (const auto* url :
+       {"http://host:abc/path",
+        "http://host:-2/path",
+        "http://host:+/path",
+        "http://host:2147483648/path"}) {
+    validateInvalidUrl(url);
+  }
+}
+
+TEST_F(URLFunctionsTest, invalidAuthority) {
+  for (const auto* url :
+       {"http://[::1/path",
+        "http://::1/path",
+        "http://[::1]extra/path",
+        "http://[]/path",
+        "http://[garbage]/path",
+        "http://[1.2.3.4]/path",
+        "http://[::1%]/path"}) {
+    validateInvalidUrl(url);
+  }
+}
+
+TEST_F(URLFunctionsTest, invalidProtocolSpecificForm) {
+  for (const auto* url :
+       {"jar:file:/tmp/a.jar",
+        "jar:file:/tmp/a.jar!entry",
+        "jar:invalid:/tmp/a.jar!/entry",
+        "jar:/tmp/a.jar!/entry",
+        "mailto:"}) {
+    validateInvalidUrl(url);
+  }
+}
+
+TEST_F(URLFunctionsTest, queryParameter) {
+  const std::string url =
+      "http://host/path?key=first&key=second&bare&empty=&=unnamed&"
+      "literal.a=value&a+b=plus";
+  EXPECT_EQ(parseUrl(url, "QUERY", "key"), "first");
+  EXPECT_EQ(parseUrl(url, "QUERY", "bare"), std::nullopt);
+  EXPECT_EQ(parseUrl(url, "QUERY", "empty"), "");
+  EXPECT_EQ(parseUrl(url, "QUERY", ""), "unnamed");
+  EXPECT_EQ(parseUrl(url, "QUERY", "literal.a"), "value");
+  EXPECT_EQ(parseUrl(url, "QUERY", "a+b"), "plus");
+  EXPECT_EQ(parseUrl(url, "QUERY", "missing"), std::nullopt);
+  EXPECT_EQ(parseUrl(url, "HOST", "key"), std::nullopt);
+  EXPECT_EQ(parseUrl("http://host/path?", "QUERY", "key"), std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, nullAndInvalidArguments) {
+  const std::string url = "http://host/path?key=value";
+  EXPECT_EQ(parseUrl(std::nullopt, "HOST"), std::nullopt);
+  EXPECT_EQ(parseUrl(url, std::nullopt), std::nullopt);
+  EXPECT_EQ(parseUrl(url, "QUERY", std::nullopt), std::nullopt);
+  EXPECT_EQ(parseUrl(url, "host"), std::nullopt);
+  EXPECT_EQ(parseUrl(url, "PORT"), std::nullopt);
+  EXPECT_EQ(parseUrl("http://host:invalid/path", "HOST"), std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, jdk8UrlSemantics) {
+  validate(
+      " \tHTTP://Example.COM/a b?x=%zz#Ref \n",
+      "Example.COM",
+      "/a b",
+      "x=%zz",
+      "Ref",
+      "http",
+      "/a b?x=%zz",
+      "Example.COM",
+      std::nullopt);
+
+  validate(
+      "file:///tmp/a?x=1#r",
+      "",
+      "/tmp/a",
+      "x=1",
+      "r",
+      "file",
+      "/tmp/a?x=1",
+      "",
+      std::nullopt);
+
+  validate(
+      "ftp://user:pass@host:21/path?x=1#r",
+      "host",
+      "/path",
+      "x=1",
+      "r",
+      "ftp",
+      "/path?x=1",
+      "user:pass@host:21",
+      "user:pass");
+
+  validate(
+      "jar:file:/tmp/a.jar!/entry?x=1#r",
+      "",
+      "file:/tmp/a.jar!/entry",
+      "x=1",
+      "r",
+      "jar",
+      "file:/tmp/a.jar!/entry?x=1",
+      std::nullopt,
+      std::nullopt);
+
+  validate(
+      "mailto:a@b.com?subject=x#discarded",
+      "",
+      "a@b.com",
+      "subject=x",
+      std::nullopt,
+      "mailto",
+      "a@b.com?subject=x",
+      std::nullopt,
+      std::nullopt);
+
+  validate(
+      "netdoc://host/path?x=1#r",
+      "host",
+      "/path",
+      "x=1",
+      "r",
+      "netdoc",
+      "/path?x=1",
+      "host",
+      std::nullopt);
+
+  EXPECT_EQ(parseUrl("jar:file:/tmp/a.jar", "PATH"), std::nullopt);
+  EXPECT_EQ(parseUrl("http://[::1]:8080/path", "HOST"), "[::1]");
+  EXPECT_EQ(parseUrl("http://[::1]:8080/path", "AUTHORITY"), "[::1]:8080");
+  EXPECT_EQ(parseUrl("http://[::1%eth0]/path", "HOST"), "[::1%eth0]");
+}
+
+TEST_F(URLFunctionsTest, fourSlashPath) {
+  validate(
+      "file:////server/share?x=1#r",
+      "",
+      "////server/share",
+      "x=1",
+      "r",
+      "file",
+      "////server/share?x=1",
+      std::nullopt,
+      std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, multipleAtAuthority) {
+  validate(
+      "http://user@@host:80/path",
+      "",
+      "/path",
+      std::nullopt,
+      std::nullopt,
+      "http",
+      "/path",
+      "user@@host:80",
+      std::nullopt);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::flinksql::test


### PR DESCRIPTION
### What problem does this PR solve?

Bolt's existing SparkSQL `parse_url` implementation does not match Flink's
`java.net.URL`-based behavior.

For example, Flink returns `NULL` for a scheme-relative URL such as
`//image-cdn.tuchong.com/path`, while the Spark-compatible implementation
extracts and returns the host.

This PR introduces an independent FlinkSQL URL function so Flink workloads can
retain their expected URL parsing semantics.

Issue Number: close #763

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR:

- adds `flink_parse_url(varchar, varchar) -> varchar`;
- adds `flink_parse_url(varchar, varchar, varchar) -> varchar`;
- implements JDK 8 `java.net.URL`-compatible protocol and component parsing;
- supports `HOST`, `PATH`, `QUERY`, `REF`, `PROTOCOL`, `FILE`, `AUTHORITY`, and
  `USERINFO`;
- supports literal query parameter lookup through the three-argument form;
- returns `NULL` for missing or unsupported protocols, invalid ports, malformed
  authorities, and invalid `jar` or `mailto` forms;
- preserves the distinction between missing and explicitly empty query or
  fragment values;
- registers the function only as `flink_parse_url`, leaving SparkSQL
  `parse_url` unchanged;
- migrates Flink's existing URL tests and adds malformed URL, built-in protocol,
  query parameter, and null argument coverage.

### Performance Impact

- [x] **No Impact**: This is an opt-in FlinkSQL function and does not modify existing function execution paths.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Added `flink_parse_url` with Flink-compatible URL parsing semantics.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

The migrated `bolt-os` checkout was intentionally not built or tested as part
of this migration.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)