### PR TITLE
refactor: use filesystem registry for Paimon HDFS

### DIFF
--- a/bolt/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
+++ b/bolt/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
@@ -43,6 +43,8 @@ namespace bytedance::bolt::filesystems {
 folly::ConcurrentHashMap<std::string, std::shared_ptr<HdfsFileSystem>>
     registeredFilesystems;
 
+namespace {
+
 std::function<std::shared_ptr<
     FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
 hdfsFileSystemGenerator() {
@@ -67,6 +69,8 @@ hdfsFileSystemGenerator() {
       };
   return filesystemGenerator;
 }
+
+} // namespace
 
 std::function<std::unique_ptr<bolt::dwio::common::FileSink>(
     const std::string&,

--- a/bolt/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h
+++ b/bolt/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "bolt/common/file/FileSystems.h"
 #include "folly/concurrency/ConcurrentHashMap.h"
 
 namespace bytedance::bolt::filesystems {
@@ -42,9 +41,5 @@ extern folly::ConcurrentHashMap<std::string, std::shared_ptr<HdfsFileSystem>>
 
 // Register the HDFS.
 void registerHdfsFileSystem();
-
-std::function<std::shared_ptr<
-    FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
-hdfsFileSystemGenerator();
 
 } // namespace bytedance::bolt::filesystems

--- a/bolt/connectors/paimon/PaimonBoltHdfsFileSystem.cpp
+++ b/bolt/connectors/paimon/PaimonBoltHdfsFileSystem.cpp
@@ -297,9 +297,8 @@ PaimonBoltHdfsFileSystem::~PaimonBoltHdfsFileSystem() = default;
 
 ::paimon::Result<std::unique_ptr<::paimon::InputStream>>
 PaimonBoltHdfsFileSystem::Open(const std::string& path) const {
-  // Construct an HDFS filesystem instance using the same generator as Hive.
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     auto file = fs->openFileForRead(path, {});
     auto shared = std::shared_ptr<bytedance::bolt::ReadFile>(std::move(file));
@@ -312,8 +311,8 @@ PaimonBoltHdfsFileSystem::Open(const std::string& path) const {
 ::paimon::Result<std::unique_ptr<::paimon::OutputStream>>
 PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
     const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     if (fs->exists(path)) {
       if (!overwrite) {
@@ -337,8 +336,8 @@ PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
 
 ::paimon::Status PaimonBoltHdfsFileSystem::Mkdirs(
     const std::string& path) const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     fs->mkdir(path);
     return ::paimon::Status::OK();
@@ -357,8 +356,8 @@ PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
         "Rename across different HDFS authorities is not supported");
   }
 
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, src);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(src, connectorProperties_);
   try {
     fs->rename(src, dst, /*overwrite=*/false);
     return ::paimon::Status::OK();
@@ -370,8 +369,8 @@ PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
 ::paimon::Status PaimonBoltHdfsFileSystem::Delete(
     const std::string& path,
     bool recursive) const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     auto* hdfsFs =
         dynamic_cast<bytedance::bolt::filesystems::HdfsFileSystem*>(fs.get());
@@ -397,8 +396,8 @@ PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
 
 ::paimon::Result<std::unique_ptr<::paimon::FileStatus>>
 PaimonBoltHdfsFileSystem::GetFileStatus(const std::string& path) const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     auto* hdfsFs =
         dynamic_cast<bytedance::bolt::filesystems::HdfsFileSystem*>(fs.get());
@@ -419,8 +418,8 @@ PaimonBoltHdfsFileSystem::GetFileStatus(const std::string& path) const {
     const std::string& directory,
     std::vector<std::unique_ptr<::paimon::BasicFileStatus>>* file_status_list)
     const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, directory);
+  auto fs = bytedance::bolt::filesystems::getFileSystem(
+      directory, connectorProperties_);
   try {
     if (!fs->exists(directory)) {
       return ::paimon::Status::OK();
@@ -456,8 +455,8 @@ PaimonBoltHdfsFileSystem::GetFileStatus(const std::string& path) const {
     const std::string& path,
     std::vector<std::unique_ptr<::paimon::FileStatus>>* file_status_list)
     const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     if (!fs->exists(path)) {
       return ::paimon::Status::OK();
@@ -494,8 +493,8 @@ PaimonBoltHdfsFileSystem::GetFileStatus(const std::string& path) const {
 
 ::paimon::Result<bool> PaimonBoltHdfsFileSystem::Exists(
     const std::string& path) const {
-  auto fs = bytedance::bolt::filesystems::hdfsFileSystemGenerator()(
-      connectorProperties_, path);
+  auto fs =
+      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
     return fs->exists(path);
   } catch (const std::exception& e) {


### PR DESCRIPTION
### What problem does this PR solve?

`PaimonBoltHdfsFileSystem` directly called
`hdfsFileSystemGenerator()` instead of resolving HDFS URIs through Bolt's
registered filesystem interface.

This bypassed the centralized scheme dispatch and coupled the Paimon adapter
to an HDFS construction detail. It was also inconsistent with the class
documentation, which states that the filesystem is resolved using
`filesystems::getFileSystem()`.

Issue Number: close #765 

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Replaced all direct `hdfsFileSystemGenerator()` calls in
  `PaimonBoltHdfsFileSystem` with
  `filesystems::getFileSystem(path, connectorProperties_)`.
- Kept `hdfsFileSystemGenerator()` private to the HDFS registration
  implementation.
- Removed the generator declaration and its now-unused include from
  `RegisterHdfsFileSystem.h`.

The registered HDFS generator and its endpoint-based filesystem cache remain
unchanged. The only change is that Paimon now reaches the generator through
the standard filesystem registry.

### Performance Impact

- [x] **No Impact**: The filesystem implementation and I/O paths are unchanged.
  The registry only performs the normal URI scheme dispatch before invoking
  the same HDFS generator.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below.

### Release Note

```text
Release Note:
- Route Paimon HDFS filesystem operations through Bolt's filesystem registry.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
