### PR TITLE
contains support arrays with elements that contain null

### DIFF
--- a/bolt/functions/prestosql/ArrayContains.cpp
+++ b/bolt/functions/prestosql/ArrayContains.cpp
@@ -308,17 +308,20 @@ core::TypedExprPtr rewriteArrayContains2In(
   return nullptr;
 }
 
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+arrayContainsSignatures() {
+  return ArrayContainsFunction::signatures();
+}
+
+std::unique_ptr<exec::VectorFunction> createArrayContainsFunction(
+    bool throwOnNestedNull) {
+  return std::make_unique<ArrayContainsFunction>(throwOnNestedNull);
+}
+
 BOLT_DECLARE_VECTOR_FUNCTION(
     udf_array_contains,
     ArrayContainsFunction::signatures(),
     std::make_unique<ArrayContainsFunction>(true));
-
-// Spark array_contains uses null-safe equality for complex elements, e.g.
-// row(1, null) matches row(1, null) and does not match row(1, 2).
-BOLT_DECLARE_VECTOR_FUNCTION(
-    udf_spark_array_contains,
-    ArrayContainsFunction::signatures(),
-    std::make_unique<ArrayContainsFunction>(false));
 
 // Internal function only used for testing. This function allows the array to
 // have null elements and considers null as a value, i.e., null == null.

--- a/bolt/functions/prestosql/ArrayContains.cpp
+++ b/bolt/functions/prestosql/ArrayContains.cpp
@@ -313,6 +313,13 @@ BOLT_DECLARE_VECTOR_FUNCTION(
     ArrayContainsFunction::signatures(),
     std::make_unique<ArrayContainsFunction>(true));
 
+// Spark array_contains uses null-safe equality for complex elements, e.g.
+// row(1, null) matches row(1, null) and does not match row(1, 2).
+BOLT_DECLARE_VECTOR_FUNCTION(
+    udf_spark_array_contains,
+    ArrayContainsFunction::signatures(),
+    std::make_unique<ArrayContainsFunction>(false));
+
 // Internal function only used for testing. This function allows the array to
 // have null elements and considers null as a value, i.e., null == null.
 BOLT_DECLARE_VECTOR_FUNCTION(

--- a/bolt/functions/sparksql/ArrayContains.cpp
+++ b/bolt/functions/sparksql/ArrayContains.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) ByteDance Ltd. and/or its affiliates
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,16 @@
  * limitations under the License.
  */
 
-#pragma once
-
-#include <memory>
-#include <vector>
-#include "bolt/core/Expressions.h"
-#include "bolt/expression/FunctionSignature.h"
+#include "bolt/functions/prestosql/ArrayContains.h"
 #include "bolt/expression/VectorFunction.h"
+
 namespace bytedance::bolt::functions {
 
-std::vector<std::shared_ptr<exec::FunctionSignature>> arrayContainsSignatures();
-
-std::unique_ptr<exec::VectorFunction> createArrayContainsFunction(
-    bool throwOnNestedNull);
-
-/// array_contains(array, element) -> boolean => element in array if array is a
-/// constant
-
-core::TypedExprPtr rewriteArrayContains2In(
-    const std::string& prefix,
-    const core::TypedExprPtr& expr);
+// Spark array_contains uses null-safe equality for complex elements, e.g.
+// row(1, null) matches row(1, null) and does not match row(1, 2).
+BOLT_DECLARE_VECTOR_FUNCTION(
+    udf_spark_array_contains,
+    arrayContainsSignatures(),
+    createArrayContainsFunction(false));
 
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/sparksql/CMakeLists.txt
+++ b/bolt/functions/sparksql/CMakeLists.txt
@@ -28,6 +28,7 @@
 add_subdirectory(specialforms)
 bolt_add_library(
   bolt_functions_spark_impl
+  ArrayContains.cpp
   ArrayGetFunction.cpp
   ArraySliceSum.cpp
   ArraySort.cpp

--- a/bolt/functions/sparksql/registration/RegisterArray.cpp
+++ b/bolt/functions/sparksql/registration/RegisterArray.cpp
@@ -52,7 +52,8 @@ void registerSparkArrayFunctions(const std::string& prefix) {
   BOLT_REGISTER_VECTOR_FUNCTION(udf_reduce, prefix + "aggregate");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_filter, prefix + "filter");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_constructor, prefix + "array");
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_array_contains, prefix + "array_contains");
+  BOLT_REGISTER_VECTOR_FUNCTION(
+      udf_spark_array_contains, prefix + "array_contains");
   BOLT_REGISTER_VECTOR_FUNCTION(
       udf_array_intersect, prefix + "array_intersect");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_array_except, prefix + "array_except");

--- a/bolt/functions/sparksql/tests/ArrayContainsTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayContainsTest.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace bytedance::bolt::test;
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class ArrayContainsTest : public SparkFunctionBaseTest {};
+
+TEST_F(ArrayContainsTest, rowWithNestedNulls) {
+  const auto rowType =
+      ROW({"author_type", "role_type"}, {INTEGER(), INTEGER()});
+  const auto nullInt = variant(TypeKind::INTEGER);
+  const auto infoList = makeArrayOfRowVector(
+      rowType,
+      std::vector<std::vector<variant>>{
+          {variant::row({2, nullInt})},
+          {variant::row({22, nullInt})},
+      });
+  const auto targetInfo = makeRowVector({
+      makeNullableFlatVector<int32_t>({2, 22}),
+      makeNullableFlatVector<int32_t>({1, std::nullopt}),
+  });
+
+  const auto result =
+      evaluate("array_contains(c0, c1)", makeRowVector({infoList, targetInfo}));
+
+  assertEqualVectors(makeFlatVector<bool>({false, true}), result);
+}
+
+TEST_F(ArrayContainsTest, arrayWithNestedNulls) {
+  const auto data = makeNullableNestedArrayVector<int32_t>({
+      {{{{{3, std::nullopt}}}}},
+      {{{{{3, std::nullopt}}}}},
+  });
+  const auto search = makeArrayVectorFromJson<int32_t>({"[3, 3]", "[3, null]"});
+
+  const auto result =
+      evaluate("array_contains(c0, c1)", makeRowVector({data, search}));
+
+  assertEqualVectors(makeFlatVector<bool>({false, true}), result);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/ArrayContainsTest.cpp
+++ b/bolt/functions/sparksql/tests/ArrayContainsTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   bolt_functions_spark_test
   ArithmeticTest.cpp
   ArrayAppendTest.cpp
+  ArrayContainsTest.cpp
   ArrayFlattenTest.cpp
   ArrayGetTest.cpp
   ArrayInsertTest.cpp


### PR DESCRIPTION
### What problem does this PR solve?

Spark SQL `array_contains` should not throw when the array element is a complex type that contains nested nulls, such as `array<row>` / `array<struct>`. However, the current SparkSQL registration reuses the Presto `contains` implementation, which treats nested null comparison as indeterminate and throws the following error:

```text
contains does not support arrays with elements that contain null
```

This is incompatible with Apache Spark behavior. Spark allows array_contains to evaluate complex values with nested nulls without throwing.


Issue Number: close #767 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR introduces a Spark-specific array_contains vector function and registers SparkSQL array_contains to it.

The new function uses ArrayContainsFunction(false), which compares nested nulls as values instead of treating them as indeterminate. This preserves the existing Presto contains behavior while making SparkSQL array_contains compatible with Spark semantics.

The PR also adds SparkSQL C++ unit tests covering complex array elements with nested nulls, including row/struct values and nested array values.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->


Release Note:

```text
Release Note:
- Fixed SparkSQL array_contains throwing an exception when array elements are complex values containing nested nulls.

```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
