### PR TITLE
perf: Add parquet V1 rep/def prefix decompress path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,6 +314,7 @@ bolt/docs/sphinx/source/README_generated_*
 bolt/docs/bindings/python/_generate/*
 
 # conan / cmake
+.conan2/
 CMakeUserPresets.json
 CMakePresets.json
 conan.lock

--- a/bolt/dwio/parquet/reader/Decompression.cpp
+++ b/bolt/dwio/parquet/reader/Decompression.cpp
@@ -25,6 +25,7 @@
 #include "bolt/dwio/parquet/reader/ParquetReaderUtil.h"
 #include "bolt/dwio/parquet/thrift/FmtParquetFormatters.h"
 
+#include <folly/ScopeGuard.h>
 #include <lz4.h>
 #include <zstd.h>
 
@@ -33,6 +34,120 @@ namespace bytedance::bolt::parquet {
 static inline std::uint32_t reverse_bytes(std::uint32_t i) {
   return (i & 0xff000000u) >> 24 | (i & 0x00ff0000u) >> 8 |
       (i & 0x0000ff00u) << 8 | (i & 0x000000ffu) << 24;
+}
+
+char* FOLLY_NONNULL ensurePrefixOutputCapacity(
+    BufferPtr& buffer,
+    uint32_t required,
+    uint32_t uncompressedSize,
+    uint32_t& outputSize) {
+  if (required > outputSize) {
+    auto nextSize = std::min<uint32_t>(
+        uncompressedSize,
+        std::max<uint32_t>(required, std::max<uint32_t>(outputSize * 2, 4096)));
+    AlignedBuffer::reallocate<char>(&buffer, nextSize);
+    outputSize = buffer->capacity();
+  }
+  return buffer->asMutable<char>();
+}
+
+bool tryDecompressZstdFramePrefix(
+    const char* compressedData,
+    BufferPtr& decompressedData,
+    uint32_t compressedSize,
+    uint32_t uncompressedSize,
+    uint32_t outputQuantum,
+    uint32_t& outputSize,
+    const std::function<bool(const char*, uint32_t)>& isPrefixReady,
+    const char*& prefixData) {
+  ZSTD_DStream* stream = ZSTD_createDStream();
+  if (stream == nullptr) {
+    return false;
+  }
+  auto streamGuard = folly::makeGuard([&]() { ZSTD_freeDStream(stream); });
+  auto ret = ZSTD_initDStream(stream);
+  if (ZSTD_isError(ret)) {
+    return false;
+  }
+
+  auto* output = decompressedData->asMutable<char>();
+  uint32_t produced = 0;
+  ZSTD_inBuffer input{compressedData, static_cast<size_t>(compressedSize), 0};
+  while (input.pos < input.size) {
+    const auto nextOutputEnd =
+        std::min<uint32_t>(uncompressedSize, produced + outputQuantum);
+    output = ensurePrefixOutputCapacity(
+        decompressedData, nextOutputEnd, uncompressedSize, outputSize);
+    ZSTD_outBuffer out{
+        output + produced, static_cast<size_t>(nextOutputEnd - produced), 0};
+    ret = ZSTD_decompressStream(stream, &out, &input);
+    if (ZSTD_isError(ret)) {
+      return false;
+    }
+    produced += out.pos;
+    if (isPrefixReady(output, produced)) {
+      prefixData = output;
+      return true;
+    }
+    if (produced >= uncompressedSize || out.pos == 0) {
+      break;
+    }
+  }
+  return false;
+}
+
+bool tryDecompressZstdBlockPrefix(
+    const char* compressedData,
+    BufferPtr& decompressedData,
+    uint32_t compressedSize,
+    uint32_t uncompressedSize,
+    uint32_t& outputSize,
+    const std::function<bool(const char*, uint32_t)>& isPrefixReady,
+    const char*& prefixData) {
+  auto* output = decompressedData->asMutable<char>();
+  uint32_t produced = 0;
+  uint32_t inputOffset = 0;
+  uint32_t cumulativeUncompressedBlockLength = 0;
+  while (produced < uncompressedSize) {
+    if (produced == cumulativeUncompressedBlockLength) {
+      if (inputOffset + sizeof(uint32_t) > compressedSize) {
+        return false;
+      }
+      cumulativeUncompressedBlockLength += folly::Endian::big(
+          folly::loadUnaligned<uint32_t>(compressedData + inputOffset));
+      inputOffset += sizeof(uint32_t);
+    }
+    if (inputOffset + sizeof(uint32_t) > compressedSize) {
+      return false;
+    }
+    const auto compressedChunkLength = folly::Endian::big(
+        folly::loadUnaligned<uint32_t>(compressedData + inputOffset));
+    inputOffset += sizeof(uint32_t);
+    if (inputOffset + compressedChunkLength > compressedSize) {
+      return false;
+    }
+
+    output = ensurePrefixOutputCapacity(
+        decompressedData,
+        cumulativeUncompressedBlockLength,
+        uncompressedSize,
+        outputSize);
+    const auto decompressedSize = ZSTD_decompress(
+        output + produced,
+        outputSize - produced,
+        compressedData + inputOffset,
+        compressedChunkLength);
+    if (ZSTD_isError(decompressedSize)) {
+      return false;
+    }
+    produced += decompressedSize;
+    inputOffset += compressedChunkLength;
+    if (isPrefixReady(output, produced)) {
+      prefixData = output;
+      return true;
+    }
+  }
+  return false;
 }
 
 const char* FOLLY_NONNULL decompressLz4AndLzo(
@@ -219,5 +334,45 @@ const char* FOLLY_NONNULL bdZstdDecompression(
     BOLT_CHECK_EQ(outputOffset, uncompressedSize);
   }
   return decompressedData->as<char>();
+}
+
+bool tryDecompressZstdPrefix(
+    const char* compressedData,
+    BufferPtr& decompressedData,
+    uint32_t compressedSize,
+    uint32_t uncompressedSize,
+    uint32_t outputQuantum,
+    memory::MemoryPool& pool,
+    const std::function<bool(const char* data, uint32_t availableSize)>&
+        isPrefixReady,
+    const char*& prefixData) {
+  BOLT_CHECK_GT(compressedSize, 4, "Not enough input bytes");
+  dwio::common::ensureCapacity<char>(
+      decompressedData,
+      std::min<uint32_t>(uncompressedSize, outputQuantum),
+      &pool);
+  auto outputSize = static_cast<uint32_t>(decompressedData->capacity());
+
+  // Handle both regular ZSTD frames and the Hadoop-style block framing used by
+  // some Parquet writers.
+  if (folly::loadUnaligned<uint32_t>(compressedData) == ZSTD_MAGICNUMBER) {
+    return tryDecompressZstdFramePrefix(
+        compressedData,
+        decompressedData,
+        compressedSize,
+        uncompressedSize,
+        outputQuantum,
+        outputSize,
+        isPrefixReady,
+        prefixData);
+  }
+  return tryDecompressZstdBlockPrefix(
+      compressedData,
+      decompressedData,
+      compressedSize,
+      uncompressedSize,
+      outputSize,
+      isPrefixReady,
+      prefixData);
 }
 } // namespace bytedance::bolt::parquet

--- a/bolt/dwio/parquet/reader/Decompression.h
+++ b/bolt/dwio/parquet/reader/Decompression.h
@@ -19,6 +19,9 @@
 #include "bolt/buffer/Buffer.h"
 #include "bolt/common/memory/MemoryPool.h"
 #include "bolt/dwio/parquet/thrift/codegen/parquet_types.h"
+
+#include <functional>
+
 namespace bytedance::bolt::parquet {
 
 // Decompress function for all bolt supported codec type,
@@ -48,4 +51,15 @@ const char* decompressLz4AndLzo(
     uint32_t uncompressedSize,
     memory::MemoryPool& pool,
     const thrift::CompressionCodec::type codec);
+
+bool tryDecompressZstdPrefix(
+    const char* compressedData,
+    BufferPtr& decompressedData,
+    uint32_t compressedSize,
+    uint32_t uncompressedSize,
+    uint32_t outputQuantum,
+    memory::MemoryPool& pool,
+    const std::function<bool(const char* data, uint32_t availableSize)>&
+        isPrefixReady,
+    const char*& prefixData);
 } // namespace bytedance::bolt::parquet

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -28,11 +28,13 @@
  * --------------------------------------------------------------------------
  */
 
+#include <folly/lang/Bits.h>
 #include <lz4.h>
 #include <thrift/protocol/TCompactProtocol.h> // @manual
-#include <zstd.h>
-#include <zstd_errors.h>
+#include <algorithm>
 
+#include "bolt/common/base/SimdUtil.h"
+#include "bolt/common/time/Timer.h"
 #include "bolt/dwio/common/BufferUtil.h"
 #include "bolt/dwio/common/ColumnVisitors.h"
 #include "bolt/dwio/parquet/reader/Decompression.h"
@@ -48,6 +50,163 @@ namespace bytedance::bolt::parquet {
 
 using thrift::Encoding;
 using thrift::PageHeader;
+
+namespace {
+constexpr uint32_t kRepDefPrefixOutputQuantum = 4096;
+
+struct DataPageV1RepDefs {
+  const char* FOLLY_NONNULL data;
+  uint32_t size;
+  const char* FOLLY_NULLABLE repeatData{nullptr};
+  uint32_t repeatSize{0};
+  const char* FOLLY_NULLABLE defineData{nullptr};
+  uint32_t defineSize{0};
+};
+
+uint32_t readUint32(const char* FOLLY_NONNULL& data) {
+  const auto value = folly::loadUnaligned<uint32_t>(data);
+  data += sizeof(uint32_t);
+  return value;
+}
+
+bool tryReadDataPageV1Level(
+    const char* FOLLY_NONNULL start,
+    uint32_t availableSize,
+    uint32_t pageBodySize,
+    const char* FOLLY_NONNULL& data,
+    const char* FOLLY_NULLABLE& levelData,
+    uint32_t& levelSize) {
+  if (availableSize < data - start + sizeof(uint32_t)) {
+    return false;
+  }
+  levelSize = readUint32(data);
+  BOLT_CHECK_LE(
+      data - start,
+      pageBodySize,
+      "Parquet V1 rep/def level length header exceeds page body size {}",
+      pageBodySize);
+  BOLT_CHECK_LE(
+      levelSize,
+      pageBodySize - static_cast<uint32_t>(data - start),
+      "Parquet V1 rep/def level length {} exceeds page body size {} at offset {}",
+      levelSize,
+      pageBodySize,
+      data - start);
+  if (availableSize < data - start + levelSize) {
+    return false;
+  }
+  levelData = data;
+  data += levelSize;
+  return true;
+}
+
+bool tryReadDataPageV1RepDefs(
+    const char* FOLLY_NONNULL data,
+    uint32_t availableSize,
+    uint32_t pageBodySize,
+    int32_t maxRepeat,
+    int32_t maxDefine,
+    DataPageV1RepDefs& repDefs) {
+  const char* start = data;
+  if (maxRepeat > 0) {
+    if (!tryReadDataPageV1Level(
+            start,
+            availableSize,
+            pageBodySize,
+            data,
+            repDefs.repeatData,
+            repDefs.repeatSize)) {
+      return false;
+    }
+  }
+  if (maxDefine > 0) {
+    if (!tryReadDataPageV1Level(
+            start,
+            availableSize,
+            pageBodySize,
+            data,
+            repDefs.defineData,
+            repDefs.defineSize)) {
+      return false;
+    }
+  }
+  repDefs.data = start;
+  repDefs.size = static_cast<uint32_t>(data - start);
+  return true;
+}
+
+bool hasDataPageV1RepDefPrefix(
+    const char* FOLLY_NONNULL data,
+    uint32_t availableSize,
+    uint32_t pageBodySize,
+    int32_t maxRepeat,
+    int32_t maxDefine,
+    DataPageV1RepDefs& repDefs) {
+  // Used while streaming partial output: returns true only after the full V1
+  // rep/def prefix is available. Required/top-level pages may have no rep/def
+  // prefix, but those cannot use this fast path.
+  return tryReadDataPageV1RepDefs(
+             data,
+             availableSize,
+             pageBodySize,
+             maxRepeat,
+             maxDefine,
+             repDefs) &&
+      repDefs.size > 0;
+}
+
+DataPageV1RepDefs readDataPageV1RepDefs(
+    const char* FOLLY_NONNULL& data,
+    uint32_t availableSize,
+    int32_t maxRepeat,
+    int32_t maxDefine) {
+  DataPageV1RepDefs repDefs;
+  BOLT_CHECK(tryReadDataPageV1RepDefs(
+      data, availableSize, availableSize, maxRepeat, maxDefine, repDefs));
+  data += repDefs.size;
+  return repDefs;
+}
+
+void copyRawDataPageV1RepDefs(
+    int32_t numRepDefsInPage,
+    DataPageV1RepDefs repDefs,
+    raw_vector<char>& output) {
+  constexpr int32_t kLenSize = sizeof(int32_t);
+  auto offset = output.size();
+  output.resize(offset + repDefs.size + kLenSize);
+  BOLT_CHECK_GT(repDefs.size, 0);
+  *(reinterpret_cast<int32_t*>(output.data() + offset)) = numRepDefsInPage;
+  simd::memcpy(output.data() + offset + kLenSize, repDefs.data, repDefs.size);
+}
+
+void makeDataPageV1RepDefDecoders(
+    DataPageV1RepDefs repDefs,
+    int32_t maxRepeat,
+    int32_t maxDefine,
+    std::unique_ptr<::arrow::util::RleDecoder>& repeatDecoder,
+    std::unique_ptr<RleBpDecoder>& defineDecoder,
+    std::unique_ptr<::arrow::util::RleDecoder>& wideDefineDecoder) {
+  if (maxRepeat > 0) {
+    repeatDecoder = std::make_unique<::arrow::util::RleDecoder>(
+        reinterpret_cast<const uint8_t*>(repDefs.repeatData),
+        repDefs.repeatSize,
+        ::arrow::bit_util::NumRequiredBits(maxRepeat));
+  }
+
+  if (maxDefine > 0) {
+    if (maxDefine == 1) {
+      defineDecoder = std::make_unique<RleBpDecoder>(
+          repDefs.defineData,
+          repDefs.defineData + repDefs.defineSize,
+          ::arrow::bit_util::NumRequiredBits(maxDefine));
+    }
+    wideDefineDecoder = std::make_unique<::arrow::util::RleDecoder>(
+        reinterpret_cast<const uint8_t*>(repDefs.defineData),
+        repDefs.defineSize,
+        ::arrow::bit_util::NumRequiredBits(maxDefine));
+  }
+}
+} // namespace
 
 void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
   defineDecoder_.reset();
@@ -365,62 +524,29 @@ void PageReader::prepareDataPageV1(
   if (cryptoCtx_.dataDecryptor != nullptr) {
     decryptPageData(compressedLen);
   }
+  if (row == kRepDefOnly &&
+      tryPrepareDataPageV1RepDefOnly(
+          pageHeader, compressedLen, keepRepDefRawData)) {
+    return;
+  }
   pageData_ = decompressData(
       pageData_, compressedLen, pageHeader.uncompressed_page_size);
   auto pageEnd = pageData_ + pageHeader.uncompressed_page_size;
 
-  // copy rep/def to preloadedRepDefs_, do not decode
+  const auto repDefs = readDataPageV1RepDefs(
+      pageData_, pageHeader.uncompressed_page_size, maxRepeat_, maxDefine_);
+  totalRefDefBytes_ += repDefs.size;
   if (row == kRepDefOnly && keepRepDefRawData) {
-    constexpr int32_t kLenSize = sizeof(int32_t);
-    auto repDefStart = pageData_;
-    auto startBytes = totalRefDefBytes_;
-    if (maxRepeat_ > 0) {
-      uint32_t repeatLength = readField<int32_t>(pageData_);
-      pageData_ += repeatLength;
-      totalRefDefBytes_ += repeatLength + kLenSize;
-    }
-    if (maxDefine_ > 0) {
-      auto defineLength = readField<uint32_t>(pageData_);
-      pageData_ += defineLength;
-      totalRefDefBytes_ += defineLength + kLenSize;
-    }
-    auto repDefLen = totalRefDefBytes_ - startBytes;
-    auto& refDefData = preloadedRepDefs_.back();
-    auto offset = refDefData.size();
-    // 4 more bytes for numRepDefsInPage_
-    auto totalSize = offset + repDefLen + kLenSize;
-    refDefData.resize(totalSize);
-    BOLT_CHECK(repDefLen > 0);
-    *(reinterpret_cast<int32_t*>(refDefData.data() + offset)) =
-        numRepDefsInPage_;
-    simd::memcpy(refDefData.data() + offset + kLenSize, repDefStart, repDefLen);
+    copyRawDataPageV1RepDefs(
+        numRepDefsInPage_, repDefs, preloadedRepDefs_.back());
   } else {
-    if (maxRepeat_ > 0) {
-      uint32_t repeatLength = readField<int32_t>(pageData_);
-      repeatDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
-          reinterpret_cast<const uint8_t*>(pageData_),
-          repeatLength,
-          ::arrow::bit_util::NumRequiredBits(maxRepeat_));
-
-      pageData_ += repeatLength;
-      totalRefDefBytes_ += repeatLength + sizeof(int32_t);
-    }
-
-    if (maxDefine_ > 0) {
-      auto defineLength = readField<uint32_t>(pageData_);
-      if (maxDefine_ == 1) {
-        defineDecoder_ = std::make_unique<RleBpDecoder>(
-            pageData_,
-            pageData_ + defineLength,
-            ::arrow::bit_util::NumRequiredBits(maxDefine_));
-      }
-      wideDefineDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
-          reinterpret_cast<const uint8_t*>(pageData_),
-          defineLength,
-          ::arrow::bit_util::NumRequiredBits(maxDefine_));
-      pageData_ += defineLength;
-      totalRefDefBytes_ += defineLength + sizeof(uint32_t);
-    }
+    makeDataPageV1RepDefDecoders(
+        repDefs,
+        maxRepeat_,
+        maxDefine_,
+        repeatDecoder_,
+        defineDecoder_,
+        wideDefineDecoder_);
   }
   encodedDataSize_ = pageEnd - pageData_;
 
@@ -432,6 +558,87 @@ void PageReader::prepareDataPageV1(
   if (row != kRepDefOnly) {
     makeDecoder();
   }
+}
+
+bool PageReader::tryPrepareDataPageV1RepDefOnly(
+    const PageHeader& pageHeader,
+    int32_t compressedLen,
+    const bool keepRepDefRawData) {
+  const char* compressedData = pageData_;
+  const auto uncompressedSize =
+      static_cast<uint32_t>(pageHeader.uncompressed_page_size);
+  DataPageV1RepDefs repDefPrefix;
+
+  if (codec_ == thrift::CompressionCodec::UNCOMPRESSED) {
+    if (!hasDataPageV1RepDefPrefix(
+            compressedData,
+            compressedLen,
+            uncompressedSize,
+            maxRepeat_,
+            maxDefine_,
+            repDefPrefix)) {
+      return false;
+    }
+    pageData_ = compressedData;
+  } else {
+    // Only ZSTD supports stopping after the rep/def prefix. Other codecs fall
+    // back to the normal full-page decompression path.
+    if (codec_ != thrift::CompressionCodec::ZSTD || compressedLen <= 4) {
+      return false;
+    }
+
+    const auto startNs =
+        FOLLY_LIKELY(statis_ != nullptr) ? getCurrentTimeNano() : 0;
+    if (!tryDecompressZstdPrefix(
+            compressedData,
+            decompressedData_,
+            compressedLen,
+            uncompressedSize,
+            kRepDefPrefixOutputQuantum,
+            pool_,
+            [&](const char* data, uint32_t availableSize) {
+              return hasDataPageV1RepDefPrefix(
+                  data,
+                  availableSize,
+                  uncompressedSize,
+                  maxRepeat_,
+                  maxDefine_,
+                  repDefPrefix);
+            },
+            pageData_)) {
+      return false;
+    }
+    if (FOLLY_LIKELY(statis_ != nullptr)) {
+      statis_->decompressDataTimeNs += getCurrentTimeNano() - startNs;
+    }
+  }
+
+  const auto repDefs = readDataPageV1RepDefs(
+      pageData_, uncompressedSize, maxRepeat_, maxDefine_);
+  totalRefDefBytes_ += repDefs.size;
+  if (keepRepDefRawData) {
+    copyRawDataPageV1RepDefs(
+        numRepDefsInPage_, repDefs, preloadedRepDefs_.back());
+  } else {
+    makeDataPageV1RepDefDecoders(
+        repDefs,
+        maxRepeat_,
+        maxDefine_,
+        repeatDecoder_,
+        defineDecoder_,
+        wideDefineDecoder_);
+  }
+  encodedDataSize_ = pageHeader.uncompressed_page_size - repDefPrefix.size;
+  encoding_ = pageHeader.data_page_header.encoding;
+
+  BOLT_CHECK_EQ(repDefs.size, repDefPrefix.size);
+  if (!keepRepDefRawData) {
+    if (!hasChunkRepDefs_ &&
+        (numRowsInPage_ == kRowsUnknown || maxDefine_ > 1)) {
+      readPageDefLevels();
+    }
+  }
+  return true;
 }
 
 void PageReader::prepareDataPageV2(

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -297,6 +297,10 @@ class PageReader {
       const thrift::PageHeader& pageHeader,
       int64_t row,
       const bool keepRepDefRawData);
+  bool tryPrepareDataPageV1RepDefOnly(
+      const thrift::PageHeader& pageHeader,
+      int32_t compressedLen,
+      const bool keepRepDefRawData);
   void prepareDataPageV2(
       const thrift::PageHeader& pageHeader,
       int64_t row,

--- a/bolt/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/reader/CMakeLists.txt
@@ -66,6 +66,13 @@ target_link_libraries(
   ${FOLLY_BENCHMARK}
 )
 
+add_executable(bolt_dwio_parquet_page_reader_preload_benchmark ParquetPageReaderPreloadBenchmark.cpp)
+target_link_libraries(
+  bolt_dwio_parquet_page_reader_preload_benchmark
+  PRIVATE bolt_testutils
+  ${FOLLY_BENCHMARK}
+)
+
 add_executable(bolt_dwio_parquet_structure_decoder_benchmark NestedStructureDecoderBenchmark.cpp)
 target_link_libraries(
   bolt_dwio_parquet_structure_decoder_benchmark PRIVATE

--- a/bolt/dwio/parquet/tests/reader/ParquetPageReaderPreloadBenchmark.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetPageReaderPreloadBenchmark.cpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/dwio/common/SeekableInputStream.h"
+#include "bolt/dwio/parquet/reader/PageReader.h"
+#include "bolt/dwio/parquet/thrift/codegen/parquet_types.h"
+
+#include <arrow/util/rle_encoding.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+#include <zstd.h>
+
+#include <random>
+
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::dwio::common;
+using namespace bytedance::bolt::parquet;
+
+namespace {
+
+constexpr int32_t kNumPages = 128;
+constexpr int32_t kValuesPerPage = 1024;
+constexpr int32_t kValuePayloadBytes = 4 * 1024 * 1024;
+constexpr uint32_t kSeed = 20260722;
+
+struct SyntheticPage {
+  thrift::PageHeader header;
+  std::string serializedHeader;
+  std::string compressed;
+  int32_t uncompressedSize;
+};
+
+void appendInt32(std::string& out, int32_t value) {
+  out.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+std::string encodeLevels(const std::vector<int16_t>& levels, int bitWidth) {
+  std::string encoded(levels.size() * sizeof(int16_t) + 64, '\0');
+  ::arrow::util::RleEncoder encoder(
+      reinterpret_cast<uint8_t*>(encoded.data()), encoded.size(), bitWidth);
+  for (auto level : levels) {
+    encoder.Put(level);
+  }
+  encoded.resize(encoder.Flush());
+  return encoded;
+}
+
+std::string zstdCompress(const std::string& data) {
+  std::string compressed(ZSTD_compressBound(data.size()), '\0');
+  const auto compressedSize = ZSTD_compress(
+      compressed.data(), compressed.size(), data.data(), data.size(), 1);
+  BOLT_CHECK(!ZSTD_isError(compressedSize), ZSTD_getErrorName(compressedSize));
+  compressed.resize(compressedSize);
+  return compressed;
+}
+
+ParquetTypeWithIdPtr makeNestedInt64Type() {
+  return std::make_shared<ParquetTypeWithId>(
+      BIGINT(),
+      std::vector<std::shared_ptr<const dwio::common::TypeWithId>>{},
+      0,
+      0,
+      0,
+      "value",
+      thrift::Type::INT64,
+      std::nullopt,
+      std::nullopt,
+      1,
+      2,
+      true,
+      true);
+}
+
+std::string serializePageHeader(const thrift::PageHeader& pageHeader) {
+  auto buffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+  apache::thrift::protocol::TCompactProtocolT<
+      apache::thrift::transport::TMemoryBuffer>
+      protocol(buffer);
+  pageHeader.write(&protocol);
+
+  uint8_t* data = nullptr;
+  uint32_t size = 0;
+  buffer->getBuffer(&data, &size);
+  return std::string(reinterpret_cast<const char*>(data), size);
+}
+
+std::string makePageBody(std::mt19937& rng) {
+  std::uniform_int_distribution<int32_t> runLengthDist(1, 6);
+  std::uniform_int_distribution<int32_t> pct(0, 99);
+  std::uniform_int_distribution<int32_t> byteDist(0, 255);
+
+  std::vector<int16_t> repetitionLevels;
+  std::vector<int16_t> definitionLevels;
+  repetitionLevels.reserve(kValuesPerPage);
+  definitionLevels.reserve(kValuesPerPage);
+
+  while (repetitionLevels.size() < kValuesPerPage) {
+    const auto runLength = std::min<int32_t>(
+        runLengthDist(rng), kValuesPerPage - repetitionLevels.size());
+    repetitionLevels.push_back(0);
+    definitionLevels.push_back(pct(rng) < 10 ? 1 : 2);
+    for (int32_t i = 1; i < runLength; ++i) {
+      repetitionLevels.push_back(1);
+      const auto roll = pct(rng);
+      definitionLevels.push_back(roll < 8 ? 0 : (roll < 20 ? 1 : 2));
+    }
+  }
+
+  auto repetitionBytes = encodeLevels(repetitionLevels, 1);
+  auto definitionBytes = encodeLevels(definitionLevels, 2);
+
+  std::string body;
+  appendInt32(body, repetitionBytes.size());
+  body.append(repetitionBytes);
+  appendInt32(body, definitionBytes.size());
+  body.append(definitionBytes);
+
+  for (int32_t i = 0; i < kValuePayloadBytes; ++i) {
+    body.push_back(static_cast<char>(byteDist(rng)));
+  }
+  return body;
+}
+
+std::vector<SyntheticPage> makePages() {
+  std::mt19937 rng(kSeed);
+  std::vector<SyntheticPage> pages;
+  pages.reserve(kNumPages);
+
+  for (int32_t page = 0; page < kNumPages; ++page) {
+    auto body = makePageBody(rng);
+    SyntheticPage syntheticPage;
+    syntheticPage.compressed = zstdCompress(body);
+
+    thrift::DataPageHeader dataPageHeader;
+    dataPageHeader.__set_num_values(kValuesPerPage);
+    dataPageHeader.__set_encoding(thrift::Encoding::PLAIN);
+    dataPageHeader.__set_definition_level_encoding(thrift::Encoding::RLE);
+    dataPageHeader.__set_repetition_level_encoding(thrift::Encoding::RLE);
+
+    thrift::PageHeader pageHeader;
+    pageHeader.__set_type(thrift::PageType::DATA_PAGE);
+    pageHeader.__set_uncompressed_page_size(body.size());
+    pageHeader.__set_compressed_page_size(syntheticPage.compressed.size());
+    pageHeader.__set_data_page_header(dataPageHeader);
+    syntheticPage.uncompressedSize = body.size();
+    syntheticPage.header = std::move(pageHeader);
+    syntheticPage.serializedHeader = serializePageHeader(syntheticPage.header);
+    pages.push_back(std::move(syntheticPage));
+  }
+
+  return pages;
+}
+
+} // namespace
+
+namespace bytedance::bolt::parquet {
+
+class PageReaderPreloadBenchmark {
+ public:
+  PageReaderPreloadBenchmark() {
+    rootPool_ =
+        memory::memoryManager()->addRootPool("PageReaderPreloadBenchmark");
+    leafPool_ = rootPool_->addLeafChild("PageReaderPreloadBenchmark");
+    pages_ = ::makePages();
+    for (const auto& page : pages_) {
+      columnChunk_.append(page.serializedHeader);
+      columnChunk_.append(page.compressed);
+    }
+  }
+
+  uint64_t run(bool usePrefixFastPath) {
+    if (!usePrefixFastPath) {
+      return runFullDecompressBaseline();
+    }
+
+    auto stream = std::make_unique<SeekableArrayInputStream>(
+        columnChunk_.data(), columnChunk_.size());
+    PageReader reader(
+        std::move(stream),
+        *leafPool_,
+        makeNestedInt64Type(),
+        thrift::CompressionCodec::ZSTD,
+        columnChunk_.size(),
+        nullptr);
+    reader.decodeRepDefs(kNumPages * kValuesPerPage);
+    return reader.repDefRange().second;
+  }
+
+ private:
+  uint64_t runFullDecompressBaseline() {
+    constexpr int32_t kLenSize = sizeof(int32_t);
+    std::string decompressed;
+    uint64_t repDefBytes = 0;
+    for (const auto& page : pages_) {
+      decompressed.resize(page.uncompressedSize);
+      const auto result = ZSTD_decompress(
+          decompressed.data(),
+          decompressed.size(),
+          page.compressed.data(),
+          page.compressed.size());
+      BOLT_CHECK(!ZSTD_isError(result), ZSTD_getErrorName(result));
+      BOLT_CHECK_EQ(result, page.uncompressedSize);
+
+      const char* data = decompressed.data();
+      const auto repeatLength = *reinterpret_cast<const int32_t*>(data);
+      data += kLenSize + repeatLength;
+      const auto defineLength = *reinterpret_cast<const uint32_t*>(data);
+      repDefBytes += kLenSize + repeatLength + kLenSize + defineLength;
+    }
+    return repDefBytes;
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> leafPool_;
+  std::vector<::SyntheticPage> pages_;
+  std::string columnChunk_;
+};
+
+} // namespace bytedance::bolt::parquet
+
+namespace {
+
+PageReaderPreloadBenchmark& benchmark() {
+  static PageReaderPreloadBenchmark instance;
+  return instance;
+}
+
+void runPreloadDecode(uint32_t iters, bool usePrefixFastPath) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = benchmark();
+  suspender.dismiss();
+  while (iters--) {
+    auto repDefBytes = instance.run(usePrefixFastPath);
+    folly::doNotOptimizeAway(repDefBytes);
+  }
+}
+
+} // namespace
+
+BENCHMARK(prefix_off, iters) {
+  runPreloadDecode(iters, false);
+}
+
+BENCHMARK_RELATIVE(prefix_on, iters) {
+  runPreloadDecode(iters, true);
+}
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -30,10 +30,110 @@
 
 #include "bolt/dwio/parquet/reader/PageReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
+
+#include <arrow/util/rle_encoding.h>
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+#include <zstd.h>
+
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::common;
 using namespace bytedance::bolt::dwio::common;
 using namespace bytedance::bolt::parquet;
+
+namespace bytedance::bolt::parquet {
+namespace {
+
+void appendInt32(std::string& out, int32_t value) {
+  out.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+std::string encodeLevels(const std::vector<int16_t>& levels, int bitWidth) {
+  std::string encoded(levels.size() * sizeof(int16_t) + 64, '\0');
+  ::arrow::util::RleEncoder encoder(
+      reinterpret_cast<uint8_t*>(encoded.data()), encoded.size(), bitWidth);
+  for (auto level : levels) {
+    encoder.Put(level);
+  }
+  auto encodedSize = encoder.Flush();
+  encoded.resize(encodedSize);
+  return encoded;
+}
+
+std::string makeRepDefPrefix(std::string& expectedData) {
+  auto repetitionLevels = encodeLevels({0, 1, 1, 0, 1, 0, 0, 1}, 1);
+  auto definitionLevels = encodeLevels({2, 2, 1, 2, 2, 0, 1, 2}, 2);
+
+  std::string prefix;
+  appendInt32(prefix, repetitionLevels.size());
+  prefix.append(repetitionLevels);
+  appendInt32(prefix, definitionLevels.size());
+  prefix.append(definitionLevels);
+
+  expectedData = prefix;
+  for (int32_t i = 0; i < 128; ++i) {
+    appendInt32(expectedData, i);
+  }
+  return prefix;
+}
+
+std::string zstdCompress(const std::string& data) {
+  std::string compressed(ZSTD_compressBound(data.size()), '\0');
+  auto compressedSize = ZSTD_compress(
+      compressed.data(), compressed.size(), data.data(), data.size(), 1);
+  BOLT_CHECK(!ZSTD_isError(compressedSize), ZSTD_getErrorName(compressedSize));
+  compressed.resize(compressedSize);
+  return compressed;
+}
+
+thrift::PageHeader makePageHeader(
+    int32_t compressedSize,
+    int32_t uncompressedSize) {
+  thrift::DataPageHeader dataPageHeader;
+  dataPageHeader.__set_num_values(8);
+  dataPageHeader.__set_encoding(thrift::Encoding::PLAIN);
+  dataPageHeader.__set_definition_level_encoding(thrift::Encoding::RLE);
+  dataPageHeader.__set_repetition_level_encoding(thrift::Encoding::RLE);
+
+  thrift::PageHeader pageHeader;
+  pageHeader.__set_type(thrift::PageType::DATA_PAGE);
+  pageHeader.__set_compressed_page_size(compressedSize);
+  pageHeader.__set_uncompressed_page_size(uncompressedSize);
+  pageHeader.__set_data_page_header(dataPageHeader);
+  return pageHeader;
+}
+
+std::string serializePageHeader(const thrift::PageHeader& pageHeader) {
+  auto buffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+  apache::thrift::protocol::TCompactProtocolT<
+      apache::thrift::transport::TMemoryBuffer>
+      protocol(buffer);
+  pageHeader.write(&protocol);
+
+  uint8_t* data = nullptr;
+  uint32_t size = 0;
+  buffer->getBuffer(&data, &size);
+  return std::string(reinterpret_cast<const char*>(data), size);
+}
+
+ParquetTypeWithIdPtr makeNestedInt64Type() {
+  return std::make_shared<ParquetTypeWithId>(
+      BIGINT(),
+      std::vector<std::shared_ptr<const dwio::common::TypeWithId>>{},
+      0,
+      0,
+      0,
+      "value",
+      thrift::Type::INT64,
+      std::nullopt,
+      std::nullopt,
+      1,
+      2,
+      true,
+      true);
+}
+
+} // namespace
 
 class ParquetPageReaderTest : public ParquetTestBase {};
 
@@ -121,3 +221,35 @@ TEST(CompressionOptionsTest, testCompressionOptions) {
       options.format.zlib.windowBits,
       dwio::common::compression::Compressor::PARQUET_ZLIB_WINDOW_BITS);
 }
+
+TEST_F(ParquetPageReaderTest, zstdDataPageV1RepDefPrefix) {
+  std::string pageBody;
+  makeRepDefPrefix(pageBody);
+  auto compressed = zstdCompress(pageBody);
+  auto pageHeader = makePageHeader(compressed.size(), pageBody.size());
+  std::string columnChunk;
+  auto serializedHeader = serializePageHeader(pageHeader);
+  columnChunk.append(serializedHeader);
+  columnChunk.append(compressed);
+
+  // First page is sampled and fully decodes rep/def levels. The second page is
+  // kept raw and exercises the prefix-only preload path through public APIs.
+  columnChunk.append(serializedHeader);
+  columnChunk.append(compressed);
+
+  auto stream = std::make_unique<SeekableArrayInputStream>(
+      columnChunk.data(), columnChunk.size());
+  PageReader reader(
+      std::move(stream),
+      *leafPool_,
+      makeNestedInt64Type(),
+      thrift::CompressionCodec::ZSTD,
+      columnChunk.size(),
+      nullptr);
+  reader.setDecodeRepDefPageCount(1);
+
+  reader.decodeRepDefs(5);
+  EXPECT_GT(reader.repDefRange().second, 8);
+}
+
+} // namespace bytedance::bolt::parquet


### PR DESCRIPTION
### What problem does this PR solve?

Parquet Data Page V1 stores repetition and definition levels as a prefix of the page body. When Bolt preloads rep/def information for nested columns, the existing path decompresses the whole page even though only the rep/def prefix is needed at that stage.

This is wasteful for nested columns with large value payloads after the prefix. The overhead is concentrated in the rep/def preload path, before leaf values are materialized.

Issue Number: N/A

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (optimization)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no logic changes)
- [ ] Build/CI or Infrastructure changes
- [ ] Documentation only

### Description

This PR adds a narrow fast path in `PageReader` for Parquet V1 rep/def-only reads.

The optimization is intentionally scoped to `row == kRepDefOnly`, which is the path used while preloading rep/def data for non-top-level nested Parquet columns. In that case, `PageReader` now attempts to decompress only enough of the page body to parse the V1 repetition/definition prefix.

If the prefix cannot be decoded from the partial output, the reader falls back to the existing full-page decompression path. The normal Page V1 full-decompress path remains unchanged.

Supported fast-path cases in this PR:

- Parquet Data Page V1
- rep/def-only page reads (`row == kRepDefOnly`)
- ZSTD compressed pages
- UNCOMPRESSED pages

This PR intentionally excludes unrelated reader refactors, level-conversion changes, and ZSTD context reuse changes.

### Performance Impact

- [ ] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] Positive Impact: I have run benchmarks.

<details>
<summary>Click to view Benchmark Results</summary>

```text
Benchmark: bolt_dwio_parquet_page_reader_preload_benchmark
Workload : synthetic multi-page Parquet V1 + ZSTD pages
Scenario : direct comparison of rep/def preload paths only
          prefix_off = full-page decompress before extracting rep/def
          prefix_on  = decode rep/def prefix without decompressing value payload

prefix_off: 51.04ms
prefix_on :  1.08ms
Speedup   : ~47x
```

This benchmark is intentionally low-level and isolates the exact hotspot this PR optimizes: preloading rep/def data from Parquet V1 pages when the value payload is large but not needed yet.

The previously tried end-to-end nested read benchmark did not reliably expose the difference because broader reader and materialization costs dominated the total runtime. The new microbenchmark measures the preload path directly, which is the intended optimization target.
</details>

- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Optimized Parquet V1 nested-column rep/def preloading by avoiding full-page decompression when only the rep/def prefix is needed.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation commands:

```bash
cmake --build --preset conan-release --target bolt_dwio_parquet_reader_test bolt_dwio_parquet_page_reader_preload_benchmark --parallel 32
_build/Release/bolt/dwio/parquet/tests/reader/bolt_dwio_parquet_reader_test --gtest_filter=ParquetPageReaderTest.zstdDataPageV1RepDefPrefix
_build/Release/bolt/dwio/parquet/tests/reader/bolt_dwio_parquet_page_reader_preload_benchmark --bm_min_iters=5
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
