### PR TITLE
perf: Optimize parquet list length conversion

### DIFF
--- a/bolt/dwio/parquet/arrow/LevelConversion.cpp
+++ b/bolt/dwio/parquet/arrow/LevelConversion.cpp
@@ -63,8 +63,9 @@ class OffsetListOutput {
       return;
     }
     if (ARROW_PREDICT_FALSE(
+            run > std::numeric_limits<OffsetType>::max() ||
             *offsets_ > std::numeric_limits<OffsetType>::max() -
-                static_cast<OffsetType>(run))) {
+                    static_cast<OffsetType>(run))) {
       throw ParquetException("List index overflow.");
     }
     *offsets_ += static_cast<OffsetType>(run);
@@ -91,6 +92,10 @@ class OffsetListOutput {
     return offsets_ == nullptr ? 0 : offsets_ - orig_;
   }
 
+  int64_t valuesReadForBounds() const {
+    return valuesRead();
+  }
+
   bool hasValuesRead() const {
     return offsets_ != nullptr;
   }
@@ -106,8 +111,8 @@ class LengthListOutput {
 
   void OnContinuationRun(int64_t run) {
     if (ARROW_PREDICT_FALSE(
-            currentLength_ >
-            std::numeric_limits<int32_t>::max() - static_cast<int32_t>(run))) {
+            run > std::numeric_limits<int32_t>::max() ||
+            currentLength_ > std::numeric_limits<int32_t>::max() - run)) {
       throw ParquetException("List index overflow.");
     }
     currentLength_ += static_cast<int32_t>(run);
@@ -129,6 +134,10 @@ class LengthListOutput {
 
   int64_t valuesRead() const {
     return valuesRead_;
+  }
+
+  int64_t valuesReadForBounds() const {
+    return valuesRead_ + (haveCurrentList_ ? 1 : 0);
   }
 
   bool hasValuesRead() const {
@@ -181,7 +190,8 @@ void DefRepLevelsToListInfo(
               (valid_bits_writer.has_value() &&
                valid_bits_writer->position() >=
                    output->values_read_upper_bound) ||
-              list_output.valuesRead() >= output->values_read_upper_bound)) {
+              list_output.valuesReadForBounds() >=
+                  output->values_read_upper_bound)) {
         std::stringstream ss;
         ss << "Definition levels exceeded upper bound: "
            << output->values_read_upper_bound;

--- a/bolt/dwio/parquet/arrow/LevelConversion.cpp
+++ b/bolt/dwio/parquet/arrow/LevelConversion.cpp
@@ -53,14 +53,103 @@ using ::arrow::internal::CpuInfo;
 using ::std::optional;
 
 template <typename OffsetType>
+class OffsetListOutput {
+ public:
+  explicit OffsetListOutput(OffsetType* offsets)
+      : offsets_(offsets), orig_(offsets) {}
+
+  void OnContinuationRun(int64_t run) {
+    if (offsets_ == nullptr) {
+      return;
+    }
+    if (ARROW_PREDICT_FALSE(
+            *offsets_ > std::numeric_limits<OffsetType>::max() -
+                static_cast<OffsetType>(run))) {
+      throw ParquetException("List index overflow.");
+    }
+    *offsets_ += static_cast<OffsetType>(run);
+  }
+
+  void OnNewList(int16_t def_level, const LevelInfo& level_info) {
+    if (offsets_ == nullptr) {
+      return;
+    }
+    ++offsets_;
+    *offsets_ = *(offsets_ - 1);
+    if (def_level >= level_info.def_level) {
+      if (ARROW_PREDICT_FALSE(
+              *offsets_ == std::numeric_limits<OffsetType>::max())) {
+        throw ParquetException("List index overflow.");
+      }
+      ++*offsets_;
+    }
+  }
+
+  void Finish() {}
+
+  int64_t valuesRead() const {
+    return offsets_ == nullptr ? 0 : offsets_ - orig_;
+  }
+
+  bool hasValuesRead() const {
+    return offsets_ != nullptr;
+  }
+
+ private:
+  OffsetType* offsets_;
+  OffsetType* orig_;
+};
+
+class LengthListOutput {
+ public:
+  explicit LengthListOutput(int32_t* lengths) : lengths_(lengths) {}
+
+  void OnContinuationRun(int64_t run) {
+    if (ARROW_PREDICT_FALSE(
+            currentLength_ >
+            std::numeric_limits<int32_t>::max() - static_cast<int32_t>(run))) {
+      throw ParquetException("List index overflow.");
+    }
+    currentLength_ += static_cast<int32_t>(run);
+  }
+
+  void OnNewList(int16_t def_level, const LevelInfo& level_info) {
+    Finish();
+    haveCurrentList_ = true;
+    currentLength_ = def_level >= level_info.def_level ? 1 : 0;
+  }
+
+  void Finish() {
+    if (haveCurrentList_) {
+      lengths_[valuesRead_++] = currentLength_;
+      currentLength_ = 0;
+      haveCurrentList_ = false;
+    }
+  }
+
+  int64_t valuesRead() const {
+    return valuesRead_;
+  }
+
+  bool hasValuesRead() const {
+    return true;
+  }
+
+ private:
+  int32_t* lengths_;
+  int64_t valuesRead_{0};
+  int32_t currentLength_{0};
+  bool haveCurrentList_{false};
+};
+
+template <typename ListOutput>
 void DefRepLevelsToListInfo(
     const int16_t* def_levels,
     const int16_t* rep_levels,
     int64_t num_def_levels,
     LevelInfo level_info,
     ValidityBitmapInputOutput* output,
-    OffsetType* offsets) {
-  OffsetType* orig_pos = offsets;
+    ListOutput& list_output) {
   optional<::arrow::internal::FirstTimeBitmapWriter> valid_bits_writer;
   if (output->valid_bits) {
     valid_bits_writer.emplace(
@@ -68,7 +157,7 @@ void DefRepLevelsToListInfo(
         output->valid_bits_offset,
         output->values_read_upper_bound);
   }
-  for (int x = 0; x < num_def_levels; x++) {
+  for (int64_t x = 0; x < num_def_levels; ++x) {
     // Skip items that belong to empty or null ancestor lists and further nested
     // lists.
     if (def_levels[x] < level_info.repeated_ancestor_def_level ||
@@ -80,19 +169,20 @@ void DefRepLevelsToListInfo(
       // A continuation of an existing list.
       // offsets can be null for structs with repeated children (we don't need
       // to know offsets until we get to the children).
-      if (offsets != nullptr) {
-        if (ARROW_PREDICT_FALSE(
-                *offsets == std::numeric_limits<OffsetType>::max())) {
-          throw ParquetException("List index overflow.");
-        }
-        *offsets += 1;
+      int64_t run = 1;
+      while (x + run < num_def_levels &&
+             rep_levels[x + run] == level_info.rep_level &&
+             def_levels[x + run] >= level_info.repeated_ancestor_def_level) {
+        ++run;
       }
+      list_output.OnContinuationRun(run);
+      x += run - 1;
     } else {
       if (ARROW_PREDICT_FALSE(
               (valid_bits_writer.has_value() &&
                valid_bits_writer->position() >=
                    output->values_read_upper_bound) ||
-              (offsets - orig_pos) >= output->values_read_upper_bound)) {
+              list_output.valuesRead() >= output->values_read_upper_bound)) {
         std::stringstream ss;
         ss << "Definition levels exceeded upper bound: "
            << output->values_read_upper_bound;
@@ -102,20 +192,7 @@ void DefRepLevelsToListInfo(
       // current_rep < list rep_level i.e. start of a list (ancestor empty lists
       // are filtered out above). offsets can be null for structs with repeated
       // children (we don't need to know offsets until we get to the children).
-      if (offsets != nullptr) {
-        ++offsets;
-        // Use cumulative offsets because variable size lists are more common
-        // than fixed size lists so it should be cheaper to make these
-        // cumulative and subtract when validating fixed size lists.
-        *offsets = *(offsets - 1);
-        if (def_levels[x] >= level_info.def_level) {
-          if (ARROW_PREDICT_FALSE(
-                  *offsets == std::numeric_limits<OffsetType>::max())) {
-            throw ParquetException("List index overflow.");
-          }
-          *offsets += 1;
-        }
-      }
+      list_output.OnNewList(def_levels[x], level_info);
 
       if (valid_bits_writer.has_value()) {
         // the level_info def level for lists reflects element present level.
@@ -130,11 +207,12 @@ void DefRepLevelsToListInfo(
       }
     }
   }
+  list_output.Finish();
   if (valid_bits_writer.has_value()) {
     valid_bits_writer->Finish();
   }
-  if (offsets != nullptr) {
-    output->values_read = offsets - orig_pos;
+  if (list_output.hasValuesRead()) {
+    output->values_read = list_output.valuesRead();
   } else if (valid_bits_writer.has_value()) {
     output->values_read = valid_bits_writer->position();
   }
@@ -189,8 +267,9 @@ void DefRepLevelsToList(
     LevelInfo level_info,
     ValidityBitmapInputOutput* output,
     int32_t* offsets) {
-  DefRepLevelsToListInfo<int32_t>(
-      def_levels, rep_levels, num_def_levels, level_info, output, offsets);
+  OffsetListOutput<int32_t> listOutput(offsets);
+  DefRepLevelsToListInfo(
+      def_levels, rep_levels, num_def_levels, level_info, output, listOutput);
 }
 
 void DefRepLevelsToList(
@@ -200,8 +279,21 @@ void DefRepLevelsToList(
     LevelInfo level_info,
     ValidityBitmapInputOutput* output,
     int64_t* offsets) {
-  DefRepLevelsToListInfo<int64_t>(
-      def_levels, rep_levels, num_def_levels, level_info, output, offsets);
+  OffsetListOutput<int64_t> listOutput(offsets);
+  DefRepLevelsToListInfo(
+      def_levels, rep_levels, num_def_levels, level_info, output, listOutput);
+}
+
+void DefRepLevelsToListLengths(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info,
+    ValidityBitmapInputOutput* output,
+    int32_t* lengths) {
+  LengthListOutput listOutput(lengths);
+  DefRepLevelsToListInfo(
+      def_levels, rep_levels, num_def_levels, level_info, output, listOutput);
 }
 
 void DefRepLevelsToBitmap(
@@ -214,13 +306,9 @@ void DefRepLevelsToBitmap(
   // method is for parent structs, so we need to bump def and ref level.
   level_info.rep_level += 1;
   level_info.def_level += 1;
-  DefRepLevelsToListInfo<int32_t>(
-      def_levels,
-      rep_levels,
-      num_def_levels,
-      level_info,
-      output,
-      /*offsets=*/nullptr);
+  OffsetListOutput<int32_t> listOutput(nullptr);
+  DefRepLevelsToListInfo(
+      def_levels, rep_levels, num_def_levels, level_info, output, listOutput);
 }
 
 } // namespace bytedance::bolt::parquet::arrow

--- a/bolt/dwio/parquet/arrow/LevelConversion.cpp
+++ b/bolt/dwio/parquet/arrow/LevelConversion.cpp
@@ -166,9 +166,8 @@ void DefRepLevelsToListInfo(
     }
 
     if (rep_levels[x] == level_info.rep_level) {
-      // A continuation of an existing list.
-      // offsets can be null for structs with repeated children (we don't need
-      // to know offsets until we get to the children).
+      // A continuation of an existing list. The list output handles whether
+      // this extends cumulative offsets or the current list length.
       int64_t run = 1;
       while (x + run < num_def_levels &&
              rep_levels[x + run] == level_info.rep_level &&
@@ -190,8 +189,8 @@ void DefRepLevelsToListInfo(
       }
 
       // current_rep < list rep_level i.e. start of a list (ancestor empty lists
-      // are filtered out above). offsets can be null for structs with repeated
-      // children (we don't need to know offsets until we get to the children).
+      // are filtered out above). The list output records the new list either as
+      // cumulative offsets or as a finalized length for the previous list.
       list_output.OnNewList(def_levels[x], level_info);
 
       if (valid_bits_writer.has_value()) {

--- a/bolt/dwio/parquet/arrow/LevelConversion.h
+++ b/bolt/dwio/parquet/arrow/LevelConversion.h
@@ -214,6 +214,17 @@ void PARQUET_EXPORT DefRepLevelsToList(
     ValidityBitmapInputOutput* output,
     int64_t* offsets);
 
+// Reconstructs a validity bitmap and list lengths directly. This is equivalent
+// to calling DefRepLevelsToList with int32 offsets and converting adjacent
+// offsets to lengths, but avoids one extra pass over the output.
+void PARQUET_EXPORT DefRepLevelsToListLengths(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info,
+    ValidityBitmapInputOutput* output,
+    int32_t* lengths);
+
 // Reconstructs a validity bitmap for a struct every member is a list or has
 // a list descendant.  See documentation on DefLevelsToBitmap for when more
 // details on this method compared to the other ones defined above.

--- a/bolt/dwio/parquet/arrow/LevelConversion.h
+++ b/bolt/dwio/parquet/arrow/LevelConversion.h
@@ -174,8 +174,8 @@ struct PARQUET_EXPORT ValidityBitmapInputOutput {
   int64_t values_read = 0;
   // Input/Output. The number of nulls encountered.
   int64_t null_count = 0;
-  // Output only. The validity bitmap to populate. Maybe be null only
-  // for DefRepLevelsToListInfo (if all that is needed is list offsets).
+  // Output only. The validity bitmap to populate. May be null when callers only
+  // need list offsets or list lengths, and do not need list validity.
   uint8_t* valid_bits = NULLPTR;
   // Input only, offset into valid_bits to start at.
   int64_t valid_bits_offset = 0;
@@ -217,6 +217,8 @@ void PARQUET_EXPORT DefRepLevelsToList(
 // Reconstructs a validity bitmap and list lengths directly. This is equivalent
 // to calling DefRepLevelsToList with int32 offsets and converting adjacent
 // offsets to lengths, but avoids one extra pass over the output.
+//
+// Lengths must be sized to values_read_upper_bound.
 void PARQUET_EXPORT DefRepLevelsToListLengths(
     const int16_t* def_levels,
     const int16_t* rep_levels,

--- a/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
@@ -50,6 +50,19 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+add_executable(
+  bolt_dwio_parquet_level_conversion_benchmark
+  LevelConversionBenchmark.cpp
+  ../LevelComparison.cpp
+  ../LevelComparisonAvx2.cpp
+  ../LevelConversion.cpp
+)
+target_link_libraries(
+  bolt_dwio_parquet_level_conversion_benchmark
+  PRIVATE arrow::arrow
+  ${FOLLY_BENCHMARK}
+)
+
 bolt_add_library(
   bolt_dwio_parquet_arrow_test_lib
   BloomFilter.cpp

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bolt/dwio/parquet/arrow/LevelConversion.h"
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <random>
+
+using namespace bytedance::bolt::parquet::arrow;
+
+namespace {
+
+constexpr int32_t kNumLists = 4 * 1024 * 1024;
+constexpr uint32_t kSeed = 20260723;
+
+enum class ListShape {
+  kSingleElement,
+  kMixed,
+  kLong,
+};
+
+struct Levels {
+  std::vector<int16_t> definitions;
+  std::vector<int16_t> repetitions;
+};
+
+Levels makeLevels(ListShape shape) {
+  std::mt19937 rng(kSeed);
+  std::uniform_int_distribution<int32_t> mixedLengthDist(0, 12);
+  std::uniform_int_distribution<int32_t> longLengthDist(16, 64);
+  std::uniform_int_distribution<int32_t> pct(0, 99);
+
+  Levels levels;
+  levels.definitions.reserve(
+      shape == ListShape::kSingleElement ? kNumLists : kNumLists * 6);
+  levels.repetitions.reserve(levels.definitions.capacity());
+
+  for (int32_t list = 0; list < kNumLists; ++list) {
+    const auto roll = pct(rng);
+    if (roll < 5) {
+      // Null list.
+      levels.definitions.push_back(0);
+      levels.repetitions.push_back(0);
+      continue;
+    }
+    if (roll < 15) {
+      // Empty list.
+      levels.definitions.push_back(1);
+      levels.repetitions.push_back(0);
+      continue;
+    }
+
+    const int32_t length = [&]() {
+      switch (shape) {
+        case ListShape::kSingleElement:
+          return 1;
+        case ListShape::kMixed:
+          return mixedLengthDist(rng);
+        case ListShape::kLong:
+          return longLengthDist(rng);
+      }
+      return 1;
+    }();
+    if (length == 0) {
+      levels.definitions.push_back(1);
+      levels.repetitions.push_back(0);
+      continue;
+    }
+
+    for (int32_t i = 0; i < length; ++i) {
+      levels.definitions.push_back(pct(rng) < 10 ? 1 : 2);
+      levels.repetitions.push_back(i == 0 ? 0 : 1);
+    }
+  }
+
+  return levels;
+}
+
+LevelInfo listLevelInfo() {
+  LevelInfo info;
+  info.rep_level = 1;
+  info.def_level = 2;
+  info.repeated_ancestor_def_level = 0;
+  return info;
+}
+
+class LevelConversionBenchmark {
+ public:
+  explicit LevelConversionBenchmark(ListShape shape)
+      : levels_(makeLevels(shape)) {
+    validity_.resize(kNumLists);
+    offsets_.resize(kNumLists + 1);
+    lengths_.resize(kNumLists);
+  }
+
+  int64_t offsetsThenLengths() {
+    resetIo();
+    std::fill(offsets_.begin(), offsets_.end(), 0);
+    DefRepLevelsToList(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        listLevelInfo(),
+        &io_,
+        offsets_.data());
+    for (int64_t i = 0; i < io_.values_read; ++i) {
+      lengths_[i] = offsets_[i + 1] - offsets_[i];
+    }
+    return io_.values_read;
+  }
+
+  int64_t directLengths() {
+    resetIo();
+    DefRepLevelsToListLengths(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        listLevelInfo(),
+        &io_,
+        lengths_.data());
+    return io_.values_read;
+  }
+
+ private:
+  void resetIo() {
+    std::fill(validity_.begin(), validity_.end(), 0);
+    io_ = ValidityBitmapInputOutput();
+    io_.valid_bits = validity_.data();
+    io_.values_read_upper_bound = kNumLists;
+  }
+
+  Levels levels_;
+  std::vector<uint8_t> validity_;
+  std::vector<int32_t> offsets_;
+  std::vector<int32_t> lengths_;
+  ValidityBitmapInputOutput io_;
+};
+
+LevelConversionBenchmark& benchmark(ListShape shape) {
+  static LevelConversionBenchmark singleElement(ListShape::kSingleElement);
+  static LevelConversionBenchmark mixed(ListShape::kMixed);
+  static LevelConversionBenchmark longLists(ListShape::kLong);
+  switch (shape) {
+    case ListShape::kSingleElement:
+      return singleElement;
+    case ListShape::kMixed:
+      return mixed;
+    case ListShape::kLong:
+      return longLists;
+  }
+  return singleElement;
+}
+
+void runOffsetsThenLengths(uint32_t iters, ListShape shape) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = benchmark(shape);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(instance.offsetsThenLengths());
+  }
+}
+
+void runDirectLengths(uint32_t iters, ListShape shape) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = benchmark(shape);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(instance.directLengths());
+  }
+}
+
+} // namespace
+
+BENCHMARK(offsetsThenLengths_single, iters) {
+  runOffsetsThenLengths(iters, ListShape::kSingleElement);
+}
+
+BENCHMARK_RELATIVE(directLengths_single, iters) {
+  runDirectLengths(iters, ListShape::kSingleElement);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(offsetsThenLengths_mixed, iters) {
+  runOffsetsThenLengths(iters, ListShape::kMixed);
+}
+
+BENCHMARK_RELATIVE(directLengths_mixed, iters) {
+  runDirectLengths(iters, ListShape::kMixed);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(offsetsThenLengths_long, iters) {
+  runOffsetsThenLengths(iters, ListShape::kLong);
+}
+
+BENCHMARK_RELATIVE(directLengths_long, iters) {
+  runDirectLengths(iters, ListShape::kLong);
+}
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
@@ -1,6 +1,31 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
  * Copyright (c) ByteDance Ltd. and/or its affiliates.
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2025-11-11.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
  */
 
 #include "bolt/dwio/parquet/arrow/LevelConversion.h"

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
@@ -478,11 +478,11 @@ TEST(NestedListTest, DirectLengthsUpperBound) {
   level_info.def_level = 2;
   level_info.repeated_ancestor_def_level = 0;
 
-  std::vector<int16_t> def_levels = {2, 2, 2};
-  std::vector<int16_t> rep_levels = {0, 0, 0};
+  std::vector<int16_t> def_levels = {2, 2};
+  std::vector<int16_t> rep_levels = {0, 0};
   ValidityBitmapInputOutput io;
   io.values_read_upper_bound = 1;
-  std::vector<int32_t> lengths(1, 0);
+  std::vector<int32_t> lengths(2, -1);
 
   ASSERT_THROW(
       DefRepLevelsToListLengths(
@@ -493,6 +493,31 @@ TEST(NestedListTest, DirectLengthsUpperBound) {
           &io,
           lengths.data()),
       ParquetException);
+  EXPECT_EQ(lengths[1], -1);
+}
+
+TEST(NestedListTest, DirectLengthsExactUpperBound) {
+  LevelInfo level_info;
+  level_info.rep_level = 1;
+  level_info.def_level = 2;
+  level_info.repeated_ancestor_def_level = 0;
+
+  std::vector<int16_t> def_levels = {2, 2};
+  std::vector<int16_t> rep_levels = {0, 0};
+  ValidityBitmapInputOutput io;
+  io.values_read_upper_bound = 2;
+  std::vector<int32_t> lengths(2, -1);
+
+  DefRepLevelsToListLengths(
+      def_levels.data(),
+      rep_levels.data(),
+      def_levels.size(),
+      level_info,
+      &io,
+      lengths.data());
+
+  EXPECT_EQ(io.values_read, 2);
+  EXPECT_THAT(lengths, testing::ElementsAre(1, 1));
 }
 
 TEST(TestOnlyExtractBitsSoftware, BasicTest) {

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
@@ -409,6 +409,92 @@ TYPED_TEST(NestedListTest, TestOverflow) {
   this->Run(test_data, level_info);
 }
 
+TEST(NestedListTest, DirectLengthsMatchesOffsets) {
+  auto check = [](const MultiLevelTestData& test_data,
+                  LevelInfo level_info,
+                  int32_t expectedValuesRead) {
+    std::vector<uint8_t> offsetsValidity(expectedValuesRead, 0);
+    ValidityBitmapInputOutput offsetsIo;
+    offsetsIo.valid_bits = offsetsValidity.data();
+    offsetsIo.values_read_upper_bound = expectedValuesRead;
+    std::vector<int32_t> offsets(expectedValuesRead + 1, 0);
+    DefRepLevelsToList(
+        test_data.def_levels.data(),
+        test_data.rep_levels.data(),
+        test_data.def_levels.size(),
+        level_info,
+        &offsetsIo,
+        offsets.data());
+
+    std::vector<uint8_t> lengthsValidity(expectedValuesRead, 0);
+    ValidityBitmapInputOutput lengthsIo;
+    lengthsIo.valid_bits = lengthsValidity.data();
+    lengthsIo.values_read_upper_bound = expectedValuesRead;
+    std::vector<int32_t> lengths(expectedValuesRead, -1);
+    DefRepLevelsToListLengths(
+        test_data.def_levels.data(),
+        test_data.rep_levels.data(),
+        test_data.def_levels.size(),
+        level_info,
+        &lengthsIo,
+        lengths.data());
+
+    ASSERT_EQ(lengthsIo.values_read, offsetsIo.values_read);
+    ASSERT_EQ(lengthsIo.null_count, offsetsIo.null_count);
+    ASSERT_EQ(
+        BitmapToString(lengthsValidity, expectedValuesRead),
+        BitmapToString(offsetsValidity, expectedValuesRead));
+    for (auto i = 0; i < offsetsIo.values_read; ++i) {
+      EXPECT_EQ(lengths[i], offsets[i + 1] - offsets[i]) << "index=" << i;
+    }
+  };
+
+  LevelInfo outer;
+  outer.rep_level = 1;
+  outer.def_level = 2;
+  check(TriplyNestedList(), outer, 4);
+
+  LevelInfo middle;
+  middle.rep_level = 2;
+  middle.def_level = 4;
+  middle.repeated_ancestor_def_level = 2;
+  check(TriplyNestedList(), middle, 7);
+
+  LevelInfo inner;
+  inner.rep_level = 3;
+  inner.def_level = 6;
+  inner.repeated_ancestor_def_level = 4;
+  check(TriplyNestedList(), inner, 6);
+
+  MultiLevelTestData nullableElements;
+  nullableElements.def_levels = std::vector<int16_t>{2, 1, 2, 0, 1, 1};
+  nullableElements.rep_levels = std::vector<int16_t>{0, 1, 1, 0, 0, 1};
+  check(nullableElements, outer, 3);
+}
+
+TEST(NestedListTest, DirectLengthsUpperBound) {
+  LevelInfo level_info;
+  level_info.rep_level = 1;
+  level_info.def_level = 2;
+  level_info.repeated_ancestor_def_level = 0;
+
+  std::vector<int16_t> def_levels = {2, 2, 2};
+  std::vector<int16_t> rep_levels = {0, 0, 0};
+  ValidityBitmapInputOutput io;
+  io.values_read_upper_bound = 1;
+  std::vector<int32_t> lengths(1, 0);
+
+  ASSERT_THROW(
+      DefRepLevelsToListLengths(
+          def_levels.data(),
+          rep_levels.data(),
+          def_levels.size(),
+          level_info,
+          &io,
+          lengths.data()),
+      ParquetException);
+}
+
 TEST(TestOnlyExtractBitsSoftware, BasicTest) {
   auto check =
       [](uint64_t bitmap, uint64_t selection, uint64_t expected) -> void {

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -1090,17 +1090,13 @@ int32_t PageReader::getLengthsAndNulls(
           definitionLevels_.data() + begin, end - begin, info, &bits);
       break;
     case LevelMode::kList: {
-      arrow::DefRepLevelsToList(
+      arrow::DefRepLevelsToListLengths(
           definitionLevels_.data() + begin,
           repetitionLevels_.data() + begin,
           end - begin,
           info,
           &bits,
           lengths);
-      // Convert offsets to lengths.
-      for (auto i = 0; i < bits.values_read; ++i) {
-        lengths[i] = lengths[i + 1] - lengths[i];
-      }
       break;
     }
     case LevelMode::kStructOverLists: {


### PR DESCRIPTION
### What problem does this PR solve?

Parquet list reconstruction currently builds cumulative list offsets first and then converts adjacent offsets into list lengths in `PageReader::getLengthsAndNulls(LevelMode::kList)`. That extra pass is avoidable because the reader ultimately needs list lengths.

Issue Number: N/A

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (optimization)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no logic changes)
- [ ] Build/CI or Infrastructure changes
- [ ] Documentation only

### Description

This PR adds `DefRepLevelsToListLengths`, a direct list-length conversion path for Parquet definition/repetition levels.

The implementation reuses the existing `DefRepLevelsToListInfo` traversal by splitting output handling into small policies:

- `OffsetListOutput` preserves the existing cumulative-offset behavior.
- `LengthListOutput` writes list lengths directly.

`PageReader::getLengthsAndNulls(LevelMode::kList)` now calls `DefRepLevelsToListLengths`, avoiding the previous offsets-to-lengths conversion loop.

### Performance Impact

- [ ] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] Positive Impact: I have run benchmarks.

<details>
<summary>Click to view Benchmark Results</summary>

```text
Benchmark: bolt_dwio_parquet_level_conversion_benchmark
Scenario : direct comparison of old offsets->lengths conversion vs direct lengths

single-element lists:
offsetsThenLengths   28.14ms
directLengths        12.39ms
speedup              2.27x

mixed-length lists:
offsetsThenLengths   89.59ms
directLengths        72.93ms
speedup              1.23x

long lists:
offsetsThenLengths  162.71ms
directLengths       147.52ms
speedup              1.10x
```

The benchmark uses fixed-seed synthetic def/rep levels and covers short, mixed, and long list distributions.
</details>

- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Optimized Parquet list length reconstruction by generating list lengths directly from def/rep levels.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation commands:

```bash
cmake --build --preset conan-release --target bolt_dwio_parquet_arrow_test bolt_dwio_parquet_level_conversion_benchmark --parallel 16
./_build/Release/bolt/dwio/parquet/arrow/tests/bolt_dwio_parquet_arrow_test --gtest_filter=NestedListTest.*
./_build/Release/bolt/dwio/parquet/arrow/tests/bolt_dwio_parquet_level_conversion_benchmark --bm_min_iters=5
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
