### PR TITLE
fix: RowBaseSpill should hold CompiledModule to ensure jit code alive

### DIFF
--- a/bolt/exec/Spill.cpp
+++ b/bolt/exec/Spill.cpp
@@ -452,6 +452,7 @@ SpillPartition::createRowBasedOrderedReader(
     bool canJit,
     bool spillUringEnabled) {
 #ifdef ENABLE_BOLT_JIT
+  bolt::jit::CompiledModuleSP jitModule;
   if (rows != nullptr && canJit && RowContainer::JITable(rows->keyTypes())) {
     // Extract compare flags from sorting keys
     std::vector<CompareFlags> cmpFlags;
@@ -462,13 +463,11 @@ SpillPartition::createRowBasedOrderedReader(
     if (cmpFlags.empty()) {
       cmpFlags.resize(rows->keyTypes().size(), CompareFlags());
     }
-    auto [jitMod, fn] = rows->codegenCompare(
+    jitModule = std::get<0>(rows->codegenCompare(
         rows->keyTypes(),
         cmpFlags,
         bytedance::bolt::jit::CmpType::CMP_SPILL,
-        true);
-    jitModuleRow_ = std::move(jitMod);
-    rowCmpRowFunc_ = (RowRowCompare)jitModuleRow_->getFuncPtr(fn);
+        true));
     LOG(INFO) << "JIT enabled for row based spill ordered reader!";
   }
 #endif
@@ -478,8 +477,12 @@ SpillPartition::createRowBasedOrderedReader(
   for (auto& fileInfo : files_) {
     BOLT_CHECK(fileInfo.rowInfo.has_value());
     streams.push_back(RowBasedFileSpillMergeStream::create(
-        RowBasedSpillReadFile::create(fileInfo, pool, spillUringEnabled),
-        rowCmpRowFunc_));
+        RowBasedSpillReadFile::create(fileInfo, pool, spillUringEnabled)
+#ifdef ENABLE_BOLT_JIT
+            ,
+        jitModule
+#endif
+        ));
   }
   files_.clear();
   // Check if the partition is empty or not.
@@ -497,6 +500,7 @@ SpillPartition::createRowBasedOrderedReaderWithLength(
     bool canJit,
     bool spillUringEnabled) {
 #ifdef ENABLE_BOLT_JIT
+  bolt::jit::CompiledModuleSP jitModule;
   if (rows != nullptr && canJit && RowContainer::JITable(rows->keyTypes())) {
     // Extract compare flags from sorting keys
     std::vector<CompareFlags> cmpFlags;
@@ -507,13 +511,11 @@ SpillPartition::createRowBasedOrderedReaderWithLength(
     if (cmpFlags.empty()) {
       cmpFlags.resize(rows->keyTypes().size(), CompareFlags());
     }
-    auto [jitMod, fn] = rows->codegenCompare(
+    jitModule = std::get<0>(rows->codegenCompare(
         rows->keyTypes(),
         cmpFlags,
         bytedance::bolt::jit::CmpType::CMP_SPILL,
-        true);
-    jitModuleRow_ = std::move(jitMod);
-    rowCmpRowFunc_ = (RowRowCompare)jitModuleRow_->getFuncPtr(fn);
+        true));
     LOG(INFO) << "JIT enabled for row based spill ordered reader!";
   }
 #endif
@@ -523,8 +525,12 @@ SpillPartition::createRowBasedOrderedReaderWithLength(
   for (auto& fileInfo : files_) {
     BOLT_CHECK(fileInfo.rowInfo.has_value());
     streams.push_back(RowBasedFileSpillMergeStream::createWithLength(
-        RowBasedSpillReadFile::create(fileInfo, pool, spillUringEnabled),
-        rowCmpRowFunc_));
+        RowBasedSpillReadFile::create(fileInfo, pool, spillUringEnabled)
+#ifdef ENABLE_BOLT_JIT
+            ,
+        jitModule
+#endif
+        ));
   }
   files_.clear();
   // Check if the partition is empty or not.

--- a/bolt/exec/Spill.h
+++ b/bolt/exec/Spill.h
@@ -367,19 +367,37 @@ class RowBasedSpillMergeStream : public MergeStream {
 class RowBasedFileSpillMergeStream : public RowBasedSpillMergeStream {
  public:
   static std::unique_ptr<RowBasedSpillMergeStream> create(
-      std::unique_ptr<RowBasedSpillReadFile> spillFile,
-      RowRowCompare cmp) {
-    auto* spillStream =
-        new RowBasedFileSpillMergeStream(std::move(spillFile), cmp);
+      std::unique_ptr<RowBasedSpillReadFile> spillFile
+#ifdef ENABLE_BOLT_JIT
+      ,
+      bolt::jit::CompiledModuleSP jitModule
+#endif
+  ) {
+    auto* spillStream = new RowBasedFileSpillMergeStream(
+        std::move(spillFile)
+#ifdef ENABLE_BOLT_JIT
+            ,
+        std::move(jitModule)
+#endif
+    );
     spillStream->nextBatch();
     return std::unique_ptr<RowBasedSpillMergeStream>(spillStream);
   }
 
   static std::unique_ptr<RowBasedSpillMergeStream> createWithLength(
-      std::unique_ptr<RowBasedSpillReadFile> spillFile,
-      RowRowCompare cmp) {
-    auto* spillStream =
-        new RowBasedFileSpillMergeStream(std::move(spillFile), cmp);
+      std::unique_ptr<RowBasedSpillReadFile> spillFile
+#ifdef ENABLE_BOLT_JIT
+      ,
+      bolt::jit::CompiledModuleSP jitModule
+#endif
+  ) {
+    auto* spillStream = new RowBasedFileSpillMergeStream(
+        std::move(spillFile)
+#ifdef ENABLE_BOLT_JIT
+            ,
+        std::move(jitModule)
+#endif
+    );
     spillStream->nextBatchWithLengths();
     return std::unique_ptr<RowBasedSpillMergeStream>(spillStream);
   }
@@ -434,9 +452,22 @@ class RowBasedFileSpillMergeStream : public RowBasedSpillMergeStream {
 
  private:
   explicit RowBasedFileSpillMergeStream(
-      std::unique_ptr<RowBasedSpillReadFile> spillFile,
-      RowRowCompare cmp)
-      : spillFile_(std::move(spillFile)), cmp_(cmp) {
+      std::unique_ptr<RowBasedSpillReadFile> spillFile
+#ifdef ENABLE_BOLT_JIT
+      ,
+      bolt::jit::CompiledModuleSP jitModule
+#endif
+      )
+      : spillFile_(std::move(spillFile))
+#ifdef ENABLE_BOLT_JIT
+        ,
+        jitModule_(std::move(jitModule)),
+        cmp_(
+            jitModule_ ? reinterpret_cast<RowRowCompare>(
+                             jitModule_->getFuncPtr(jitModule_->getKey()))
+                       : nullptr)
+#endif
+  {
     BOLT_CHECK_NOT_NULL(spillFile_);
   }
 
@@ -792,10 +823,6 @@ class SpillPartition {
   uint64_t size_{0};
   // Total row count from this spilled partition.
   uint64_t rowCount_{0};
-  RowRowCompare rowCmpRowFunc_{nullptr};
-#ifdef ENABLE_BOLT_JIT
-  bolt::jit::CompiledModuleSP jitModuleRow_;
-#endif
 };
 
 using SpillPartitionSet =


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #771

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
