### PR TITLE
perf: reuse direct parquet small-file preload

### DIFF
--- a/bolt/dwio/common/DirectBufferedInput.cpp
+++ b/bolt/dwio/common/DirectBufferedInput.cpp
@@ -71,7 +71,6 @@ std::unique_ptr<SeekableInputStream> DirectBufferedInput::enqueue(
     id = TrackingId(sid->getId());
   }
   BOLT_CHECK_LE(region.offset + region.length, fileSize_);
-  requests_.emplace_back(region, id);
   if (tracker_) {
     tracker_->recordReference(id, region.length, fileNum_, groupId_);
   }
@@ -85,13 +84,16 @@ std::unique_ptr<SeekableInputStream> DirectBufferedInput::enqueue(
       id,
       groupId_,
       options_.loadQuantum());
-  requests_.back().stream = stream.get();
+  if (!preloaded()) {
+    requests_.emplace_back(region, id);
+    requests_.back().stream = stream.get();
+  }
   return stream;
 }
 
 bool DirectBufferedInput::isBuffered(uint64_t /*offset*/, uint64_t /*length*/)
     const {
-  return false;
+  return preloaded();
 }
 
 bool DirectBufferedInput::shouldPreload(int32_t numPages) {
@@ -107,6 +109,28 @@ bool isPrefetchablePct(int32_t pct) {
 
 bool lessThan(const LoadRequest* left, const LoadRequest* right) {
   return *left < *right;
+}
+
+void appendRanges(
+    memory::Allocation& allocation,
+    size_t length,
+    std::vector<folly::Range<char*>>& buffers) {
+  BOLT_CHECK_LE(
+      length,
+      memory::AllocationTraits::pageBytes(allocation.numPages()),
+      "Length exceeds allocation size");
+  uint64_t offsetInRuns = 0;
+  for (int i = 0; i < allocation.numRuns(); ++i) {
+    BOLT_CHECK_GE(length, offsetInRuns);
+    auto run = allocation.runAt(i);
+    const uint64_t bytes = memory::AllocationTraits::pageBytes(run.numPages());
+    const uint64_t readSize = std::min(bytes, length - offsetInRuns);
+    buffers.emplace_back(run.data<char>(), readSize);
+    offsetInRuns += readSize;
+    if (offsetInRuns >= length) {
+      break;
+    }
+  }
 }
 
 } // namespace
@@ -285,6 +309,58 @@ std::shared_ptr<DirectCoalescedLoad> DirectBufferedInput::coalescedLoad(
       });
 }
 
+void DirectBufferedInput::preload() {
+  BOLT_CHECK(!preloadData_.has_value(), "preload() called more than once");
+  BOLT_CHECK(requests_.empty(), "preload() must be called before enqueue()");
+
+  preloadData_.emplace(fileSize_);
+
+  std::vector<folly::Range<char*>> buffers;
+  if (fileSize_ <= kTinySize) {
+    preloadData_->tinyData.resize(fileSize_);
+    buffers.emplace_back(preloadData_->tinyData.data(), fileSize_);
+  } else {
+    const auto numPages = memory::AllocationTraits::numPages(fileSize_);
+    pool_.allocateNonContiguous(numPages, preloadData_->data);
+    appendRanges(preloadData_->data, fileSize_, buffers);
+  }
+
+  uint64_t usecs = 0;
+  {
+    MicrosecondTimer timer(&usecs);
+    input_->read(buffers, 0, LogType::FILE);
+  }
+  if (ioStats_) {
+    ioStats_->read().increment(fileSize_);
+    ioStats_->incRawBytesRead(fileSize_);
+    ioStats_->queryThreadIoLatencySync().increment(usecs);
+    ioStats_->queryThreadIoLatency().increment(usecs);
+    ioStats_->incTotalScanTime(usecs * 1'000);
+  }
+}
+
+folly::Range<const char*> DirectBufferedInput::preloadedData(
+    uint64_t offset,
+    uint64_t length) const {
+  BOLT_CHECK(
+      preloadData_.has_value(), "preloadedData() called without preload");
+  BOLT_CHECK_LT(offset, preloadData_->size, "Offset exceeds preloaded size");
+  const auto available =
+      std::min<uint64_t>(length, preloadData_->size - offset);
+  if (preloadData_->data.numPages() == 0) {
+    return {preloadData_->tinyData.data() + offset, available};
+  }
+
+  int32_t runIndex;
+  int32_t offsetInRun;
+  preloadData_->data.findRun(offset, &runIndex, &offsetInRun);
+  auto run = preloadData_->data.runAt(runIndex);
+  const auto runBytes = memory::AllocationTraits::pageBytes(run.numPages());
+  const auto contiguousBytes =
+      std::min<uint64_t>(available, runBytes - offsetInRun);
+  return {run.data<const char>() + offsetInRun, contiguousBytes};
+}
+
 std::unique_ptr<SeekableInputStream> DirectBufferedInput::read(
     uint64_t offset,
     uint64_t length,
@@ -301,22 +377,6 @@ std::unique_ptr<SeekableInputStream> DirectBufferedInput::read(
       0,
       options_.loadQuantum());
 }
-
-namespace {
-void appendRanges(
-    memory::Allocation& allocation,
-    size_t length,
-    std::vector<folly::Range<char*>>& buffers) {
-  uint64_t offsetInRuns = 0;
-  for (int i = 0; i < allocation.numRuns(); ++i) {
-    auto run = allocation.runAt(i);
-    const uint64_t bytes = memory::AllocationTraits::pageBytes(run.numPages());
-    const uint64_t readSize = std::min(bytes, length - offsetInRuns);
-    buffers.push_back(folly::Range<char*>(run.data<char>(), readSize));
-    offsetInRuns += readSize;
-  }
-}
-} // namespace
 
 std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool isPrefetch) {
   std::vector<folly::Range<char*>> buffers;

--- a/bolt/dwio/common/DirectBufferedInput.h
+++ b/bolt/dwio/common/DirectBufferedInput.h
@@ -31,9 +31,11 @@
 #pragma once
 
 #include <folly/Executor.h>
+#include <folly/Range.h>
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 #include "bolt/common/caching/AsyncDataCache.h"
 #include "bolt/common/caching/FileGroupStats.h"
@@ -198,6 +200,12 @@ class DirectBufferedInput : public BufferedInput {
     return false;
   }
 
+  void preload();
+
+  bool preloaded() const {
+    return preloadData_.has_value();
+  }
+
   void load(const LogType /*unused*/) override;
 
   bool isBuffered(uint64_t offset, uint64_t length) const override;
@@ -231,6 +239,12 @@ class DirectBufferedInput : public BufferedInput {
   memory::MemoryPool* pool() {
     return &pool_;
   }
+
+  /// Returns a contiguous byte range from preloaded whole-file data. The
+  /// returned range can be shorter than 'length' if it reaches an allocation
+  /// run boundary.
+  folly::Range<const char*> preloadedData(uint64_t offset, uint64_t length)
+      const;
 
   /// Returns the CoalescedLoad that contains the correlated loads for
   /// 'stream' or nullptr if none. Returns nullptr on all but first
@@ -383,6 +397,14 @@ class DirectBufferedInput : public BufferedInput {
   folly::Executor* const executor_;
   const uint64_t fileSize_;
 
+  struct PreloadData {
+    explicit PreloadData(uint64_t size) : size(size) {}
+
+    memory::Allocation data;
+    std::string tinyData;
+    uint64_t size{0};
+  };
+
   // Regions that are candidates for loading.
   std::vector<LoadRequest> requests_;
 
@@ -397,6 +419,7 @@ class DirectBufferedInput : public BufferedInput {
 
   io::ReaderOptions options_;
   std::shared_ptr<connector::AsyncThreadCtx> asyncThreadCtx_ = nullptr;
+  std::optional<PreloadData> preloadData_;
 };
 
 } // namespace bytedance::bolt::dwio::common

--- a/bolt/dwio/common/DirectInputStream.cpp
+++ b/bolt/dwio/common/DirectInputStream.cpp
@@ -178,6 +178,16 @@ void DirectInputStream::loadSync() {
 
 void DirectInputStream::loadPosition() {
   BOLT_CHECK_LT(offsetInRegion_, region_.length);
+  if (bufferedInput_->preloaded()) {
+    const auto range = bufferedInput_->preloadedData(
+        region_.offset + offsetInRegion_, region_.length - offsetInRegion_);
+    run_ = reinterpret_cast<uint8_t*>(const_cast<char*>(range.data()));
+    runSize_ = range.size();
+    offsetInRun_ = 0;
+    offsetOfRun_ = 0;
+    BOLT_CHECK_GT(runSize_, 0);
+    return;
+  }
   if (!loaded_) {
     loaded_ = true;
     auto load = bufferedInput_->coalescedLoad(this);

--- a/bolt/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/bolt/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -220,3 +220,66 @@ TEST_F(DirectBufferedInputTest, coalesedPrefetchOverlap) {
   testLoads({{100, 100}, {201, 1, false}, {201, 2, false}, {203, 100}}, 2);
   testLoads({{100, 100}, {201, 1, true}, {201, 2, true}, {203, 100}}, 2);
 }
+
+TEST_F(DirectBufferedInputTest, preload) {
+  struct TestParam {
+    uint64_t fileSize;
+    int32_t offset;
+    int32_t length;
+  };
+  std::vector<TestParam> testSettings = {
+      {DirectBufferedInput::kTinySize - 100, 10, 100},
+      {DirectBufferedInput::kTinySize + 1000, 1000, 1200},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.fileSize);
+    file_ = std::make_shared<TestReadFile>(11, testData.fileSize, fileIoStats_);
+    auto input = makeInput();
+
+    EXPECT_FALSE(input->preloaded());
+    EXPECT_FALSE(input->isBuffered(testData.offset, testData.length));
+    const auto iosBeforePreload = file_->numIos();
+    const auto rawBytesBeforePreload = ioStats_->rawBytesRead();
+    const auto readBytesBeforePreload = ioStats_->read().sum();
+
+    input->preload();
+
+    EXPECT_TRUE(input->preloaded());
+    EXPECT_TRUE(input->isBuffered(testData.offset, testData.length));
+    EXPECT_EQ(file_->numIos() - iosBeforePreload, 1);
+    EXPECT_EQ(
+        ioStats_->rawBytesRead() - rawBytesBeforePreload, testData.fileSize);
+    EXPECT_EQ(
+        ioStats_->read().sum() - readBytesBeforePreload, testData.fileSize);
+
+    auto fullFileStream = input->read(0, testData.fileSize, LogType::FILE);
+    checkRead(
+        fullFileStream.get(), {0, static_cast<int32_t>(testData.fileSize)});
+    EXPECT_EQ(file_->numIos() - iosBeforePreload, 1);
+
+    auto stream = input->enqueue(
+        {static_cast<uint64_t>(testData.offset),
+         static_cast<uint64_t>(testData.length)},
+        nullptr);
+    checkRead(stream.get(), {testData.offset, testData.length});
+    EXPECT_EQ(file_->numIos() - iosBeforePreload, 1);
+  }
+}
+
+TEST_F(DirectBufferedInputTest, preloadCalledTwice) {
+  file_ = std::make_shared<TestReadFile>(11, 1024, fileIoStats_);
+  auto input = makeInput();
+
+  input->preload();
+  ASSERT_TRUE(input->preloaded());
+  EXPECT_THROW(input->preload(), BoltException);
+}
+
+TEST_F(DirectBufferedInputTest, preloadAfterEnqueue) {
+  file_ = std::make_shared<TestReadFile>(11, 1024, fileIoStats_);
+  auto input = makeInput();
+
+  input->enqueue({0, 100}, nullptr);
+  EXPECT_THROW(input->preload(), BoltException);
+}

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -34,6 +34,7 @@
 #include <thrift/protocol/TCompactProtocol.h> //@manual
 #include <cstdint>
 #include "bolt/dwio/common/CachedBufferedInput.h"
+#include "bolt/dwio/common/DirectBufferedInput.h"
 #include "bolt/dwio/common/Options.h"
 #include "bolt/dwio/parquet/encryption/KmsClient.h"
 #include "bolt/dwio/parquet/reader/ParquetColumnReader.h"
@@ -335,7 +336,13 @@ void ReaderBase::loadFileMetaData() {
 
   std::unique_ptr<dwio::common::SeekableInputStream> stream;
   if (preloadFile) {
-    stream = input_->loadCompleteFile();
+    if (auto* directInput =
+            dynamic_cast<dwio::common::DirectBufferedInput*>(input_.get())) {
+      directInput->preload();
+      stream = input_->read(0, fileLength_, dwio::common::LogType::FILE);
+    } else {
+      stream = input_->loadCompleteFile();
+    }
   } else {
     stream = input_->read(
         fileLength_ - readSize, readSize, dwio::common::LogType::FOOTER);

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -37,6 +37,7 @@
 #include "bolt/common/base/tests/GTestUtils.h"
 #endif
 #include "bolt/core/QueryCtx.h"
+#include "bolt/dwio/common/DirectBufferedInput.h"
 #include "bolt/dwio/parquet/reader/RepeatedColumnReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 #include "bolt/dwio/parquet/writer/Writer.h"
@@ -1354,6 +1355,51 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
     // Check no duplicate reads.
     ASSERT_EQ(file->bytesRead(), 0);
   }
+}
+
+TEST_F(ParquetReaderTest, directPreloadMultiRowGroupFileReusesPreload) {
+  auto rowType = ROW({"id"}, {BIGINT()});
+  const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
+
+  auto file = std::make_shared<LocalReadFile>(sample);
+  const auto fileSize = file->size();
+
+  bytedance::bolt::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFilePreloadThreshold(fileSize);
+  auto ioStats = std::make_shared<io::IoStatistics>();
+  auto input = std::make_unique<DirectBufferedInput>(
+      file,
+      MetricsLog::voidLog(),
+      0,
+      nullptr,
+      0,
+      ioStats,
+      nullptr,
+      readerOptions,
+      nullptr);
+  auto reader =
+      std::make_unique<ParquetReader>(std::move(input), readerOptions);
+
+  EXPECT_EQ(reader->fileMetaData().numRowGroups(), 4);
+  const auto rawBytesAfterPreload = ioStats->rawBytesRead();
+  const auto readBytesAfterPreload = ioStats->read().sum();
+  EXPECT_EQ(rawBytesAfterPreload, fileSize);
+  EXPECT_EQ(readBytesAfterPreload, fileSize);
+
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  constexpr int kBatchSize = 1000;
+  auto result = BaseVector::create(rowType, kBatchSize, pool_.get());
+  uint64_t totalRows = 0;
+  while (auto rows = rowReader->next(kBatchSize, result)) {
+    totalRows += rows;
+  }
+
+  EXPECT_EQ(totalRows, reader->numberOfRows().value());
+  EXPECT_EQ(ioStats->rawBytesRead(), rawBytesAfterPreload);
+  EXPECT_EQ(ioStats->read().sum(), readBytesAfterPreload);
 }
 
 TEST_F(ParquetReaderTest, prefetchRowGroups) {


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Parquet small-file footer loading can read the entire file up front, but the DirectBufferedInput path did not retain that data as a reusable buffer. After footer parsing, row group streams still saw isBuffered() as false, cloned a fresh input, and issued additional direct reads for row group byte ranges that were already covered by the whole-file preload.


### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add native whole-file preload support to DirectBufferedInput and let DirectInputStream serve sub-ranges from the preloaded data. Wire the Parquet metadata preload path to call the DirectBufferedInput preload path while leaving CachedBufferedInput, CacheInputStream, and DWRF reader behavior unchanged. Add focused DirectBufferedInput tests and a Parquet regression test that verifies row group reads do not increase IO counters after preload.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
