### PR TITLE
(build) fix some compile and conan problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,17 @@ option(BOLT_ENABLE_TXT "Enable TXT read support" OFF)
 option(BOLT_ENABLE_ARROW "Enable Arrow support" OFF)
 option(BOLT_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
 option(BOLT_ENABLE_CCACHE "Use ccache if installed." ON)
+option(BOLT_ENABLE_FILE_PREFIX_MAP
+       "Hide absolute source and build paths embedded by the compiler." ON
+)
+set(BOLT_MAPPED_SOURCE_PREFIX
+    "."
+    CACHE STRING "Path used instead of the absolute Bolt source directory."
+)
+set(BOLT_MAPPED_BINARY_PREFIX
+    "./_build"
+    CACHE STRING "Path used instead of the absolute Bolt build directory."
+)
 
 option(BOLT_BUILD_TEST_UTILS "Builds Bolt test utilities" OFF)
 option(BOLT_BUILD_PYTHON_PACKAGE "Builds Bolt Python bindings" OFF)
@@ -441,6 +452,43 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+if(BOLT_ENABLE_FILE_PREFIX_MAP)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(BOLT_FILE_PREFIX_MAP_OPTIONS
+        "-ffile-prefix-map=${CMAKE_BINARY_DIR}=${BOLT_MAPPED_BINARY_PREFIX}"
+        "-ffile-prefix-map=${CMAKE_SOURCE_DIR}=${BOLT_MAPPED_SOURCE_PREFIX}"
+    )
+
+    # GCC's -ffile-prefix-map covers all individual -f*-prefix-map options.
+    # Clang uses a separate option for coverage metadata.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      list(
+        APPEND
+        BOLT_FILE_PREFIX_MAP_OPTIONS
+        "-fcoverage-prefix-map=${CMAKE_BINARY_DIR}=${BOLT_MAPPED_BINARY_PREFIX}"
+        "-fcoverage-prefix-map=${CMAKE_SOURCE_DIR}=${BOLT_MAPPED_SOURCE_PREFIX}"
+      )
+    endif()
+
+    foreach(BOLT_FILE_PREFIX_MAP_OPTION IN LISTS BOLT_FILE_PREFIX_MAP_OPTIONS)
+      add_compile_options(
+        "$<$<COMPILE_LANGUAGE:C,CXX>:${BOLT_FILE_PREFIX_MAP_OPTION}>"
+      )
+    endforeach()
+    message(
+      STATUS
+        "Mapping Bolt source path to '${BOLT_MAPPED_SOURCE_PREFIX}' "
+        "and build path to '${BOLT_MAPPED_BINARY_PREFIX}'"
+    )
+  else()
+    message(
+      WARNING
+        "BOLT_ENABLE_FILE_PREFIX_MAP is enabled, but "
+        "${CMAKE_CXX_COMPILER_ID} does not support the configured path mapping"
+    )
+  endif()
+endif()
+
 # execute_process( COMMAND bash -c "( source
 # ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup-helper-functions.sh && echo -n $(get_cxx_flags
 # $ENV{CPU_TARGET}))" OUTPUT_VARIABLE SCRIPT_CXX_FLAGS RESULT_VARIABLE COMMAND_STATUS)
@@ -585,19 +633,14 @@ endif()
 
 find_package(Protobuf CONFIG REQUIRED)
 
-# GCC needs to link a library to enable std::filesystem.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  set(FILESYSTEM "stdc++fs")
-
-  # Ensure we have gcc at least 9+.
-  if(CMAKE_CXX_COMPILER_VERSION LESS 10.0)
-    message(FATAL_ERROR "BOLT requires gcc > 10. Found ${CMAKE_CXX_COMPILER_VERSION}")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # Ensure we have GCC 10 or newer.
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+    message(FATAL_ERROR "BOLT requires GCC >= 10. Found ${CMAKE_CXX_COMPILER_VERSION}")
   endif()
 
   # Find Threads library
   find_package(Threads REQUIRED)
-else()
-  set(FILESYSTEM "")
 endif()
 
 set(BOLT_DISABLE_GOOGLETEST OFF)

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,8 @@ conan_install:
 	mkdir -p _build/${BUILD_TYPE} && \
 	cd _build/${BUILD_TYPE} && \
 	echo " \
-	-pr ${PROFILE} -pr ../../scripts/conan/bolt.profile \
+	-pr:h ${PROFILE} \
+	-pr:h ../../scripts/conan/bolt.profile \
 	${CONAN_OPTIONS} ${CONAN_OVERRIDE}" > new_conan.options && \
 	set -x && \
 	if [ -f conan.options ] && [ -f ../.build_type ] && cmp -s new_conan.options conan.options && [ "`cat ../.build_type`" = "${BUILD_TYPE}" ]; then \
@@ -189,7 +190,12 @@ conan_install:
 	mv new_conan.options conan.options && \
 	echo ${BUILD_TYPE} > ../.build_type && \
 	read ALL_CONAN_OPTIONS < conan.options && \
-	conan graph info ../.. $${ALL_CONAN_OPTIONS} --format=html > bolt.conan.graph.html  && \
+	conan graph info ../.. --name=bolt --version=${BUILD_VERSION} --user=${BUILD_USER} --channel=${BUILD_CHANNEL} \
+	   -s llvm-core/*:build_type=Release \
+	   -s "&:build_type=${BUILD_TYPE}" \
+	   -s build_type=$${DEPENDENCY_BUILD_TYPE:-${BUILD_TYPE}} \
+	   $${ALL_CONAN_OPTIONS} ${CONAN_CONFIG} --build=missing \
+	   --format=html > bolt.conan.graph.html && \
 	export NUM_LINK_JOB=$(NUM_LINK_JOB) && \
 	conan install ../.. --name=bolt --version=${BUILD_VERSION} --user=${BUILD_USER} --channel=${BUILD_CHANNEL} \
 	   -s llvm-core/*:build_type=Release \

--- a/bolt/dwio/common/tests/utils/CMakeLists.txt
+++ b/bolt/dwio/common/tests/utils/CMakeLists.txt
@@ -40,8 +40,3 @@ target_link_libraries(
   bolt_type_fbhive
   bolt_vector
 )
-
-# older versions of GCC need it to allow std::filesystem
-if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-  target_link_libraries(bolt_dwio_common_test_utils stdc++fs)
-endif()

--- a/bolt/dwio/dwrf/test/CMakeLists.txt
+++ b/bolt/dwio/dwrf/test/CMakeLists.txt
@@ -42,7 +42,6 @@ set(TEST_LINK_LIBS
     GTest::gtest_main
     GTest::gmock
     glog::glog
-    ${FILESYSTEM}
 )
 
 include_directories("${CMAKE_BINARY_DIR}")

--- a/bolt/dwio/dwrf/test/utils/CMakeLists.txt
+++ b/bolt/dwio/dwrf/test/utils/CMakeLists.txt
@@ -41,8 +41,3 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main
 )
-
-# older versions of GCC need it to allow std::filesystem
-if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-  target_link_libraries(bolt_dwrf_test_utils stdc++fs)
-endif()

--- a/bolt/dwio/parquet/tests/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/CMakeLists.txt
@@ -33,7 +33,6 @@ set(TEST_LINK_LIBS
     GTest::gmock
     gflags::gflags
     ${GLOG}
-    ${FILESYSTEM}
 )
 
 add_subdirectory(reader)

--- a/bolt/jit/tests/CMakeLists.txt
+++ b/bolt/jit/tests/CMakeLists.txt
@@ -89,7 +89,6 @@ if(${ENABLE_BOLT_EXPR_JIT})
     bolt_process
     glog::glog
     ${FMT}
-    ${FILESYSTEM}
   )
 
 endif() # ENABLE_BOLT_EXPR_JIT

--- a/bolt/substrait/tests/CMakeLists.txt
+++ b/bolt/substrait/tests/CMakeLists.txt
@@ -50,7 +50,6 @@ target_link_libraries(
   bolt_testutils
   GTest::gtest
   GTest::gtest_main
-  ${FILESYSTEM}
 )
 
 if(${BOLT_ENABLE_TORCH})

--- a/conanfile.py
+++ b/conanfile.py
@@ -344,8 +344,7 @@ class BoltConan(ConanFile):
         self.options[arrow].substrait = True
         # substrait depends on protobuf
         self.options[arrow].with_protobuf = True
-        self.options[arrow].arrow_acero = True
-        self.options[arrow].arrow_bundled_dependencies = True
+        self.options[arrow].acero = True
         if self.options.get_safe("enable_colocate"):
             self.options[arrow].with_boost = True
             self.options[arrow].with_gflags = True
@@ -368,7 +367,8 @@ class BoltConan(ConanFile):
         if self.options.get_safe("enable_hdfs") and self.options.get_safe(
             "use_arrow_hdfs"
         ):
-            self.options[arrow].with_hdfs = True
+            # This is the legacy spelling exposed by the pinned Arrow recipe.
+            self.options[arrow].hdfs_bridgs = True
 
         if self.options.get_safe("es_build"):
             self.options[arrow].with_pyarrow = False

--- a/scripts/conan/patches/arrow.15.0.1-csv-support.patch
+++ b/scripts/conan/patches/arrow.15.0.1-csv-support.patch
@@ -50,7 +50,7 @@ index ed8cb79fd..a25132990 100644
      - patch_file: "patches/11.0.0-0001-fix-cmake.patch"
        patch_description: "use cci package"
 diff --git a/recipes/arrow/all/conanfile.py b/recipes/arrow/all/conanfile.py
-index 24a7af89b..27655cdf4 100644
+index 24a7af89b..8fc7a0ccf 100644
 --- a/recipes/arrow/all/conanfile.py
 +++ b/recipes/arrow/all/conanfile.py
 @@ -1,15 +1,16 @@
@@ -449,7 +449,7 @@ index 24a7af89b..27655cdf4 100644
  
          if self.options.get_safe("skyhook", False):
              raise ConanInvalidConfiguration("CCI has no librados recipe (yet)")
-@@ -248,16 +388,13 @@ class ArrowConan(ConanFile):
+@@ -248,17 +388,14 @@ class ArrowConan(ConanFile):
              if self.dependencies["jemalloc"].options.enable_cxx:
                  raise ConanInvalidConfiguration("jemmalloc.enable_cxx of a static jemalloc must be disabled")
  
@@ -471,7 +471,8 @@ index 24a7af89b..27655cdf4 100644
 +            self.tool_requires("protobuf/<host_version>")
  
      def source(self):
-@@ -292,7 +427,7 @@ class ArrowConan(ConanFile):
+         get(self, **self.conan_data["sources"][self.version],
+@@ -292,7 +429,7 @@ class ArrowConan(ConanFile):
          tc.variables["ARROW_NO_DEPRECATED_API"] = not bool(self.options.deprecated)
          tc.variables["ARROW_FLIGHT"] = self.options.with_flight_rpc
          tc.variables["ARROW_FLIGHT_SQL"] = bool(self.options.get_safe("with_flight_sql", False))
@@ -480,7 +481,7 @@ index 24a7af89b..27655cdf4 100644
          tc.variables["ARROW_CSV"] = bool(self.options.with_csv)
          tc.variables["ARROW_CUDA"] = bool(self.options.with_cuda)
          tc.variables["ARROW_JEMALLOC"] = self.options.with_jemalloc
-@@ -313,7 +448,6 @@ class ArrowConan(ConanFile):
+@@ -313,7 +450,6 @@ class ArrowConan(ConanFile):
          tc.variables["GLOG_SOURCE"] = "SYSTEM"
          tc.variables["ARROW_WITH_BACKTRACE"] = bool(self.options.with_backtrace)
          tc.variables["ARROW_WITH_BROTLI"] = bool(self.options.with_brotli)
@@ -488,7 +489,7 @@ index 24a7af89b..27655cdf4 100644
          tc.variables["brotli_SOURCE"] = "SYSTEM"
          if self.options.with_brotli:
              tc.variables["ARROW_BROTLI_USE_SHARED"] = bool(self.dependencies["brotli"].options.shared)
-@@ -338,18 +472,19 @@ class ArrowConan(ConanFile):
+@@ -338,18 +474,19 @@ class ArrowConan(ConanFile):
          tc.variables["ZLIB_SOURCE"] = "SYSTEM"
          tc.variables["xsimd_SOURCE"] = "SYSTEM"
          tc.variables["ARROW_WITH_ZSTD"] = bool(self.options.with_zstd)
@@ -513,7 +514,7 @@ index 24a7af89b..27655cdf4 100644
              tc.variables["THRIFT_VERSION"] = bool(self.dependencies["thrift"].ref.version) # a recent thrift does not require boost
              tc.variables["ARROW_THRIFT_USE_SHARED"] = bool(self.dependencies["thrift"].options.shared)
          tc.variables["ARROW_USE_OPENSSL"] = self.options.with_openssl
-@@ -379,26 +514,47 @@ class ArrowConan(ConanFile):
+@@ -379,26 +516,49 @@ class ArrowConan(ConanFile):
              tc.variables["ARROW_USE_STATIC_CRT"] = is_msvc_static_runtime(self)
          if self.options.with_llvm:
              tc.variables["LLVM_DIR"] = self.dependencies["llvm-core"].package_folder.replace("\\", "/")
@@ -527,6 +528,8 @@ index 24a7af89b..27655cdf4 100644
  
          deps = CMakeDeps(self)
 -        deps.set_property("mimalloc", "cmake_target_name", "mimalloc::mimalloc")
++        if self._requires_rapidjson():
++            deps.set_property("rapidjson", "system_package_version", "1.1.0")
          deps.generate()
  
      def _patch_sources(self):
@@ -564,7 +567,7 @@ index 24a7af89b..27655cdf4 100644
          cmake.install()
  
          rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-@@ -411,10 +567,8 @@ class ArrowConan(ConanFile):
+@@ -411,10 +571,8 @@ class ArrowConan(ConanFile):
          self.cpp_info.set_property("cmake_file_name", "Arrow")
  
          suffix = "_static" if is_msvc(self) and not self.options.shared else ""
@@ -575,7 +578,7 @@ index 24a7af89b..27655cdf4 100644
          self.cpp_info.components["libarrow"].libs = [f"arrow{suffix}"]
          if not self.options.shared:
              self.cpp_info.components["libarrow"].defines = ["ARROW_STATIC"]
-@@ -423,7 +577,6 @@ class ArrowConan(ConanFile):
+@@ -423,7 +581,6 @@ class ArrowConan(ConanFile):
  
          if self.options.parquet:
              self.cpp_info.components["libparquet"].set_property("pkg_config_name", "parquet")
@@ -583,7 +586,7 @@ index 24a7af89b..27655cdf4 100644
              self.cpp_info.components["libparquet"].libs = [f"parquet{suffix}"]
              self.cpp_info.components["libparquet"].requires = ["libarrow"]
              if not self.options.shared:
-@@ -431,7 +584,6 @@ class ArrowConan(ConanFile):
+@@ -431,7 +588,6 @@ class ArrowConan(ConanFile):
  
          if self.options.get_safe("substrait"):
              self.cpp_info.components["libarrow_substrait"].set_property("pkg_config_name", "arrow_substrait")
@@ -591,7 +594,7 @@ index 24a7af89b..27655cdf4 100644
              self.cpp_info.components["libarrow_substrait"].libs = [f"arrow_substrait{suffix}"]
              self.cpp_info.components["libarrow_substrait"].requires = ["libparquet", "dataset"]
  
-@@ -439,26 +591,14 @@ class ArrowConan(ConanFile):
+@@ -439,26 +595,14 @@ class ArrowConan(ConanFile):
          del self.options.plasma
  
          if self.options.acero:
@@ -618,7 +621,7 @@ index 24a7af89b..27655cdf4 100644
              self.cpp_info.components["libgandiva"].libs = [f"gandiva{suffix}"]
              self.cpp_info.components["libgandiva"].requires = ["libarrow"]
              if not self.options.shared:
-@@ -466,16 +606,11 @@ class ArrowConan(ConanFile):
+@@ -466,16 +610,11 @@ class ArrowConan(ConanFile):
  
          if self.options.with_flight_rpc:
              self.cpp_info.components["libarrow_flight"].set_property("pkg_config_name", "flight_rpc")
@@ -635,7 +638,7 @@ index 24a7af89b..27655cdf4 100644
              self.cpp_info.components["libarrow_flight_sql"].libs = [f"arrow_flight_sql{suffix}"]
              self.cpp_info.components["libarrow_flight_sql"].requires = ["libarrow", "libarrow_flight"]
  
-@@ -483,8 +618,6 @@ class ArrowConan(ConanFile):
+@@ -483,8 +622,6 @@ class ArrowConan(ConanFile):
              self.cpp_info.components["dataset"].libs = ["arrow_dataset"]
              if self.options.parquet:
                  self.cpp_info.components["dataset"].requires = ["libparquet"]
@@ -644,7 +647,7 @@ index 24a7af89b..27655cdf4 100644
  
          if self.options.cli and (self.options.with_cuda or self.options.with_flight_rpc or self.options.parquet):
              binpath = os.path.join(self.package_folder, "bin")
-@@ -497,8 +630,9 @@ class ArrowConan(ConanFile):
+@@ -497,8 +634,9 @@ class ArrowConan(ConanFile):
                  self.cpp_info.components["libgandiva"].requires.append("boost::boost")
              if self.options.parquet and self.settings.compiler == "gcc" and self.settings.compiler.version < Version("4.9"):
                  self.cpp_info.components["libparquet"].requires.append("boost::boost")
@@ -656,7 +659,7 @@ index 24a7af89b..27655cdf4 100644
          if self.options.with_openssl:
              self.cpp_info.components["libarrow"].requires.append("openssl::openssl")
          if self.options.with_gflags:
-@@ -530,8 +664,7 @@ class ArrowConan(ConanFile):
+@@ -530,8 +668,7 @@ class ArrowConan(ConanFile):
          if self._requires_rapidjson():
              self.cpp_info.components["libarrow"].requires.append("rapidjson::rapidjson")
          if self.options.with_s3:
@@ -666,7 +669,7 @@ index 24a7af89b..27655cdf4 100644
          if self.options.get_safe("with_gcs"):
              self.cpp_info.components["libarrow"].requires.append("google-cloud-cpp::storage")
          if self.options.with_orc:
-@@ -552,7 +685,37 @@ class ArrowConan(ConanFile):
+@@ -552,7 +689,37 @@ class ArrowConan(ConanFile):
              self.cpp_info.components["libarrow"].requires.append("zlib::zlib")
          if self.options.with_zstd:
              self.cpp_info.components["libarrow"].requires.append("zstd::zstd")
@@ -706,10 +709,10 @@ index 24a7af89b..27655cdf4 100644
 +            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
 diff --git a/recipes/arrow/all/patches/15.0.0-0001-fix-cmake.patch b/recipes/arrow/all/patches/15.0.0-0001-fix-cmake.patch
 new file mode 100644
-index 000000000..6f24d5ed6
+index 000000000..fdb2c51dd
 --- /dev/null
 +++ b/recipes/arrow/all/patches/15.0.0-0001-fix-cmake.patch
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,26 @@
 +diff --git a/cpp/src/parquet/CMakeLists.txt b/cpp/src/parquet/CMakeLists.txt
 +index 04028431b..fcf8f0f5f 100644
 +--- a/cpp/src/parquet/CMakeLists.txt
@@ -723,6 +726,19 @@ index 000000000..6f24d5ed6
 +   set(PARQUET_SRCS ${PARQUET_SRCS} encryption/encryption_internal.cc
 +                    encryption/openssl_internal.cc)
 +   # Encryption key management
++diff --git a/cpp/cmake_modules/FindSnappyAlt.cmake b/cpp/cmake_modules/FindSnappyAlt.cmake
++index 4d3134006..f5d58b240 100644
++--- a/cpp/cmake_modules/FindSnappyAlt.cmake
+++++ b/cpp/cmake_modules/FindSnappyAlt.cmake
++@@ -42,7 +42,7 @@ if(Snappy_FOUND)
++     else()
++       # The Conan's Snappy package always uses Snappy::snappy and it's
++       # an INTERFACE_LIBRARY.
++-      get_target_property(Snappy Snappy::snappy TYPE)
+++      get_target_property(Snappy_TYPE Snappy::snappy TYPE)
++       if(Snappy_TYPE STREQUAL "STATIC_LIBRARY" OR Snappy_TYPE STREQUAL
++                                                   "INTERFACE_LIBRARY")
++         set(Snappy_TARGET Snappy::snappy)
 diff --git a/recipes/arrow/all/patches/15.0.0-0001-include-assert.patch b/recipes/arrow/all/patches/15.0.0-0001-include-assert.patch
 new file mode 100644
 index 000000000..1a93f8c58

--- a/scripts/conan/patches/gnu-source-mirrors.patch
+++ b/scripts/conan/patches/gnu-source-mirrors.patch
@@ -1,0 +1,72 @@
+diff --git a/recipes/autoconf/all/conandata.yml b/recipes/autoconf/all/conandata.yml
+--- a/recipes/autoconf/all/conandata.yml
++++ b/recipes/autoconf/all/conandata.yml
+@@ -6,6 +6,7 @@ sources:
+     sha256: "ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a"
+   "2.71":
+     url:
++      - "https://mirrors.kernel.org/gnu/autoconf/autoconf-2.71.tar.xz"
+       - "https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.xz"
+       - "https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.xz"
+     sha256: "f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4"
+diff --git a/recipes/automake/all/conandata.yml b/recipes/automake/all/conandata.yml
+--- a/recipes/automake/all/conandata.yml
++++ b/recipes/automake/all/conandata.yml
+@@ -1,6 +1,8 @@
+ sources:
+   "1.16.5":
+-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
++    url:
++      - "https://mirrors.kernel.org/gnu/automake/automake-1.16.5.tar.gz"
++      - "https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
+     sha256: "07bd24ad08a64bc17250ce09ec56e921d6343903943e99ccf63bbf0705e34605"
+   "1.16.4":
+     url: "https://ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
+diff --git a/recipes/bison/all/conandata.yml b/recipes/bison/all/conandata.yml
+--- a/recipes/bison/all/conandata.yml
++++ b/recipes/bison/all/conandata.yml
+@@ -1,6 +1,8 @@
+ sources:
+   "3.8.2":
+-    url: "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
++    url:
++      - "https://mirrors.kernel.org/gnu/bison/bison-3.8.2.tar.gz"
++      - "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+     sha256: "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
+   "3.7.6":
+     url: "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
+diff --git a/recipes/libiberty/all/conandata.yml b/recipes/libiberty/all/conandata.yml
+--- a/recipes/libiberty/all/conandata.yml
++++ b/recipes/libiberty/all/conandata.yml
+@@ -1,4 +1,6 @@
+ sources:
+   "9.1.0":
+-    url: "https://ftp.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
++    url:
++      - "https://mirrors.kernel.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
++      - "https://ftp.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
+     sha256: "be303f7a8292982a35381489f5a9178603cbe9a4715ee4fa4a815d6bcd2b658d"
+diff --git a/recipes/libtool/all/conandata.yml b/recipes/libtool/all/conandata.yml
+--- a/recipes/libtool/all/conandata.yml
++++ b/recipes/libtool/all/conandata.yml
+@@ -1,6 +1,8 @@
+ sources:
+   "2.4.7":
+-    url: "https://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
++    url:
++      - "https://mirrors.kernel.org/gnu/libtool/libtool-2.4.7.tar.gz"
++      - "https://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
+     sha256: "04e96c2404ea70c590c546eba4202a4e12722c640016c12b9b2f1ce3d481e9a8"
+   "2.4.6":
+     url: "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
+diff --git a/recipes/m4/all/conandata.yml b/recipes/m4/all/conandata.yml
+--- a/recipes/m4/all/conandata.yml
++++ b/recipes/m4/all/conandata.yml
+@@ -1,6 +1,7 @@
+ sources:
+   "1.4.19":
+     url:
++      - "https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz"
+       - "https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.xz"
+       - "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.19.tar.xz"
+     sha256: "63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96"

--- a/scripts/conan/patches/pkgconf-2.2.0-fix-gnu99.patch
+++ b/scripts/conan/patches/pkgconf-2.2.0-fix-gnu99.patch
@@ -1,0 +1,9 @@
+diff --git a/recipes/pkgconf/all/conanfile.py b/recipes/pkgconf/all/conanfile.py
+index cc30d5628..a224911b2 100644
+--- a/recipes/pkgconf/all/conanfile.py
++++ b/recipes/pkgconf/all/conanfile.py
+@@ -72,2 +72,2 @@ class PkgConfConan(ConanFile):
+-            "project('pkgconf', 'c',",
+-            "project('pkgconf', 'c',\ndefault_options : ['c_std=gnu99'],")
++                "default_options : ['c_std=c99'],",
++                "default_options : ['c_std=gnu99'],")

--- a/scripts/conan/patches/source-mirrors-apache.patch
+++ b/scripts/conan/patches/source-mirrors-apache.patch
@@ -1,0 +1,42 @@
+diff --git a/recipes/arrow/all/conandata.yml b/recipes/arrow/all/conandata.yml
+--- a/recipes/arrow/all/conandata.yml
++++ b/recipes/arrow/all/conandata.yml
+@@ -21,7 +21,9 @@ sources:
+     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-16.1.0/apache-arrow-16.1.0.tar.gz?action=download"
+     sha256: "c9e60c7e87e59383d21b20dc874b17153729ee153264af6d21654b7dff2c60d7"
+   "15.0.1-oss":
+-    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-15.0.1/apache-arrow-15.0.1.tar.gz?action=download"
++    url:
++      - "https://mirrors.huaweicloud.com/apache/arrow/arrow-15.0.1/apache-arrow-15.0.1.tar.gz"
++      - "https://www.apache.org/dyn/closer.lua/arrow/arrow-15.0.1/apache-arrow-15.0.1.tar.gz?action=download"
+     sha256: "55db63ed9fd6917b7abfe5d4186c9f532cbe48aa53f4040d57e7c29ad70bcefa"
+   "15.0.0":
+     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-15.0.0/apache-arrow-15.0.0.tar.gz?action=download"
+diff --git a/recipes/orc/all/conandata.yml b/recipes/orc/all/conandata.yml
+--- a/recipes/orc/all/conandata.yml
++++ b/recipes/orc/all/conandata.yml
+@@ -5,7 +5,9 @@ sources:
+     url: "https://archive.apache.org/dist/orc/orc-2.0.3/orc-2.0.3.tar.gz"
+     sha256: "082cba862b5a8a0d14c225404d0b51cd8d1b64ca81b8f1e500322ce8922cb86d"
+   "2.0.0":
+-    url: "https://archive.apache.org/dist/orc/orc-2.0.0/orc-2.0.0.tar.gz"
++    url:
++      - "https://mirrors.huaweicloud.com/apache/orc/orc-2.0.0/orc-2.0.0.tar.gz"
++      - "https://archive.apache.org/dist/orc/orc-2.0.0/orc-2.0.0.tar.gz"
+     sha256: "9107730919c29eb39efaff1b9e36166634d1d4d9477e5fee76bfd6a8fec317df"
+   "1.9.5":
+     url: "https://archive.apache.org/dist/orc/orc-1.9.5/orc-1.9.5.tar.gz"
+diff --git a/recipes/thrift/all/conandata.yml b/recipes/thrift/all/conandata.yml
+--- a/recipes/thrift/all/conandata.yml
++++ b/recipes/thrift/all/conandata.yml
+@@ -5,7 +5,9 @@ sources:
+     url: "http://archive.apache.org/dist/thrift/0.18.1/thrift-0.18.1.tar.gz"
+     sha256: "04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726"
+   "0.17.0":
+-    url: "http://archive.apache.org/dist/thrift/0.17.0/thrift-0.17.0.tar.gz"
++    url:
++      - "https://mirrors.huaweicloud.com/apache/thrift/0.17.0/thrift-0.17.0.tar.gz"
++      - "http://archive.apache.org/dist/thrift/0.17.0/thrift-0.17.0.tar.gz"
+     sha256: "b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f"
+   "0.16.0":
+     url: "http://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"

--- a/scripts/conan/recipes/paimon-cpp/all/patches/paimon-cpp-conan-deps.patch
+++ b/scripts/conan/recipes/paimon-cpp/all/patches/paimon-cpp-conan-deps.patch
@@ -149,7 +149,7 @@ index 0000000..e9318f6
 +    find_package(ZLIB QUIET)
 +    find_package(zstd QUIET CONFIG)
 +    find_package(lz4 QUIET CONFIG)
-+    find_package(snappy QUIET CONFIG)
++    find_package(Snappy QUIET CONFIG)
 +    find_package(Protobuf QUIET CONFIG)
 +
 +    # --- Helper: get the config suffix from the active build type ---
@@ -274,8 +274,8 @@ index 0000000..e9318f6
 +
 +    if(NOT TARGET snappy)
 +        add_library(snappy INTERFACE IMPORTED)
-+        if(TARGET snappy::snappy)
-+            target_link_libraries(snappy INTERFACE snappy::snappy)
++        if(TARGET Snappy::snappy)
++            target_link_libraries(snappy INTERFACE Snappy::snappy)
 +            target_include_directories(snappy INTERFACE ${SNAPPY_INCLUDE_DIR})
 +        endif()
 +    endif()
@@ -344,10 +344,10 @@ index 9e3c47d..ba7695c 100644
 +    # Ensure required compression/utility targets exist; use Conan packages if
 +    # available, otherwise build from source.
 +    if(NOT TARGET snappy)
-+        find_package(snappy QUIET CONFIG)
-+        if(TARGET snappy::snappy)
++        find_package(Snappy QUIET CONFIG)
++        if(TARGET Snappy::snappy)
 +            add_library(snappy INTERFACE IMPORTED)
-+            target_link_libraries(snappy INTERFACE snappy::snappy)
++            target_link_libraries(snappy INTERFACE Snappy::snappy)
 +        else()
 +            build_snappy()
 +        endif()
@@ -392,7 +392,27 @@ index 9e3c47d..ba7695c 100644
      set(AVRO_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/avro_ep-install")
      set(AVRO_INCLUDE_DIR "${AVRO_PREFIX}/include")
      set(AVRO_STATIC_LIB_NAME avrocpp_s)
-@@ -1006,11 +1062,74 @@ macro(build_avro)
+@@ -989,7 +1045,19 @@ macro(build_avro)
+         "-DZLIB_ROOT=${AVRO_ZLIB_ROOT}"
+         "-Dfmt_ROOT=${AVRO_FMT_ROOT}"
+         "-Dzstd_ROOT=${AVRO_ZSTD_ROOT}"
+         "-DSnappy_ROOT=${AVRO_SNAPPY_ROOT}")
++    if(PAIMON_USE_CONAN_DEPS)
++        # The Avro ExternalProject starts a separate CMake configure. Point it
++        # at the parent's CMakeDeps configs explicitly so sysroot-only
++        # toolchains don't re-root the Conan package paths.
++        get_filename_component(AVRO_CONAN_GENERATORS_DIR
++                               "${CMAKE_TOOLCHAIN_FILE}" DIRECTORY)
++        list(APPEND AVRO_CMAKE_ARGS
++             "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
++             "-DZLIB_DIR=${AVRO_CONAN_GENERATORS_DIR}"
++             "-DSnappy_DIR=${AVRO_CONAN_GENERATORS_DIR}"
++             "-Dzstd_DIR=${AVRO_CONAN_GENERATORS_DIR}")
++    endif()
+     externalproject_add(avro_ep
+                         URL ${AVRO_SOURCE_URL}
+                         URL_HASH "SHA256=${PAIMON_AVRO_BUILD_SHA256_CHECKSUM}"
+@@ -1006,11 +1074,74 @@ macro(build_avro)
      target_include_directories(avro INTERFACE ${AVRO_INCLUDE_DIR})
      target_link_libraries(avro INTERFACE zlib zstd snappy)
      add_dependencies(avro avro_ep)
@@ -413,10 +433,10 @@ index 9e3c47d..ba7695c 100644
 
 +    # Ensure required compression targets exist; if not, build them from source.
 +    if(NOT TARGET snappy)
-+        find_package(snappy QUIET CONFIG)
-+        if(TARGET snappy::snappy)
++        find_package(Snappy QUIET CONFIG)
++        if(TARGET Snappy::snappy)
 +            add_library(snappy INTERFACE IMPORTED)
-+            target_link_libraries(snappy INTERFACE snappy::snappy)
++            target_link_libraries(snappy INTERFACE Snappy::snappy)
 +        else()
 +            build_snappy()
 +        endif()
@@ -467,7 +487,7 @@ index 9e3c47d..ba7695c 100644
      get_target_property(ORC_SNAPPY_INCLUDE_DIR snappy INTERFACE_INCLUDE_DIRECTORIES)
      get_filename_component(ORC_SNAPPY_ROOT "${ORC_SNAPPY_INCLUDE_DIR}" DIRECTORY)
 
-@@ -1070,7 +1189,8 @@ macro(build_orc)
+@@ -1070,7 +1201,8 @@ macro(build_orc)
          -DBUILD_TOOLS=OFF
          -DBUILD_CPP_ENABLE_METRICS=ON)
 
@@ -477,7 +497,7 @@ index 9e3c47d..ba7695c 100644
      externalproject_add(orc_ep
                          URL ${ORC_SOURCE_URL}
                          URL_HASH "SHA256=${PAIMON_ORC_BUILD_SHA256_CHECKSUM}"
-@@ -1193,7 +1313,8 @@ macro(build_arrow)
+@@ -1193,7 +1325,8 @@ macro(build_arrow)
          -DBUILD_WARNING_LEVEL=PRODUCTION) # ignore warnings under gcc8
 
      set(ARROW_CONFIGURE SOURCE_SUBDIR "cpp" CMAKE_ARGS ${ARROW_CMAKE_ARGS})
@@ -487,7 +507,7 @@ index 9e3c47d..ba7695c 100644
      externalproject_add(arrow_ep
                          URL ${ARROW_SOURCE_URL}
                          URL_HASH "SHA256=${PAIMON_ARROW_BUILD_SHA256_CHECKSUM}"
-@@ -1438,30 +1559,32 @@ macro(build_glog)
+@@ -1438,30 +1571,32 @@ macro(build_glog)
      endif()
  endmacro()
 

--- a/scripts/conan/recipes/tos_client/all/conandata.yml
+++ b/scripts/conan/recipes/tos_client/all/conandata.yml
@@ -1,0 +1,93 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sources:
+  "2.6.28":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.28.tar.gz"
+    sha256: "f70c54c51f519cc85ffcbc68ce1c349921cd11afdda419339a043e0536e3b4ec"
+  "2.6.27":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.27.tar.gz"
+    sha256: "cadac3d11c9c4890422f59c9950e1e82860f31b5d710a4d460a6fc0069fe6382"
+  "2.6.26":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.26.tar.gz"
+    sha256: "3d5568b99283d37442cb556fa84e5f519d4111acbae6236dd6a518612fb2a17e"
+  "2.6.25":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.25.tar.gz"
+    sha256: "7fe86315abce0fc66101d712d86e7e805d9b284704e9e60a026123e43f62ccb7"
+  "2.6.24":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.24.tar.gz"
+    sha256: "7b5d30551b95b8d6ab78333a972102cdbeb2a8856d33a7a0258245d95ac29e90"
+  "2.6.23":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.23.tar.gz"
+    sha256: "dcf461b6aaed6937cb835bef41b43e882af8a61babe1a152b52ea3306609046c"
+  "2.6.22":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.22.tar.gz"
+    sha256: "13464fdb5e3e7284ba6c38487f1e1e973f651c843516af437b2c059f0ed6eaef"
+  "2.6.21":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.21.tar.gz"
+    sha256: "b685901d3dc2420d1869af9983b74e7d8612897d9d03e29fd23020895f840e4c"
+  "2.6.20":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.20.tar.gz"
+    sha256: "4da53feb9cf989e6c3c895d48f547149f94324965323514f11b09b28eb706399"
+  "2.6.19":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.19.tar.gz"
+    sha256: "3ee262b47e187ac4bccfd65025e7d960e9aee9568f4eb15ea822fe07cbf25e2e"
+  "2.6.18":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.18.tar.gz"
+    sha256: "8f519e645ce33eb59202cdc531c21fcc8b25078bca5023e78487b3d563a95ab2"
+  "2.6.17":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.17.tar.gz"
+    sha256: "810791bd3d507a27b2188f6ec83eebfd8366a735a415c87370b74b9175919980"
+  "2.6.16":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.16.tar.gz"
+    sha256: "5f81f46aa9a861f438a34dbf7e633e64289634bf1768e29a7cf71e083a32588e"
+  "2.6.15":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.15.tar.gz"
+    sha256: "a03590e69e1f01fae8d039edbb2e677b3c504c747356565e4d93b36d7f6d6642"
+  "2.6.13":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.13.tar.gz"
+    sha256: "a5daa49a73371153d381e2dcfd82c9cfc679c962fc79bef4b0ae753f2cac84b7"
+  "2.6.12":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.12.tar.gz"
+    sha256: "0d725c9b8f134ec41a973082e70ec7c304c3ad96a495382b6c80ab0eda1d5cf8"
+  "2.6.11":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/v2.6.11.tar.gz"
+    sha256: "6f93d9cdede3ffa93c3ea379a8aec8fe63b6b240e79f8f93a7a779eb7d4efc54"
+  "2.6.10":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.10.tar.gz"
+    sha256: "a2363dcc06150a9acbe8548a4cf7a13af666ff6d3ddba7585516e93f37664c8b"
+  "2.6.9":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.9.tar.gz"
+    sha256: "a73f03cb3d8b8dff652d2db2978e00768d88c09d3ec2d47228a2eb2d6ff59a3c"
+  "2.6.8":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.8.tar.gz"
+    sha256: "5ef5ec1f6649f44eaa993bf12a640637535058fc7e90299564e6b76cb574772d"
+  "2.6.7":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.7.tar.gz"
+    sha256: "e187c63fa5e7baf2f0e095a6f171fd7539bde1cb22a82b37a55c6d1a917c778b"
+  "2.6.6":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.6.tar.gz"
+    sha256: "8c87451097554530c9e92045e40b7ce38dedeb67bc12086929917acb0e2f5b6d"
+  "2.6.5":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.5.tar.gz"
+    sha256: "11edc0056ec35a7bc1558f790f6fe334802e8713c685b6554157ce5c3b8c9529"
+  "2.6.3":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.3.tar.gz"
+    sha256: "b4800b1d134fa8fb21c3aad2704106012a1b38488d7fbd1ad32986eea76d0099"
+  "2.6.1":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.1.tar.gz"
+    sha256: "47ef696f5f7a5ec8e1c0ae2a88188978f01b7ad400fa1aadad81937b71fae5a5"
+  "2.6.0":
+    url: "https://github.com/volcengine/ve-tos-cpp-sdk/archive/refs/tags/2.6.0.tar.gz"
+    sha256: "c89905978ff8ba9bfe691acdd29d2cf6a816719028c103e83a0be3c64415d5f7"

--- a/scripts/conan/recipes/tos_client/all/conanfile.py
+++ b/scripts/conan/recipes/tos_client/all/conanfile.py
@@ -1,0 +1,100 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get
+
+
+required_conan_version = ">=1.54.0"
+
+
+class TOSClientConan(ConanFile):
+    name = "tos_client"
+    description = "Volcengine TOS SDK for C++"
+    license = "Apache-2.0"
+    url = "https://github.com/volcengine/ve-tos-cpp-sdk"
+    homepage = "https://github.com/volcengine/ve-tos-cpp-sdk"
+    topics = ("tos", "object-storage", "volcengine")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def requirements(self):
+        self.requires("libcurl/8.12.1")
+        self.requires("openssl/1.1.1w")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/3.31.10")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src", build_folder="_build")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        build_env = VirtualBuildEnv(self)
+        build_env.generate()
+
+        toolchain = CMakeToolchain(self, generator="Ninja")
+        toolchain.cache_variables["BUILD_SHARED_LIB"] = bool(self.options.shared)
+        toolchain.cache_variables["BUILD_UNITTEST"] = False
+        toolchain.cache_variables["BUILD_DEMO"] = False
+        toolchain.cache_variables["BUILD_ASYNC_SDK"] = False
+        toolchain.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        toolchain.generate()
+
+        dependencies = CMakeDeps(self)
+        dependencies.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE*",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "tos_client")
+        self.cpp_info.set_property("cmake_target_name", "tos_client::tos_client")
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.libs = ["ve-tos-cpp-sdk-lib"]

--- a/scripts/conan/recipes/tos_client/all/test_package/CMakeLists.txt
+++ b/scripts/conan/recipes/tos_client/all/test_package/CMakeLists.txt
@@ -1,5 +1,4 @@
-#
-# Copyright (c) ByteDance Ltd. and/or its affiliates
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(TXT_TEST_LINK_LIBS
-    bolt_dwio_common_test_utils
-    bolt_vector_test_lib
-    bolt_exec_test_lib
-    bolt_temp_path
-    GTest::gtest
-    GTest::gtest_main
-    GTest::gmock
-    gflags::gflags
-    ${GLOG}
-)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-add_subdirectory(reader)
-add_subdirectory(writer)
+find_package(tos_client REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE tos_client::tos_client)

--- a/scripts/conan/recipes/tos_client/all/test_package/conanfile.py
+++ b/scripts/conan/recipes/tos_client/all/test_package/conanfile.py
@@ -1,0 +1,50 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+
+required_conan_version = ">=1.54.0"
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            executable = os.path.join(
+                self.cpp.build.bindirs[0],
+                "test_package",
+            )
+            self.run(executable, env="conanrun")

--- a/scripts/conan/recipes/tos_client/all/test_package/test_package.cpp
+++ b/scripts/conan/recipes/tos_client/all/test_package/test_package.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) ByteDance Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "TosClient.h"
+
+int main() {
+  return VolcengineTos::DefaultUserAgent().empty() ? 1 : 0;
+}

--- a/scripts/conan/recipes/tos_client/config.yml
+++ b/scripts/conan/recipes/tos_client/config.yml
@@ -1,0 +1,67 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+versions:
+  "2.6.28":
+    folder: all
+  "2.6.27":
+    folder: all
+  "2.6.26":
+    folder: all
+  "2.6.25":
+    folder: all
+  "2.6.24":
+    folder: all
+  "2.6.23":
+    folder: all
+  "2.6.22":
+    folder: all
+  "2.6.21":
+    folder: all
+  "2.6.20":
+    folder: all
+  "2.6.19":
+    folder: all
+  "2.6.18":
+    folder: all
+  "2.6.17":
+    folder: all
+  "2.6.16":
+    folder: all
+  "2.6.15":
+    folder: all
+  "2.6.13":
+    folder: all
+  "2.6.12":
+    folder: all
+  "2.6.11":
+    folder: all
+  "2.6.10":
+    folder: all
+  "2.6.9":
+    folder: all
+  "2.6.8":
+    folder: all
+  "2.6.7":
+    folder: all
+  "2.6.6":
+    folder: all
+  "2.6.5":
+    folder: all
+  "2.6.3":
+    folder: all
+  "2.6.1":
+    folder: all
+  "2.6.0":
+    folder: all

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -617,7 +617,7 @@ def parse_args():
     )
     parser.add_argument(
         "--exclude",
-        default="_build/|tests/|.*Test\.cpp$|benchmark/|benchmarks/|.*Benchmark\.cpp$|.*Benchmarks\.cpp$|test/|.*\.pb\.cc$|.*\.pb\.h$|(^|/)bolt/python/",
+        default="_build/|tests/|test_package/|.*Test\.cpp$|benchmark/|benchmarks/|.*Benchmark\.cpp$|.*Benchmarks\.cpp$|test/|.*\.pb\.cc$|.*\.pb\.h$|(^|/)bolt/python/",
         help="Regular expression to exclude files or paths (e.g. 'tests/|.*Test\.cpp$')",
     )
     parser.add_argument(


### PR DESCRIPTION
  ### What problem does this PR solve?

  Bolt builds in strict or isolated toolchain environments exposed several build and dependency-management issues:

  - Supported GCC versions no longer require a separate libstdc++fs, but Bolt still linked against -lstdc++fs, causing linker failures in environments where that library is unavailable.
  - Absolute source and build paths could be embedded in generated artifacts.
  - The Makefile did not automatically consume externally supplied Conan host and build profiles.
  - Several pinned Conan recipes had incompatible option names, CMake targets, or compiler settings.
  - GNU and Apache source downloads lacked preferred mirrors.
  - The Volcengine TOS C++ SDK did not have a local Conan recipe based on upstream release archives.

  Issue Number: N/A

  ### Type of Change

  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 🚀 Performance improvement (optimization)
  - [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] 🔨 Refactoring (no logic changes)
  - [x] 🔧 Build/CI or Infrastructure changes
  - [ ] 📝 Documentation only

  ### Description

  This PR improves Bolt build compatibility across different compiler, sysroot, and Conan environments:

  - Add configurable compiler prefix mapping for GCC and Clang to replace absolute source and build paths embedded in binaries, debug information, predefined macros, and coverage metadata.
  - Automatically consume externally supplied Conan host and build profiles while preserving the existing profile fallback.
  - Align conan graph info arguments with the actual conan install invocation.
  - Standardize the minimum supported GCC version as GCC 10 and remove obsolete stdc++fs linkage from Bolt and its test targets.
  - Align Arrow options with the pinned Conan recipe, including acero and the legacy hdfs_bridgs option.
  - Fix Arrow integration for RapidJSON and Snappy CMake target detection.
  - Build pkgconf with GNU99 extensions required by its source.
  - Fix Snappy target naming and Conan dependency discovery for Paimon and its Avro external project.
  - Prepend Kernel.org mirrors for the required GNU sources while retaining all original URLs as fallbacks.
  - Prepend Huawei Cloud mirrors for Arrow 15.0.1, ORC 2.0.0, and Thrift 0.17.0 while retaining their original Apache URLs.
  - Add a Conan recipe for all published Volcengine TOS C++ SDK releases from 2.6.0 through 2.6.28:
      - Source URLs and SHA-256 checksums are managed through conandata.yml.
      - Sources are downloaded from upstream GitHub tag archives.
      - CMake package metadata and a Conan test_package are included.

  Validation performed:

  - Ran scripts/install-bolt-deps.sh with an isolated Conan home and confirmed that all Conan Center patches apply successfully.
  - Downloaded the added Apache mirror artifacts and verified their SHA-256 checksums.
  - Exported and fetched the TOS recipes for versions 2.6.0 and 2.6.28.

  ### Performance Impact

  - [x] No Impact: This change only affects the build system and dependency recipes and does not modify runtime critical paths.
  - [ ] Positive Impact: I have run benchmarks.
  - [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

  ### Release Note

  Release Note:

  Release Note:
  - Improved Bolt build compatibility across strict and isolated toolchain environments.
  - Added compiler path mapping to avoid embedding absolute source and build paths.
  - Added fallback mirrors for pinned GNU and Apache dependencies.
  - Added Conan recipes for Volcengine TOS C++ SDK releases from 2.6.0 through 2.6.28.

  ### Checklist (For Author)

  - [ ] I have added/updated unit tests (ctest).
  - [ ] I have verified the code with local build (Release/Debug).
  - [x] I have run clang-format / linters.
  - [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
  - [ ] No need to test or manual test.

  ### Breaking Changes

  - [x] No
  - [ ] Yes (Description: ...)