### PR TITLE
fix: cast all-null array elements to varchar

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -1107,14 +1107,16 @@ void doCastArrayToVarchar(
   }
 
   context.ensureWritable(nestedRows, VARCHAR(), resultElements);
-  doCast(
-      *remainingRows,
-      *arrayElements,
-      context,
-      arrayElements->type(),
-      VARCHAR(),
-      resultElements,
-      errorPolicy);
+  if (remainingRows->hasSelections()) {
+    doCast(
+        *remainingRows,
+        *arrayElements,
+        context,
+        arrayElements->type(),
+        VARCHAR(),
+        resultElements,
+        errorPolicy);
+  }
 
   resultElements->addNulls(remainingRows->asRange().bits(), nestedRows);
 

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -2961,11 +2961,9 @@ TEST_F(CastExprTest, complexTypeToString) {
         {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
         2,
         ARRAY(UNKNOWN()));
-    BOLT_ASSERT_THROW(
-        testCast(
-            unknownArray,
-            makeFlatVector<StringView>({"[null, null]", "[null, null]"})),
-        "");
+    testCast(
+        unknownArray,
+        makeFlatVector<StringView>({"[null, null]", "[null, null]"}));
 
     // map(bigint, array(bigint))
     auto mapOfArray = createMapOfArraysVector<int64_t, int64_t>(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #776 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Skip `doCast` for array elements when all selected nested rows are null.
- Keep the existing null propagation path responsible for marking the element results.
- Update the complex type cast test so `array(unknown)` with all-null elements casts to `"[null, null]"` instead of throwing.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: cast all-null array elements to varchar
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
