### PR TITLE
docs: add an example of JIT for developers

### DIFF
--- a/doc/blog/_posts/2026-07-03-accelerating-bolt-via-jit.md
+++ b/doc/blog/_posts/2026-07-03-accelerating-bolt-via-jit.md
@@ -151,6 +151,26 @@ This generated IR offers several performance improvements over the generic C++ i
 - **Inlined comparisons:** Function calls for comparing primitive types are eliminated.
 - **Simplified branching:** `if` branch checks for runtime flags (e.g., `nulls_first`, descending order) are resolved at compile time.
 
+## An example for developers
+
+Bolt generates a comparison function specifically for sorting. It passes metadata—such as data types, null ordering, and sort direction—to `RowContainerCodeGenerator`, which returns a `shared_ptr<CompiledModule>`. The `CompiledModule` owns the compiled machine code and provides access to the comparison function. The sorting algorithm then uses this generated function to compare rows.
+
+```cpp
+auto [jitMod, rowRowCmpfn] = data_->codegenCompare(
+    data_->keyTypes(),
+    sortCompareFlags_,
+    bytedance::bolt::jit::CmpType::SORT_LESS,
+    true);
+jitModule_ = std::move(jitMod);
+cmp_ = (RowRowCompare)jitModule_->getFuncPtr(rowRowCmpfn);
+// ...
+if (cmp_) {
+  sorter_.sort(sortedRows_.begin(), sortedRows_.end(), cmp_);
+}
+```
+
+> **Note:** Keep the `shared_ptr<CompiledModule>` alive for as long as the generated function may be called. When the `shared_ptr` is destroyed, the module is moved to the LRU cache and its generated code may later be evicted to reclaim memory. Therefore, retaining only a raw function pointer is unsafe; retain the `shared_ptr<CompiledModule>` as well.
+
 ## Benchmarks
 
 We benchmarked the Sort operator on a development machine, yielding the following results:


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [x] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
