### PR TITLE
bugfix: async threads should acquire enough memory or non

### DIFF
--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/GlobalParameters.h"
 #include "bolt/common/base/SuccinctPrinter.h"
 #include "bolt/common/memory/MemoryUtils.h"
 #include "bolt/common/memory/sparksql/ExecutionMemoryPool.h"

--- a/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
+++ b/bolt/common/memory/sparksql/ExecutionMemoryPool.cpp
@@ -185,6 +185,13 @@ int64_t ExecutionMemoryPool::acquireMemory(
         std::min(numBytes, std::max<int64_t>(0L, maxMemoryPerTask - curMem));
     int64_t toGrant = std::min(maxToGrant, freeMemory);
 
+    if (isAsyncPreloadThread() && toGrant < numBytes) {
+      // if async threads unreserve non-enough memory, there may be a dead lock
+      // with the growing memory process of the main thread. so we directly
+      // return 0 to avoid calling unreserve(bytes).
+      return 0;
+    }
+
     if (toGrant < numBytes && curMem + toGrant < minMemoryPerTask) {
       LOG(INFO) << "TID " << taskAttemptId
                 << " waiting for at least 1/2N to be free. "

--- a/bolt/common/memory/sparksql/tests/MemoryConsumerTest.cpp
+++ b/bolt/common/memory/sparksql/tests/MemoryConsumerTest.cpp
@@ -15,8 +15,10 @@
  */
 
 #include <folly/Random.h>
+#include <folly/system/ThreadName.h>
 #include <gtest/gtest.h>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <exception>
 #include <memory>
@@ -27,6 +29,7 @@
 
 #include "bolt/common/base/BoltException.h"
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/GlobalParameters.h"
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/memory/sparksql/ExecutionMemoryPool.h"
 #include "bolt/common/memory/sparksql/MemoryConsumer.h"
@@ -531,6 +534,139 @@ TEST_F(MemoryConsumerTest, toStringRacesWithConcurrentMemoryUpdates) {
   }
 
   EXPECT_GT(stringifyCalls.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(memoryPool->memoryUsed(), 0);
+}
+
+// Regression test for the deadlock guard at
+// ExecutionMemoryPool::acquireMemory (see comment "if async threads unreserve
+// non-enough memory, there may be a dead lock ..."). Reproduces the scenario
+// described in https://github.com/bytedance/bolt/issues/781:
+//
+// 1. Main task holds most of the pool. It calls acquireMemory for more bytes
+//    than are free and, per Spark's 1/2N rule, blocks inside cv_.wait_for
+//    while still holding a share of the pool.
+// 2. An async preload thread (thread name starts with "AsyncLoadThr") also
+//    calls acquireMemory. Without the guard, it would see the same
+//    "toGrant < numBytes && curMem + toGrant < minMemoryPerTask" condition
+//    and enter cv_.wait_for too. Both threads then wait for the other side
+//    to release memory that nobody is going to release, so both hang until
+//    minMemoryMaxWaitMs_ expires (300s in prod) -> effectively a deadlock.
+// 3. With the guard, the async thread returns 0 immediately so its caller
+//    can skip the unreserve(bytes) path and let the main thread progress.
+TEST_F(MemoryConsumerTest, asyncPreloadThreadDoesNotDeadlockOnPartialGrant) {
+  constexpr int64_t kCapacity = 1024;
+  constexpr int64_t kMainTaskAttemptId = 1;
+  constexpr int64_t kAsyncTaskAttemptId = 2;
+
+  auto memoryPool = std::make_shared<ExecutionMemoryPool>();
+  memoryPool->setPoolSize(kCapacity);
+
+  // Step 1: register the main task and grab almost everything so any further
+  // request is guaranteed to be a partial grant.
+  ASSERT_EQ(
+      memoryPool->acquireMemory(kCapacity - 1, kMainTaskAttemptId),
+      kCapacity - 1);
+
+  std::atomic_bool mainEnteredWait{false};
+  std::atomic_bool mainDone{false};
+  std::atomic_bool asyncDone{false};
+  int64_t asyncGranted = -1;
+
+  // Step 2: main task now asks for the full pool. Only 1 byte is free, and
+  // the 1/2N floor (1024 / (2 * 1) = 512) is not met, so the main thread
+  // blocks inside cv_.wait_for holding its share of the pool.
+  std::thread mainThread([&]() {
+    mainEnteredWait.store(true, std::memory_order_release);
+    // Blocks until the async thread creates the second task and then
+    // releases its memory below.
+    int64_t got = memoryPool->acquireMemory(kCapacity, kMainTaskAttemptId);
+    // Note: after the async task appears, numActiveTasks == 2, so the
+    // 1/2N floor drops to 256 and the main task can be served with the
+    // remaining free budget (>= 256) once the cv fires.
+    EXPECT_GT(got, 0);
+    memoryPool->releaseMemory(got, kMainTaskAttemptId);
+    mainDone.store(true, std::memory_order_release);
+  });
+
+  // Wait until the main thread has entered acquireMemory. A short sleep is
+  // enough because the second acquireMemory call blocks on cv_.wait_for.
+  while (!mainEnteredWait.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // Step 3: async preload thread requests memory. The guard must make it
+  // return 0 promptly instead of waiting on cv_.
+  std::thread asyncThread([&]() {
+    folly::setThreadName(std::string(kAsyncPreloadThreadName) + "1");
+    ASSERT_TRUE(isAsyncPreloadThread());
+    const auto start = std::chrono::steady_clock::now();
+    asyncGranted = memoryPool->acquireMemory(kCapacity, kAsyncTaskAttemptId);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    // The whole point of the guard: don't wait on cv_.
+    EXPECT_LT(
+        std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 5);
+    asyncDone.store(true, std::memory_order_release);
+  });
+
+  asyncThread.join();
+  EXPECT_TRUE(asyncDone.load(std::memory_order_acquire));
+  EXPECT_EQ(asyncGranted, 0);
+
+  // Registering the async task made numActiveTasks == 2, which lowered the
+  // 1/2N floor and notified cv_. The main thread should now be able to
+  // finish. Give it a bounded window; a real deadlock would exceed it.
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (!mainDone.load(std::memory_order_acquire) &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_TRUE(mainDone.load(std::memory_order_acquire))
+      << "main thread appears to be deadlocked with the async preload thread";
+
+  mainThread.join();
+  memoryPool->releaseMemory(kCapacity - 1, kMainTaskAttemptId);
+  EXPECT_EQ(memoryPool->memoryUsed(), 0);
+}
+
+// Sanity check: a regular (non-preload) thread must still take the cv_.wait_for
+// path on a partial grant, so we don't accidentally regress the Spark
+// semantics for main-execution threads.
+TEST_F(MemoryConsumerTest, nonAsyncPreloadThreadStillWaitsOnPartialGrant) {
+  constexpr int64_t kCapacity = 1024;
+  constexpr int64_t kTaskAOwnerId = 1;
+  constexpr int64_t kTaskBOwnerId = 2;
+
+  auto memoryPool = std::make_shared<ExecutionMemoryPool>();
+  memoryPool->setPoolSize(kCapacity);
+
+  // Task A holds most of the pool.
+  ASSERT_EQ(
+      memoryPool->acquireMemory(kCapacity - 1, kTaskAOwnerId), kCapacity - 1);
+
+  std::atomic_bool started{false};
+  int64_t granted = -1;
+
+  std::thread waiter([&]() {
+    // Ensure this thread is NOT recognised as an async preload thread.
+    ASSERT_FALSE(isAsyncPreloadThread());
+    started.store(true, std::memory_order_release);
+    granted = memoryPool->acquireMemory(kCapacity, kTaskBOwnerId);
+  });
+
+  while (!started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // Freeing memory now should unblock the waiter and let it get a full
+  // grant (proving it really was waiting on cv_ rather than returning 0).
+  memoryPool->releaseMemory(kCapacity - 1, kTaskAOwnerId);
+  waiter.join();
+
+  EXPECT_EQ(granted, kCapacity);
+  memoryPool->releaseMemory(granted, kTaskBOwnerId);
   EXPECT_EQ(memoryPool->memoryUsed(), 0);
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #781 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

deadlock happens when async threads unreserve() and the main thread apply memory, so we forbidden async threads recalling unreserve() when get non-enough memory by only allocating 0 or enough memory for async threads.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
