### PR TITLE
 refactor: measure splitTime in doSplit and shuffleWriteTime at operator level

### DIFF
--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -58,7 +58,6 @@ arrow::Status BoltRowBasedSortShuffleWriter::init() {
 arrow::Status BoltRowBasedSortShuffleWriter::split(
     bytedance::bolt::RowVectorPtr rv,
     int64_t memLimit) {
-  bytedance::bolt::NanosecondTimer splitTimer(&totalSplitTime_);
   updateInputMetrics(rv);
   if (bytedance::bolt::RowVector::isComposite(rv)) {
     // from columnar to composite, flush all previous batches
@@ -78,10 +77,11 @@ arrow::Status BoltRowBasedSortShuffleWriter::split(
   vectorLayout_ = RowVectorLayout::kColumnar;
   ShuffleColumnarToRowConverter::RowVectorWithStats fullStats;
   {
-    bytedance::bolt::NanosecondTimer timer(&flattenTime_);
-
-    ensurePartialFlatten(rv, {0});
-    ensureVectorLoaded(rv);
+    {
+      bytedance::bolt::NanosecondTimer timer(&flattenTime_);
+      ensurePartialFlatten(rv, {0});
+      ensureVectorLoaded(rv);
+    }
     BOLT_CHECK(
         rv != nullptr && (options_.partitioning != Partitioning::kSingle) &&
         partitioner_->hasPid());
@@ -211,7 +211,6 @@ arrow::Status BoltRowBasedSortShuffleWriter::reclaimFixedSize(
 }
 
 arrow::Status BoltRowBasedSortShuffleWriter::stop() {
-  bytedance::bolt::NanosecondTimer stopTimer(&stopTime_);
   setSplitState(SplitState::kStop);
   RETURN_NOT_OK(tryEvict());
   {

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -528,7 +528,6 @@ BoltShuffleWriter::generateComplexTypeBuffers(
 arrow::Status BoltShuffleWriter::split(
     bytedance::bolt::RowVectorPtr rv,
     int64_t memLimit) {
-  bytedance::bolt::NanosecondTimer splitTimer(&totalSplitTime_);
   updateInputMetrics(rv);
   if (options_.partitioning == Partitioning::kSingle) {
     if (bytedance::bolt::RowVector::isComposite(rv)) {
@@ -691,7 +690,6 @@ arrow::Status BoltShuffleWriter::split(
 }
 
 arrow::Status BoltShuffleWriter::stop() {
-  bytedance::bolt::NanosecondTimer stopTimer(&stopTime_);
   if (vectorLayout_ != RowVectorLayout::kComposite) {
     partitionWriter_->setRowFormat(false);
     if (accumulateDataset_ != nullptr) {
@@ -811,25 +809,28 @@ void BoltShuffleWriter::setSplitState(SplitState state) {
 arrow::Status BoltShuffleWriter::doSplit(
     const bytedance::bolt::RowVector& rv,
     int64_t memLimit) {
-  auto rowNum = rv.size();
-  RETURN_NOT_OK(buildPartition2Row(rowNum));
-  RETURN_NOT_OK(updateInputHasNull(rv));
+  {
+    bytedance::bolt::NanosecondTimer splitTimer(&splitTime_);
+    auto rowNum = rv.size();
+    RETURN_NOT_OK(buildPartition2Row(rowNum));
+    RETURN_NOT_OK(updateInputHasNull(rv));
 
-  START_TIMING(cpuWallTimingList_[CpuWallTimingIteratePartitions]);
+    START_TIMING(cpuWallTimingList_[CpuWallTimingIteratePartitions]);
 
-  setSplitState(SplitState::kPreAlloc);
-  // Calculate buffer size based on available offheap memory, history average
-  // bytes per row and options_.bufferSize.
-  auto preAllocBufferSize = calculatePartitionBufferSize(rv, memLimit);
-  ++preallocCount_;
-  totalPreallocSize_ += preAllocBufferSize;
-  RETURN_NOT_OK(preAllocPartitionBuffers(preAllocBufferSize));
-  END_TIMING();
+    setSplitState(SplitState::kPreAlloc);
+    // Calculate buffer size based on available offheap memory, history average
+    // bytes per row and options_.bufferSize.
+    auto preAllocBufferSize = calculatePartitionBufferSize(rv, memLimit);
+    ++preallocCount_;
+    totalPreallocSize_ += preAllocBufferSize;
+    RETURN_NOT_OK(preAllocPartitionBuffers(preAllocBufferSize));
+    END_TIMING();
 
-  printPartitionBuffer();
+    printPartitionBuffer();
 
-  setSplitState(SplitState::kSplit);
-  RETURN_NOT_OK(splitRowVector(rv));
+    setSplitState(SplitState::kSplit);
+    RETURN_NOT_OK(splitRowVector(rv));
+  }
 
   printPartitionBuffer();
 
@@ -2353,10 +2354,12 @@ arrow::Status BoltShuffleWriter::splitCompositeVector(
   bytedance::bolt::CompositeRowVectorPtr rv;
   vectorLayout_ = RowVectorLayout::kComposite;
   {
-    bytedance::bolt::NanosecondTimer timer(&flattenTime_);
-    ensurePartialFlatten(rowVector, {0});
-    rv = std::dynamic_pointer_cast<bytedance::bolt::CompositeRowVector>(
-        rowVector);
+    {
+      bytedance::bolt::NanosecondTimer timer(&flattenTime_);
+      ensurePartialFlatten(rowVector, {0});
+      rv = std::dynamic_pointer_cast<bytedance::bolt::CompositeRowVector>(
+          rowVector);
+    }
     BOLT_CHECK(
         rv != nullptr && partitioner_->hasPid(),
         "Failed to cast rowVector to CompositeRowVector or partitioner missing PID. "

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -586,12 +586,11 @@ class BoltShuffleWriter : public ShuffleWriter {
     metrics_.combinedVectorNumber = combinedVectorNumber_;
     metrics_.combineVectorTimes = combineVectorTimes_;
     metrics_.combineVectorCost = combineVectorCost_;
-    metrics_.shuffleWriteTime = stopTime_ + totalSplitTime_;
-
-    metrics_.splitTime = totalSplitTime_ -
-        (metrics_.totalEvictTime + metrics_.totalWriteTime +
-         metrics_.totalCompressTime + metrics_.flattenTime +
-         metrics_.computePidTime + metrics_.convertTime);
+    // splitTime is now measured directly around doSplit() instead of being
+    // derived by subtracting the other sub-phases from the whole split().
+    // shuffleWriteTime is measured at the operator level (SparkShuffleWriter),
+    // so it also covers init/reclaim, and is populated there.
+    metrics_.splitTime = splitTime_;
 
     metrics_.dataSize = std::accumulate(
         metrics_.rawPartitionLengths.begin(),
@@ -826,8 +825,8 @@ class BoltShuffleWriter : public ShuffleWriter {
   // detailed time
   uint64_t flattenTime_{0};
   uint64_t computePidTime_{0};
-  uint64_t totalSplitTime_{0};
-  uint64_t stopTime_{0};
+  // Time spent inside doSplit() (buildPartition2Row + preAlloc + splitRowVector).
+  uint64_t splitTime_{0};
   uint64_t shuffleCheckTimeNanos_{0};
   uint64_t shuffleCheckCount_{0};
   std::mt19937 shuffleCheckRandomEngine_{std::random_device{}()};

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -825,7 +825,8 @@ class BoltShuffleWriter : public ShuffleWriter {
   // detailed time
   uint64_t flattenTime_{0};
   uint64_t computePidTime_{0};
-  // Time spent inside doSplit() (buildPartition2Row + preAlloc + splitRowVector).
+  // Time spent inside doSplit() (buildPartition2Row + preAlloc +
+  // splitRowVector).
   uint64_t splitTime_{0};
   uint64_t shuffleCheckTimeNanos_{0};
   uint64_t shuffleCheckCount_{0};

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -370,8 +370,8 @@ arrow::Status BoltShuffleWriterV2::doSplit(
       RETURN_NOT_OK(updateInputHasNull(rv));
       START_TIMING(cpuWallTimingList_[CpuWallTimingIteratePartitions]);
       setSplitState(SplitState::kPreAlloc);
-      // Calculate buffer size based on available offheap memory, history average
-      // bytes per row and options_.buffer_size.
+      // Calculate buffer size based on available offheap memory, history
+      // average bytes per row and options_.buffer_size.
       RETURN_NOT_OK(
           preAllocPartitionBuffers(partition2RowCount_, partitionUsed_));
       END_TIMING();

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -43,7 +43,6 @@ namespace bytedance::bolt::shuffle::sparksql {
 arrow::Status BoltShuffleWriterV2::split(
     bytedance::bolt::RowVectorPtr rv,
     int64_t memLimit) {
-  bytedance::bolt::NanosecondTimer splitTimer(&totalSplitTime_);
   updateInputMetrics(rv);
   BOLT_DCHECK(options_.partitioning != Partitioning::kSingle);
   if (bytedance::bolt::RowVector::isComposite(rv)) {
@@ -64,38 +63,38 @@ arrow::Status BoltShuffleWriterV2::split(
     bytedance::bolt::NanosecondTimer timer(&flattenTime_);
     ensureLoaded(rv);
     ensureFlatten(rv);
-    // Use post-flatten estimateFlatSize which leverages StringStats
-    // computed during flatten for accurate string size estimation.
-    auto flatSize = rv->estimateFlatSize();
-    // try evict before split if current batch size is larger than memLimit
-    if (flatSize > memLimit && hasEnoughMemoryUsageToSpill()) {
-      requestSpill_ = true;
-    }
-    RETURN_NOT_OK(tryEvict(memLimit));
-    // tryEvict may release memory to boltPool
-    memLimit = std::max(memLimit, (int64_t)boltPool_->freeBytes());
+  }
+  // Use post-flatten estimateFlatSize which leverages StringStats
+  // computed during flatten for accurate string size estimation.
+  auto flatSize = rv->estimateFlatSize();
+  // try evict before split if current batch size is larger than memLimit
+  if (flatSize > memLimit && hasEnoughMemoryUsageToSpill()) {
+    requestSpill_ = true;
+  }
+  RETURN_NOT_OK(tryEvict(memLimit));
+  // tryEvict may release memory to boltPool
+  memLimit = std::max(memLimit, (int64_t)boltPool_->freeBytes());
 
-    auto maxBatchBytes = std::min(
-        maxBatchBytes_, (uint64_t)std::max(memLimit, kMinMemLimit) / 2);
-    maxBatchBytes = hasComplexType_
-        ? std::min(maxBatchBytes, (uint64_t)maxCombinedBytesWithComplexType_)
-        : maxBatchBytes;
-    if (flatSize > maxBatchBytes) {
-      return splitExtremelyLargeBatch(rv, memLimit, flatSize, maxBatchBytes);
-    }
-    numRowsInBatches_ += rv->size();
-    numBytesInBatches_ += flatSize;
-    batches_.emplace_back(rv);
-    // when BoltMemoryManager is enabled, memLimit is lower than what we got in
-    // Java, so we make threshold lower to store more batches.
-    double ratio = memory::sparksql::ExecutionMemoryPool::inited() ? 0.5 : 0.25;
-    if (options_.enableVectorCombination &&
-        (!hasComplexType_ ||
-         numBytesInBatches_ < maxCombinedBytesWithComplexType_) &&
-        numRowsInBatches_ < options_.bufferSize &&
-        numBytesInBatches_ < memLimit * ratio && !boltColumnTypes_.empty()) {
-      return arrow::Status::OK();
-    }
+  auto maxBatchBytes =
+      std::min(maxBatchBytes_, (uint64_t)std::max(memLimit, kMinMemLimit) / 2);
+  maxBatchBytes = hasComplexType_
+      ? std::min(maxBatchBytes, (uint64_t)maxCombinedBytesWithComplexType_)
+      : maxBatchBytes;
+  if (flatSize > maxBatchBytes) {
+    return splitExtremelyLargeBatch(rv, memLimit, flatSize, maxBatchBytes);
+  }
+  numRowsInBatches_ += rv->size();
+  numBytesInBatches_ += flatSize;
+  batches_.emplace_back(rv);
+  // when BoltMemoryManager is enabled, memLimit is lower than what we got in
+  // Java, so we make threshold lower to store more batches.
+  double ratio = memory::sparksql::ExecutionMemoryPool::inited() ? 0.5 : 0.25;
+  if (options_.enableVectorCombination &&
+      (!hasComplexType_ ||
+       numBytesInBatches_ < maxCombinedBytesWithComplexType_) &&
+      numRowsInBatches_ < options_.bufferSize &&
+      numBytesInBatches_ < memLimit * ratio && !boltColumnTypes_.empty()) {
+    return arrow::Status::OK();
   }
   BOLT_CHECK(partitioner_->hasPid());
   if (batches_.size() == 1) {
@@ -259,7 +258,6 @@ arrow::Status BoltShuffleWriterV2::initPartitions() {
 }
 
 arrow::Status BoltShuffleWriterV2::stop() {
-  bytedance::bolt::NanosecondTimer stopTimer(&stopTime_);
   if (vectorLayout_ == RowVectorLayout::kColumnar) {
     partitionWriter_->setRowFormat(false);
     if (batches_.size()) {
@@ -363,22 +361,25 @@ arrow::Status BoltShuffleWriterV2::doSplit(
     bool doAlloc,
     bool doEvict,
     int64_t memLimit) {
-  auto rowNum = rv.size();
-  RETURN_NOT_OK(buildPartition2Row(rowNum));
+  {
+    bytedance::bolt::NanosecondTimer splitTimer(&splitTime_);
+    auto rowNum = rv.size();
+    RETURN_NOT_OK(buildPartition2Row(rowNum));
 
-  if (doAlloc) {
-    RETURN_NOT_OK(updateInputHasNull(rv));
-    START_TIMING(cpuWallTimingList_[CpuWallTimingIteratePartitions]);
-    setSplitState(SplitState::kPreAlloc);
-    // Calculate buffer size based on available offheap memory, history average
-    // bytes per row and options_.buffer_size.
-    RETURN_NOT_OK(
-        preAllocPartitionBuffers(partition2RowCount_, partitionUsed_));
-    END_TIMING();
+    if (doAlloc) {
+      RETURN_NOT_OK(updateInputHasNull(rv));
+      START_TIMING(cpuWallTimingList_[CpuWallTimingIteratePartitions]);
+      setSplitState(SplitState::kPreAlloc);
+      // Calculate buffer size based on available offheap memory, history average
+      // bytes per row and options_.buffer_size.
+      RETURN_NOT_OK(
+          preAllocPartitionBuffers(partition2RowCount_, partitionUsed_));
+      END_TIMING();
+    }
+
+    setSplitState(SplitState::kSplit);
+    RETURN_NOT_OK(splitRowVector(rv));
   }
-
-  setSplitState(SplitState::kSplit);
-  RETURN_NOT_OK(splitRowVector(rv));
 
   if (doEvict) {
     RETURN_NOT_OK(tryEvict(memLimit));

--- a/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
@@ -59,6 +59,7 @@ void SparkShuffleWriter::init(const bytedance::bolt::RowVectorPtr& rv) {
 }
 
 void SparkShuffleWriter::addInput(RowVectorPtr input) {
+  bytedance::bolt::NanosecondTimer shuffleWriteTimer(&shuffleWriteTime_);
   Operator::ReclaimableSectionGuard guard(this);
   std::call_once(initOnceFlag_, [this, &input]() { this->init(input); });
   auto freeMem = ExecutionMemoryPool::getMinimumFreeMemoryForTask(
@@ -89,7 +90,11 @@ void SparkShuffleWriter::noMoreInput() {
   Operator::noMoreInput();
   ShuffleWriterMetrics metrics;
   if (shuffleWriter_) {
-    auto status = shuffleWriter_->stop();
+    arrow::Status status;
+    {
+      bytedance::bolt::NanosecondTimer shuffleWriteTimer(&shuffleWriteTime_);
+      status = shuffleWriter_->stop();
+    }
     BOLT_CHECK(
         status.ok(),
         "Native shuffle write: ShuffleWriter stop failed, status: {}, shuffleWriter: {}",
@@ -104,6 +109,8 @@ void SparkShuffleWriter::noMoreInput() {
 
     LOG(INFO) << "ShuffleWriter is null";
   }
+
+  metrics.shuffleWriteTime = shuffleWriteTime_;
 
   reportShuffleStatusCallback_(metrics);
 }
@@ -120,6 +127,7 @@ void SparkShuffleWriter::reclaim(
     memory::MemoryReclaimer::Stats& stats) {
   int64_t evictedSize;
   if (shuffleWriter_) {
+    bytedance::bolt::NanosecondTimer shuffleWriteTimer(&shuffleWriteTime_);
     auto status = shuffleWriter_->reclaimFixedSize(targetBytes, &evictedSize);
     BOLT_CHECK(status.ok(), "(shuffle) nativeEvict: evict failed");
   } else {

--- a/bolt/shuffle/sparksql/ShuffleWriterNode.h
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.h
@@ -131,6 +131,9 @@ class SparkShuffleWriter : public bytedance::bolt::exec::Operator {
   std::once_flag initOnceFlag_;
   ShuffleWriterOptions shuffleWriterOptions_;
   uint64_t minMemLimit_;
+  // Total wall time spent inside the shuffle write operator, covering init,
+  // addInput (split), reclaim (spill) and stop.
+  uint64_t shuffleWriteTime_{0};
   std::unique_ptr<BoltArrowMemoryPool> arrowPool_;
   std::shared_ptr<BoltShuffleWriter> shuffleWriter_;
   bool finished_ = false;


### PR DESCRIPTION

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

 1. Measure splitTime directly. Replace the subtraction with a dedicated NanosecondTimer splitTimer(&splitTime_) scoped to the real split work inside doSplit() (buildPartition2Row + preAlloc + splitRowVector). finalizeMetrics() now simply assigns metrics_.splitTime= splitTime_.

  2. Measure shuffleWriteTime at the operator level. Move it into SparkShuffleWriter (ShuffleWriterNode), wrapping addInput (split), reclaim (spill) and noMoreInput→stop. It now reflects the full wall time of the shuffle-write operator (init + addInput + reclaim + stop) instead of just split + stop.

  3. Narrow the flattenTime scope. Tighten the NanosecondTimer(&flattenTime_) blocks so they cover only the flatten calls (ensureFlatten / ensurePartialFlatten / ensureVectorLoaded), excluding the subsequent split/evict logic.
  4. Remove the now-unused totalSplitTime_ and stopTime_ members and their timers in split() / stop() across all three writers.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
