### PR TITLE
Optimize Parquet lazy repdef window decode

### DIFF
--- a/bolt/dwio/common/Options.h
+++ b/bolt/dwio/common/Options.h
@@ -175,6 +175,7 @@ class RowReaderOptions {
   bool enableDictionaryFilter_ = false;
 
   int32_t decodeRepDefPageCount_{10};
+  int32_t parquetRepDefPreloadWindowCount_{0};
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
   bool useColumnNamesForColumnMapping_{false};
 
@@ -483,6 +484,14 @@ class RowReaderOptions {
     return decodeRepDefPageCount_;
   }
 
+  void setParquetRepDefPreloadWindowCount(int32_t windowCount) {
+    parquetRepDefPreloadWindowCount_ = windowCount < 0 ? 0 : windowCount;
+  }
+
+  int32_t getParquetRepDefPreloadWindowCount() const {
+    return parquetRepDefPreloadWindowCount_;
+  }
+
   void setParquetRepDefMemoryLimit(int32_t memlimit) {
     parquetRepDefMemoryLimit_ = memlimit;
   }
@@ -556,8 +565,10 @@ class RowReaderOptions {
        << ", ";
     ss << "fileName_=" << fileName_ << ", ";
     ss << "fileId_=" << fileId_ << ", ";
-    ss << "enableDictionaryFilter_=" << enableDictionaryFilter_;
-    ss << "decodeRepDefPageCount_=" << decodeRepDefPageCount_;
+    ss << "enableDictionaryFilter_=" << enableDictionaryFilter_ << ", ";
+    ss << "decodeRepDefPageCount_=" << decodeRepDefPageCount_ << ", ";
+    ss << "parquetRepDefPreloadWindowCount_="
+       << parquetRepDefPreloadWindowCount_ << ", ";
     ss << "parquetRepDefMemoryLimit_=" << parquetRepDefMemoryLimit_ << ", ";
     ss << "maxBatchBytes_=" << maxBatchBytes_ << ", ";
     ss << "useColumnNamesForColumnMapping_="

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -103,10 +103,11 @@ void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
       numRowsInPage_ = 0;
       break;
     }
-    if (row != kRepDefOnly && windowRepDefMode_ && hasChunkRepDefs_ &&
+    if (row != kRepDefOnly && windowRepDef_.enabled && hasChunkRepDefs_ &&
         !isTopLevel_ && maxRepeat_ > 0) {
-      while (pageIndex_ + 1 >= static_cast<int32_t>(numLeavesInPage_.size()) &&
-             (!preloadedRepDefs_.empty() || windowRepDefsRemaining_ > 0)) {
+      while (
+          pageIndex_ + 1 >= static_cast<int32_t>(numLeavesInPage_.size()) &&
+          (!preloadedRepDefs_.empty() || windowRepDef_.repDefsRemaining > 0)) {
         ensureNumLeavesInPage(pageIndex_ + 1);
       }
     } else if (
@@ -852,13 +853,7 @@ void PageReader::preloadPageRepDefs(const bool keepRepDefRawData) {
 void PageReader::preloadRepDefs() {
   const auto startNs = getCurrentTimeNano();
   hasChunkRepDefs_ = true;
-  windowRepDefMode_ = false;
-  windowTopLevelOffsets_.clear();
-  windowRepDefPageData_.clear();
-  windowRepDefsRemaining_ = 0;
-  windowCurrentPageLeafCount_ = 0;
-  windowDecodedPageCount_ = 0;
-  windowTopLevelOffsetBase_ = 0;
+  windowRepDef_.reset();
   bool startWithDictinoaryPage = cryptoCtx_.startDecryptWithDictionaryPage;
   if (maxRepeat_ > 0 && maxDefine_ > 0) {
     const int32_t samplePages = decodeRepDefPageCount_;
@@ -926,19 +921,11 @@ void PageReader::preloadRepDefs() {
 void PageReader::preloadRepDefsRawOnly() {
   const auto startNs = getCurrentTimeNano();
   hasChunkRepDefs_ = true;
-  windowRepDefMode_ = true;
+  windowRepDef_.reset(true);
   const bool startWithDictionaryPage =
       cryptoCtx_.startDecryptWithDictionaryPage;
   totalRefDefBytes_ = 0;
   numLeavesInPage_.clear();
-  windowRepeatDecoder_.reset();
-  windowDefineDecoder_.reset();
-  windowRepDefsRemaining_ = 0;
-  windowCurrentPageLeafCount_ = 0;
-  windowDecodedPageCount_ = 0;
-  windowRepDefPageData_.clear();
-  windowTopLevelOffsets_.clear();
-  windowTopLevelOffsetBase_ = 0;
 
   while (pageStart_ < chunkSize_) {
     preloadedRepDefs_.emplace_back(raw_vector<char>(&pool_));
@@ -988,6 +975,9 @@ int32_t PageReader::countLeavesInRepDefPage(
     return numRepDefsInPage;
   }
 
+  // This is a count-only fast path for raw rep/def pages. It intentionally
+  // skips repetition levels and scans definition RLE runs directly so we can
+  // compute the page leaf count without materializing definitionLevels_.
   auto bitReader = ::arrow::bit_util::BitReader(
       reinterpret_cast<const uint8_t*>(rawData), defineLength);
   const auto bitWidth = ::arrow::bit_util::NumRequiredBits(maxDefine_);
@@ -1049,6 +1039,9 @@ void PageReader::compactConsumedLeafNulls() {
     uint64_t* rawData = leafNulls_.data();
     size_t copyBytes = unConsumedNullWords * sizeof(uint64_t);
 
+    // Avoid memmove on glibc versions affected by the Intel FSRM overlap bug.
+    // See
+    // https://lore.kernel.org/all/20211101044955.2295495-1-goldstein.w.n@gmail.com/
 #if (defined(__x86_64__) || defined(__i386__)) && defined(__GLIBC__) && \
     (__GLIBC__ * 100 + __GLIBC_MINOR__ < 233)
 #if defined(__GNUC__) && !defined(__clang__)
@@ -1111,23 +1104,23 @@ void PageReader::compactWindowRepDefs() {
 }
 
 void PageReader::compactWindowTopLevelOffsets(int32_t consumedLevels) {
-  if (consumedLevels == 0 || windowTopLevelOffsets_.empty()) {
+  if (consumedLevels == 0 || windowRepDef_.topLevelOffsets.empty()) {
     return;
   }
 
-  windowTopLevelOffsetBase_ += consumedLevels;
+  windowRepDef_.topLevelOffsetBase += consumedLevels;
   auto firstKept = std::lower_bound(
-      windowTopLevelOffsets_.begin(),
-      windowTopLevelOffsets_.end(),
-      windowTopLevelOffsetBase_);
-  const auto kept = windowTopLevelOffsets_.end() - firstKept;
-  if (kept > 0 && firstKept != windowTopLevelOffsets_.begin()) {
+      windowRepDef_.topLevelOffsets.begin(),
+      windowRepDef_.topLevelOffsets.end(),
+      windowRepDef_.topLevelOffsetBase);
+  const auto kept = windowRepDef_.topLevelOffsets.end() - firstKept;
+  if (kept > 0 && firstKept != windowRepDef_.topLevelOffsets.begin()) {
     memmove(
-        windowTopLevelOffsets_.data(),
+        windowRepDef_.topLevelOffsets.data(),
         &*firstKept,
-        kept * sizeof(windowTopLevelOffsets_[0]));
+        kept * sizeof(windowRepDef_.topLevelOffsets[0]));
   }
-  windowTopLevelOffsets_.resize(kept);
+  windowRepDef_.topLevelOffsets.resize(kept);
 }
 
 int32_t PageReader::appendWindowTopLevelOffsets(int32_t begin, int32_t end) {
@@ -1138,7 +1131,8 @@ int32_t PageReader::appendWindowTopLevelOffsets(int32_t begin, int32_t end) {
   int32_t added = 0;
   for (int32_t i = begin; i < end; ++i) {
     if (repetitionLevels_[i] == 0) {
-      windowTopLevelOffsets_.push_back(windowTopLevelOffsetBase_ + i);
+      windowRepDef_.topLevelOffsets.push_back(
+          windowRepDef_.topLevelOffsetBase + i);
       ++added;
     }
   }
@@ -1154,15 +1148,17 @@ int32_t PageReader::decodeWindowRepDefsBatch(int32_t batchSize) {
   const auto end = begin + batchSize;
   repetitionLevels_.resize(end);
   BOLT_CHECK_NOT_NULL(
-      windowRepeatDecoder_, "Missing incremental repetition decoder");
-  windowRepeatDecoder_->GetBatch(repetitionLevels_.data() + begin, batchSize);
+      windowRepDef_.repeatDecoder, "Missing incremental repetition decoder");
+  windowRepDef_.repeatDecoder->GetBatch(
+      repetitionLevels_.data() + begin, batchSize);
 
   definitionLevels_.resize(end);
   BOLT_CHECK_NOT_NULL(
-      windowDefineDecoder_, "Missing incremental definition decoder");
-  windowDefineDecoder_->GetBatch(definitionLevels_.data() + begin, batchSize);
+      windowRepDef_.defineDecoder, "Missing incremental definition decoder");
+  windowRepDef_.defineDecoder->GetBatch(
+      definitionLevels_.data() + begin, batchSize);
 
-  windowRepDefsRemaining_ -= batchSize;
+  windowRepDef_.repDefsRemaining -= batchSize;
   leafNulls_.resize(bits::nwords(leafNullsSize_ + batchSize));
   const auto numLeaves = getLengthsAndNulls(
       LevelMode::kNulls,
@@ -1174,47 +1170,47 @@ int32_t PageReader::decodeWindowRepDefsBatch(int32_t batchSize) {
       leafNulls_.data(),
       leafNullsSize_);
   leafNullsSize_ += numLeaves;
-  windowCurrentPageLeafCount_ += numLeaves;
+  windowRepDef_.currentPageLeafCount += numLeaves;
   appendWindowTopLevelOffsets(begin, end);
   finishCurrentWindowRepDefPage();
   return numLeaves;
 }
 
 void PageReader::finishCurrentWindowRepDefPage() {
-  if (windowRepDefsRemaining_ == 0 && !windowRepDefPageData_.empty()) {
-    if (windowDecodedPageCount_ == numLeavesInPage_.size()) {
-      numLeavesInPage_.push_back(windowCurrentPageLeafCount_);
+  if (windowRepDef_.repDefsRemaining == 0 && !windowRepDef_.pageData.empty()) {
+    if (windowRepDef_.decodedPageCount == numLeavesInPage_.size()) {
+      numLeavesInPage_.push_back(windowRepDef_.currentPageLeafCount);
     } else {
-      BOLT_CHECK_LT(windowDecodedPageCount_, numLeavesInPage_.size());
+      BOLT_CHECK_LT(windowRepDef_.decodedPageCount, numLeavesInPage_.size());
       BOLT_DCHECK_EQ(
-          numLeavesInPage_[windowDecodedPageCount_],
-          windowCurrentPageLeafCount_);
+          numLeavesInPage_[windowRepDef_.decodedPageCount],
+          windowRepDef_.currentPageLeafCount);
     }
-    ++windowDecodedPageCount_;
-    windowCurrentPageLeafCount_ = 0;
-    windowRepDefPageData_.clear();
+    ++windowRepDef_.decodedPageCount;
+    windowRepDef_.currentPageLeafCount = 0;
+    windowRepDef_.pageData.clear();
   }
 }
 
 void PageReader::ensureNumLeavesInPage(int32_t targetPageIndex) {
-  if (windowRepDefMode_) {
+  if (windowRepDef_.enabled) {
     if (targetPageIndex < static_cast<int32_t>(numLeavesInPage_.size())) {
       return;
     }
 
     auto nextPageToCount = static_cast<int32_t>(numLeavesInPage_.size());
-    if (!windowRepDefPageData_.empty() &&
-        windowDecodedPageCount_ == nextPageToCount) {
+    if (!windowRepDef_.pageData.empty() &&
+        windowRepDef_.decodedPageCount == nextPageToCount) {
       numLeavesInPage_.push_back(
-          countLeavesInRepDefPage(windowRepDefPageData_));
+          countLeavesInRepDefPage(windowRepDef_.pageData));
       nextPageToCount = static_cast<int32_t>(numLeavesInPage_.size());
       if (targetPageIndex < static_cast<int32_t>(numLeavesInPage_.size())) {
         return;
       }
     }
 
-    const auto firstPreloadedPageIndex =
-        windowDecodedPageCount_ + (windowRepDefPageData_.empty() ? 0 : 1);
+    const auto firstPreloadedPageIndex = windowRepDef_.decodedPageCount +
+        (windowRepDef_.pageData.empty() ? 0 : 1);
     auto pagesToSkip = nextPageToCount - firstPreloadedPageIndex;
     BOLT_CHECK_GE(pagesToSkip, 0);
     for (const auto& repDefData : preloadedRepDefs_) {
@@ -1240,34 +1236,34 @@ void PageReader::ensureNumLeavesInPage(int32_t targetPageIndex) {
 }
 
 bool PageReader::loadNextWindowRepDefPage() {
-  if (windowRepDefsRemaining_ > 0) {
+  if (windowRepDef_.repDefsRemaining > 0) {
     return true;
   }
 
   finishCurrentWindowRepDefPage();
-  windowRepeatDecoder_.reset();
-  windowDefineDecoder_.reset();
+  windowRepDef_.repeatDecoder.reset();
+  windowRepDef_.defineDecoder.reset();
   while (!preloadedRepDefs_.empty()) {
-    windowRepDefPageData_ = std::move(preloadedRepDefs_.front());
+    windowRepDef_.pageData = std::move(preloadedRepDefs_.front());
     preloadedRepDefs_.pop_front();
-    if (windowRepDefPageData_.empty()) {
+    if (windowRepDef_.pageData.empty()) {
       continue;
     }
 
-    const char* rawData = windowRepDefPageData_.data();
+    const char* rawData = windowRepDef_.pageData.data();
     const char* pageEnd =
-        windowRepDefPageData_.data() + windowRepDefPageData_.size();
-    windowRepDefsRemaining_ = readField<int32_t>(rawData);
-    if (windowRepDefsRemaining_ <= 0) {
+        windowRepDef_.pageData.data() + windowRepDef_.pageData.size();
+    windowRepDef_.repDefsRemaining = readField<int32_t>(rawData);
+    if (windowRepDef_.repDefsRemaining <= 0) {
       finishCurrentWindowRepDefPage();
       continue;
     }
-    windowCurrentPageLeafCount_ = 0;
+    windowRepDef_.currentPageLeafCount = 0;
 
     const auto repeatLength = readField<int32_t>(rawData);
     BOLT_CHECK_GE(repeatLength, 0);
     BOLT_CHECK_LE(rawData + repeatLength, pageEnd);
-    windowRepeatDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
+    windowRepDef_.repeatDecoder = std::make_unique<::arrow::util::RleDecoder>(
         reinterpret_cast<const uint8_t*>(rawData),
         repeatLength,
         ::arrow::bit_util::NumRequiredBits(maxRepeat_));
@@ -1275,7 +1271,7 @@ bool PageReader::loadNextWindowRepDefPage() {
 
     const auto defineLength = readField<uint32_t>(rawData);
     BOLT_CHECK_LE(rawData + defineLength, pageEnd);
-    windowDefineDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
+    windowRepDef_.defineDecoder = std::make_unique<::arrow::util::RleDecoder>(
         reinterpret_cast<const uint8_t*>(rawData),
         defineLength,
         ::arrow::bit_util::NumRequiredBits(maxDefine_));
@@ -1293,18 +1289,19 @@ void PageReader::loadWindowRepDefs(int32_t targetTopLevelRows) {
   constexpr int32_t kMaxRepDefDecodeBatch = 64 * 1024;
   compactConsumedLeafNulls();
   compactWindowTopLevelOffsets(repDefBegin_);
-  auto topLevelRows = static_cast<int32_t>(windowTopLevelOffsets_.size());
+  auto topLevelRows =
+      static_cast<int32_t>(windowRepDef_.topLevelOffsets.size());
   int32_t decodeBatchCount = 0;
   while (topLevelRows < targetTopLevelRows && loadNextWindowRepDefPage()) {
     const auto batchSize =
-        std::min(windowRepDefsRemaining_, kMaxRepDefDecodeBatch);
+        std::min(windowRepDef_.repDefsRemaining, kMaxRepDefDecodeBatch);
     if (batchSize <= 0) {
       continue;
     }
     const auto topLevelCountBefore =
-        static_cast<int32_t>(windowTopLevelOffsets_.size());
+        static_cast<int32_t>(windowRepDef_.topLevelOffsets.size());
     decodeWindowRepDefsBatch(batchSize);
-    topLevelRows += static_cast<int32_t>(windowTopLevelOffsets_.size()) -
+    topLevelRows += static_cast<int32_t>(windowRepDef_.topLevelOffsets.size()) -
         topLevelCountBefore;
     ++decodeBatchCount;
   }
@@ -1361,11 +1358,11 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
       const auto findStartNs = getCurrentTimeNano();
       compactWindowTopLevelOffsets(repDefBegin_);
       topFound = std::min<int32_t>(
-          numTopLevelRows + 1,
-          static_cast<int32_t>(windowTopLevelOffsets_.size()));
-      if (topFound == numTopLevelRows + 1) {
-        repDefEnd_ =
-            windowTopLevelOffsets_[numTopLevelRows] - windowTopLevelOffsetBase_;
+          requiredTopLevelRows,
+          static_cast<int32_t>(windowRepDef_.topLevelOffsets.size()));
+      if (topFound == requiredTopLevelRows) {
+        repDefEnd_ = windowRepDef_.topLevelOffsets[numTopLevelRows] -
+            windowRepDef_.topLevelOffsetBase;
       } else {
         repDefEnd_ = numLevels;
       }
@@ -1394,8 +1391,9 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
       const auto findStartNs = getCurrentTimeNano();
       findTopLevelLevels += foundTopLevel();
       findTopLevelTimeNs += getCurrentTimeNano() - findStartNs;
-      while (repDefEnd_ == numLevels && topFound < numTopLevelRows + 1 &&
-             (!preloadedRepDefs_.empty() || windowRepDefsRemaining_ > 0)) {
+      while (
+          repDefEnd_ == numLevels && topFound < numTopLevelRows + 1 &&
+          (!preloadedRepDefs_.empty() || windowRepDef_.repDefsRemaining > 0)) {
         const auto loadMoreStartNs = getCurrentTimeNano();
         loadMoreRepDefs();
         ++loadMoreCount;
@@ -1485,67 +1483,7 @@ void PageReader::loadMoreRepDefs() {
 void PageReader::decodeRepDefsFromBuffer() {
   const auto& repDefData = preloadedRepDefs_.front();
   const auto* rawData = repDefData.data();
-  constexpr int32_t WordBits = 64;
-  int64_t erasedBits = erasedLeafNullWords_ * WordBits;
-  BOLT_CHECK_LE(numLeafNullsConsumed_, leafNullsSize_ + erasedBits);
-  // clear consumed nulls
-  if (numLeafNullsConsumed_ - erasedBits > WordBits) {
-    auto consumedWords = bits::nwords(numLeafNullsConsumed_ - erasedBits) - 1;
-    auto totalNullWords = bits::nwords(leafNullsSize_);
-    auto unConsumedNullWords = totalNullWords - consumedWords;
-    if (unConsumedNullWords > 0) {
-      uint64_t* rawData = leafNulls_.data();
-      size_t copyBytes = unConsumedNullWords * sizeof(uint64_t);
-
-      /*
-       * Intel FSRM Bug Detection Macro
-       *
-       * Background:
-       * Intel CPUs with FSRM (Fast Short REP MOVSB) feature have a hardware bug
-       * that causes memory corruption when source and destination pointers in
-       * memcpy/memmove have specific offset ranges: (0,63] or (4GB, 4GB+63].
-       *
-       * Affected: Ice Lake 8336C, Sapphire Rapids (SPR), and all FSRM-enabled
-       * CPUs Fixed in: glibc 2.33+
-       * see
-       * https://lore.kernel.org/all/20211101044955.2295495-1-goldstein.w.n@gmail.com/
-       */
-#if (defined(__x86_64__) || defined(__i386__)) && defined(__GLIBC__) && \
-    (__GLIBC__ * 100 + __GLIBC_MINOR__ < 233)
-
-      // Suppress false positive -Wrestrict warnings from GCC 12+
-      // The memcpy calls below are intentionally designed to avoid overlap
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wrestrict"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-warning-option"
-#pragma clang diagnostic ignored "-Wrestrict"
-#endif
-      if (unConsumedNullWords < consumedWords) {
-        memcpy(rawData, rawData + consumedWords, copyBytes);
-      } else {
-        raw_vector<uint64_t> tmpBuffer;
-        tmpBuffer.resize(unConsumedNullWords);
-        uint64_t* tmpDest = tmpBuffer.data();
-        memcpy(tmpDest, rawData + consumedWords, copyBytes);
-        memcpy(rawData, tmpDest, copyBytes);
-      }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-#else
-      memmove(rawData, rawData + consumedWords, copyBytes);
-#endif
-      leafNulls_.resize(unConsumedNullWords);
-      leafNullsSize_ -= consumedWords * WordBits;
-      erasedLeafNullWords_ += consumedWords;
-      BOLT_CHECK_EQ(leafNulls_.size(), bits::nwords(leafNullsSize_));
-    }
-  }
+  compactConsumedLeafNulls();
 
   while (rawData < repDefData.data() + repDefData.size()) {
     auto begin = definitionLevels_.size();
@@ -1584,7 +1522,7 @@ void PageReader::decodeRepDefsFromBuffer() {
     numLeavesInPage_.push_back(numLeaves);
   }
   preloadedRepDefs_.pop_front();
-  windowRepDefMode_ = false;
+  windowRepDef_.reset();
 }
 
 int32_t PageReader::getLengthsAndNulls(

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -103,7 +103,14 @@ void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
       numRowsInPage_ = 0;
       break;
     }
-    if (row != kRepDefOnly && hasChunkRepDefs_ && !isTopLevel_ &&
+    if (row != kRepDefOnly && windowRepDefMode_ && hasChunkRepDefs_ &&
+        !isTopLevel_ && maxRepeat_ > 0) {
+      while (pageIndex_ + 1 >= static_cast<int32_t>(numLeavesInPage_.size()) &&
+             (!preloadedRepDefs_.empty() || windowRepDefsRemaining_ > 0)) {
+        ensureNumLeavesInPage(pageIndex_ + 1);
+      }
+    } else if (
+        row != kRepDefOnly && hasChunkRepDefs_ && !isTopLevel_ &&
         maxRepeat_ > 0) {
       // In non-window mode we still need the existing sampled-preload guard
       // to materialize leaf counts before crossing the sampling boundary.
@@ -845,8 +852,13 @@ void PageReader::preloadPageRepDefs(const bool keepRepDefRawData) {
 void PageReader::preloadRepDefs() {
   const auto startNs = getCurrentTimeNano();
   hasChunkRepDefs_ = true;
+  windowRepDefMode_ = false;
+  windowTopLevelOffsets_.clear();
   windowRepDefPageData_.clear();
   windowRepDefsRemaining_ = 0;
+  windowCurrentPageLeafCount_ = 0;
+  windowDecodedPageCount_ = 0;
+  windowTopLevelOffsetBase_ = 0;
   bool startWithDictinoaryPage = cryptoCtx_.startDecryptWithDictionaryPage;
   if (maxRepeat_ > 0 && maxDefine_ > 0) {
     const int32_t samplePages = decodeRepDefPageCount_;
@@ -866,12 +878,12 @@ void PageReader::preloadRepDefs() {
       auto avgRefDefBytes = totalRefDefBytes_ / samplePages + 1;
       auto avgPageLen = pageStart_ / samplePages + 1;
       VLOG(1) << __FUNCTION__ << "[" << this
-                << "] : def/rep levels = " << definitionLevels_.size()
-                << ", avgPageLen = " << avgPageLen
-                << ", chunkSize = " << chunkSize_
-                << ", pagesCntPerBatch = " << pageCntPerBatch
-                << ", samplePages = " << samplePages << ", repDefMemoryLimit_ "
-                << repDefMemoryLimit_;
+              << "] : def/rep levels = " << definitionLevels_.size()
+              << ", avgPageLen = " << avgPageLen
+              << ", chunkSize = " << chunkSize_
+              << ", pagesCntPerBatch = " << pageCntPerBatch
+              << ", samplePages = " << samplePages << ", repDefMemoryLimit_ "
+              << repDefMemoryLimit_;
       pageCnt = 0;
       do {
         while (pageStart_ < chunkSize_ && ++pageCnt <= pageCntPerBatch) {
@@ -914,6 +926,7 @@ void PageReader::preloadRepDefs() {
 void PageReader::preloadRepDefsRawOnly() {
   const auto startNs = getCurrentTimeNano();
   hasChunkRepDefs_ = true;
+  windowRepDefMode_ = true;
   const bool startWithDictionaryPage =
       cryptoCtx_.startDecryptWithDictionaryPage;
   totalRefDefBytes_ = 0;
@@ -921,16 +934,17 @@ void PageReader::preloadRepDefsRawOnly() {
   windowRepeatDecoder_.reset();
   windowDefineDecoder_.reset();
   windowRepDefsRemaining_ = 0;
+  windowCurrentPageLeafCount_ = 0;
+  windowDecodedPageCount_ = 0;
   windowRepDefPageData_.clear();
+  windowTopLevelOffsets_.clear();
+  windowTopLevelOffsetBase_ = 0;
 
   while (pageStart_ < chunkSize_) {
     preloadedRepDefs_.emplace_back(raw_vector<char>(&pool_));
     preloadPageRepDefs(true);
     if (preloadedRepDefs_.back().empty()) {
       preloadedRepDefs_.pop_back();
-    } else {
-      numLeavesInPage_.push_back(
-          countLeavesInRepDefPage(preloadedRepDefs_.back()));
     }
   }
 
@@ -947,8 +961,7 @@ void PageReader::preloadRepDefsRawOnly() {
   cryptoCtx_.startDecryptWithDictionaryPage = startWithDictionaryPage;
   addPageReaderStat("pageReaderPreloadRepDefsRawOnlyCount", 1);
   addPageReaderNanos(
-      "pageReaderPreloadRepDefsRawOnlyTimeNs",
-      getCurrentTimeNano() - startNs);
+      "pageReaderPreloadRepDefsRawOnlyTimeNs", getCurrentTimeNano() - startNs);
 }
 
 int32_t PageReader::countLeavesInRepDefPage(
@@ -971,32 +984,52 @@ int32_t PageReader::countLeavesInRepDefPage(
 
   const auto defineLength = readField<uint32_t>(rawData);
   BOLT_CHECK_LE(rawData + defineLength, pageEnd);
-  auto defineDecoder = ::arrow::util::RleDecoder(
-      reinterpret_cast<const uint8_t*>(rawData),
-      defineLength,
-      ::arrow::bit_util::NumRequiredBits(maxDefine_));
+  if (leafInfo_.rep_level == 0) {
+    return numRepDefsInPage;
+  }
 
-  constexpr int32_t kMaxRepDefDecodeBatch = 64 * 1024;
-  raw_vector<int16_t> definitionScratch(&pool_);
-  raw_vector<uint64_t> nullScratch(&pool_);
-  definitionScratch.resize(std::min(numRepDefsInPage, kMaxRepDefDecodeBatch));
-
-  int32_t decoded = 0;
+  auto bitReader = ::arrow::bit_util::BitReader(
+      reinterpret_cast<const uint8_t*>(rawData), defineLength);
+  const auto bitWidth = ::arrow::bit_util::NumRequiredBits(maxDefine_);
+  const auto presentLevel = leafInfo_.repeated_ancestor_def_level;
+  auto remaining = numRepDefsInPage;
   int32_t numLeaves = 0;
-  while (decoded < numRepDefsInPage) {
-    const auto batchSize =
-        std::min(numRepDefsInPage - decoded, kMaxRepDefDecodeBatch);
-    defineDecoder.GetBatch(definitionScratch.data(), batchSize);
-    nullScratch.resize(bits::nwords(batchSize));
-    arrow::ValidityBitmapInputOutput bits;
-    bits.values_read_upper_bound = batchSize;
-    bits.values_read = 0;
-    bits.null_count = 0;
-    bits.valid_bits = reinterpret_cast<uint8_t*>(nullScratch.data());
-    bits.valid_bits_offset = 0;
-    DefLevelsToBitmap(definitionScratch.data(), batchSize, leafInfo_, &bits);
-    numLeaves += bits.values_read;
-    decoded += batchSize;
+
+  while (remaining > 0) {
+    uint32_t indicator = 0;
+    BOLT_CHECK(bitReader.GetVlqInt(&indicator), "Invalid definition RLE run");
+    const bool isLiteral = indicator & 1;
+    const uint32_t count = indicator >> 1;
+
+    if (isLiteral) {
+      BOLT_CHECK_GT(count, 0);
+      BOLT_CHECK_LE(count, static_cast<uint32_t>(INT32_MAX) / 8);
+      const auto literalCount =
+          std::min<int32_t>(remaining, static_cast<int32_t>(count * 8));
+      for (auto i = 0; i < literalCount; ++i) {
+        uint64_t value = 0;
+        BOLT_CHECK(
+            bitReader.GetValue(bitWidth, &value),
+            "Invalid definition literal run");
+        numLeaves += value >= presentLevel ? 1 : 0;
+      }
+      remaining -= literalCount;
+    } else {
+      BOLT_CHECK_GT(count, 0);
+      BOLT_CHECK_LE(count, static_cast<uint32_t>(INT32_MAX));
+      uint64_t value = 0;
+      BOLT_CHECK(
+          bitReader.GetAligned(
+              static_cast<int>(::arrow::bit_util::CeilDiv(bitWidth, 8)),
+              &value),
+          "Invalid definition repeated run");
+      const auto repeatCount =
+          std::min<int32_t>(remaining, static_cast<int32_t>(count));
+      if (value >= presentLevel) {
+        numLeaves += repeatCount;
+      }
+      remaining -= repeatCount;
+    }
   }
   return numLeaves;
 }
@@ -1072,8 +1105,138 @@ void PageReader::compactWindowRepDefs() {
   }
   definitionLevels_.resize(keptLevels);
   repetitionLevels_.resize(keptLevels);
+  compactWindowTopLevelOffsets(repDefEnd_);
   repDefBegin_ = 0;
   repDefEnd_ = 0;
+}
+
+void PageReader::compactWindowTopLevelOffsets(int32_t consumedLevels) {
+  if (consumedLevels == 0 || windowTopLevelOffsets_.empty()) {
+    return;
+  }
+
+  windowTopLevelOffsetBase_ += consumedLevels;
+  auto firstKept = std::lower_bound(
+      windowTopLevelOffsets_.begin(),
+      windowTopLevelOffsets_.end(),
+      windowTopLevelOffsetBase_);
+  const auto kept = windowTopLevelOffsets_.end() - firstKept;
+  if (kept > 0 && firstKept != windowTopLevelOffsets_.begin()) {
+    memmove(
+        windowTopLevelOffsets_.data(),
+        &*firstKept,
+        kept * sizeof(windowTopLevelOffsets_[0]));
+  }
+  windowTopLevelOffsets_.resize(kept);
+}
+
+int32_t PageReader::appendWindowTopLevelOffsets(int32_t begin, int32_t end) {
+  if (maxRepeat_ == 0) {
+    return std::max(end - begin, 0);
+  }
+
+  int32_t added = 0;
+  for (int32_t i = begin; i < end; ++i) {
+    if (repetitionLevels_[i] == 0) {
+      windowTopLevelOffsets_.push_back(windowTopLevelOffsetBase_ + i);
+      ++added;
+    }
+  }
+  return added;
+}
+
+int32_t PageReader::decodeWindowRepDefsBatch(int32_t batchSize) {
+  if (batchSize <= 0) {
+    return 0;
+  }
+
+  const auto begin = static_cast<int32_t>(definitionLevels_.size());
+  const auto end = begin + batchSize;
+  repetitionLevels_.resize(end);
+  BOLT_CHECK_NOT_NULL(
+      windowRepeatDecoder_, "Missing incremental repetition decoder");
+  windowRepeatDecoder_->GetBatch(repetitionLevels_.data() + begin, batchSize);
+
+  definitionLevels_.resize(end);
+  BOLT_CHECK_NOT_NULL(
+      windowDefineDecoder_, "Missing incremental definition decoder");
+  windowDefineDecoder_->GetBatch(definitionLevels_.data() + begin, batchSize);
+
+  windowRepDefsRemaining_ -= batchSize;
+  leafNulls_.resize(bits::nwords(leafNullsSize_ + batchSize));
+  const auto numLeaves = getLengthsAndNulls(
+      LevelMode::kNulls,
+      leafInfo_,
+      begin,
+      end,
+      batchSize,
+      nullptr,
+      leafNulls_.data(),
+      leafNullsSize_);
+  leafNullsSize_ += numLeaves;
+  windowCurrentPageLeafCount_ += numLeaves;
+  appendWindowTopLevelOffsets(begin, end);
+  finishCurrentWindowRepDefPage();
+  return numLeaves;
+}
+
+void PageReader::finishCurrentWindowRepDefPage() {
+  if (windowRepDefsRemaining_ == 0 && !windowRepDefPageData_.empty()) {
+    if (windowDecodedPageCount_ == numLeavesInPage_.size()) {
+      numLeavesInPage_.push_back(windowCurrentPageLeafCount_);
+    } else {
+      BOLT_CHECK_LT(windowDecodedPageCount_, numLeavesInPage_.size());
+      BOLT_DCHECK_EQ(
+          numLeavesInPage_[windowDecodedPageCount_],
+          windowCurrentPageLeafCount_);
+    }
+    ++windowDecodedPageCount_;
+    windowCurrentPageLeafCount_ = 0;
+    windowRepDefPageData_.clear();
+  }
+}
+
+void PageReader::ensureNumLeavesInPage(int32_t targetPageIndex) {
+  if (windowRepDefMode_) {
+    if (targetPageIndex < static_cast<int32_t>(numLeavesInPage_.size())) {
+      return;
+    }
+
+    auto nextPageToCount = static_cast<int32_t>(numLeavesInPage_.size());
+    if (!windowRepDefPageData_.empty() &&
+        windowDecodedPageCount_ == nextPageToCount) {
+      numLeavesInPage_.push_back(
+          countLeavesInRepDefPage(windowRepDefPageData_));
+      nextPageToCount = static_cast<int32_t>(numLeavesInPage_.size());
+      if (targetPageIndex < static_cast<int32_t>(numLeavesInPage_.size())) {
+        return;
+      }
+    }
+
+    const auto firstPreloadedPageIndex =
+        windowDecodedPageCount_ + (windowRepDefPageData_.empty() ? 0 : 1);
+    auto pagesToSkip = nextPageToCount - firstPreloadedPageIndex;
+    BOLT_CHECK_GE(pagesToSkip, 0);
+    for (const auto& repDefData : preloadedRepDefs_) {
+      if (repDefData.empty()) {
+        continue;
+      }
+      if (pagesToSkip > 0) {
+        --pagesToSkip;
+        continue;
+      }
+      numLeavesInPage_.push_back(countLeavesInRepDefPage(repDefData));
+      if (targetPageIndex < static_cast<int32_t>(numLeavesInPage_.size())) {
+        break;
+      }
+    }
+    return;
+  }
+
+  while (targetPageIndex >= static_cast<int32_t>(numLeavesInPage_.size()) &&
+         !preloadedRepDefs_.empty()) {
+    loadMoreRepDefs();
+  }
 }
 
 bool PageReader::loadNextWindowRepDefPage() {
@@ -1081,6 +1244,7 @@ bool PageReader::loadNextWindowRepDefPage() {
     return true;
   }
 
+  finishCurrentWindowRepDefPage();
   windowRepeatDecoder_.reset();
   windowDefineDecoder_.reset();
   while (!preloadedRepDefs_.empty()) {
@@ -1095,8 +1259,10 @@ bool PageReader::loadNextWindowRepDefPage() {
         windowRepDefPageData_.data() + windowRepDefPageData_.size();
     windowRepDefsRemaining_ = readField<int32_t>(rawData);
     if (windowRepDefsRemaining_ <= 0) {
+      finishCurrentWindowRepDefPage();
       continue;
     }
+    windowCurrentPageLeafCount_ = 0;
 
     const auto repeatLength = readField<int32_t>(rawData);
     BOLT_CHECK_GE(repeatLength, 0);
@@ -1118,17 +1284,6 @@ bool PageReader::loadNextWindowRepDefPage() {
   return false;
 }
 
-int32_t PageReader::countTopLevelRepDefs(int32_t begin, int32_t end) const {
-  if (maxRepeat_ == 0) {
-    return std::max<int32_t>(end - begin, 0);
-  }
-  int32_t topLevelRows = 0;
-  for (int32_t i = begin; i < end; ++i) {
-    topLevelRows += repetitionLevels_[i] == 0 ? 1 : 0;
-  }
-  return topLevelRows;
-}
-
 void PageReader::loadWindowRepDefs(int32_t targetTopLevelRows) {
   const auto startNs = getCurrentTimeNano();
   if (targetTopLevelRows <= 0) {
@@ -1137,8 +1292,8 @@ void PageReader::loadWindowRepDefs(int32_t targetTopLevelRows) {
 
   constexpr int32_t kMaxRepDefDecodeBatch = 64 * 1024;
   compactConsumedLeafNulls();
-  auto topLevelRows =
-      countTopLevelRepDefs(repDefBegin_, definitionLevels_.size());
+  compactWindowTopLevelOffsets(repDefBegin_);
+  auto topLevelRows = static_cast<int32_t>(windowTopLevelOffsets_.size());
   int32_t decodeBatchCount = 0;
   while (topLevelRows < targetTopLevelRows && loadNextWindowRepDefPage()) {
     const auto batchSize =
@@ -1146,40 +1301,17 @@ void PageReader::loadWindowRepDefs(int32_t targetTopLevelRows) {
     if (batchSize <= 0) {
       continue;
     }
-
-    const auto begin = static_cast<int32_t>(definitionLevels_.size());
-    const auto end = begin + batchSize;
-    repetitionLevels_.resize(end);
-    BOLT_CHECK_NOT_NULL(
-        windowRepeatDecoder_, "Missing incremental repetition decoder");
-    windowRepeatDecoder_->GetBatch(repetitionLevels_.data() + begin, batchSize);
-
-    definitionLevels_.resize(end);
-    BOLT_CHECK_NOT_NULL(
-        windowDefineDecoder_, "Missing incremental definition decoder");
-    windowDefineDecoder_->GetBatch(definitionLevels_.data() + begin, batchSize);
-
-    windowRepDefsRemaining_ -= batchSize;
-    leafNulls_.resize(bits::nwords(leafNullsSize_ + batchSize));
-    const auto numLeaves = getLengthsAndNulls(
-        LevelMode::kNulls,
-        leafInfo_,
-        begin,
-        end,
-        batchSize,
-        nullptr,
-        leafNulls_.data(),
-        leafNullsSize_);
-    leafNullsSize_ += numLeaves;
-    topLevelRows += countTopLevelRepDefs(begin, end);
+    const auto topLevelCountBefore =
+        static_cast<int32_t>(windowTopLevelOffsets_.size());
+    decodeWindowRepDefsBatch(batchSize);
+    topLevelRows += static_cast<int32_t>(windowTopLevelOffsets_.size()) -
+        topLevelCountBefore;
     ++decodeBatchCount;
   }
   addPageReaderStat("pageReaderLoadWindowRepDefsCount", 1);
-  addPageReaderStat(
-      "pageReaderLoadWindowRepDefsBatches", decodeBatchCount);
+  addPageReaderStat("pageReaderLoadWindowRepDefsBatches", decodeBatchCount);
   addPageReaderNanos(
-      "pageReaderLoadWindowRepDefsTimeNs",
-      getCurrentTimeNano() - startNs);
+      "pageReaderLoadWindowRepDefsTimeNs", getCurrentTimeNano() - startNs);
 }
 
 void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
@@ -1222,51 +1354,62 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
   }
   int32_t numLevels = definitionLevels_.size();
   int32_t topFound = 0;
-  int32_t i = repDefBegin_;
   int32_t loadMoreCount = 0;
 
-  auto foundTopLevel = [&]() {
-    const auto scanBegin = i;
-    for (; i < numLevels; ++i) {
-      if (repetitionLevels_[i] == 0) {
-        ++topFound;
-        if (topFound == numTopLevelRows + 1) {
-          break;
+  if (maxRepeat_ > 0) {
+    if (windowPreload) {
+      const auto findStartNs = getCurrentTimeNano();
+      compactWindowTopLevelOffsets(repDefBegin_);
+      topFound = std::min<int32_t>(
+          numTopLevelRows + 1,
+          static_cast<int32_t>(windowTopLevelOffsets_.size()));
+      if (topFound == numTopLevelRows + 1) {
+        repDefEnd_ =
+            windowTopLevelOffsets_[numTopLevelRows] - windowTopLevelOffsetBase_;
+      } else {
+        repDefEnd_ = numLevels;
+      }
+      findTopLevelLevels =
+          repDefEnd_ > repDefBegin_ ? repDefEnd_ - repDefBegin_ : 0;
+      findTopLevelTimeNs += getCurrentTimeNano() - findStartNs;
+    } else {
+      int32_t i = repDefBegin_;
+      auto foundTopLevel = [&]() {
+        const auto scanBegin = i;
+        for (; i < numLevels; ++i) {
+          if (repetitionLevels_[i] == 0) {
+            ++topFound;
+            if (topFound == numTopLevelRows + 1) {
+              break;
+            }
+          }
         }
+        auto scannedLevels = i - scanBegin;
+        if (i < numLevels && topFound == numTopLevelRows + 1) {
+          ++scannedLevels;
+        }
+        repDefEnd_ = i;
+        return scannedLevels;
+      };
+      const auto findStartNs = getCurrentTimeNano();
+      findTopLevelLevels += foundTopLevel();
+      findTopLevelTimeNs += getCurrentTimeNano() - findStartNs;
+      while (repDefEnd_ == numLevels && topFound < numTopLevelRows + 1 &&
+             (!preloadedRepDefs_.empty() || windowRepDefsRemaining_ > 0)) {
+        const auto loadMoreStartNs = getCurrentTimeNano();
+        loadMoreRepDefs();
+        ++loadMoreCount;
+        numLevels = definitionLevels_.size();
+        i = repDefEnd_;
+        findTopLevelLevels += foundTopLevel();
+        loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
+        BOLT_CHECK(topFound == numTopLevelRows + 1 || repDefEnd_ == numLevels);
       }
     }
-    auto scannedLevels = i - scanBegin;
-    if (i < numLevels && topFound == numTopLevelRows + 1) {
-      ++scannedLevels;
-    }
-    repDefEnd_ = i;
-    return scannedLevels;
-  };
-
-  if (maxRepeat_ > 0) {
-    const auto findStartNs = getCurrentTimeNano();
-    findTopLevelLevels += foundTopLevel();
-    findTopLevelTimeNs += getCurrentTimeNano() - findStartNs;
   } else {
-    repDefEnd_ = i + numTopLevelRows;
+    repDefEnd_ = repDefBegin_ + numTopLevelRows;
   }
   if (maxRepeat_ > 0 && maxDefine_ > 0) {
-    // definitionLevels_ has been consumed, decode more if any
-    while (repDefEnd_ == numLevels && topFound < numTopLevelRows + 1 &&
-           (!preloadedRepDefs_.empty() || windowRepDefsRemaining_ > 0)) {
-      const auto loadMoreStartNs = getCurrentTimeNano();
-      if (windowPreload) {
-        loadWindowRepDefs(targetTopLevelRows);
-      } else {
-        loadMoreRepDefs();
-      }
-      ++loadMoreCount;
-      numLevels = definitionLevels_.size();
-      i = repDefEnd_;
-      findTopLevelLevels += foundTopLevel();
-      loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
-      BOLT_CHECK(topFound == numTopLevelRows + 1 || repDefEnd_ == numLevels);
-    }
     // after topFound done, left decoded rep/def is less than 1 page, decode
     // more
     if (!windowPreload && !numLeavesInPage_.empty() &&
@@ -1441,6 +1584,7 @@ void PageReader::decodeRepDefsFromBuffer() {
     numLeavesInPage_.push_back(numLeaves);
   }
   preloadedRepDefs_.pop_front();
+  windowRepDefMode_ = false;
 }
 
 int32_t PageReader::getLengthsAndNulls(

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -58,6 +58,8 @@ using thrift::PageHeader;
 
 namespace {
 
+constexpr uint64_t kMinRepDefPreloadRows = 512;
+
 uint64_t configuredRepDefPreloadWindowCount() {
   const char* configured =
       std::getenv("BOLT_PARQUET_REPDEF_PRELOAD_WINDOW_COUNT");
@@ -1322,9 +1324,6 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
       : configuredRepDefPreloadWindowCount();
   const bool windowPreload =
       preloadWindowCount > 0 && maxRepeat_ > 0 && maxDefine_ > 0;
-  if (windowPreload) {
-    compactWindowRepDefs();
-  }
   if (!hasChunkRepDefs_ && maxDefine_ > 0) {
     const auto preloadStartNs = getCurrentTimeNano();
     if (windowPreload) {
@@ -1336,18 +1335,36 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
   }
   repDefBegin_ = repDefEnd_;
   const auto requiredTopLevelRows = numTopLevelRows + 1;
-  const auto targetTopLevelRows = windowPreload
-      ? std::max<int32_t>(
-            requiredTopLevelRows,
-            static_cast<int32_t>(std::min<uint64_t>(
-                static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
-                static_cast<uint64_t>(numTopLevelRows) * preloadWindowCount +
-                    1)))
-      : requiredTopLevelRows;
+  const auto maxTargetTopLevelRows =
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
+  uint64_t targetTopLevelRows64 = requiredTopLevelRows;
   if (windowPreload) {
-    const auto loadMoreStartNs = getCurrentTimeNano();
-    loadWindowRepDefs(targetTopLevelRows);
-    loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
+    const auto requestedTopLevelRows = static_cast<uint64_t>(numTopLevelRows) >
+            (maxTargetTopLevelRows - 1) / preloadWindowCount
+        ? maxTargetTopLevelRows
+        : static_cast<uint64_t>(numTopLevelRows) * preloadWindowCount + 1;
+    targetTopLevelRows64 = std::max<uint64_t>(
+        std::max<uint64_t>(
+            static_cast<uint64_t>(requiredTopLevelRows), requestedTopLevelRows),
+        kMinRepDefPreloadRows + 1);
+  }
+  const auto targetTopLevelRows = static_cast<int32_t>(
+      std::min<uint64_t>(maxTargetTopLevelRows, targetTopLevelRows64));
+  if (windowPreload) {
+    const auto firstNeededTopLevelOffset =
+        windowRepDef_.topLevelOffsetBase + repDefBegin_;
+    const auto firstCachedTopLevelOffset = std::lower_bound(
+        windowRepDef_.topLevelOffsets.begin(),
+        windowRepDef_.topLevelOffsets.end(),
+        firstNeededTopLevelOffset);
+    const auto cachedTopLevelRows =
+        windowRepDef_.topLevelOffsets.end() - firstCachedTopLevelOffset;
+    if (cachedTopLevelRows < requiredTopLevelRows) {
+      const auto loadMoreStartNs = getCurrentTimeNano();
+      compactWindowRepDefs();
+      loadWindowRepDefs(targetTopLevelRows);
+      loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
+    }
   }
   int32_t numLevels = definitionLevels_.size();
   int32_t topFound = 0;
@@ -1356,12 +1373,17 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
   if (maxRepeat_ > 0) {
     if (windowPreload) {
       const auto findStartNs = getCurrentTimeNano();
-      compactWindowTopLevelOffsets(repDefBegin_);
-      topFound = std::min<int32_t>(
-          requiredTopLevelRows,
-          static_cast<int32_t>(windowRepDef_.topLevelOffsets.size()));
+      const auto firstNeededTopLevelOffset =
+          windowRepDef_.topLevelOffsetBase + repDefBegin_;
+      const auto firstCachedTopLevelOffset = std::lower_bound(
+          windowRepDef_.topLevelOffsets.begin(),
+          windowRepDef_.topLevelOffsets.end(),
+          firstNeededTopLevelOffset);
+      const auto cachedTopLevelRows = static_cast<int32_t>(
+          windowRepDef_.topLevelOffsets.end() - firstCachedTopLevelOffset);
+      topFound = std::min<int32_t>(requiredTopLevelRows, cachedTopLevelRows);
       if (topFound == requiredTopLevelRows) {
-        repDefEnd_ = windowRepDef_.topLevelOffsets[numTopLevelRows] -
+        repDefEnd_ = firstCachedTopLevelOffset[numTopLevelRows] -
             windowRepDef_.topLevelOffsetBase;
       } else {
         repDefEnd_ = numLevels;

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -33,6 +33,13 @@
 #include <zstd.h>
 #include <zstd_errors.h>
 
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
+#include "bolt/common/base/RuntimeMetrics.h"
+#include "bolt/common/time/Timer.h"
 #include "bolt/dwio/common/BufferUtil.h"
 #include "bolt/dwio/common/ColumnVisitors.h"
 #include "bolt/dwio/parquet/reader/Decompression.h"
@@ -48,6 +55,34 @@ namespace bytedance::bolt::parquet {
 
 using thrift::Encoding;
 using thrift::PageHeader;
+
+namespace {
+
+uint64_t configuredRepDefPreloadWindowCount() {
+  const char* configured =
+      std::getenv("BOLT_PARQUET_REPDEF_PRELOAD_WINDOW_COUNT");
+  if (configured == nullptr || *configured == '\0') {
+    return 0;
+  }
+
+  char* end = nullptr;
+  const auto parsed = std::strtoull(configured, &end, 10);
+  if (end == configured) {
+    return 0;
+  }
+  return parsed;
+}
+
+void addPageReaderStat(const std::string& name, int64_t value) {
+  addThreadLocalRuntimeStat(name, RuntimeCounter(value));
+}
+
+void addPageReaderNanos(const std::string& name, uint64_t value) {
+  addThreadLocalRuntimeStat(
+      name, RuntimeCounter(value, RuntimeCounter::Unit::kNanos));
+}
+
+} // namespace
 
 void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
   defineDecoder_.reset();
@@ -68,21 +103,10 @@ void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
       numRowsInPage_ = 0;
       break;
     }
-    // For nested (non top level) columns, 'preloadRepDefs' only fully
-    // decodes the first 'decodeRepDefPageCount_' pages and keeps the
-    // remaining pages as raw rep/def bytes inside 'preloadedRepDefs_'.
-    // When a leaf-level filter pushdown triggers a skip()/seekToPage()
-    // that walks past the sampled boundary, the consumer side
-    // ('setPageRowInfo' inside 'prepareDataPageV1') indexes
-    // 'numLeavesInPage_[pageIndex_]' and would go out of bounds.
-    //
-    // Materialise just enough preloaded rep/def bytes BEFORE entering
-    // the next page so that 'setPageRowInfo' remains a pure lookup.
-    // The loop only fires when we are about to cross the sampled
-    // boundary and there is something left to decode, mirroring (and
-    // complementing) the "ahead by one page" invariant established at
-    // the exit of 'decodeRepDefs'.
-    if (hasChunkRepDefs_ && !isTopLevel_ && maxRepeat_ > 0) {
+    if (row != kRepDefOnly && hasChunkRepDefs_ && !isTopLevel_ &&
+        maxRepeat_ > 0) {
+      // In non-window mode we still need the existing sampled-preload guard
+      // to materialize leaf counts before crossing the sampling boundary.
       while (pageIndex_ + 1 >= static_cast<int32_t>(numLeavesInPage_.size()) &&
              !preloadedRepDefs_.empty()) {
         loadMoreRepDefs();
@@ -771,6 +795,7 @@ int32_t parquetTypeBytes(thrift::Type::type type) {
 } // namespace
 
 void PageReader::preloadPageRepDefs(const bool keepRepDefRawData) {
+  const auto startNs = getCurrentTimeNano();
   seekToPage(kRepDefOnly, keepRepDefRawData);
   if (!keepRepDefRawData) {
     BOLT_CHECK_GE(
@@ -807,11 +832,21 @@ void PageReader::preloadPageRepDefs(const bool keepRepDefRawData) {
     leafNullsSize_ += numLeaves;
     numLeavesInPage_.push_back(numLeaves);
   }
+  addPageReaderStat("pageReaderPreloadPageRepDefsCount", 1);
+  addPageReaderStat("pageReaderPreloadPageRepDefsLevels", numRepDefsInPage_);
+  if (keepRepDefRawData) {
+    addPageReaderStat("pageReaderPreloadPageRepDefsKeepRawCount", 1);
+  }
+  addPageReaderNanos(
+      "pageReaderPreloadPageRepDefsTimeNs", getCurrentTimeNano() - startNs);
   return;
 }
 
 void PageReader::preloadRepDefs() {
+  const auto startNs = getCurrentTimeNano();
   hasChunkRepDefs_ = true;
+  windowRepDefPageData_.clear();
+  windowRepDefsRemaining_ = 0;
   bool startWithDictinoaryPage = cryptoCtx_.startDecryptWithDictionaryPage;
   if (maxRepeat_ > 0 && maxDefine_ > 0) {
     const int32_t samplePages = decodeRepDefPageCount_;
@@ -830,7 +865,7 @@ void PageReader::preloadRepDefs() {
           1;
       auto avgRefDefBytes = totalRefDefBytes_ / samplePages + 1;
       auto avgPageLen = pageStart_ / samplePages + 1;
-      LOG(INFO) << __FUNCTION__ << "[" << this
+      VLOG(1) << __FUNCTION__ << "[" << this
                 << "] : def/rep levels = " << definitionLevels_.size()
                 << ", avgPageLen = " << avgPageLen
                 << ", chunkSize = " << chunkSize_
@@ -871,18 +906,327 @@ void PageReader::preloadRepDefs() {
   totalRefDefBytes_ = 0;
   pageOrdinal_ = 0;
   cryptoCtx_.startDecryptWithDictionaryPage = startWithDictinoaryPage;
+  addPageReaderStat("pageReaderPreloadRepDefsCount", 1);
+  addPageReaderNanos(
+      "pageReaderPreloadRepDefsTimeNs", getCurrentTimeNano() - startNs);
+}
+
+void PageReader::preloadRepDefsRawOnly() {
+  const auto startNs = getCurrentTimeNano();
+  hasChunkRepDefs_ = true;
+  const bool startWithDictionaryPage =
+      cryptoCtx_.startDecryptWithDictionaryPage;
+  totalRefDefBytes_ = 0;
+  numLeavesInPage_.clear();
+  windowRepeatDecoder_.reset();
+  windowDefineDecoder_.reset();
+  windowRepDefsRemaining_ = 0;
+  windowRepDefPageData_.clear();
+
+  while (pageStart_ < chunkSize_) {
+    preloadedRepDefs_.emplace_back(raw_vector<char>(&pool_));
+    preloadPageRepDefs(true);
+    if (preloadedRepDefs_.back().empty()) {
+      preloadedRepDefs_.pop_back();
+    } else {
+      numLeavesInPage_.push_back(
+          countLeavesInRepDefPage(preloadedRepDefs_.back()));
+    }
+  }
+
+  std::vector<uint64_t> rewind = {0};
+  pageStart_ = 0;
+  dwio::common::PositionProvider position(rewind);
+  inputStream_->seekToPosition(position);
+  bufferStart_ = bufferEnd_ = nullptr;
+  rowOfPage_ = 0;
+  numRowsInPage_ = 0;
+  pageData_ = nullptr;
+  totalRefDefBytes_ = 0;
+  pageOrdinal_ = 0;
+  cryptoCtx_.startDecryptWithDictionaryPage = startWithDictionaryPage;
+  addPageReaderStat("pageReaderPreloadRepDefsRawOnlyCount", 1);
+  addPageReaderNanos(
+      "pageReaderPreloadRepDefsRawOnlyTimeNs",
+      getCurrentTimeNano() - startNs);
+}
+
+int32_t PageReader::countLeavesInRepDefPage(
+    const raw_vector<char>& repDefData) {
+  if (repDefData.empty()) {
+    return 0;
+  }
+
+  const char* rawData = repDefData.data();
+  const char* pageEnd = repDefData.data() + repDefData.size();
+  const auto numRepDefsInPage = readField<int32_t>(rawData);
+  if (numRepDefsInPage <= 0) {
+    return 0;
+  }
+
+  const auto repeatLength = readField<int32_t>(rawData);
+  BOLT_CHECK_GE(repeatLength, 0);
+  BOLT_CHECK_LE(rawData + repeatLength, pageEnd);
+  rawData += repeatLength;
+
+  const auto defineLength = readField<uint32_t>(rawData);
+  BOLT_CHECK_LE(rawData + defineLength, pageEnd);
+  auto defineDecoder = ::arrow::util::RleDecoder(
+      reinterpret_cast<const uint8_t*>(rawData),
+      defineLength,
+      ::arrow::bit_util::NumRequiredBits(maxDefine_));
+
+  constexpr int32_t kMaxRepDefDecodeBatch = 64 * 1024;
+  raw_vector<int16_t> definitionScratch(&pool_);
+  raw_vector<uint64_t> nullScratch(&pool_);
+  definitionScratch.resize(std::min(numRepDefsInPage, kMaxRepDefDecodeBatch));
+
+  int32_t decoded = 0;
+  int32_t numLeaves = 0;
+  while (decoded < numRepDefsInPage) {
+    const auto batchSize =
+        std::min(numRepDefsInPage - decoded, kMaxRepDefDecodeBatch);
+    defineDecoder.GetBatch(definitionScratch.data(), batchSize);
+    nullScratch.resize(bits::nwords(batchSize));
+    arrow::ValidityBitmapInputOutput bits;
+    bits.values_read_upper_bound = batchSize;
+    bits.values_read = 0;
+    bits.null_count = 0;
+    bits.valid_bits = reinterpret_cast<uint8_t*>(nullScratch.data());
+    bits.valid_bits_offset = 0;
+    DefLevelsToBitmap(definitionScratch.data(), batchSize, leafInfo_, &bits);
+    numLeaves += bits.values_read;
+    decoded += batchSize;
+  }
+  return numLeaves;
+}
+
+void PageReader::compactConsumedLeafNulls() {
+  constexpr int32_t WordBits = 64;
+  int64_t erasedBits = erasedLeafNullWords_ * WordBits;
+  BOLT_CHECK_LE(numLeafNullsConsumed_, leafNullsSize_ + erasedBits);
+  if (numLeafNullsConsumed_ - erasedBits <= WordBits) {
+    return;
+  }
+
+  auto consumedWords = bits::nwords(numLeafNullsConsumed_ - erasedBits) - 1;
+  auto totalNullWords = bits::nwords(leafNullsSize_);
+  auto unConsumedNullWords = totalNullWords - consumedWords;
+  if (unConsumedNullWords > 0) {
+    uint64_t* rawData = leafNulls_.data();
+    size_t copyBytes = unConsumedNullWords * sizeof(uint64_t);
+
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GLIBC__) && \
+    (__GLIBC__ * 100 + __GLIBC_MINOR__ < 233)
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wrestrict"
+#endif
+    if (unConsumedNullWords < consumedWords) {
+      memcpy(rawData, rawData + consumedWords, copyBytes);
+    } else {
+      raw_vector<uint64_t> tmpBuffer;
+      tmpBuffer.resize(unConsumedNullWords);
+      uint64_t* tmpDest = tmpBuffer.data();
+      memcpy(tmpDest, rawData + consumedWords, copyBytes);
+      memcpy(rawData, tmpDest, copyBytes);
+    }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#else
+    memmove(rawData, rawData + consumedWords, copyBytes);
+#endif
+  }
+  leafNulls_.resize(unConsumedNullWords);
+  leafNullsSize_ -= consumedWords * WordBits;
+  erasedLeafNullWords_ += consumedWords;
+  BOLT_CHECK_EQ(leafNulls_.size(), bits::nwords(leafNullsSize_));
+}
+
+void PageReader::compactWindowRepDefs() {
+  if (repDefEnd_ == 0) {
+    return;
+  }
+
+  BOLT_CHECK_LE(repDefEnd_, definitionLevels_.size());
+  BOLT_CHECK_EQ(definitionLevels_.size(), repetitionLevels_.size());
+  const auto keptLevels =
+      static_cast<int32_t>(definitionLevels_.size()) - repDefEnd_;
+  if (keptLevels > 0) {
+    const auto copySize = keptLevels * sizeof(int16_t);
+    memmove(
+        definitionLevels_.data(),
+        definitionLevels_.data() + repDefEnd_,
+        copySize);
+    memmove(
+        repetitionLevels_.data(),
+        repetitionLevels_.data() + repDefEnd_,
+        copySize);
+  }
+  definitionLevels_.resize(keptLevels);
+  repetitionLevels_.resize(keptLevels);
+  repDefBegin_ = 0;
+  repDefEnd_ = 0;
+}
+
+bool PageReader::loadNextWindowRepDefPage() {
+  if (windowRepDefsRemaining_ > 0) {
+    return true;
+  }
+
+  windowRepeatDecoder_.reset();
+  windowDefineDecoder_.reset();
+  while (!preloadedRepDefs_.empty()) {
+    windowRepDefPageData_ = std::move(preloadedRepDefs_.front());
+    preloadedRepDefs_.pop_front();
+    if (windowRepDefPageData_.empty()) {
+      continue;
+    }
+
+    const char* rawData = windowRepDefPageData_.data();
+    const char* pageEnd =
+        windowRepDefPageData_.data() + windowRepDefPageData_.size();
+    windowRepDefsRemaining_ = readField<int32_t>(rawData);
+    if (windowRepDefsRemaining_ <= 0) {
+      continue;
+    }
+
+    const auto repeatLength = readField<int32_t>(rawData);
+    BOLT_CHECK_GE(repeatLength, 0);
+    BOLT_CHECK_LE(rawData + repeatLength, pageEnd);
+    windowRepeatDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
+        reinterpret_cast<const uint8_t*>(rawData),
+        repeatLength,
+        ::arrow::bit_util::NumRequiredBits(maxRepeat_));
+    rawData += repeatLength;
+
+    const auto defineLength = readField<uint32_t>(rawData);
+    BOLT_CHECK_LE(rawData + defineLength, pageEnd);
+    windowDefineDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
+        reinterpret_cast<const uint8_t*>(rawData),
+        defineLength,
+        ::arrow::bit_util::NumRequiredBits(maxDefine_));
+    return true;
+  }
+  return false;
+}
+
+int32_t PageReader::countTopLevelRepDefs(int32_t begin, int32_t end) const {
+  if (maxRepeat_ == 0) {
+    return std::max<int32_t>(end - begin, 0);
+  }
+  int32_t topLevelRows = 0;
+  for (int32_t i = begin; i < end; ++i) {
+    topLevelRows += repetitionLevels_[i] == 0 ? 1 : 0;
+  }
+  return topLevelRows;
+}
+
+void PageReader::loadWindowRepDefs(int32_t targetTopLevelRows) {
+  const auto startNs = getCurrentTimeNano();
+  if (targetTopLevelRows <= 0) {
+    return;
+  }
+
+  constexpr int32_t kMaxRepDefDecodeBatch = 64 * 1024;
+  compactConsumedLeafNulls();
+  auto topLevelRows =
+      countTopLevelRepDefs(repDefBegin_, definitionLevels_.size());
+  int32_t decodeBatchCount = 0;
+  while (topLevelRows < targetTopLevelRows && loadNextWindowRepDefPage()) {
+    const auto batchSize =
+        std::min(windowRepDefsRemaining_, kMaxRepDefDecodeBatch);
+    if (batchSize <= 0) {
+      continue;
+    }
+
+    const auto begin = static_cast<int32_t>(definitionLevels_.size());
+    const auto end = begin + batchSize;
+    repetitionLevels_.resize(end);
+    BOLT_CHECK_NOT_NULL(
+        windowRepeatDecoder_, "Missing incremental repetition decoder");
+    windowRepeatDecoder_->GetBatch(repetitionLevels_.data() + begin, batchSize);
+
+    definitionLevels_.resize(end);
+    BOLT_CHECK_NOT_NULL(
+        windowDefineDecoder_, "Missing incremental definition decoder");
+    windowDefineDecoder_->GetBatch(definitionLevels_.data() + begin, batchSize);
+
+    windowRepDefsRemaining_ -= batchSize;
+    leafNulls_.resize(bits::nwords(leafNullsSize_ + batchSize));
+    const auto numLeaves = getLengthsAndNulls(
+        LevelMode::kNulls,
+        leafInfo_,
+        begin,
+        end,
+        batchSize,
+        nullptr,
+        leafNulls_.data(),
+        leafNullsSize_);
+    leafNullsSize_ += numLeaves;
+    topLevelRows += countTopLevelRepDefs(begin, end);
+    ++decodeBatchCount;
+  }
+  addPageReaderStat("pageReaderLoadWindowRepDefsCount", 1);
+  addPageReaderStat(
+      "pageReaderLoadWindowRepDefsBatches", decodeBatchCount);
+  addPageReaderNanos(
+      "pageReaderLoadWindowRepDefsTimeNs",
+      getCurrentTimeNano() - startNs);
 }
 
 void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
-  if (definitionLevels_.empty() && maxDefine_ > 0) {
-    preloadRepDefs();
+  const auto startNs = getCurrentTimeNano();
+  uint64_t preloadTimeNs = 0;
+  uint64_t findTopLevelTimeNs = 0;
+  uint64_t loadMoreTimeNs = 0;
+  int64_t findTopLevelLevels = 0;
+  const auto preloadWindowCount = repDefPreloadWindowCount_ > 0
+      ? static_cast<uint64_t>(repDefPreloadWindowCount_)
+      : configuredRepDefPreloadWindowCount();
+  const bool windowPreload =
+      preloadWindowCount > 0 && maxRepeat_ > 0 && maxDefine_ > 0;
+  if (windowPreload) {
+    compactWindowRepDefs();
+  }
+  if (!hasChunkRepDefs_ && maxDefine_ > 0) {
+    const auto preloadStartNs = getCurrentTimeNano();
+    if (windowPreload) {
+      preloadRepDefsRawOnly();
+    } else {
+      preloadRepDefs();
+    }
+    preloadTimeNs += getCurrentTimeNano() - preloadStartNs;
   }
   repDefBegin_ = repDefEnd_;
+  const auto requiredTopLevelRows = numTopLevelRows + 1;
+  const auto targetTopLevelRows = windowPreload
+      ? std::max<int32_t>(
+            requiredTopLevelRows,
+            static_cast<int32_t>(std::min<uint64_t>(
+                static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
+                static_cast<uint64_t>(numTopLevelRows) * preloadWindowCount +
+                    1)))
+      : requiredTopLevelRows;
+  if (windowPreload) {
+    const auto loadMoreStartNs = getCurrentTimeNano();
+    loadWindowRepDefs(targetTopLevelRows);
+    loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
+  }
   int32_t numLevels = definitionLevels_.size();
   int32_t topFound = 0;
   int32_t i = repDefBegin_;
+  int32_t loadMoreCount = 0;
 
   auto foundTopLevel = [&]() {
+    const auto scanBegin = i;
     for (; i < numLevels; ++i) {
       if (repetitionLevels_[i] == 0) {
         ++topFound;
@@ -891,32 +1235,63 @@ void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
         }
       }
     }
+    auto scannedLevels = i - scanBegin;
+    if (i < numLevels && topFound == numTopLevelRows + 1) {
+      ++scannedLevels;
+    }
     repDefEnd_ = i;
+    return scannedLevels;
   };
 
   if (maxRepeat_ > 0) {
-    foundTopLevel();
+    const auto findStartNs = getCurrentTimeNano();
+    findTopLevelLevels += foundTopLevel();
+    findTopLevelTimeNs += getCurrentTimeNano() - findStartNs;
   } else {
     repDefEnd_ = i + numTopLevelRows;
   }
   if (maxRepeat_ > 0 && maxDefine_ > 0) {
     // definitionLevels_ has been consumed, decode more if any
     while (repDefEnd_ == numLevels && topFound < numTopLevelRows + 1 &&
-           !preloadedRepDefs_.empty()) {
-      loadMoreRepDefs();
+           (!preloadedRepDefs_.empty() || windowRepDefsRemaining_ > 0)) {
+      const auto loadMoreStartNs = getCurrentTimeNano();
+      if (windowPreload) {
+        loadWindowRepDefs(targetTopLevelRows);
+      } else {
+        loadMoreRepDefs();
+      }
+      ++loadMoreCount;
       numLevels = definitionLevels_.size();
       i = repDefEnd_;
-      foundTopLevel();
+      findTopLevelLevels += foundTopLevel();
+      loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
       BOLT_CHECK(topFound == numTopLevelRows + 1 || repDefEnd_ == numLevels);
     }
     // after topFound done, left decoded rep/def is less than 1 page, decode
     // more
-    if (!numLeavesInPage_.empty() &&
+    if (!windowPreload && !numLeavesInPage_.empty() &&
         numLevels - repDefEnd_ < numLeavesInPage_.back() &&
         topFound == numTopLevelRows + 1 && !preloadedRepDefs_.empty()) {
+      const auto loadMoreStartNs = getCurrentTimeNano();
       loadMoreRepDefs();
+      ++loadMoreCount;
+      loadMoreTimeNs += getCurrentTimeNano() - loadMoreStartNs;
     }
   }
+  const auto elapsedNs = getCurrentTimeNano() - startNs;
+  addPageReaderStat("pageReaderDecodeRepDefsRows", numTopLevelRows);
+  addPageReaderStat("pageReaderDecodeRepDefsLevels", repDefEnd_ - repDefBegin_);
+  addPageReaderStat("pageReaderDecodeRepDefsLoadMoreCount", loadMoreCount);
+  addPageReaderStat(
+      "pageReaderDecodeRepDefsFindTopLevelLevels", findTopLevelLevels);
+  addPageReaderNanos("pageReaderDecodeRepDefsTotalTimeNs", elapsedNs);
+  addPageReaderNanos("pageReaderDecodeRepDefsPreloadTimeNs", preloadTimeNs);
+  addPageReaderNanos(
+      "pageReaderDecodeRepDefsFindTopLevelTimeNs", findTopLevelTimeNs);
+  addPageReaderNanos("pageReaderDecodeRepDefsLoadMoreTimeNs", loadMoreTimeNs);
+  // Keep the legacy aggregate for compatibility while final reporting moves to
+  // the non-overlapping breakdown above.
+  addPageReaderNanos("pageReaderDecodeRepDefsTimeNs", elapsedNs);
 }
 
 void PageReader::loadMoreRepDefs() {

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -94,6 +94,7 @@ class PageReader {
         repetitionLevels_(&pool_),
         nullConcatenation_(pool_),
         windowRepDefPageData_(&pool_),
+        windowTopLevelOffsets_(&pool_),
         statis_(statis) {
     type_->makeLevelInfo(leafInfo_);
     pageOrdinal_ = 0;
@@ -115,7 +116,8 @@ class PageReader {
         definitionLevels_(&pool_),
         repetitionLevels_(&pool_),
         nullConcatenation_(pool_),
-        windowRepDefPageData_(&pool_) {
+        windowRepDefPageData_(&pool_),
+        windowTopLevelOffsets_(&pool_) {
     pageOrdinal_ = 0;
   }
 
@@ -479,9 +481,13 @@ class PageReader {
   int32_t countLeavesInRepDefPage(const raw_vector<char>& repDefData);
   void compactConsumedLeafNulls();
   void compactWindowRepDefs();
+  void compactWindowTopLevelOffsets(int32_t consumedLevels);
+  int32_t appendWindowTopLevelOffsets(int32_t begin, int32_t end);
+  int32_t decodeWindowRepDefsBatch(int32_t batchSize);
+  void finishCurrentWindowRepDefPage();
+  void ensureNumLeavesInPage(int32_t pageIndex);
   void loadWindowRepDefs(int32_t targetTopLevelRows);
   bool loadNextWindowRepDefPage();
-  int32_t countTopLevelRepDefs(int32_t begin, int32_t end) const;
   void decodeRepDefsFromBuffer();
 
   memory::MemoryPool& pool_;
@@ -639,10 +645,15 @@ class PageReader {
 
   // preload undecoded RepDefs
   std::list<raw_vector<char>> preloadedRepDefs_;
+  bool windowRepDefMode_{false};
   raw_vector<char> windowRepDefPageData_;
+  raw_vector<int32_t> windowTopLevelOffsets_;
+  int32_t windowTopLevelOffsetBase_{0};
   std::unique_ptr<::arrow::util::RleDecoder> windowRepeatDecoder_;
   std::unique_ptr<::arrow::util::RleDecoder> windowDefineDecoder_;
   int32_t windowRepDefsRemaining_{0};
+  int32_t windowCurrentPageLeafCount_{0};
+  int32_t windowDecodedPageCount_{0};
   int32_t repDefMemoryLimit_{16L << 20};
   int64_t totalRefDefBytes_{0};
   int32_t decodeRepDefPageCount_{10};

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -93,6 +93,7 @@ class PageReader {
         definitionLevels_(&pool_),
         repetitionLevels_(&pool_),
         nullConcatenation_(pool_),
+        windowRepDefPageData_(&pool_),
         statis_(statis) {
     type_->makeLevelInfo(leafInfo_);
     pageOrdinal_ = 0;
@@ -113,7 +114,8 @@ class PageReader {
         chunkSize_(chunkSize),
         definitionLevels_(&pool_),
         repetitionLevels_(&pool_),
-        nullConcatenation_(pool_) {
+        nullConcatenation_(pool_),
+        windowRepDefPageData_(&pool_) {
     pageOrdinal_ = 0;
   }
 
@@ -473,6 +475,13 @@ class PageReader {
 
   void preloadPageRepDefs(const bool keepRepDefRawData);
   void loadMoreRepDefs();
+  void preloadRepDefsRawOnly();
+  int32_t countLeavesInRepDefPage(const raw_vector<char>& repDefData);
+  void compactConsumedLeafNulls();
+  void compactWindowRepDefs();
+  void loadWindowRepDefs(int32_t targetTopLevelRows);
+  bool loadNextWindowRepDefPage();
+  int32_t countTopLevelRepDefs(int32_t begin, int32_t end) const;
   void decodeRepDefsFromBuffer();
 
   memory::MemoryPool& pool_;
@@ -630,6 +639,10 @@ class PageReader {
 
   // preload undecoded RepDefs
   std::list<raw_vector<char>> preloadedRepDefs_;
+  raw_vector<char> windowRepDefPageData_;
+  std::unique_ptr<::arrow::util::RleDecoder> windowRepeatDecoder_;
+  std::unique_ptr<::arrow::util::RleDecoder> windowDefineDecoder_;
+  int32_t windowRepDefsRemaining_{0};
   int32_t repDefMemoryLimit_{16L << 20};
   int64_t totalRefDefBytes_{0};
   int32_t decodeRepDefPageCount_{10};

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -247,6 +247,10 @@ class PageReader {
     decodeRepDefPageCount_ = count;
   }
 
+  void setParquetRepDefPreloadWindowCount(int32_t count) {
+    repDefPreloadWindowCount_ = count < 0 ? 0 : count;
+  }
+
   void setParquetRepDefMemoryLimit(int32_t memlimit) {
     repDefMemoryLimit_ = memlimit;
   }
@@ -629,6 +633,7 @@ class PageReader {
   int32_t repDefMemoryLimit_{16L << 20};
   int64_t totalRefDefBytes_{0};
   int32_t decodeRepDefPageCount_{10};
+  int32_t repDefPreloadWindowCount_{0};
 
   dwio::common::RuntimeStatistics* statis_{nullptr};
   // Tracks output count for the current physical page. -1 means there is no

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -93,8 +93,7 @@ class PageReader {
         definitionLevels_(&pool_),
         repetitionLevels_(&pool_),
         nullConcatenation_(pool_),
-        windowRepDefPageData_(&pool_),
-        windowTopLevelOffsets_(&pool_),
+        windowRepDef_(&pool_),
         statis_(statis) {
     type_->makeLevelInfo(leafInfo_);
     pageOrdinal_ = 0;
@@ -116,8 +115,7 @@ class PageReader {
         definitionLevels_(&pool_),
         repetitionLevels_(&pool_),
         nullConcatenation_(pool_),
-        windowRepDefPageData_(&pool_),
-        windowTopLevelOffsets_(&pool_) {
+        windowRepDef_(&pool_) {
     pageOrdinal_ = 0;
   }
 
@@ -490,6 +488,33 @@ class PageReader {
   bool loadNextWindowRepDefPage();
   void decodeRepDefsFromBuffer();
 
+  struct WindowRepDefState {
+    explicit WindowRepDefState(memory::MemoryPool* pool = nullptr)
+        : pageData(pool), topLevelOffsets(pool) {}
+
+    void reset(bool newEnabled = false) {
+      enabled = newEnabled;
+      pageData.clear();
+      topLevelOffsets.clear();
+      topLevelOffsetBase = 0;
+      repeatDecoder.reset();
+      defineDecoder.reset();
+      repDefsRemaining = 0;
+      currentPageLeafCount = 0;
+      decodedPageCount = 0;
+    }
+
+    bool enabled{false};
+    raw_vector<char> pageData;
+    raw_vector<int32_t> topLevelOffsets;
+    int32_t topLevelOffsetBase{0};
+    std::unique_ptr<::arrow::util::RleDecoder> repeatDecoder;
+    std::unique_ptr<::arrow::util::RleDecoder> defineDecoder;
+    int32_t repDefsRemaining{0};
+    int32_t currentPageLeafCount{0};
+    int32_t decodedPageCount{0};
+  };
+
   memory::MemoryPool& pool_;
 
   std::unique_ptr<dwio::common::SeekableInputStream> inputStream_;
@@ -645,15 +670,7 @@ class PageReader {
 
   // preload undecoded RepDefs
   std::list<raw_vector<char>> preloadedRepDefs_;
-  bool windowRepDefMode_{false};
-  raw_vector<char> windowRepDefPageData_;
-  raw_vector<int32_t> windowTopLevelOffsets_;
-  int32_t windowTopLevelOffsetBase_{0};
-  std::unique_ptr<::arrow::util::RleDecoder> windowRepeatDecoder_;
-  std::unique_ptr<::arrow::util::RleDecoder> windowDefineDecoder_;
-  int32_t windowRepDefsRemaining_{0};
-  int32_t windowCurrentPageLeafCount_{0};
-  int32_t windowDecodedPageCount_{0};
+  WindowRepDefState windowRepDef_;
   int32_t repDefMemoryLimit_{16L << 20};
   int64_t totalRefDefBytes_{0};
   int32_t decodeRepDefPageCount_{10};

--- a/bolt/dwio/parquet/reader/ParquetData.cpp
+++ b/bolt/dwio/parquet/reader/ParquetData.cpp
@@ -49,6 +49,7 @@ std::unique_ptr<dwio::common::FormatData> ParquetParams::toFormatData(
       schemaHelper_,
       enableDictionaryFilter_,
       decodeRepDefPageCount_,
+      parquetRepDefPreloadWindowCount_,
       parquetRepDefMemoryLimit_);
 }
 
@@ -373,6 +374,8 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
       metadata.total_compressed_size,
       statis_);
   reader_->setDecodeRepDefPageCount(decodeRepDefPageCount_);
+  reader_->setParquetRepDefPreloadWindowCount(
+      parquetRepDefPreloadWindowCount_);
   reader_->setParquetRepDefMemoryLimit(parquetRepDefMemoryLimit_);
 
   if (columnChunkMeta.__isset.crypto_metadata) {

--- a/bolt/dwio/parquet/reader/ParquetData.cpp
+++ b/bolt/dwio/parquet/reader/ParquetData.cpp
@@ -374,8 +374,7 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
       metadata.total_compressed_size,
       statis_);
   reader_->setDecodeRepDefPageCount(decodeRepDefPageCount_);
-  reader_->setParquetRepDefPreloadWindowCount(
-      parquetRepDefPreloadWindowCount_);
+  reader_->setParquetRepDefPreloadWindowCount(parquetRepDefPreloadWindowCount_);
   reader_->setParquetRepDefMemoryLimit(parquetRepDefMemoryLimit_);
 
   if (columnChunkMeta.__isset.crypto_metadata) {

--- a/bolt/dwio/parquet/reader/ParquetData.h
+++ b/bolt/dwio/parquet/reader/ParquetData.h
@@ -61,6 +61,7 @@ class ParquetParams : public dwio::common::FormatParams {
       const SchemaHelper& schemaHelper,
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
+      int32_t parquetRepDefPreloadWindowCount,
       int32_t parquetRepDefMemoryLimit)
       : FormatParams(pool, stats),
         metaData_(metaData),
@@ -69,6 +70,7 @@ class ParquetParams : public dwio::common::FormatParams {
         schemaHelper_(schemaHelper),
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
+        parquetRepDefPreloadWindowCount_(parquetRepDefPreloadWindowCount),
         parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {}
 
   std::unique_ptr<dwio::common::FormatData> toFormatData(
@@ -90,6 +92,7 @@ class ParquetParams : public dwio::common::FormatParams {
   const SchemaHelper& schemaHelper_;
   const bool enableDictionaryFilter_;
   const int32_t decodeRepDefPageCount_;
+  const int32_t parquetRepDefPreloadWindowCount_;
   const int32_t parquetRepDefMemoryLimit_;
 };
 
@@ -105,6 +108,7 @@ class ParquetData : public dwio::common::FormatData {
       const SchemaHelper& schemaHelper,
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
+      int32_t parquetRepDefPreloadWindowCount,
       int32_t parquetRepDefMemoryLimit)
       : pool_(pool),
         type_(std::static_pointer_cast<const ParquetTypeWithId>(type)),
@@ -117,6 +121,7 @@ class ParquetData : public dwio::common::FormatData {
         schemaHelper_(schemaHelper),
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
+        parquetRepDefPreloadWindowCount_(parquetRepDefPreloadWindowCount),
         parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {
     rowGroupOffsets_ = std::vector<int64_t>(rowGroups_.size());
     rowGroupOffsets_[0] = 0;
@@ -331,6 +336,7 @@ class ParquetData : public dwio::common::FormatData {
   const SchemaHelper& schemaHelper_;
   const bool enableDictionaryFilter_;
   const int32_t decodeRepDefPageCount_;
+  const int32_t parquetRepDefPreloadWindowCount_;
   const int32_t parquetRepDefMemoryLimit_;
 };
 

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1536,6 +1536,7 @@ class ParquetRowReader::Impl {
         schemaHelper_,
         options_.isDictionaryFilterEnabled(),
         options_.getDecodeRepDefPageCount(),
+        options_.getParquetRepDefPreloadWindowCount(),
         options_.getParquetRepDefMemoryLimit());
 
     if (auto selector = options_.getSelector()) {

--- a/bolt/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/reader/CMakeLists.txt
@@ -99,6 +99,18 @@ target_link_libraries(
   bolt_testutils
 )
 
+# This binary is intended for manual real-file memory baselines and therefore
+# is not registered as a default ctest case.
+add_executable(bolt_dwio_parquet_memory_test ParquetReaderMemoryTest.cpp)
+target_link_libraries(
+  bolt_dwio_parquet_memory_test PRIVATE
+  bolt_testutils
+  GTest::gtest
+)
+if(BOLT_ENABLE_HDFS)
+  target_link_libraries(bolt_dwio_parquet_memory_test PRIVATE bolt_hdfs)
+endif()
+
 if(${BOLT_ENABLE_ARROW})
 
   add_executable(bolt_dwio_parquet_rlebp_decoder_test RleBpDecoderTest.cpp)

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderMemoryTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderMemoryTest.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/resource.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <fmt/format.h>
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "bolt/common/base/Fs.h"
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/common/file/FileSystems.h"
+#include "bolt/core/Config.h"
+#include "bolt/dwio/common/BufferedInput.h"
+#include "bolt/dwio/parquet/reader/ParquetReader.h"
+#include "bolt/dwio/parquet/tests/ParquetTestBase.h"
+
+#ifdef BOLT_ENABLE_HDFS
+#include "bolt/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
+#endif
+
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::dwio;
+using namespace bytedance::bolt::dwio::common;
+using namespace bytedance::bolt::parquet;
+
+DEFINE_string(
+    parquet_memory_input_file,
+    "",
+    "Absolute path of the parquet file to read for memory baseline.");
+DEFINE_uint64(
+    parquet_memory_next_batch_size,
+    1000,
+    "Batch size passed to RowReader::next().");
+DEFINE_int32(
+    parquet_memory_repdef_preload_window_count,
+    0,
+    "Parquet rep/def preload window count. 0 disables window preload.");
+DEFINE_bool(
+    parquet_memory_verbose_batches,
+    false,
+    "Print per-batch RSS and memory-pool stats.");
+
+namespace {
+
+struct ProcessRssStats {
+  int64_t vmRssKb{-1};
+  int64_t vmHwmKb{-1};
+  int64_t ruMaxRssKb{-1};
+};
+
+std::optional<int64_t> readProcStatusValueKb(const std::string& key) {
+  std::ifstream input("/proc/self/status");
+  if (!input.is_open()) {
+    return std::nullopt;
+  }
+
+  const auto prefix = key + ":";
+  std::string line;
+  while (std::getline(input, line)) {
+    if (line.rfind(prefix, 0) != 0) {
+      continue;
+    }
+
+    std::istringstream lineStream(line.substr(prefix.size()));
+    int64_t value = 0;
+    std::string unit;
+    if (lineStream >> value >> unit) {
+      return value;
+    }
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+ProcessRssStats captureProcessRssStats() {
+  struct rusage usage {};
+  getrusage(RUSAGE_SELF, &usage);
+  return ProcessRssStats{
+      .vmRssKb = readProcStatusValueKb("VmRSS").value_or(-1),
+      .vmHwmKb = readProcStatusValueKb("VmHWM").value_or(-1),
+      .ruMaxRssKb = usage.ru_maxrss};
+}
+
+bool startsWith(std::string_view value, std::string_view prefix) {
+  return value.size() >= prefix.size() &&
+      value.compare(0, prefix.size(), prefix) == 0;
+}
+
+bool isHdfsPath(std::string_view path) {
+  return startsWith(path, "hdfs://") || startsWith(path, "viewfs://");
+}
+
+struct ReadIoStats {
+  std::atomic<uint64_t> preadCalls{0};
+  std::atomic<uint64_t> preadBytes{0};
+  std::atomic<uint64_t> preadvCalls{0};
+  std::atomic<uint64_t> preadvRegions{0};
+  std::atomic<uint64_t> preadvBytes{0};
+};
+
+class InstrumentedReadFile final : public ReadFile {
+ public:
+  InstrumentedReadFile(std::shared_ptr<ReadFile> inner, ReadIoStats& stats)
+      : inner_(std::move(inner)), stats_(stats) {}
+
+  std::string_view pread(uint64_t offset, uint64_t length, void* buf)
+      const override {
+    stats_.preadCalls.fetch_add(1, std::memory_order_relaxed);
+    stats_.preadBytes.fetch_add(length, std::memory_order_relaxed);
+    return inner_->pread(offset, length, buf);
+  }
+
+  std::string pread(uint64_t offset, uint64_t length) const override {
+    stats_.preadCalls.fetch_add(1, std::memory_order_relaxed);
+    stats_.preadBytes.fetch_add(length, std::memory_order_relaxed);
+    return inner_->pread(offset, length);
+  }
+
+  void preadv(
+      folly::Range<const bytedance::bolt::common::Region*> regions,
+      folly::Range<folly::IOBuf*> iobufs) const override {
+    stats_.preadvCalls.fetch_add(1, std::memory_order_relaxed);
+    stats_.preadvRegions.fetch_add(regions.size(), std::memory_order_relaxed);
+    uint64_t bytes = 0;
+    for (const auto& region : regions) {
+      bytes += region.length;
+    }
+    stats_.preadvBytes.fetch_add(bytes, std::memory_order_relaxed);
+    inner_->preadv(regions, iobufs);
+  }
+
+  uint64_t preadv(
+      uint64_t offset,
+      const std::vector<folly::Range<char*>>& buffers) const override {
+    stats_.preadvCalls.fetch_add(1, std::memory_order_relaxed);
+    stats_.preadvRegions.fetch_add(buffers.size(), std::memory_order_relaxed);
+    uint64_t bytes = 0;
+    for (const auto& buffer : buffers) {
+      bytes += buffer.size();
+    }
+    stats_.preadvBytes.fetch_add(bytes, std::memory_order_relaxed);
+    return inner_->preadv(offset, buffers);
+  }
+
+  bool shouldCoalesce() const override {
+    return inner_->shouldCoalesce();
+  }
+
+  uint64_t size() const override {
+    return inner_->size();
+  }
+
+  uint64_t memoryUsage() const override {
+    return inner_->memoryUsage();
+  }
+
+  uint64_t bytesRead() const override {
+    return inner_->bytesRead();
+  }
+
+  void resetBytesRead() override {
+    inner_->resetBytesRead();
+  }
+
+  std::string getName() const override {
+    return inner_->getName();
+  }
+
+  uint64_t getNaturalReadSize() const override {
+    return inner_->getNaturalReadSize();
+  }
+
+ private:
+  std::shared_ptr<ReadFile> inner_;
+  ReadIoStats& stats_;
+};
+
+class ParquetReaderMemoryTest : public ParquetTestBase {};
+
+TEST_F(ParquetReaderMemoryTest, readRealFileAndReportMemory) {
+  ASSERT_FALSE(FLAGS_parquet_memory_input_file.empty())
+      << "--parquet_memory_input_file must be provided";
+  ASSERT_GT(FLAGS_parquet_memory_next_batch_size, 0)
+      << "--parquet_memory_next_batch_size must be > 0";
+  ASSERT_GE(FLAGS_parquet_memory_repdef_preload_window_count, 0)
+      << "--parquet_memory_repdef_preload_window_count must be >= 0";
+
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  std::shared_ptr<ReadFile> readFile;
+  if (isHdfsPath(FLAGS_parquet_memory_input_file)) {
+#ifdef BOLT_ENABLE_HDFS
+    filesystems::registerHdfsFileSystem();
+    auto fsConfig = std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{});
+    auto fileSystem =
+        filesystems::getFileSystem(FLAGS_parquet_memory_input_file, fsConfig);
+    ASSERT_NE(fileSystem, nullptr) << "failed to resolve HDFS filesystem for: "
+                                   << FLAGS_parquet_memory_input_file;
+    ASSERT_TRUE(fileSystem->exists(FLAGS_parquet_memory_input_file))
+        << "input parquet file does not exist: "
+        << FLAGS_parquet_memory_input_file;
+    readFile = fileSystem->openFileForRead(FLAGS_parquet_memory_input_file);
+#else
+    FAIL() << "HDFS input requires BOLT_ENABLE_HDFS=ON: "
+           << FLAGS_parquet_memory_input_file;
+#endif
+  } else {
+    ASSERT_TRUE(fs::exists(FLAGS_parquet_memory_input_file))
+        << "input parquet file does not exist: "
+        << FLAGS_parquet_memory_input_file;
+    readFile = std::make_shared<LocalReadFile>(FLAGS_parquet_memory_input_file);
+  }
+
+  ReadIoStats readIoStats;
+  readFile =
+      std::make_shared<InstrumentedReadFile>(std::move(readFile), readIoStats);
+
+  auto input = std::make_unique<dwio::common::BufferedInput>(
+      readFile, readerOptions.getMemoryPool());
+  auto reader = std::make_unique<bytedance::bolt::parquet::ParquetReader>(
+      std::move(input), readerOptions);
+  auto rowType = reader->rowType();
+  ASSERT_NE(rowType, nullptr);
+
+  RowReaderOptions rowReaderOptions;
+  rowReaderOptions.select(
+      std::make_shared<ColumnSelector>(rowType, rowType->names()));
+  rowReaderOptions.setScanSpec(makeScanSpec(rowType));
+  rowReaderOptions.setParquetRepDefPreloadWindowCount(
+      FLAGS_parquet_memory_repdef_preload_window_count);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  const auto fileRows = reader->numberOfRows().value_or(0);
+  const auto fileMeta = reader->fileMetaData();
+  const auto rowGroupCount = fileMeta.numRowGroups();
+
+  auto rssBefore = captureProcessRssStats();
+  int64_t sampledPeakRssKb = std::max<int64_t>(0, rssBefore.vmRssKb);
+  uint64_t rowsRead = 0;
+  uint64_t batches = 0;
+  uint64_t maxBatchRows = 0;
+  uint64_t rowReaderNextNs = 0;
+
+  VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+  while (true) {
+    const auto nextStart = std::chrono::steady_clock::now();
+    const auto numRows =
+        rowReader->next(FLAGS_parquet_memory_next_batch_size, result);
+    const auto nextEnd = std::chrono::steady_clock::now();
+    rowReaderNextNs += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           nextEnd - nextStart)
+                           .count();
+    if (numRows == 0) {
+      break;
+    }
+
+    auto rowVector = result->asUnchecked<RowVector>();
+    for (auto i = 0; i < rowVector->childrenSize(); ++i) {
+      rowVector->childAt(i)->loadedVector();
+    }
+
+    rowsRead += rowVector->size();
+    maxBatchRows = std::max<uint64_t>(maxBatchRows, rowVector->size());
+    ++batches;
+
+    const auto rssNow = captureProcessRssStats();
+    sampledPeakRssKb = std::max(sampledPeakRssKb, rssNow.vmRssKb);
+
+    if (FLAGS_parquet_memory_verbose_batches) {
+      fmt::print(
+          "PARQUET_MEMORY_BATCH batch={} rows={} vm_rss_kb={} vm_hwm_kb={} "
+          "root_current_bytes={} root_peak_bytes={} leaf_current_bytes={} "
+          "leaf_peak_bytes={}\n",
+          batches,
+          rowVector->size(),
+          rssNow.vmRssKb,
+          rssNow.vmHwmKb,
+          rootPool_->currentBytes(),
+          rootPool_->peakBytes(),
+          leafPool_->currentBytes(),
+          leafPool_->peakBytes());
+    }
+  }
+
+  const auto rssAfter = captureProcessRssStats();
+
+  fmt::print(
+      "PARQUET_MEMORY_SUMMARY\n"
+      "input_file={}\n"
+      "next_batch_size={}\n"
+      "repdef_preload_window_count={}\n"
+      "column_count={}\n"
+      "file_rows={}\n"
+      "rows_read={}\n"
+      "row_groups={}\n"
+      "batches={}\n"
+      "max_batch_rows={}\n"
+      "row_reader_next_ns={}\n"
+      "rss_before_kb={}\n"
+      "rss_after_kb={}\n"
+      "rss_sampled_peak_kb={}\n"
+      "vm_hwm_kb={}\n"
+      "ru_maxrss_kb={}\n"
+      "root_current_bytes={}\n"
+      "root_peak_bytes={}\n"
+      "leaf_current_bytes={}\n"
+      "leaf_peak_bytes={}\n"
+      "pread_calls={}\n"
+      "pread_bytes={}\n"
+      "preadv_calls={}\n"
+      "preadv_regions={}\n"
+      "preadv_bytes={}\n",
+      FLAGS_parquet_memory_input_file,
+      FLAGS_parquet_memory_next_batch_size,
+      FLAGS_parquet_memory_repdef_preload_window_count,
+      rowType->size(),
+      fileRows,
+      rowsRead,
+      rowGroupCount,
+      batches,
+      maxBatchRows,
+      rowReaderNextNs,
+      rssBefore.vmRssKb,
+      rssAfter.vmRssKb,
+      sampledPeakRssKb,
+      rssAfter.vmHwmKb,
+      rssAfter.ruMaxRssKb,
+      rootPool_->currentBytes(),
+      rootPool_->peakBytes(),
+      leafPool_->currentBytes(),
+      leafPool_->peakBytes(),
+      readIoStats.preadCalls.load(std::memory_order_relaxed),
+      readIoStats.preadBytes.load(std::memory_order_relaxed),
+      readIoStats.preadvCalls.load(std::memory_order_relaxed),
+      readIoStats.preadvRegions.load(std::memory_order_relaxed),
+      readIoStats.preadvBytes.load(std::memory_order_relaxed));
+
+  ASSERT_GT(rowsRead, 0);
+  if (fileRows > 0) {
+    ASSERT_EQ(rowsRead, fileRows);
+  }
+  ASSERT_GT(rootPool_->peakBytes(), 0);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -129,7 +129,127 @@ class ParquetReaderTest : public ParquetTestBase {
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
   }
+
+  RowVectorPtr makeRepDefWindowData(vector_size_t size = 512) {
+    auto items = makeArrayVector<int32_t>(
+        size,
+        [](vector_size_t row) { return row % 7; },
+        [](vector_size_t index) {
+          return static_cast<int32_t>((index * 13) % 997);
+        },
+        [](vector_size_t row) { return row % 17 == 0; },
+        [](vector_size_t index) { return index % 11 == 3; });
+    return makeRowVector({"items"}, {items});
+  }
+
+  std::string writeRepDefWindowData(const RowVectorPtr& data) {
+    auto sink = std::make_unique<MemorySink>(
+        1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+    auto* sinkPtr = sink.get();
+    bytedance::bolt::parquet::WriterOptions writerOptions;
+    writerOptions.memoryPool = rootPool_.get();
+    writerOptions.enableDictionary = false;
+    writerOptions.dataPageSize = 128;
+
+    auto writer = std::make_unique<bytedance::bolt::parquet::Writer>(
+        std::move(sink),
+        writerOptions,
+        std::static_pointer_cast<const RowType>(data->type()));
+    writer->write(data);
+    writer->close();
+    return std::string(sinkPtr->data(), sinkPtr->size());
+  }
+
+  std::unique_ptr<ParquetReader> createMemoryReader(
+      const std::string& fileData,
+      const RowTypePtr& rowType) {
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    readerOptions.setFileSchema(rowType);
+    auto file = std::make_shared<InMemoryReadFile>(std::string(fileData));
+    return std::make_unique<ParquetReader>(
+        std::make_unique<dwio::common::BufferedInput>(file, *leafPool_),
+        readerOptions);
+  }
+
+  std::unique_ptr<dwio::common::RowReader> createMemoryRowReader(
+      const std::string& fileData,
+      const RowTypePtr& rowType,
+      int32_t repDefPreloadWindowCount) {
+    auto reader = createMemoryReader(fileData, rowType);
+    auto rowReaderOpts = getReaderOpts(rowType);
+    rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+    rowReaderOpts.setParquetRepDefPreloadWindowCount(repDefPreloadWindowCount);
+    return reader->createRowReader(rowReaderOpts);
+  }
+
+  void assertHasMultipleDataPages(
+      const std::string& fileData,
+      const RowTypePtr& rowType) {
+    auto reader = createMemoryReader(fileData, rowType);
+    const auto& stats =
+        reader->fileMetaData().rowGroup(0).columnChunk(0).pageEncodingStats();
+    int32_t dataPages = 0;
+    for (const auto& stat : stats) {
+      if (stat.page_type == thrift::PageType::DATA_PAGE ||
+          stat.page_type == thrift::PageType::DATA_PAGE_V2) {
+        dataPages += stat.count;
+      }
+    }
+    ASSERT_GT(dataPages, 1);
+  }
+
+  void assertReadInBatches(
+      const std::string& fileData,
+      const RowTypePtr& rowType,
+      const RowVectorPtr& expected,
+      int32_t repDefPreloadWindowCount) {
+    auto rowReader =
+        createMemoryRowReader(fileData, rowType, repDefPreloadWindowCount);
+    VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+    const std::vector<vector_size_t> batches{1, 2, 3, 5, 8, 13, 21, 34};
+    vector_size_t total = 0;
+    auto batchIndex = 0;
+    while (total < expected->size()) {
+      const auto batch = batches[batchIndex++ % batches.size()];
+      const auto read = rowReader->next(batch, result);
+      ASSERT_GT(read, 0);
+      ASSERT_EQ(result->size(), read);
+      assertEqualVectorPart(expected, result, total);
+      total += read;
+    }
+    EXPECT_EQ(total, expected->size());
+    EXPECT_EQ(rowReader->next(1000, result), 0);
+  }
 };
+
+TEST_F(ParquetReaderTest, repDefPreloadWindowMatchesDefaultAcrossPages) {
+  auto expected = makeRepDefWindowData();
+  auto rowType = std::static_pointer_cast<const RowType>(expected->type());
+  const auto fileData = writeRepDefWindowData(expected);
+
+  assertHasMultipleDataPages(fileData, rowType);
+  assertReadInBatches(fileData, rowType, expected, 0);
+  assertReadInBatches(fileData, rowType, expected, 1);
+}
+
+TEST_F(ParquetReaderTest, repDefPreloadWindowSkipAfterPartialDecode) {
+  auto expected = makeRepDefWindowData();
+  auto rowType = std::static_pointer_cast<const RowType>(expected->type());
+  const auto fileData = writeRepDefWindowData(expected);
+  auto rowReader = createMemoryRowReader(fileData, rowType, 1);
+
+  VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+  ASSERT_EQ(rowReader->next(3, result), 3);
+  assertEqualVectorPart(expected, result, 0);
+
+  rowReader->skip(5);
+  ASSERT_EQ(rowReader->next(4, result), 4);
+  assertEqualVectorPart(expected, result, 8);
+
+  rowReader->skip(11);
+  ASSERT_EQ(rowReader->next(7, result), 7);
+  assertEqualVectorPart(expected, result, 23);
+}
 
 TEST_F(ParquetReaderTest, parseDecimal) {
   // decimal_int96.parquet holds one column (s: Decimal(28, 10))


### PR DESCRIPTION
## Summary

This PR optimizes Parquet repetition/definition level decoding by adding a lazy windowed decode path.

The change is split into three logical commits:

1. Add option plumbing for Parquet repdef preload window mode.
2. Add the preload window implementation.
3. Optimize the hot path by avoiding extra leaf-count decode work and repeated top-level row boundary scans.

## Validation

Validated locally with:

- bolt_dwio_parquet_reader_test
- bolt_dwio_parquet_table_scan_test
- bolt_dwio_parquet_cli_test

Both default mode and window preload mode passed.