### PR TITLE
fix: Spark SQL timestamp gap issue fixes

### DIFF
--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -143,21 +143,55 @@ struct UnixTimestampFunctionBase {
     return result.timestamp.getDays() < kFirstNonNegativeYearDay;
   }
 
+  void checkSparkTimestampMicrosInRange(int64_t seconds, uint64_t nanos) {
+    constexpr __int128 kMicrosInSecond = 1'000'000;
+    constexpr __int128 kSparkMinTimestampMicros =
+        std::numeric_limits<int64_t>::min();
+    constexpr __int128 kSparkMaxTimestampMicros =
+        std::numeric_limits<int64_t>::max();
+    const auto micros = static_cast<__int128>(seconds) * kMicrosInSecond +
+        static_cast<__int128>(nanos / 1'000);
+    BOLT_USER_CHECK(
+        micros >= kSparkMinTimestampMicros &&
+            micros <= kSparkMaxTimestampMicros,
+        "long overflow");
+  }
+
+  bool tryAssignConvertedTimestamp(Timestamp& timestamp, int64_t seconds) {
+    checkSparkTimestampMicrosInRange(seconds, timestamp.getNanos());
+    if (seconds < Timestamp::kMinSeconds || seconds > Timestamp::kMaxSeconds) {
+      return false;
+    }
+    timestamp = Timestamp(seconds, timestamp.getNanos());
+    return true;
+  }
+
+  bool trySubtractOffsetAndAssign(Timestamp& timestamp, int64_t offsetSeconds) {
+    int64_t seconds;
+    BOLT_USER_CHECK(
+        !__builtin_sub_overflow(
+            timestamp.getSeconds(), offsetSeconds, &seconds),
+        "long overflow");
+    return tryAssignConvertedTimestamp(timestamp, seconds);
+  }
+
   bool tryConvertToGMT(
       Timestamp& timestamp,
       const tz::TimeZone& zone,
       bool nullOnNonexistentLocalTime) {
+    // -32767-01-01 00:00:00. date::time_zone conversion aborts below this
+    // bound, so keep one extra day for timezone adjustment safety.
+    constexpr int64_t kMinSecondsSupportedByTimeZoneAdjustment =
+        -1096193779200l;
     constexpr int64_t kMinSecondsForTimeZoneAdjustment =
-        -1096193779200l + 86400l;
+        kMinSecondsSupportedByTimeZoneAdjustment + Timestamp::kSecondsInDay;
     if (timestamp.getSeconds() < kMinSecondsForTimeZoneAdjustment ||
         timestamp.getSeconds() > Timestamp::kMaxSeconds) {
       return false;
     }
 
     if (const auto offset = zone.offset()) {
-      timestamp = Timestamp(
-          timestamp.getSeconds() - offset->count() * 60, timestamp.getNanos());
-      return true;
+      return trySubtractOffsetAndAssign(timestamp, offset->count() * 60);
     }
 
     ::date::local_time<std::chrono::seconds> localTime{
@@ -172,12 +206,7 @@ struct UnixTimestampFunctionBase {
     // forward by the gap duration. This is equivalent to converting using the
     // offset before the transition. For ambiguous timestamps, Spark picks the
     // earlier instant, which also uses the first offset.
-    auto sysTime =
-        ::date::sys_time<std::chrono::seconds>{localTime.time_since_epoch()} -
-        info.first.offset;
-    timestamp =
-        Timestamp(sysTime.time_since_epoch().count(), timestamp.getNanos());
-    return true;
+    return trySubtractOffsetAndAssign(timestamp, info.first.offset.count());
   }
 
   bool tryConvertToGMT(
@@ -185,13 +214,11 @@ struct UnixTimestampFunctionBase {
       int16_t tzID,
       bool nullOnNonexistentLocalTime) {
     if (tzID == 0) {
-      return true;
+      return tryAssignConvertedTimestamp(timestamp, timestamp.getSeconds());
     }
     if (tzID <= 1680) {
-      timestamp = Timestamp(
-          timestamp.getSeconds() - getPrestoTZOffsetInSeconds(tzID),
-          timestamp.getNanos());
-      return true;
+      return trySubtractOffsetAndAssign(
+          timestamp, getPrestoTZOffsetInSeconds(tzID));
     }
     return tryConvertToGMT(
         timestamp,
@@ -220,15 +247,18 @@ struct UnixTimestampFunctionBase {
     //   post-1991   (>= 1992-01-01 local)
     //   mid-century (1950-01-01 .. 1985-12-31 local)
     // Other eras fall through to tzdata + correct_nonexistent_time.
-    const int64_t utcSeconds =
-        timestamp.getSeconds() - sessionTzOffsetInSeconds_;
+    int64_t utcSeconds;
+    BOLT_USER_CHECK(
+        !__builtin_sub_overflow(
+            timestamp.getSeconds(), sessionTzOffsetInSeconds_, &utcSeconds),
+        "long overflow");
     if (utcSeconds >= kLastDstEndUtc) {
-      result = Timestamp(utcSeconds, timestamp.getNanos());
-      return true;
+      result = timestamp;
+      return tryAssignConvertedTimestamp(result, utcSeconds);
     }
     if (utcSeconds >= kMidCenturyStartUtc && utcSeconds < kMidCenturyEndUtc) {
-      result = Timestamp(utcSeconds, timestamp.getNanos());
-      return true;
+      result = timestamp;
+      return tryAssignConvertedTimestamp(result, utcSeconds);
     }
 
     // Route through tzdata for every Shanghai regime (LMT, CST, and DST in
@@ -256,16 +286,16 @@ struct UnixTimestampFunctionBase {
       return true;
     }
 
-    if (timestamp.getSeconds() - sessionTzOffsetInSeconds_ < kShseparator) {
-      result = Timestamp(
-          timestamp.getSeconds() - sessionTzOffsetInSeconds_ + kShSpecOffset,
-          timestamp.getNanos());
+    if (utcSeconds < kShseparator) {
+      BOLT_USER_CHECK(
+          !__builtin_add_overflow(utcSeconds, kShSpecOffset, &utcSeconds),
+          "long overflow");
+      result = timestamp;
+      return tryAssignConvertedTimestamp(result, utcSeconds);
     } else {
-      result = Timestamp(
-          timestamp.getSeconds() - sessionTzOffsetInSeconds_,
-          timestamp.getNanos());
+      result = timestamp;
+      return tryAssignConvertedTimestamp(result, utcSeconds);
     }
-    return true;
   }
 
   bool getTimestampResultInGMT(DateTimeResultValue& dtr, Timestamp& result) {
@@ -287,9 +317,8 @@ struct UnixTimestampFunctionBase {
       }
       result = dtr.timestamp;
     } else {
-      result = Timestamp(
-          dtr.timestamp.getSeconds() - sessionTzOffsetInSeconds_,
-          dtr.timestamp.getNanos());
+      result = dtr.timestamp;
+      return trySubtractOffsetAndAssign(result, sessionTzOffsetInSeconds_);
     }
 
     return true;
@@ -329,10 +358,8 @@ struct UnixTimestampFunctionBase {
     }
 
     if (sessionTimeZone_ == nullptr) {
-      result = Timestamp(
-          timestamp.getSeconds() - sessionTzOffsetInSeconds_,
-          timestamp.getNanos());
-      return true;
+      result = timestamp;
+      return trySubtractOffsetAndAssign(result, sessionTzOffsetInSeconds_);
     }
 
     result = timestamp;

--- a/bolt/functions/sparksql/DateTimeFunctions.h
+++ b/bolt/functions/sparksql/DateTimeFunctions.h
@@ -137,8 +137,71 @@ struct UnixTimestampFunctionBase {
                                    : sessionTzID_.value_or(0);
   }
 
-  // calculate china/shanghai unix-timestamp
-  Timestamp calculateCnUnixTimestamp(Timestamp& timestamp) {
+  bool hasNegativeYear(const DateTimeResultValue& result) {
+    static const int64_t kFirstNonNegativeYearDay =
+        util::daysSinceEpochFromDate(0, 1, 1);
+    return result.timestamp.getDays() < kFirstNonNegativeYearDay;
+  }
+
+  bool tryConvertToGMT(
+      Timestamp& timestamp,
+      const tz::TimeZone& zone,
+      bool nullOnNonexistentLocalTime) {
+    constexpr int64_t kMinSecondsForTimeZoneAdjustment =
+        -1096193779200l + 86400l;
+    if (timestamp.getSeconds() < kMinSecondsForTimeZoneAdjustment ||
+        timestamp.getSeconds() > Timestamp::kMaxSeconds) {
+      return false;
+    }
+
+    if (const auto offset = zone.offset()) {
+      timestamp = Timestamp(
+          timestamp.getSeconds() - offset->count() * 60, timestamp.getNanos());
+      return true;
+    }
+
+    ::date::local_time<std::chrono::seconds> localTime{
+        std::chrono::seconds(timestamp.getSeconds())};
+    const auto info = zone.tz()->get_info(localTime);
+    if (info.result == ::date::local_info::nonexistent &&
+        nullOnNonexistentLocalTime) {
+      return false;
+    }
+
+    // Spark Java shifts nonexistent local timestamps in ordinary DST gaps
+    // forward by the gap duration. This is equivalent to converting using the
+    // offset before the transition. For ambiguous timestamps, Spark picks the
+    // earlier instant, which also uses the first offset.
+    auto sysTime =
+        ::date::sys_time<std::chrono::seconds>{localTime.time_since_epoch()} -
+        info.first.offset;
+    timestamp =
+        Timestamp(sysTime.time_since_epoch().count(), timestamp.getNanos());
+    return true;
+  }
+
+  bool tryConvertToGMT(
+      Timestamp& timestamp,
+      int16_t tzID,
+      bool nullOnNonexistentLocalTime) {
+    if (tzID == 0) {
+      return true;
+    }
+    if (tzID <= 1680) {
+      timestamp = Timestamp(
+          timestamp.getSeconds() - getPrestoTZOffsetInSeconds(tzID),
+          timestamp.getNanos());
+      return true;
+    }
+    return tryConvertToGMT(
+        timestamp,
+        *tz::locateZone(tzID),
+        nullOnNonexistentLocalTime || tzID == 1980);
+  }
+
+  // Calculate china/shanghai unix-timestamp. Return false if the local time is
+  // in a DST gap and should become NULL.
+  bool calculateCnUnixTimestamp(Timestamp& timestamp, Timestamp& result) {
     constexpr int64_t kLastDstEndUtc = 694195200; // 1992-01-01 local
     constexpr int64_t kMidCenturyStartUtc = -631180800; // 1950-01-01 local
     constexpr int64_t kMidCenturyEndUtc = 504892800; // 1986-01-01 local
@@ -146,11 +209,11 @@ struct UnixTimestampFunctionBase {
     if (timestamp.getSeconds() > kMidCenturyEndUtc &&
         timestamp.getSeconds() < kLastDstEndUtc) {
       if (sessionTzID_.has_value()) {
-        timestamp.toGMT(sessionTzID_.value());
-        return timestamp;
+        result = timestamp;
+        return tryConvertToGMT(result, sessionTzID_.value(), true);
       } else if (sessionTimeZone_ != nullptr) {
-        timestamp.toGMT(*sessionTimeZone_);
-        return timestamp;
+        result = timestamp;
+        return tryConvertToGMT(result, *sessionTimeZone_, true);
       }
     }
     // STDOFF fast paths for pure-CST windows (no DST, no LMT):
@@ -160,10 +223,12 @@ struct UnixTimestampFunctionBase {
     const int64_t utcSeconds =
         timestamp.getSeconds() - sessionTzOffsetInSeconds_;
     if (utcSeconds >= kLastDstEndUtc) {
-      return Timestamp(utcSeconds, timestamp.getNanos());
+      result = Timestamp(utcSeconds, timestamp.getNanos());
+      return true;
     }
     if (utcSeconds >= kMidCenturyStartUtc && utcSeconds < kMidCenturyEndUtc) {
-      return Timestamp(utcSeconds, timestamp.getNanos());
+      result = Timestamp(utcSeconds, timestamp.getNanos());
+      return true;
     }
 
     // Route through tzdata for every Shanghai regime (LMT, CST, and DST in
@@ -172,9 +237,9 @@ struct UnixTimestampFunctionBase {
     if (sessionTimeZone_ != nullptr) {
       const auto adjusted = sessionTimeZone_->correct_nonexistent_time(
           std::chrono::seconds(timestamp.getSeconds()));
-      timestamp = Timestamp(adjusted.count(), timestamp.getNanos());
-      timestamp.toGMT(*sessionTimeZone_);
-      return timestamp;
+      result = Timestamp(adjusted.count(), timestamp.getNanos());
+      result.toGMT(*sessionTimeZone_);
+      return true;
     }
     if (sessionTzID_.has_value()) {
       const auto* zone = tz::locateZone(
@@ -182,42 +247,68 @@ struct UnixTimestampFunctionBase {
       if (zone != nullptr) {
         const auto adjusted = zone->correct_nonexistent_time(
             std::chrono::seconds(timestamp.getSeconds()));
-        timestamp = Timestamp(adjusted.count(), timestamp.getNanos());
-        timestamp.toGMT(*zone);
+        result = Timestamp(adjusted.count(), timestamp.getNanos());
+        result.toGMT(*zone);
       } else {
-        timestamp.toGMT(sessionTzID_.value());
+        result = timestamp;
+        result.toGMT(sessionTzID_.value());
       }
-      return timestamp;
+      return true;
     }
 
     if (timestamp.getSeconds() - sessionTzOffsetInSeconds_ < kShseparator) {
-      return Timestamp(
+      result = Timestamp(
           timestamp.getSeconds() - sessionTzOffsetInSeconds_ + kShSpecOffset,
           timestamp.getNanos());
     } else {
-      return Timestamp(
+      result = Timestamp(
           timestamp.getSeconds() - sessionTzOffsetInSeconds_,
           timestamp.getNanos());
     }
+    return true;
+  }
 
-    BOLT_UNREACHABLE();
+  bool getTimestampResultInGMT(DateTimeResultValue& dtr, Timestamp& result) {
+    if (hasNegativeYear(dtr)) {
+      return false;
+    }
+
+    if (dtr.timezoneId != -1) {
+      // Use parsed timezone
+      if (!tryConvertToGMT(dtr.timestamp, dtr.timezoneId, false)) {
+        return false;
+      }
+      result = dtr.timestamp;
+    } else if (this->isShanghai) {
+      return calculateCnUnixTimestamp(dtr.timestamp, result);
+    } else if (sessionTimeZone_ != nullptr) {
+      if (!tryConvertToGMT(dtr.timestamp, *sessionTimeZone_, false)) {
+        return false;
+      }
+      result = dtr.timestamp;
+    } else {
+      result = Timestamp(
+          dtr.timestamp.getSeconds() - sessionTzOffsetInSeconds_,
+          dtr.timestamp.getNanos());
+    }
+
+    return true;
+  }
+
+  bool getResultInGMT(DateTimeResultValue& dtr, int64_t& result) {
+    Timestamp timestampResult;
+    if (!getTimestampResultInGMT(dtr, timestampResult)) {
+      return false;
+    }
+    result = timestampResult.getSeconds();
+    return true;
   }
 
   int64_t getResultInGMT(DateTimeResultValue& dtr) {
     int64_t result = 0;
-    if (dtr.timezoneId != -1) {
-      // Use parsed timezone
-      dtr.timestamp.toGMT(dtr.timezoneId);
-      result = dtr.timestamp.getSeconds();
-    } else if (this->isShanghai) {
-      return calculateCnUnixTimestamp(dtr.timestamp).getSeconds();
-    } else if (sessionTimeZone_ != nullptr) {
-      dtr.timestamp.toGMT(*sessionTimeZone_);
-      result = dtr.timestamp.getSeconds();
-    } else {
-      result = dtr.timestamp.getSeconds() - sessionTzOffsetInSeconds_;
-    }
-
+    BOLT_USER_CHECK(
+        getResultInGMT(dtr, result),
+        "Timestamp does not exist in the specified time zone");
     return result;
   }
   int64_t getResultInGMT(DateTimeResultValue&& dtr) {
@@ -225,35 +316,35 @@ struct UnixTimestampFunctionBase {
   }
 
   Timestamp getTimestampResultInGMT(DateTimeResultValue& dtr) {
-    if (dtr.timezoneId != -1) {
-      // Use parsed timezone
-      dtr.timestamp.toGMT(dtr.timezoneId);
-    } else if (this->isShanghai) {
-      return calculateCnUnixTimestamp(dtr.timestamp);
-    } else if (sessionTimeZone_ != nullptr) {
-      dtr.timestamp.toGMT(*sessionTimeZone_);
-    } else {
-      return Timestamp(
-          dtr.timestamp.getSeconds() - sessionTzOffsetInSeconds_,
-          dtr.timestamp.getNanos());
-    }
-
-    return dtr.timestamp;
+    Timestamp result;
+    BOLT_USER_CHECK(
+        getTimestampResultInGMT(dtr, result),
+        "Timestamp does not exist in the specified time zone");
+    return result;
   }
 
-  Timestamp getTimestampResultInGMT(Timestamp& timestamp) {
+  bool getTimestampResultInGMT(Timestamp& timestamp, Timestamp& result) {
     if (this->isShanghai) {
-      return calculateCnUnixTimestamp(timestamp);
+      return calculateCnUnixTimestamp(timestamp, result);
     }
 
     if (sessionTimeZone_ == nullptr) {
-      return Timestamp(
+      result = Timestamp(
           timestamp.getSeconds() - sessionTzOffsetInSeconds_,
           timestamp.getNanos());
+      return true;
     }
 
-    timestamp.toGMT(*sessionTimeZone_);
-    return timestamp;
+    result = timestamp;
+    return tryConvertToGMT(result, *sessionTimeZone_, this->isShanghai);
+  }
+
+  Timestamp getTimestampResultInGMT(Timestamp& timestamp) {
+    Timestamp result;
+    BOLT_USER_CHECK(
+        getTimestampResultInGMT(timestamp, result),
+        "Timestamp does not exist in the specified time zone");
+    return result;
   }
 
   Timestamp getTimestampResultInGMT(Timestamp&& timestamp) {
@@ -395,8 +486,7 @@ struct UnixTimestampParseFunction : public UnixTimestampFunctionBase<T> {
     if (dateTimeResult.hasError()) {
       return false;
     }
-    result = this->getResultInGMT(dateTimeResult.value());
-    return true;
+    return this->getResultInGMT(dateTimeResult.value(), result);
   }
 
   FOLLY_ALWAYS_INLINE void call(int64_t& result, const arg_type<Date>& input) {
@@ -478,8 +568,7 @@ struct UnixTimestampParseWithFormatFunction
       }
       return false;
     }
-    result = this->getResultInGMT(dateTimeResult.value());
-    return true;
+    return this->getResultInGMT(dateTimeResult.value(), result);
   }
 
   FOLLY_ALWAYS_INLINE bool call(
@@ -527,11 +616,7 @@ struct UnixTimestampParseWithFormatFunction
       return false;
     }
 
-    auto timestamp = dateTimeResult.value();
-
-    result = this->getTimestampResultInGMT(dateTimeResult.value());
-
-    return true;
+    return this->getTimestampResultInGMT(dateTimeResult.value(), result);
   }
 
   // get_timestamp(date, format)

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -99,6 +99,24 @@ class SparkSqlDateTimeFunctionsTest : public SparkFunctionBaseTest {
     result.resize(view.size());
     return result;
   }
+
+  template <typename T>
+  void assertSimpleVector(
+      const std::shared_ptr<SimpleVector<T>>& result,
+      const std::vector<std::optional<T>>& expected) {
+    ASSERT_EQ(expected.size(), result->size());
+    for (auto i = 0; i < expected.size(); ++i) {
+      if (expected[i].has_value()) {
+        if (result->isNullAt(i)) {
+          ADD_FAILURE() << "Unexpected null at " << i;
+          continue;
+        }
+        EXPECT_EQ(expected[i].value(), result->valueAt(i)) << "at " << i;
+      } else {
+        EXPECT_TRUE(result->isNullAt(i)) << "at " << i;
+      }
+    }
+  }
 };
 
 TEST_F(SparkSqlDateTimeFunctionsTest, year) {
@@ -599,6 +617,8 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampCustomFormat) {
   };
 
   EXPECT_EQ(0, unixTimestamp("1970-01-01", "yyyy-MM-dd"));
+  EXPECT_EQ(0, unixTimestamp("-1970-01-01", "'-'yyyy-MM-dd"));
+  EXPECT_EQ(std::nullopt, unixTimestamp("-0001-01-01", "yyyy-MM-dd"));
   EXPECT_EQ(0, unixTimestamp(" 1970-01-01 00:00:00", " yyyy-MM-dd HH:mm:ss"));
   EXPECT_EQ(
       std::nullopt,
@@ -637,6 +657,256 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampCustomFormat) {
   EXPECT_EQ(
       std::nullopt,
       unixTimestamp("2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd HH:mm:ss"));
+}
+
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampInDstGapReturnsNull) {
+  setQueryTimeZone("Asia/Shanghai");
+
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "unix_timestamp(c0, 'yyyy-MM-dd HH:mm:ss')",
+      makeRowVector({makeFlatVector<std::string>({
+          "1991-04-14 01:59:59",
+          "1991-04-14 02:00:00",
+          "1991-04-14 02:30:00",
+          "1991-04-14 03:00:00",
+      })}));
+
+  ASSERT_EQ(4, result->size());
+  EXPECT_FALSE(result->isNullAt(0));
+  EXPECT_EQ(671565599, result->valueAt(0));
+  EXPECT_TRUE(result->isNullAt(1));
+  EXPECT_TRUE(result->isNullAt(2));
+  EXPECT_FALSE(result->isNullAt(3));
+  EXPECT_EQ(671565600, result->valueAt(3));
+}
+
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampDefaultFormatDstGap) {
+  const auto unixTimestamp = [&](const std::vector<std::string>& inputs) {
+    return evaluate<SimpleVector<int64_t>>(
+        "unix_timestamp(c0)",
+        makeRowVector({makeFlatVector<std::string>(inputs)}));
+  };
+
+  setPolicyAndTimeZone("corrected", "Asia/Shanghai");
+  assertSimpleVector<int64_t>(
+      unixTimestamp({
+          "1991-04-14 01:59:59",
+          "1991-04-14 02:30:00",
+          "1991-04-14 03:00:00",
+          "-0001-01-01 00:00:00",
+      }),
+      {
+          671565599,
+          std::nullopt,
+          671565600,
+          std::nullopt,
+      });
+
+  setPolicyAndTimeZone("corrected", "America/Los_Angeles");
+  assertSimpleVector<int64_t>(
+      unixTimestamp({
+          "2015-03-08 02:30:00",
+          "2015-11-01 01:30:00",
+      }),
+      {
+          1425810600,
+          1446366600,
+      });
+}
+
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampNamedTimeZoneDstGap) {
+  const auto unixTimestamp = [&](const std::vector<std::string>& inputs) {
+    return evaluate<SimpleVector<int64_t>>(
+        "unix_timestamp(c0, 'yyyy-MM-dd HH:mm:ss')",
+        makeRowVector({makeFlatVector<std::string>(inputs)}));
+  };
+
+  setPolicyAndTimeZone("corrected", "America/Los_Angeles");
+  assertSimpleVector<int64_t>(
+      unixTimestamp({
+          "2015-03-08 01:59:59",
+          "2015-03-08 02:00:00",
+          "2015-03-08 02:30:00",
+          "2015-03-08 03:00:00",
+          "2015-11-01 01:30:00",
+      }),
+      {
+          1425808799,
+          1425808800,
+          1425810600,
+          1425808800,
+          1446366600,
+      });
+
+  setPolicyAndTimeZone("corrected", "Europe/Berlin");
+  assertSimpleVector<int64_t>(
+      unixTimestamp({
+          "2021-03-28 01:59:59",
+          "2021-03-28 02:00:00",
+          "2021-03-28 02:30:00",
+          "2021-03-28 03:00:00",
+          "2021-10-31 02:30:00",
+      }),
+      {
+          1616893199,
+          1616893200,
+          1616895000,
+          1616893200,
+          1635640200,
+      });
+}
+
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampWithExplicitOffset) {
+  setPolicyAndTimeZone("corrected", "Asia/Shanghai");
+
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "unix_timestamp(c0, 'yyyy-MM-dd HH:mm:ss Z')",
+      makeRowVector({makeFlatVector<std::string>({
+          "2015-03-08 03:30:00 -0700",
+          "2015-03-08 02:30:00 -0800",
+          "1970-01-01 08:00:00 +0800",
+          "1991-04-14 02:30:00 +0800",
+          "1970-01-01 00:00:00 +0000",
+      })}));
+
+  assertSimpleVector<int64_t>(
+      result,
+      {
+          1425810600,
+          1425810600,
+          0,
+          671567400,
+          0,
+      });
+}
+
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampOutOfRangeYears) {
+  setPolicyAndTimeZone("corrected", "Asia/Shanghai");
+
+  auto result = evaluate<SimpleVector<int64_t>>(
+      "unix_timestamp(c0, 'yyyy-MM-dd HH:mm:ss')",
+      makeRowVector({makeFlatVector<std::string>({
+          "0001-01-01 00:00:00",
+          "9999-12-31 23:59:59",
+          "10000-01-01 00:00:00",
+          "40000-01-01 00:00:00",
+          "-0001-01-01 00:00:00",
+          "-40000-01-01 00:00:00",
+      })}));
+
+  assertSimpleVector<int64_t>(
+      result,
+      {
+          -62135625943,
+          253402271999,
+          253402272000,
+          1200110832000,
+          std::nullopt,
+          std::nullopt,
+      });
+}
+
+TEST_F(SparkSqlDateTimeFunctionsTest, getTimestampDstGapSparkCompatibility) {
+  const auto getTimestamp = [&](const std::vector<std::string>& inputs,
+                                const std::string& format) {
+    return evaluate<SimpleVector<Timestamp>>(
+        fmt::format("get_timestamp(c0, '{}')", format),
+        makeRowVector({makeFlatVector<std::string>(inputs)}));
+  };
+
+  setPolicyAndTimeZone("corrected", "Asia/Shanghai");
+  assertSimpleVector<Timestamp>(
+      getTimestamp(
+          {
+              "1991-04-14 01:59:59",
+              "1991-04-14 02:00:00",
+              "1991-04-14 02:30:00",
+              "1991-04-14 03:00:00",
+          },
+          "yyyy-MM-dd HH:mm:ss"),
+      {
+          Timestamp(671565599, 0),
+          std::nullopt,
+          std::nullopt,
+          Timestamp(671565600, 0),
+      });
+
+  setPolicyAndTimeZone("corrected", "America/Los_Angeles");
+  assertSimpleVector<Timestamp>(
+      getTimestamp(
+          {
+              "2015-03-08 01:59:59",
+              "2015-03-08 02:00:00",
+              "2015-03-08 02:30:00",
+              "2015-03-08 03:00:00",
+              "2015-11-01 01:30:00",
+          },
+          "yyyy-MM-dd HH:mm:ss"),
+      {
+          Timestamp(1425808799, 0),
+          Timestamp(1425808800, 0),
+          Timestamp(1425810600, 0),
+          Timestamp(1425808800, 0),
+          Timestamp(1446366600, 0),
+      });
+
+  setPolicyAndTimeZone("corrected", "Europe/Berlin");
+  assertSimpleVector<Timestamp>(
+      getTimestamp(
+          {
+              "2021-03-28 01:59:59",
+              "2021-03-28 02:00:00",
+              "2021-03-28 02:30:00",
+              "2021-03-28 03:00:00",
+              "2021-10-31 02:30:00",
+          },
+          "yyyy-MM-dd HH:mm:ss"),
+      {
+          Timestamp(1616893199, 0),
+          Timestamp(1616893200, 0),
+          Timestamp(1616895000, 0),
+          Timestamp(1616893200, 0),
+          Timestamp(1635640200, 0),
+      });
+
+  setPolicyAndTimeZone("corrected", "Asia/Shanghai");
+  assertSimpleVector<Timestamp>(
+      getTimestamp(
+          {
+              "2015-03-08 03:30:00 -0700",
+              "2015-03-08 02:30:00 -0800",
+              "1970-01-01 08:00:00 +0800",
+              "1991-04-14 02:30:00 +0800",
+              "1970-01-01 00:00:00 +0000",
+          },
+          "yyyy-MM-dd HH:mm:ss Z"),
+      {
+          Timestamp(1425810600, 0),
+          Timestamp(1425810600, 0),
+          Timestamp(0, 0),
+          Timestamp(671567400, 0),
+          Timestamp(0, 0),
+      });
+
+  assertSimpleVector<Timestamp>(
+      getTimestamp(
+          {
+              "0001-01-01 00:00:00",
+              "9999-12-31 23:59:59",
+              "10000-01-01 00:00:00",
+              "40000-01-01 00:00:00",
+              "-0001-01-01 00:00:00",
+              "-40000-01-01 00:00:00",
+          },
+          "yyyy-MM-dd HH:mm:ss"),
+      {
+          Timestamp(-62135625943, 0),
+          Timestamp(253402271999, 0),
+          Timestamp(253402272000, 0),
+          Timestamp(1200110832000, 0),
+          std::nullopt,
+          std::nullopt,
+      });
 }
 
 TEST_F(
@@ -1349,8 +1619,16 @@ TEST_F(SparkSqlDateTimeFunctionsTest, getTimestamp) {
         auto ts = getTimestamp(dateString, format);
         return ts.has_value() ? ts.value().toString() : "null";
       };
+  const auto getTimestampWithFormat = [&](std::optional<StringView> dateString,
+                                          std::optional<StringView> formatStr) {
+    return evaluateOnce<Timestamp>(
+        "get_timestamp(c0, c1)", dateString, formatStr);
+  };
 
   EXPECT_EQ(getTimestamp("1970-01-01", "yyyy-MM-dd"), Timestamp(0, 0));
+  EXPECT_EQ(
+      Timestamp(0, 0), getTimestampWithFormat("-1970-01-01", "'-'yyyy-MM-dd"));
+  EXPECT_EQ(std::nullopt, getTimestampWithFormat("-0001-01-01", "yyyy-MM-dd"));
   EXPECT_EQ(Timestamp(-31536000, 0), getTimestamp("1969", "yyyy"));
   EXPECT_EQ(Timestamp(86400, 0), getTimestamp("1970-01-02", "yyyy-MM-dd"));
   EXPECT_EQ(

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -780,6 +780,46 @@ TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampWithExplicitOffset) {
       });
 }
 
+TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampSparkMicrosOverflow) {
+  const auto unixTimestamp = [&](std::optional<StringView> dateStr,
+                                 std::optional<StringView> formatStr) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0, c1)", dateStr, formatStr);
+  };
+  const auto getTimestamp = [&](std::optional<StringView> dateStr,
+                                std::optional<StringView> formatStr) {
+    return evaluateOnce<Timestamp>("get_timestamp(c0, c1)", dateStr, formatStr);
+  };
+
+  setPolicyAndTimeZone("corrected", "UTC");
+  EXPECT_EQ(
+      9223372036854,
+      unixTimestamp("294247-01-10 04:00:54", "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ(
+      9223372008054,
+      unixTimestamp("294247-01-10 04:00:54 +0800", "yyyy-MM-dd HH:mm:ss Z"));
+  BOLT_ASSERT_THROW(
+      unixTimestamp("294247-01-10 04:00:54 -0800", "yyyy-MM-dd HH:mm:ss Z"),
+      "long overflow");
+
+  EXPECT_EQ(
+      Timestamp(9223372036854, 0),
+      getTimestamp("294247-01-10 04:00:54", "yyyy-MM-dd HH:mm:ss"));
+  EXPECT_EQ(
+      Timestamp(9223372008054, 0),
+      getTimestamp("294247-01-10 04:00:54 +0800", "yyyy-MM-dd HH:mm:ss Z"));
+  BOLT_ASSERT_THROW(
+      getTimestamp("294247-01-10 04:00:54 -0800", "yyyy-MM-dd HH:mm:ss Z"),
+      "long overflow");
+
+  setPolicyAndTimeZone("corrected", "America/Los_Angeles");
+  BOLT_ASSERT_THROW(
+      unixTimestamp("294247-01-10 04:00:54", "yyyy-MM-dd HH:mm:ss"),
+      "long overflow");
+  BOLT_ASSERT_THROW(
+      getTimestamp("294247-01-10 04:00:54", "yyyy-MM-dd HH:mm:ss"),
+      "long overflow");
+}
+
 TEST_F(SparkSqlDateTimeFunctionsTest, unixTimestampOutOfRangeYears) {
   setPolicyAndTimeZone("corrected", "Asia/Shanghai");
 


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #785 

This PR fixes Spark SQL timestamp parsing behavior around time zone conversion, especially for daylight saving time (DST) gaps and historical `Asia/Shanghai` transitions.

Before this change, `unix_timestamp` / `to_unix_timestamp` / `get_timestamp` could return incorrect results for local timestamps that fall into DST gaps or ambiguous transition periods. Some invalid or unsupported timestamp values, such as negative years, were also not consistently converted to `NULL` as expected by Spark-compatible behavior.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
This PR updates Spark SQL timestamp-to-GMT conversion logic to better match Spark/JVM behavior.

Main changes:

- Added a shared GMT conversion helper that handles:
  - fixed-offset time zones,
  - named TZ time zones,
  - nonexistent local timestamps during DST gaps,
  - ambiguous local timestamps during DST fallback transitions,
  - out-of-range timestamp values.

- Updated `unix_timestamp` and `get_timestamp` conversion paths to return `NULL` instead of throwing or producing incorrect results when the parsed timestamp cannot be represented or should be treated as nonexistent.

- Fixed Spark-compatible behavior for DST gaps:
  - For `Asia/Shanghai`, local timestamps inside the 1991 DST gap return `NULL`.
  - For regular named time zones such as `America/Los_Angeles` and `Europe/Berlin`, nonexistent local timestamps are shifted forward using Spark/JVM-compatible semantics.
  - Ambiguous fallback timestamps use the earlier instant, matching Spark behavior.

- Preserved the existing optimized `Asia/Shanghai` fast paths for pure CST ranges while routing historical DST/LMT ranges through tzdata when needed.

- Added regression tests covering:
  - `unix_timestamp` with default and custom formats,
  - `get_timestamp`,
  - DST gaps in `Asia/Shanghai`,
  - DST gap/fallback behavior in `America/Los_Angeles` and `Europe/Berlin`,
  - explicit time zone offsets,
  - out-of-range and negative-year inputs.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Release Note:
```text
- Fixed Spark SQL timestamp parsing for DST gaps, ambiguous timezone transitions, and negative-year inputs.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
