### PR TITLE
perf: elide result null bitmap allocation for is-not-null scans

### DIFF
--- a/bolt/dwio/common/SelectiveColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveColumnReader.cpp
@@ -119,6 +119,9 @@ void SelectiveColumnReader::prepareNulls(
     int32_t extraRows) {
   if (!hasNulls) {
     anyNulls_ = false;
+    resultNulls_ = nullptr;
+    rawResultNulls_ = nullptr;
+    returnReaderNulls_ = false;
     return;
   }
   auto numRows = rows.size() + extraRows;
@@ -151,6 +154,32 @@ void SelectiveColumnReader::prepareNulls(
       numRows + (simd::kPadding * 8), &memoryPool_);
   rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
   simd::memset(rawResultNulls_, bits::kNotNullByte, resultNulls_->capacity());
+}
+
+void SelectiveColumnReader::prepareOutputNulls(
+    const RowSet& rows,
+    bool inputHasNulls,
+    int32_t extraRows) {
+  prepareNulls(
+      rows, inputHasNulls && !filterGuaranteesRawOutputNonNull(), extraRows);
+}
+
+bool SelectiveColumnReader::filterGuaranteesRawOutputNonNull() const {
+  auto* filter = scanSpec_->filter();
+  if (!filter || filter->kind() != bolt::common::FilterKind::kIsNotNull) {
+    return false;
+  }
+  if (!scanSpec_->keepValues() || scanSpec_->valueHook()) {
+    return false;
+  }
+  // IS NOT NULL only proves that the input value passed the filter. A cast can
+  // still produce a nullable result, so only elide result nulls when the raw
+  // read type is also the requested output type.
+  if (!requestedType_->equivalent(*fileType_->type())) {
+    return false;
+  }
+  const auto& type = fileType_->type();
+  return type->isPrimitiveType() || type->isVarchar() || type->isVarbinary();
 }
 
 const uint64_t* SelectiveColumnReader::shouldMoveNulls(RowSet rows) {

--- a/bolt/dwio/common/SelectiveColumnReader.h
+++ b/bolt/dwio/common/SelectiveColumnReader.h
@@ -471,8 +471,16 @@ class SelectiveColumnReader {
   template <typename T>
   void ensureValuesCapacity(vector_size_t numRows);
 
+  // Prepares output nulls for reading 'rows'. Keeps null decoding for
+  // filtering, but skips result nulls when the filter proves raw output values
+  // are non-null.
+  void prepareOutputNulls(
+      const RowSet& rows,
+      bool inputHasNulls,
+      int32_t extraRows = 0);
+
   // Prepares the result buffer for nulls for reading 'rows'. Leaves
-  // 'extraSpace' bits worth of space in the nulls buffer.
+  // 'extraRows' bits worth of space in the nulls buffer.
   void prepareNulls(const RowSet& rows, bool hasNulls, int32_t extraRows = 0);
 
   void makeCastExpr(TypePtr castSourceType = nullptr);
@@ -543,6 +551,8 @@ class SelectiveColumnReader {
   // should move null flags.  Return nullptr if nulls does not need to be moved.
   // Checks consistency of nulls-related state.
   const uint64_t* shouldMoveNulls(RowSet rows);
+
+  bool filterGuaranteesRawOutputNonNull() const;
 
   void addStringValue(folly::StringPiece value);
 

--- a/bolt/dwio/common/SelectiveColumnReaderInternal.h
+++ b/bolt/dwio/common/SelectiveColumnReaderInternal.h
@@ -102,7 +102,7 @@ void SelectiveColumnReader::prepareRead(
   ensureValuesCapacity<T>(rows.size());
   if (scanSpec_->keepValues() && !scanSpec_->valueHook()) {
     valueRows_.clear();
-    prepareNulls(rows, nullsInReadRange_ != nullptr);
+    prepareOutputNulls(rows, nullsInReadRange_ != nullptr);
   }
 }
 

--- a/bolt/dwio/common/tests/ReaderTest.cpp
+++ b/bolt/dwio/common/tests/ReaderTest.cpp
@@ -30,10 +30,13 @@
 
 #include "bolt/dwio/common/Reader.h"
 #include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/dwio/common/FormatData.h"
+#include "bolt/dwio/common/SelectiveColumnReader.h"
 #include "bolt/type/Subfield.h"
 #include "bolt/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
+#include <array>
 namespace bytedance::bolt::dwio::common {
 namespace {
 using namespace bytedance::bolt::common;
@@ -44,6 +47,341 @@ class ReaderTest : public testing::Test, public test::VectorTestBase {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 };
+
+class TestFormatData : public FormatData {
+ public:
+  void readNulls(
+      vector_size_t /*numValues*/,
+      const uint64_t* FOLLY_NULLABLE /*incomingNulls*/,
+      BufferPtr& nulls,
+      bool /*nullsOnly*/ = false) override {
+    nulls = nullptr;
+  }
+
+  uint64_t skipNulls(uint64_t numValues, bool /*nullsOnly*/ = false) override {
+    return numValues;
+  }
+
+  uint64_t skip(uint64_t numValues) override {
+    return numValues;
+  }
+
+  bool hasNulls() const override {
+    return true;
+  }
+
+  PositionProvider seekToRowGroup(int64_t /*index*/) override {
+    return PositionProvider(emptyPositions_);
+  }
+
+  void filterRowGroups(
+      const common::ScanSpec& /*scanSpec*/,
+      uint64_t /*rowsPerRowGroup*/,
+      const StatsContext& /*writerContext*/,
+      FilterRowGroupsResult& /*result*/,
+      BufferedInput& /*input*/) override {}
+
+ private:
+  std::vector<uint64_t> emptyPositions_;
+};
+
+class TestFormatParams : public FormatParams {
+ public:
+  explicit TestFormatParams(
+      memory::MemoryPool& pool,
+      ColumnReaderStatistics& stats)
+      : FormatParams(pool, stats) {}
+
+  std::unique_ptr<FormatData> toFormatData(
+      const std::shared_ptr<const TypeWithId>& /*type*/,
+      const common::ScanSpec& /*scanSpec*/) override {
+    return std::make_unique<TestFormatData>();
+  }
+};
+
+class TestSelectiveColumnReader : public SelectiveColumnReader {
+ public:
+  TestSelectiveColumnReader(
+      const TypePtr& requestedType,
+      const std::shared_ptr<const TypeWithId>& fileType,
+      FormatParams& params,
+      common::ScanSpec& scanSpec)
+      : SelectiveColumnReader(requestedType, fileType, params, scanSpec) {}
+
+  void read(
+      int64_t /*offset*/,
+      const RowSet& /*rows*/,
+      const uint64_t* /*incomingNulls*/) override {}
+
+  void getValues(const RowSet& /*rows*/, VectorPtr* /*result*/) override {}
+
+  void prepareOutputNullsForTest(
+      const RowSet& rows,
+      bool inputHasNulls,
+      int32_t extraRows = 0) {
+    prepareOutputNulls(rows, inputHasNulls, extraRows);
+  }
+
+  const BufferPtr& storedResultNullsForTest() const {
+    return resultNulls_;
+  }
+
+  const uint64_t* rawResultNullsForTest() const {
+    return rawResultNulls_;
+  }
+
+  bool returnReaderNullsForTest() const {
+    return returnReaderNulls_;
+  }
+};
+
+class TestValueHook : public ValueHook {
+ public:
+  void addValue(vector_size_t /*row*/, const void* /*value*/) override {}
+};
+
+enum class TestFilterKind { kNone, kIsNotNull, kIsNull, kBigintRange };
+
+std::unique_ptr<common::Filter> makeTestFilter(TestFilterKind kind) {
+  switch (kind) {
+    case TestFilterKind::kNone:
+      return nullptr;
+    case TestFilterKind::kIsNotNull:
+      return std::make_unique<common::IsNotNull>();
+    case TestFilterKind::kIsNull:
+      return std::make_unique<common::IsNull>();
+    case TestFilterKind::kBigintRange:
+      return std::make_unique<common::BigintRange>(0, 10, false);
+  }
+  BOLT_UNREACHABLE();
+}
+
+struct PrepareOutputNullsCase {
+  const char* name;
+  TypePtr requestedType;
+  TypePtr fileType;
+  TestFilterKind filterKind;
+  bool projectOut{true};
+  bool extractValues{false};
+  bool hasValueHook{false};
+  bool inputHasNulls{true};
+  int32_t extraRows{0};
+  bool expectAllocation{true};
+};
+
+PrepareOutputNullsCase prepareOutputNullsCase(
+    const char* name,
+    TypePtr requestedType,
+    TypePtr fileType,
+    TestFilterKind filterKind,
+    bool expectAllocation,
+    bool projectOut = true,
+    bool extractValues = false,
+    bool hasValueHook = false,
+    bool inputHasNulls = true,
+    int32_t extraRows = 0) {
+  return PrepareOutputNullsCase{
+      name,
+      std::move(requestedType),
+      std::move(fileType),
+      filterKind,
+      projectOut,
+      extractValues,
+      hasValueHook,
+      inputHasNulls,
+      extraRows,
+      expectAllocation};
+}
+
+class PrepareOutputNullsTest
+    : public ReaderTest,
+      public testing::WithParamInterface<PrepareOutputNullsCase> {};
+
+TEST_P(PrepareOutputNullsTest, allocation) {
+  auto testCase = GetParam();
+  common::ScanSpec scanSpec("c0");
+  scanSpec.setProjectOut(testCase.projectOut);
+  scanSpec.setExtractValues(testCase.extractValues);
+  scanSpec.setFilter(makeTestFilter(testCase.filterKind));
+  TestValueHook hook;
+  if (testCase.hasValueHook) {
+    scanSpec.setValueHook(&hook);
+  }
+
+  ColumnReaderStatistics stats;
+  TestFormatParams params(*pool(), stats);
+  auto fileTypeWithId = TypeWithId::create(testCase.fileType);
+  TestSelectiveColumnReader reader(
+      testCase.requestedType, fileTypeWithId, params, scanSpec);
+
+  const std::array<vector_size_t, 4> rowNumbers = {0, 1, 2, 3};
+  RowSet rows(rowNumbers.data(), rowNumbers.size());
+  const auto allocsBefore = pool()->stats().numAllocs;
+  reader.prepareOutputNullsForTest(
+      rows, testCase.inputHasNulls, testCase.extraRows);
+  const auto allocsAfter = pool()->stats().numAllocs;
+
+  if (testCase.expectAllocation) {
+    EXPECT_GT(allocsAfter, allocsBefore);
+  } else {
+    EXPECT_EQ(allocsAfter, allocsBefore);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IsNotNullNullBufferElision,
+    PrepareOutputNullsTest,
+    testing::Values(
+        prepareOutputNullsCase(
+            "no_filter_may_need_output_nulls",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kNone,
+            true),
+        prepareOutputNullsCase(
+            "bigint_is_not_null_projected",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kIsNotNull,
+            false),
+        prepareOutputNullsCase(
+            "varchar_is_not_null_extracted",
+            VARCHAR(),
+            VARCHAR(),
+            TestFilterKind::kIsNotNull,
+            false,
+            false,
+            true),
+        prepareOutputNullsCase(
+            "varbinary_is_not_null_projected",
+            VARBINARY(),
+            VARBINARY(),
+            TestFilterKind::kIsNotNull,
+            false),
+        prepareOutputNullsCase(
+            "no_input_nulls",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kBigintRange,
+            false,
+            true,
+            false,
+            false,
+            false),
+        prepareOutputNullsCase(
+            "range_filter_may_need_output_nulls",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kBigintRange,
+            true),
+        prepareOutputNullsCase(
+            "is_null_filter_may_need_output_nulls",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kIsNull,
+            true),
+        prepareOutputNullsCase(
+            "is_not_null_filter_only",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kIsNotNull,
+            true,
+            false,
+            false),
+        prepareOutputNullsCase(
+            "is_not_null_with_value_hook",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kIsNotNull,
+            true,
+            true,
+            false,
+            true),
+        prepareOutputNullsCase(
+            "is_not_null_cast_output",
+            INTEGER(),
+            BIGINT(),
+            TestFilterKind::kIsNotNull,
+            true),
+        prepareOutputNullsCase(
+            "is_not_null_complex_output",
+            ARRAY(BIGINT()),
+            ARRAY(BIGINT()),
+            TestFilterKind::kIsNotNull,
+            true),
+        prepareOutputNullsCase(
+            "is_not_null_with_extra_rows",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kIsNotNull,
+            false,
+            true,
+            false,
+            false,
+            true,
+            7),
+        prepareOutputNullsCase(
+            "range_filter_with_extra_rows",
+            BIGINT(),
+            BIGINT(),
+            TestFilterKind::kBigintRange,
+            true,
+            true,
+            false,
+            false,
+            true,
+            7)),
+    [](const testing::TestParamInfo<PrepareOutputNullsCase>& info) {
+      return info.param.name;
+    });
+
+TEST_F(ReaderTest, prepareOutputNullsClearsPreviouslyAllocatedNulls) {
+  common::ScanSpec scanSpec("c0");
+  scanSpec.setProjectOut(true);
+  scanSpec.setFilter(makeTestFilter(TestFilterKind::kBigintRange));
+
+  ColumnReaderStatistics stats;
+  TestFormatParams params(*pool(), stats);
+  auto fileTypeWithId = TypeWithId::create(BIGINT());
+  TestSelectiveColumnReader reader(BIGINT(), fileTypeWithId, params, scanSpec);
+
+  const std::array<vector_size_t, 4> rowNumbers = {0, 1, 2, 3};
+  RowSet rows(rowNumbers.data(), rowNumbers.size());
+  reader.prepareOutputNullsForTest(rows, true);
+  ASSERT_NE(nullptr, reader.storedResultNullsForTest().get());
+  ASSERT_NE(nullptr, reader.rawResultNullsForTest());
+
+  scanSpec.setFilter(makeTestFilter(TestFilterKind::kIsNotNull));
+  const auto allocsBefore = pool()->stats().numAllocs;
+  reader.prepareOutputNullsForTest(rows, true);
+  EXPECT_EQ(allocsBefore, pool()->stats().numAllocs);
+  EXPECT_EQ(nullptr, reader.storedResultNullsForTest().get());
+  EXPECT_EQ(nullptr, reader.rawResultNullsForTest());
+}
+
+TEST_F(ReaderTest, prepareOutputNullsClearsReturnedReaderNulls) {
+  common::ScanSpec scanSpec("c0");
+  scanSpec.setProjectOut(true);
+
+  ColumnReaderStatistics stats;
+  TestFormatParams params(*pool(), stats);
+  auto fileTypeWithId = TypeWithId::create(BIGINT());
+  TestSelectiveColumnReader reader(BIGINT(), fileTypeWithId, params, scanSpec);
+
+  const std::array<vector_size_t, 4> rowNumbers = {0, 1, 2, 3};
+  RowSet rows(rowNumbers.data(), rowNumbers.size());
+  reader.nullsInReadRange() =
+      AlignedBuffer::allocate<bool>(rows.size(), pool(), bits::kNotNull);
+
+  reader.prepareOutputNullsForTest(rows, true);
+  ASSERT_TRUE(reader.returnReaderNullsForTest());
+
+  scanSpec.setFilter(makeTestFilter(TestFilterKind::kIsNotNull));
+  reader.prepareOutputNullsForTest(rows, true);
+  EXPECT_FALSE(reader.returnReaderNullsForTest());
+  EXPECT_EQ(nullptr, reader.storedResultNullsForTest().get());
+  EXPECT_EQ(nullptr, reader.rawResultNullsForTest());
+}
 
 TEST_F(ReaderTest, projectColumnsFilterStruct) {
   constexpr int kSize = 10;

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -1642,7 +1642,7 @@ bool PageReader::rowsForPage(
     rows = folly::Range<const vector_size_t*>(
         rowsCopy_->data(), rowsCopy_->size());
   }
-  reader.prepareNulls(rows, nulls != nullptr, currentVisitorRow_);
+  reader.prepareOutputNulls(rows, nulls != nullptr, currentVisitorRow_);
   currentVisitorRow_ += numToVisit;
   firstUnvisited_ = visitBase_ + visitorRows_[currentVisitorRow_ - 1] + 1;
   return true;

--- a/bolt/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -35,6 +35,8 @@
 #include "bolt/vector/tests/utils/VectorTestBase.h"
 
 #include <folly/init/Init.h>
+#include <limits>
+#include <utility>
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::common;
 using namespace bytedance::bolt::dwio::common;
@@ -98,6 +100,59 @@ class E2EFilterTest : public E2EFilterTestBase, public test::VectorTestBase {
       const dwio::common::ReaderOptions& opts,
       std::unique_ptr<dwio::common::BufferedInput> input) override {
     return std::make_unique<ParquetReader>(std::move(input), opts);
+  }
+
+  std::pair<VectorPtr, uint64_t> readWithSpec(
+      const RowVectorPtr& data,
+      const std::shared_ptr<common::ScanSpec>& spec,
+      uint64_t size,
+      const RowTypePtr& outputType = nullptr) {
+    writeToMemory(data->type(), {data}, false);
+
+    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(spec);
+    std::string_view serializedData(sinkPtr_->data(), sinkPtr_->size());
+    auto input = std::make_unique<BufferedInput>(
+        std::make_shared<InMemoryReadFile>(serializedData),
+        readerOpts.getMemoryPool());
+    auto reader = makeReader(readerOpts, std::move(input));
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+
+    auto result = BaseVector::create(
+        outputType ? outputType : data->type(), 0, leafPool_.get());
+    auto rowsScanned = rowReader->next(size, result);
+    return {result, rowsScanned};
+  }
+
+  std::unique_ptr<RowReader> makeRowReader(
+      const RowVectorPtr& data,
+      const std::shared_ptr<common::ScanSpec>& spec) {
+    writeToMemory(data->type(), {data}, false);
+
+    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(spec);
+    std::string_view serializedData(sinkPtr_->data(), sinkPtr_->size());
+    auto input = std::make_unique<BufferedInput>(
+        std::make_shared<InMemoryReadFile>(serializedData),
+        readerOpts.getMemoryPool());
+    auto reader = makeReader(readerOpts, std::move(input));
+    return reader->createRowReader(rowReaderOpts);
+  }
+
+  void assertNoNullBuffer(const VectorPtr& vector) {
+    ASSERT_FALSE(vector->isLazy());
+    EXPECT_EQ(nullptr, vector->nulls().get());
+    EXPECT_EQ(nullptr, vector->rawNulls());
+    EXPECT_FALSE(vector->mayHaveNulls());
+  }
+
+  void assertHasNullBuffer(const VectorPtr& vector) {
+    ASSERT_FALSE(vector->isLazy());
+    EXPECT_NE(nullptr, vector->nulls().get());
+    EXPECT_NE(nullptr, vector->rawNulls());
+    EXPECT_TRUE(vector->mayHaveNulls());
   }
 
   std::unique_ptr<bytedance::bolt::parquet::Writer> writer_;
@@ -652,6 +707,467 @@ TEST_F(E2EFilterTest, largeMetadata) {
       std::make_shared<InMemoryReadFile>(data), readerOpts.getMemoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   EXPECT_EQ(1000, reader->numberOfRows());
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsAfterCompaction) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {makeNullableFlatVector<int64_t>(
+           {10, std::nullopt, 30, 40, std::nullopt, 60}),
+       makeFlatVector<int64_t>({5, 7, 12, 3, 8, 20})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("b", 1)->setFilter(std::make_unique<common::BigintRange>(
+      std::numeric_limits<int64_t>::min(), 9, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 6);
+  EXPECT_EQ(6, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  ASSERT_EQ(2, row->size());
+  test::assertEqualVectors(
+      makeRowVector(
+          {"a", "b"},
+          {makeFlatVector<int64_t>({10, 40}), makeFlatVector<int64_t>({5, 3})}),
+      result);
+
+  assertNoNullBuffer(row->childAt(0));
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputOnlyElidesProvenNonNullColumn) {
+  auto data = makeRowVector(
+      {"a", "b", "guard"},
+      {makeNullableFlatVector<int64_t>(
+           {10, std::nullopt, 30, 40, 50, std::nullopt}),
+       makeNullableFlatVector<int64_t>(
+           {std::nullopt, 21, 22, std::nullopt, 24, 25}),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("b", 1);
+  spec->addField("guard", 2)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 4, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 6);
+  EXPECT_EQ(6, rowsScanned);
+  test::assertEqualVectors(
+      makeRowVector(
+          {"a", "b", "guard"},
+          {makeFlatVector<int64_t>({10, 30, 40, 50}),
+           makeNullableFlatVector<int64_t>(
+               {std::nullopt, 22, std::nullopt, 24}),
+           makeFlatVector<int64_t>({0, 2, 3, 4})}),
+      result);
+
+  auto row = result->asUnchecked<RowVector>();
+  assertNoNullBuffer(row->childAt(0));
+  assertHasNullBuffer(row->childAt(1));
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsAfterDictionaryFallback) {
+  options_.dictionaryPageSizeLimit = 128;
+
+  constexpr vector_size_t kSize = 2048;
+  auto data = makeRowVector(
+      {"s", "guard"},
+      {makeFlatVector<std::string>(
+           kSize,
+           [](auto row) { return fmt::format("value_{}", row); },
+           [](auto row) { return row % 7 == 0; }),
+       makeFlatVector<int64_t>(kSize, [](auto row) { return row % 13; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("s", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("guard", 1)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 5, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, kSize);
+  EXPECT_EQ(kSize, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  auto s = row->childAt(0)->asUnchecked<FlatVector<StringView>>();
+  auto guard = row->childAt(1)->asUnchecked<FlatVector<int64_t>>();
+  assertNoNullBuffer(row->childAt(0));
+  for (auto i = 0; i < row->size(); ++i) {
+    auto sourceRow = std::stoll(s->valueAt(i).getString().substr(6));
+    EXPECT_NE(0, sourceRow % 7);
+    EXPECT_LT(guard->valueAt(i), 6);
+  }
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHandlesAllRowsFiltered) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt, 3}),
+       makeFlatVector<int64_t>({10, 11, 12})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("b", 1)->setFilter(
+      std::make_unique<common::BigintRange>(0, 1, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 3);
+  (void)rowsScanned;
+  EXPECT_EQ(0, result->size());
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsWithResultReuse) {
+  constexpr vector_size_t kSize = 32;
+  auto data = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>(
+           kSize,
+           [](auto row) { return row; },
+           [](auto row) { return row % 4 == 0; }),
+       makeFlatVector<int64_t>(kSize, [](auto row) { return row % 3; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("b", 1)->setFilter(
+      std::make_unique<common::BigintRange>(0, 1, false));
+
+  auto rowReader = makeRowReader(data, spec);
+  auto result = BaseVector::create(data->type(), 0, leafPool_.get());
+  uint64_t totalScanned = 0;
+  for (;;) {
+    auto scanned = rowReader->next(7, result);
+    if (!scanned) {
+      break;
+    }
+    totalScanned += scanned;
+    if (!result->size()) {
+      continue;
+    }
+    auto row = result->asUnchecked<RowVector>();
+    assertNoNullBuffer(row->childAt(0));
+    auto a = row->childAt(0)->asUnchecked<FlatVector<int64_t>>();
+    auto b = row->childAt(1)->asUnchecked<FlatVector<int64_t>>();
+    for (auto i = 0; i < row->size(); ++i) {
+      EXPECT_NE(0, a->valueAt(i) % 4);
+      EXPECT_LT(b->valueAt(i), 2);
+    }
+  }
+  EXPECT_EQ(kSize, totalScanned);
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHandlesEmptyBatchReuse) {
+  constexpr vector_size_t kSize = 12;
+  auto data = makeRowVector(
+      {"a", "guard"},
+      {makeFlatVector<int64_t>(
+           kSize,
+           [](auto row) { return row; },
+           [](auto row) { return row == 1 || row == 9; }),
+       makeFlatVector<int64_t>(
+           kSize, [](auto row) { return row >= 4 && row < 8 ? 9 : 0; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("guard", 1)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 0, false));
+
+  auto rowReader = makeRowReader(data, spec);
+  auto result = BaseVector::create(data->type(), 0, leafPool_.get());
+
+  ASSERT_EQ(4, rowReader->next(4, result));
+  test::assertEqualVectors(
+      makeRowVector(
+          {"a", "guard"},
+          {makeFlatVector<int64_t>({0, 2, 3}),
+           makeFlatVector<int64_t>({0, 0, 0})}),
+      result);
+  assertNoNullBuffer(result->asUnchecked<RowVector>()->childAt(0));
+
+  ASSERT_EQ(4, rowReader->next(4, result));
+  EXPECT_EQ(0, result->size());
+
+  ASSERT_EQ(4, rowReader->next(4, result));
+  test::assertEqualVectors(
+      makeRowVector(
+          {"a", "guard"},
+          {makeFlatVector<int64_t>({8, 10, 11}),
+           makeFlatVector<int64_t>({0, 0, 0})}),
+      result);
+  assertNoNullBuffer(result->asUnchecked<RowVector>()->childAt(0));
+  ASSERT_FALSE(rowReader->next(4, result));
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsAcrossPages) {
+  options_.enableDictionary = false;
+  options_.dataPageSize = 128;
+
+  constexpr vector_size_t kSize = 4096;
+  auto data = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>(
+           kSize,
+           [](auto row) { return row; },
+           [](auto row) { return row % 5 == 0; }),
+       makeFlatVector<int64_t>(kSize, [](auto row) { return row % 11; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("b", 1)->setFilter(
+      std::make_unique<common::BigintRange>(0, 4, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, kSize);
+  EXPECT_EQ(kSize, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  auto a = row->childAt(0)->asUnchecked<FlatVector<int64_t>>();
+  auto b = row->childAt(1)->asUnchecked<FlatVector<int64_t>>();
+  ASSERT_EQ(a->size(), b->size());
+  assertNoNullBuffer(row->childAt(0));
+  for (auto i = 0; i < row->size(); ++i) {
+    EXPECT_NE(0, a->valueAt(i) % 5);
+    EXPECT_LT(b->valueAt(i), 5);
+  }
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsAcrossRowGroups) {
+  rowsInRowGroup_ = 4;
+  constexpr vector_size_t kSize = 12;
+  auto data = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>(
+           kSize,
+           [](auto row) { return row; },
+           [](auto row) { return row < 4 || row == 8; }),
+       makeFlatVector<int64_t>(kSize, [](auto row) { return row % 5; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("b", 1)->setFilter(
+      std::make_unique<common::BigintRange>(0, 3, false));
+
+  auto rowReader = makeRowReader(data, spec);
+  auto result = BaseVector::create(data->type(), 0, leafPool_.get());
+  std::vector<int64_t> values;
+  for (;;) {
+    auto scanned = rowReader->next(4, result);
+    if (!scanned) {
+      break;
+    }
+    if (!result->size()) {
+      continue;
+    }
+    auto row = result->asUnchecked<RowVector>();
+    auto a = row->childAt(0)->asUnchecked<FlatVector<int64_t>>();
+    auto b = row->childAt(1)->asUnchecked<FlatVector<int64_t>>();
+    assertNoNullBuffer(row->childAt(0));
+    for (auto i = 0; i < row->size(); ++i) {
+      EXPECT_FALSE(a->valueAt(i) < 4 || a->valueAt(i) == 8);
+      EXPECT_LT(b->valueAt(i), 4);
+      values.push_back(a->valueAt(i));
+    }
+  }
+  EXPECT_EQ((std::vector<int64_t>{5, 6, 7, 10, 11}), values);
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsForScalarTypes) {
+  auto data = makeRowVector(
+      {"s", "vb", "d", "guard"},
+      {makeNullableFlatVector<std::string>(
+           {"apple", std::nullopt, "banana", "cherry", std::nullopt, "date"}),
+       makeNullableFlatVector<std::string>(
+           {"aa", "bb", std::nullopt, "cc", "dd", std::nullopt}, VARBINARY()),
+       makeFlatVector<double>(
+           6,
+           [](auto row) { return row + 0.5; },
+           [](auto row) { return row == 4; }),
+       makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("s", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("vb", 1)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("d", 2)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("guard", 3)
+      ->setFilter(std::make_unique<common::BigintRange>(2, 4, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 6);
+  EXPECT_EQ(6, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  ASSERT_EQ(1, row->size());
+  test::assertEqualVectors(
+      makeRowVector(
+          {"s", "vb", "d", "guard"},
+          {makeFlatVector<std::string>({"cherry"}),
+           makeFlatVector<std::string>({"cc"}, VARBINARY()),
+           makeFlatVector<double>({3.5}),
+           makeFlatVector<int64_t>({4})}),
+      result);
+  assertNoNullBuffer(row->childAt(0));
+  assertNoNullBuffer(row->childAt(1));
+  assertNoNullBuffer(row->childAt(2));
+}
+
+TEST_F(E2EFilterTest, isNotNullOutputHasNoNullsForAdditionalScalarTypes) {
+  auto data = makeRowVector(
+      {"flag", "ts", "dec", "guard"},
+      {makeFlatVector<bool>(
+           6,
+           [](auto row) { return row % 2 == 0; },
+           [](auto row) { return row == 1; }),
+       makeFlatVector<Timestamp>(
+           6,
+           [](auto row) { return Timestamp(row, row * 1000); },
+           [](auto row) { return row == 2; }),
+       makeNullableFlatVector<int64_t>(
+           {100, std::nullopt, 300, 400, std::nullopt, 600}, DECIMAL(10, 2)),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("flag", 0)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("ts", 1)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("dec", 2)->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("guard", 3)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 4, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 6);
+  EXPECT_EQ(6, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  ASSERT_EQ(2, row->size());
+  test::assertEqualVectors(
+      makeRowVector(
+          {"flag", "ts", "dec", "guard"},
+          {makeFlatVector<bool>({true, false}),
+           makeFlatVector<Timestamp>({Timestamp(0, 0), Timestamp(3, 0)}),
+           makeFlatVector<int64_t>({100, 400}, DECIMAL(10, 2)),
+           makeFlatVector<int64_t>({0, 3})}),
+      result);
+  assertNoNullBuffer(row->childAt(0));
+  assertNoNullBuffer(row->childAt(1));
+  assertNoNullBuffer(row->childAt(2));
+}
+
+TEST_F(E2EFilterTest, complexIsNotNullOutputKeepsCorrectNulls) {
+  auto data = makeRowVector(
+      {"arr", "guard"},
+      {makeArrayVector<int64_t>(
+           5,
+           [](auto) { return 2; },
+           [](auto row, auto index) { return row * 10 + index; },
+           [](auto row) { return row == 1 || row == 4; }),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addFieldRecursively("arr", *ARRAY(BIGINT()), 0)
+      ->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("guard", 1)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 3, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 5);
+  EXPECT_EQ(5, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  ASSERT_EQ(3, row->size());
+  auto arr = row->childAt(0)->asUnchecked<ArrayVector>();
+  ASSERT_FALSE(arr->isNullAt(0));
+  ASSERT_FALSE(arr->isNullAt(1));
+  ASSERT_FALSE(arr->isNullAt(2));
+  EXPECT_EQ(2, arr->sizeAt(0));
+  EXPECT_EQ(2, arr->sizeAt(1));
+  EXPECT_EQ(2, arr->sizeAt(2));
+  test::assertEqualVectors(
+      makeRowVector(
+          {"arr", "guard"},
+          {makeArrayVector<int64_t>({{0, 1}, {20, 21}, {30, 31}}),
+           makeFlatVector<int64_t>({0, 2, 3})}),
+      result);
+}
+
+TEST_F(E2EFilterTest, mapIsNotNullOutputKeepsCorrectNulls) {
+  auto data = makeRowVector(
+      {"m", "guard"},
+      {makeNullableMapVector<int64_t, int64_t>(
+           {std::vector<std::pair<int64_t, std::optional<int64_t>>>{
+                {1, 10}, {2, std::nullopt}},
+            std::nullopt,
+            std::vector<std::pair<int64_t, std::optional<int64_t>>>{
+                {4, 40}, {5, 50}},
+            std::vector<std::pair<int64_t, std::optional<int64_t>>>{{6, 60}},
+            std::nullopt},
+           MAP(BIGINT(), BIGINT())),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4})});
+
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addFieldRecursively("m", *MAP(BIGINT(), BIGINT()), 0)
+      ->setFilter(std::make_unique<common::IsNotNull>());
+  spec->addField("guard", 1)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 3, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 5);
+  EXPECT_EQ(5, rowsScanned);
+  auto row = result->asUnchecked<RowVector>();
+  ASSERT_EQ(3, row->size());
+  auto map = row->childAt(0)->asUnchecked<MapVector>();
+  ASSERT_FALSE(map->isNullAt(0));
+  ASSERT_FALSE(map->isNullAt(1));
+  ASSERT_FALSE(map->isNullAt(2));
+  EXPECT_EQ(2, map->sizeAt(0));
+  EXPECT_EQ(2, map->sizeAt(1));
+  EXPECT_EQ(1, map->sizeAt(2));
+}
+
+TEST_F(E2EFilterTest, siblingFilterPreservesNullableOutputAcrossPages) {
+  options_.enableDictionary = false;
+  options_.dataPageSize = 128;
+
+  constexpr vector_size_t kSize = 4096;
+  auto data = makeRowVector(
+      {"a", "guard"},
+      {makeFlatVector<int64_t>(
+           kSize,
+           [](auto row) { return row; },
+           [](auto row) { return row < 64; }),
+       makeFlatVector<int64_t>(kSize, [](auto row) { return row % 5; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0);
+  spec->addField("guard", 1)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 3, false));
+
+  std::vector<std::optional<int64_t>> expectedA;
+  std::vector<int64_t> expectedGuard;
+  for (auto row = 0; row < kSize; ++row) {
+    const auto guard = row % 5;
+    if (guard > 3) {
+      continue;
+    }
+    expectedA.push_back(row < 64 ? std::nullopt : std::make_optional(row));
+    expectedGuard.push_back(guard);
+  }
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, kSize);
+  EXPECT_EQ(kSize, rowsScanned);
+  test::assertEqualVectors(
+      makeRowVector(
+          {"a", "guard"},
+          {makeNullableFlatVector<int64_t>(expectedA),
+           makeFlatVector<int64_t>(expectedGuard)}),
+      result);
+
+  auto row = result->asUnchecked<RowVector>();
+  assertHasNullBuffer(row->childAt(0));
+}
+
+TEST_F(E2EFilterTest, isNotNullFilterOnlyFiltersRows) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 3, 4}),
+       makeFlatVector<int64_t>({10, 20, 30, 40})});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  auto* aSpec = spec->getOrCreateChild("a");
+  aSpec->setFilter(std::make_unique<common::IsNotNull>());
+  aSpec->setProjectOut(false);
+  spec->addField("b", 0);
+
+  auto [result, rowsScanned] =
+      readWithSpec(data, spec, 4, ROW({"b"}, {BIGINT()}));
+  EXPECT_EQ(4, rowsScanned);
+  test::assertEqualVectors(
+      makeRowVector({"b"}, {makeFlatVector<int64_t>({10, 30, 40})}), result);
+}
+
+TEST_F(E2EFilterTest, nonIsNotNullFilterDoesNotUseOutputElision) {
+  auto data = makeRowVector(
+      {"a"},
+      {makeFlatVector<int64_t>(
+          6, [](auto row) { return row; }, [](auto row) { return row == 4; })});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addField("a", 0)->setFilter(
+      std::make_unique<common::BigintRange>(0, 3, false));
+
+  auto [result, rowsScanned] = readWithSpec(data, spec, 6);
+  EXPECT_EQ(6, rowsScanned);
+  test::assertEqualVectors(
+      makeRowVector({"a"}, {makeFlatVector<int64_t>({0, 1, 2, 3})}), result);
 }
 
 TEST_F(E2EFilterTest, DISABLED_date) {

--- a/bolt/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -107,18 +107,7 @@ class E2EFilterTest : public E2EFilterTestBase, public test::VectorTestBase {
       const std::shared_ptr<common::ScanSpec>& spec,
       uint64_t size,
       const RowTypePtr& outputType = nullptr) {
-    writeToMemory(data->type(), {data}, false);
-
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
-    dwio::common::RowReaderOptions rowReaderOpts;
-    rowReaderOpts.setScanSpec(spec);
-    std::string_view serializedData(sinkPtr_->data(), sinkPtr_->size());
-    auto input = std::make_unique<BufferedInput>(
-        std::make_shared<InMemoryReadFile>(serializedData),
-        readerOpts.getMemoryPool());
-    auto reader = makeReader(readerOpts, std::move(input));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
-
+    auto rowReader = makeRowReader(data, spec);
     auto result = BaseVector::create(
         outputType ? outputType : data->type(), 0, leafPool_.get());
     auto rowsScanned = rowReader->next(size, result);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
When a scan predicate is IS NOT NULL and the raw value is kept as the output type, selected output rows cannot contain nulls. The previous path could still prepare an internal result null bitmap whenever the input range had nulls. That bitmap was initialized and maintained by the reader, but was not attached to the final output vector.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Teach SelectiveColumnReader to prepare output nulls through a guarded helper that skips result null bitmap allocation only for raw projected or extracted primitive, string, and binary outputs proven non-null by IS NOT NULL. Use the same helper from Parquet page reads so cross-page reads get the same behavior, and clear stale null state when output nulls are elided.

Add common allocation tests and Parquet E2E coverage for compacted output, page and row-group paths, result reuse, scalar types, complex negative cases, filter-only columns, and mixed nullable outputs.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
