### PR TITLE
 perf : Buffer spill-file writes in LocalPartitionWriter to reduce syscall overhead

### DIFF
--- a/bolt/shuffle/sparksql/Options.h
+++ b/bolt/shuffle/sparksql/Options.h
@@ -53,6 +53,7 @@ static constexpr int32_t kDefaultBufferAlignment = 64;
 static constexpr double kDefaultBufferReallocThreshold = 0.25;
 static constexpr double kDefaultMergeBufferThreshold = 0.25;
 static constexpr bool kEnableBufferedWrite = true;
+static constexpr bool kEnableBufferedSpillWrite = false;
 static constexpr int32_t kDefaultForceShuffleWriterType = 0;
 static constexpr int32_t kDefaultUseV2PreallocSizeThreshold = 0;
 static constexpr int32_t kDefaultRowVectorModeCompressionMinColumns = 20;
@@ -133,6 +134,8 @@ struct PartitionWriterOptions {
   std::string compressionMode = "buffer";
 
   bool bufferedWrite = kEnableBufferedWrite;
+
+  bool bufferedSpillWrite = kEnableBufferedSpillWrite;
 
   int32_t numSubDirs = kDefaultNumSubDirs;
 

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
@@ -43,17 +43,32 @@
 #include "bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.h"
 namespace bytedance::bolt::shuffle::sparksql {
 
+arrow::Result<std::shared_ptr<arrow::io::OutputStream>> openSpillFile(
+    const std::string& file,
+    bool bufferWrite,
+    arrow::MemoryPool* pool) {
+  std::shared_ptr<arrow::io::OutputStream> out;
+  ARROW_ASSIGN_OR_RAISE(out, arrow::io::FileOutputStream::Open(file, true));
+  if (bufferWrite) {
+    ARROW_ASSIGN_OR_RAISE(
+        out, arrow::io::BufferedOutputStream::Create(16384, pool, out));
+  }
+  return out;
+}
+
 class LocalPartitionWriter::LocalSpiller {
  public:
   LocalSpiller(
       uint32_t numPartitions,
       const std::string& spillFile,
       uint32_t compressionThreshold,
+      bool bufferWrite,
       arrow::MemoryPool* pool,
       Codec* codec)
       : numPartitions_(numPartitions),
         spillFile_(spillFile),
         compressionThreshold_(compressionThreshold),
+        bufferWrite_(bufferWrite),
         pool_(pool),
         codec_(codec) {}
 
@@ -69,8 +84,7 @@ class LocalPartitionWriter::LocalSpiller {
 
     if (!opened_) {
       opened_ = true;
-      ARROW_ASSIGN_OR_RAISE(
-          os_, arrow::io::FileOutputStream::Open(spillFile_, true));
+      ARROW_ASSIGN_OR_RAISE(os_, openSpillFile(spillFile_, bufferWrite_, pool_))
       diskSpill_ = std::make_unique<Spill>(
           Spill::SpillType::kSequentialSpill, numPartitions_, spillFile_);
     }
@@ -110,6 +124,7 @@ class LocalPartitionWriter::LocalSpiller {
       return arrow::Status::Invalid("SpillEvictor has no data spilled.");
     }
     RETURN_NOT_OK(os_->Close());
+    os_.reset();
     return std::move(diskSpill_);
   }
 
@@ -125,13 +140,14 @@ class LocalPartitionWriter::LocalSpiller {
   uint32_t numPartitions_;
   std::string spillFile_;
   uint32_t compressionThreshold_;
+  bool bufferWrite_;
   arrow::MemoryPool* pool_;
   Codec* codec_;
 
   bool opened_{false};
   bool finished_{false};
   std::shared_ptr<Spill> diskSpill_{nullptr};
-  std::shared_ptr<arrow::io::FileOutputStream> os_;
+  std::shared_ptr<arrow::io::OutputStream> os_;
   int64_t spillTime_{0};
 };
 
@@ -348,7 +364,8 @@ class LocalPartitionWriter::PayloadMerger {
 
 class LocalPartitionWriter::PayloadCache {
  public:
-  PayloadCache(uint32_t numPartitions) : numPartitions_(numPartitions) {}
+  PayloadCache(uint32_t numPartitions, bool bufferedWrite)
+      : numPartitions_(numPartitions), bufferedWrite_(bufferedWrite) {}
 
   arrow::Status cache(
       uint32_t partitionId,
@@ -396,7 +413,7 @@ class LocalPartitionWriter::PayloadCache {
   spill(const std::string& spillFile, arrow::MemoryPool* pool, Codec* codec) {
     std::shared_ptr<Spill> diskSpill = nullptr;
     ARROW_ASSIGN_OR_RAISE(
-        auto os, arrow::io::FileOutputStream::Open(spillFile, true));
+        auto os, openSpillFile(spillFile, bufferedWrite_, pool));
     ARROW_ASSIGN_OR_RAISE(auto start, os->Tell());
     for (uint32_t pid = 0; pid < numPartitions_; ++pid) {
       if (hasCachedPayloads(pid)) {
@@ -430,6 +447,7 @@ class LocalPartitionWriter::PayloadCache {
       }
     }
     RETURN_NOT_OK(os->Close());
+    os.reset();
     return diskSpill;
   }
 
@@ -444,6 +462,7 @@ class LocalPartitionWriter::PayloadCache {
 
   arrow::Result<std::shared_ptr<Spill>> stopSpill() {
     RETURN_NOT_OK(os_->Close());
+    os_.reset();
     os_ = nullptr;
     return std::move(diskSpill_);
   }
@@ -494,30 +513,33 @@ class LocalPartitionWriter::PayloadCache {
   int64_t compressTime_{0};
   int64_t spillTime_{0};
   int64_t writeTime_{0};
+  bool bufferedWrite_;
   std::unordered_map<uint32_t, std::list<std::unique_ptr<BlockPayload>>>
       partitionCachedPayload_;
   // for V2
   std::shared_ptr<Spill> diskSpill_;
-  std::shared_ptr<arrow::io::FileOutputStream> os_;
+  std::shared_ptr<arrow::io::OutputStream> os_;
 };
 
 // class for BoltRowBasedSortShuffleWriter
 class LocalPartitionWriter::PartitionRowWriter {
  public:
-  PartitionRowWriter() = default;
+  explicit PartitionRowWriter(bool bufferedWrite)
+      : bufferedWrite_(bufferedWrite) {}
 
   arrow::Status startSpill(
       uint32_t numPartitions,
-      const std::string& spillFile) {
+      const std::string& spillFile,
+      arrow::MemoryPool* pool) {
     diskSpill_ = std::make_shared<Spill>(
         Spill::SpillType::kBatchedSpill, numPartitions, spillFile);
-    ARROW_ASSIGN_OR_RAISE(
-        os_, arrow::io::FileOutputStream::Open(spillFile, true));
+    ARROW_ASSIGN_OR_RAISE(os_, openSpillFile(spillFile, bufferedWrite_, pool));
     return arrow::Status::OK();
   }
 
   arrow::Result<std::shared_ptr<Spill>> stopSpill() {
     RETURN_NOT_OK(os_->Close());
+    os_.reset();
     os_ = nullptr;
     return std::move(diskSpill_);
   }
@@ -544,7 +566,8 @@ class LocalPartitionWriter::PartitionRowWriter {
 
  private:
   std::shared_ptr<Spill> diskSpill_;
-  std::shared_ptr<arrow::io::FileOutputStream> os_;
+  std::shared_ptr<arrow::io::OutputStream> os_;
+  bool bufferedWrite_;
 };
 
 LocalPartitionWriter::LocalPartitionWriter(
@@ -702,6 +725,7 @@ arrow::Status LocalPartitionWriter::requestSpill() {
         numPartitions_,
         spillFile,
         options_.compressionThreshold,
+        options_.bufferedSpillWrite,
         payloadPool_.get(),
         codec_.get());
   }
@@ -749,7 +773,8 @@ arrow::Status LocalPartitionWriter::evict(
             codec_.get(),
             hasComplexType));
     if (UNLIKELY(!payloadCache_)) {
-      payloadCache_ = std::make_shared<PayloadCache>(numPartitions_);
+      payloadCache_ = std::make_shared<PayloadCache>(
+          numPartitions_, options_.bufferedSpillWrite);
     }
     RETURN_NOT_OK(payloadCache_->cache(partitionId, std::move(payload)));
     return arrow::Status::OK();
@@ -767,7 +792,8 @@ arrow::Status LocalPartitionWriter::evict(
       merger_->merge(partitionId, std::move(inMemoryPayload), reuseBuffers));
   if (!merged.empty()) {
     if (UNLIKELY(!payloadCache_)) {
-      payloadCache_ = std::make_shared<PayloadCache>(numPartitions_);
+      payloadCache_ = std::make_shared<PayloadCache>(
+          numPartitions_, options_.bufferedSpillWrite);
     }
     for (auto& payload : merged) {
       RETURN_NOT_OK(payloadCache_->cache(partitionId, std::move(payload)));
@@ -886,7 +912,8 @@ arrow::Status LocalPartitionWriter::startClearPayLoadCacheSequential() {
   ARROW_ASSIGN_OR_RAISE(
       auto spillFile, createTempShuffleFile(nextSpilledFileDir()));
   if (UNLIKELY(!payloadCache_)) {
-    payloadCache_ = std::make_shared<PayloadCache>(numPartitions_);
+    payloadCache_ = std::make_shared<PayloadCache>(
+        numPartitions_, options_.bufferedSpillWrite);
   }
   RETURN_NOT_OK(payloadCache_->startSpill(spillFile));
   return arrow::Status::OK();
@@ -919,7 +946,8 @@ arrow::Status LocalPartitionWriter::evict(
         true,
         payloadPool_.get(),
         options_.checksumEnabled);
-    partitionRowWriter_ = std::make_shared<PartitionRowWriter>();
+    partitionRowWriter_ =
+        std::make_shared<PartitionRowWriter>(options_.bufferedSpillWrite);
   }
   RowVectorLayout layout = isCompositeVector ? RowVectorLayout::kComposite
                                              : RowVectorLayout::kColumnar;
@@ -962,7 +990,8 @@ arrow::Status LocalPartitionWriter::evict(
 arrow::Status LocalPartitionWriter::startEvictRowsSequential() {
   ARROW_ASSIGN_OR_RAISE(
       auto spillFile, createTempShuffleFile(nextSpilledFileDir()));
-  RETURN_NOT_OK(partitionRowWriter_->startSpill(numPartitions_, spillFile));
+  RETURN_NOT_OK(
+      partitionRowWriter_->startSpill(numPartitions_, spillFile, pool_));
   return arrow::Status::OK();
 }
 

--- a/bolt/shuffle/sparksql/tests/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/tests/CMakeLists.txt
@@ -179,3 +179,23 @@ add_test(
     NAME bolt_shuffle_reader_test
     COMMAND bolt_shuffle_reader_test
 )
+
+add_executable(
+    bolt_shuffle_local_partition_writer_test
+    LocalPartitionWriterTest.cpp
+)
+
+target_link_libraries(
+    bolt_shuffle_local_partition_writer_test
+    PRIVATE
+        bolt_shuffle_spark_impl
+        bolt_testutils
+        GTest::gtest
+        GTest::gtest_main
+        GTest::gmock
+)
+
+add_test(
+    NAME bolt_shuffle_local_partition_writer_test
+    COMMAND bolt_shuffle_local_partition_writer_test
+)

--- a/bolt/shuffle/sparksql/tests/LocalPartitionWriterTest.cpp
+++ b/bolt/shuffle/sparksql/tests/LocalPartitionWriterTest.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <arrow/io/interfaces.h>
+#include <arrow/memory_pool.h>
+#include <arrow/result.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bytedance::bolt::shuffle::sparksql {
+
+// Defined in partition_writer/LocalPartitionWriter.cpp. Opens a spill file for
+// append. When 'bufferWrite' is true the raw file stream is wrapped in a 16KB
+// arrow::io::BufferedOutputStream (buffer allocated from 'pool'); otherwise the
+// raw arrow::io::FileOutputStream is returned as-is.
+arrow::Result<std::shared_ptr<arrow::io::OutputStream>> openSpillFile(
+    const std::string& file,
+    bool bufferWrite,
+    arrow::MemoryPool* pool);
+
+} // namespace bytedance::bolt::shuffle::sparksql
+
+namespace bytedance::bolt::shuffle::sparksql::test {
+namespace {
+
+// The buffer size hard-coded in openSpillFile's BufferedOutputStream.
+constexpr int64_t kSpillBufferSize = 16384;
+
+void writeAll(arrow::io::OutputStream* os, std::string_view data) {
+  ASSERT_TRUE(os->Write(data.data(), static_cast<int64_t>(data.size())).ok());
+}
+
+std::string readFile(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  return std::string(
+      std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+class OpenSpillFileTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    tempDir_ = std::filesystem::temp_directory_path() /
+        (std::string("bolt_open_spill_file_") + info->name());
+    std::filesystem::remove_all(tempDir_);
+    std::filesystem::create_directories(tempDir_);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(tempDir_, ec);
+  }
+
+  std::string filePath(const std::string& name) const {
+    return (tempDir_ / name).string();
+  }
+
+  std::filesystem::path tempDir_;
+};
+
+// Unbuffered mode returns the raw file stream, so bytes hit the file
+// immediately (visible before Close) and the memory pool is never touched.
+TEST_F(OpenSpillFileTest, UnbufferedWriteIsImmediateOnDisk) {
+  auto pool = arrow::MemoryPool::CreateDefault();
+  const auto file = filePath("unbuffered.bin");
+
+  auto maybeOs = openSpillFile(file, /*bufferWrite=*/false, pool.get());
+  ASSERT_TRUE(maybeOs.ok()) << maybeOs.status().ToString();
+  auto os = maybeOs.ValueOrDie();
+
+  const std::string data(1000, 'a');
+  writeAll(os.get(), data);
+
+  // No buffering: the data is already on disk before Close().
+  EXPECT_EQ(std::filesystem::file_size(file), data.size());
+  // The raw FileOutputStream does not allocate from the pool.
+  EXPECT_EQ(pool->bytes_allocated(), 0);
+
+  ASSERT_TRUE(os->Close().ok());
+  EXPECT_EQ(readFile(file), data);
+}
+
+// Buffered mode holds small writes (< 16KB) in an in-memory buffer charged to
+// the provided pool, flushing to the file only on Close().
+TEST_F(OpenSpillFileTest, BufferedWriteIsDelayedUntilClose) {
+  auto pool = arrow::MemoryPool::CreateDefault();
+  const auto file = filePath("buffered.bin");
+
+  auto maybeOs = openSpillFile(file, /*bufferWrite=*/true, pool.get());
+  ASSERT_TRUE(maybeOs.ok()) << maybeOs.status().ToString();
+  auto os = maybeOs.ValueOrDie();
+
+  const std::string data(1000, 'b'); // smaller than the 16KB buffer
+  writeAll(os.get(), data);
+
+  // Still buffered in memory: nothing has reached the file yet.
+  EXPECT_EQ(std::filesystem::file_size(file), 0u);
+  // The 16KB write buffer is charged to the supplied pool.
+  EXPECT_GE(pool->bytes_allocated(), kSpillBufferSize);
+
+  ASSERT_TRUE(os->Close().ok());
+  EXPECT_EQ(std::filesystem::file_size(file), data.size());
+  EXPECT_EQ(readFile(file), data);
+}
+
+// A single write larger than the 16KB buffer cannot be held, so it is flushed
+// straight through to disk (bytes visible before Close()).
+TEST_F(OpenSpillFileTest, BufferedLargeWriteOverflowsToDisk) {
+  auto pool = arrow::MemoryPool::CreateDefault();
+  const auto file = filePath("buffered_large.bin");
+
+  auto maybeOs = openSpillFile(file, /*bufferWrite=*/true, pool.get());
+  ASSERT_TRUE(maybeOs.ok()) << maybeOs.status().ToString();
+  auto os = maybeOs.ValueOrDie();
+
+  const std::string big(64 * 1024, 'q'); // 64KB > 16KB buffer
+  writeAll(os.get(), big);
+
+  // Overflowed the buffer, so at least part has already been written out.
+  EXPECT_GT(std::filesystem::file_size(file), 0u);
+
+  ASSERT_TRUE(os->Close().ok());
+  EXPECT_EQ(readFile(file), big);
+}
+
+// Regardless of buffering, a stream of mixed small/large writes must produce
+// byte-identical file content.
+TEST_F(OpenSpillFileTest, BufferedAndUnbufferedProduceIdenticalContent) {
+  const std::vector<std::string> chunks = {
+      std::string(10, 'x'),
+      std::string(50 * 1024, 'y'), // exceeds the 16KB buffer
+      std::string(100, 'z'),
+      std::string(5, 'w'),
+  };
+  std::string expected;
+  for (const auto& c : chunks) {
+    expected += c;
+  }
+
+  const auto bufferedFile = filePath("mixed_buffered.bin");
+  const auto unbufferedFile = filePath("mixed_unbuffered.bin");
+
+  for (bool buffered : {true, false}) {
+    auto pool = arrow::MemoryPool::CreateDefault();
+    const auto file = buffered ? bufferedFile : unbufferedFile;
+    auto maybeOs = openSpillFile(file, buffered, pool.get());
+    ASSERT_TRUE(maybeOs.ok()) << maybeOs.status().ToString();
+    auto os = maybeOs.ValueOrDie();
+    for (const auto& c : chunks) {
+      writeAll(os.get(), c);
+    }
+    ASSERT_TRUE(os->Close().ok());
+  }
+
+  EXPECT_EQ(readFile(bufferedFile), expected);
+  EXPECT_EQ(readFile(unbufferedFile), expected);
+  EXPECT_EQ(readFile(bufferedFile), readFile(unbufferedFile));
+}
+
+// openSpillFile opens the file in append mode, so writing to an existing file
+// preserves its prior content instead of truncating it.
+TEST_F(OpenSpillFileTest, OpensInAppendMode) {
+  const auto file = filePath("append.bin");
+  {
+    std::ofstream out(file, std::ios::binary);
+    out << "HEAD";
+  }
+
+  auto pool = arrow::MemoryPool::CreateDefault();
+  auto maybeOs = openSpillFile(file, /*bufferWrite=*/false, pool.get());
+  ASSERT_TRUE(maybeOs.ok()) << maybeOs.status().ToString();
+  auto os = maybeOs.ValueOrDie();
+
+  writeAll(os.get(), "TAIL");
+  ASSERT_TRUE(os->Close().ok());
+
+  EXPECT_EQ(readFile(file), "HEADTAIL");
+}
+
+} // namespace
+} // namespace bytedance::bolt::shuffle::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #790 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
adds a bufferedSpillWrite option (default false) that wraps all three spill paths in the same 16KB BufferedOutputStream, coalescing the small writes.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
