### PR TITLE
bugfix: tolerate invalid null count when filter row groups

### DIFF
--- a/bolt/dwio/parquet/reader/Statistics.cpp
+++ b/bolt/dwio/parquet/reader/Statistics.cpp
@@ -42,16 +42,20 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
         std::unique_ptr<NGramBloomFilter>>> nGramStats,
     const bolt::Type& type,
     uint64_t numRowsInRowGroup) {
-  std::optional<uint64_t> nullCount = columnChunkStats.__isset.null_count
-      ? std::optional<uint64_t>(columnChunkStats.null_count)
-      : std::nullopt;
-  std::optional<uint64_t> valueCount = nullCount.has_value()
-      ? std::optional<uint64_t>(numRowsInRowGroup - nullCount.value())
-      : std::nullopt;
-  std::optional<bool> hasNull = columnChunkStats.__isset.null_count
-      ? std::optional<bool>(columnChunkStats.null_count > 0)
-      : std::nullopt;
+  const int64_t rawNullCount = columnChunkStats.null_count;
+  const bool validNullCount = columnChunkStats.__isset.null_count &&
+      rawNullCount >= 0 &&
+      static_cast<uint64_t>(rawNullCount) <= numRowsInRowGroup;
 
+  std::optional<uint64_t> nullCount = validNullCount
+      ? std::optional<uint64_t>(static_cast<uint64_t>(rawNullCount))
+      : std::nullopt;
+  std::optional<uint64_t> valueCount = validNullCount
+      ? std::optional<uint64_t>(
+            numRowsInRowGroup - static_cast<uint64_t>(rawNullCount))
+      : std::nullopt;
+  std::optional<bool> hasNull =
+      validNullCount ? std::optional<bool>(rawNullCount > 0) : std::nullopt;
   switch (type.kind()) {
     case TypeKind::BOOLEAN:
       return std::make_unique<dwio::common::BooleanColumnStatistics>(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #795 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

null count of column stats may be negetive, it is invalid and cause errors when filtering row groups.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
