### PR TITLE
feat(flinksql): add Flink-compatible regexp_extract and icu_regexp_extract functions

### DIFF
--- a/bolt/functions/flinksql/CMakeLists.txt
+++ b/bolt/functions/flinksql/CMakeLists.txt
@@ -16,6 +16,7 @@
 bolt_add_library(
   bolt_functions_flink_impl
   HashCodeFunction.cpp
+  ICURegexFunctions.cpp
   JsonFunctions.cpp
   RegexFunctions.cpp
   ElementAt.cpp

--- a/bolt/functions/flinksql/ICURegexFunctions.cpp
+++ b/bolt/functions/flinksql/ICURegexFunctions.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/flinksql/ICURegexFunctions.h"
+
+#include <cstring>
+#include <type_traits>
+
+#include <unicode/localpointer.h>
+#include <unicode/regex.h>
+#include <unicode/stringpiece.h>
+#include <unicode/unistr.h>
+
+#include "bolt/functions/lib/string/RegexUtils.h"
+#include "bolt/functions/lib/string/StringCore.h"
+#include "bolt/vector/ConstantVector.h"
+
+namespace bytedance::bolt::functions::flinksql {
+namespace {
+
+icu::LocalPointer<icu::RegexPattern> compileJavaRegex(StringView pattern) {
+  try {
+    return regex::compileRegexPattern(regex::transRegexPattern(pattern));
+  } catch (const BoltUserError&) {
+    // Flink's regexpExtract catches PatternSyntaxException and returns null.
+    return icu::LocalPointer<icu::RegexPattern>(nullptr);
+  }
+}
+
+template <typename T>
+int32_t narrowGroupIdLikeJava(T groupId) {
+  if constexpr (std::is_same_v<T, int32_t>) {
+    return groupId;
+  }
+
+  // Java narrowing from long to int keeps the low 32 bits. Use memcpy to
+  // preserve the bit pattern without relying on implementation-defined signed
+  // integer conversion.
+  const uint32_t lowBits = static_cast<uint32_t>(groupId);
+  int32_t narrowed;
+  static_assert(sizeof(narrowed) == sizeof(lowBits));
+  std::memcpy(&narrowed, &lowBits, sizeof(narrowed));
+  return narrowed;
+}
+
+bool extract(
+    FlatVector<StringView>& result,
+    vector_size_t row,
+    const exec::LocalDecodedVector& inputs,
+    int32_t groupId,
+    const icu::LocalPointer<icu::RegexPattern>& regexPattern) {
+  const auto input = inputs->valueAt<StringView>(row);
+  const auto unicodeInput = icu::UnicodeString::fromUTF8(
+      icu::StringPiece(input.data(), input.size()));
+
+  UErrorCode status = U_ZERO_ERROR;
+  icu::LocalPointer<icu::RegexMatcher> matcher(
+      regexPattern->matcher(unicodeInput, status));
+  if (U_FAILURE(status) || !matcher->find(status) || U_FAILURE(status)) {
+    result.setNull(row, true);
+    return false;
+  }
+
+  if (groupId < 0 || groupId > matcher->groupCount()) {
+    result.setNull(row, true);
+    return false;
+  }
+
+  const auto start = matcher->start(groupId, status);
+  const auto end = matcher->end(groupId, status);
+  if (U_FAILURE(status) || start < 0 || end < 0) {
+    result.setNull(row, true);
+    return false;
+  }
+  if (start == end) {
+    result.setNoCopy(row, StringView(nullptr, 0));
+    return false;
+  }
+
+  const auto startIndex = stringCore::char16IndexToByteIndex(
+      unicodeInput.getBuffer(), input.size(), start);
+  const auto resultSize = stringCore::char16IndexToByteIndex(
+      unicodeInput.getBuffer() + start, input.size(), end - start);
+  result.setNoCopy(
+      row,
+      StringView(input.data() + startIndex, static_cast<int32_t>(resultSize)));
+  return !StringView::isInline(resultSize);
+}
+
+template <typename T>
+class ICURegexpExtractConstantPatternFunction final
+    : public exec::VectorFunction {
+ public:
+  ICURegexpExtractConstantPatternFunction() = default;
+
+  explicit ICURegexpExtractConstantPatternFunction(StringView pattern)
+      : regexPattern_(compileJavaRegex(pattern)) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx& context,
+      VectorPtr& resultRef) const override {
+    BOLT_CHECK(args.size() == 2 || args.size() == 3);
+    context.ensureWritable(rows, VARCHAR(), resultRef);
+    auto& result = *resultRef->asFlatVector<StringView>();
+
+    if (regexPattern_.isNull()) {
+      rows.applyToSelected(
+          [&](vector_size_t row) { result.setNull(row, true); });
+      return;
+    }
+
+    exec::LocalDecodedVector inputs(context, *args[0], rows);
+    bool mustRefInputStrings = false;
+    const auto extractGroup = [&](vector_size_t row, T groupId) {
+      mustRefInputStrings |= extract(
+          result, row, inputs, narrowGroupIdLikeJava(groupId), regexPattern_);
+    };
+
+    if (args.size() == 2) {
+      context.applyToSelectedNoThrow(
+          rows, [&](vector_size_t row) { extractGroup(row, T{0}); });
+    } else if (args[2]->isConstantEncoding() && !args[2]->isNullAt(0)) {
+      const auto groupId = args[2]->as<ConstantVector<T>>()->valueAt(0);
+      context.applyToSelectedNoThrow(
+          rows, [&](vector_size_t row) { extractGroup(row, groupId); });
+    } else {
+      exec::LocalDecodedVector groupIds(context, *args[2], rows);
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+        extractGroup(row, groupIds->valueAt<T>(row));
+      });
+    }
+
+    if (mustRefInputStrings) {
+      result.acquireSharedStringBuffers(inputs->base());
+    }
+  }
+
+ private:
+  const icu::LocalPointer<icu::RegexPattern> regexPattern_;
+};
+
+} // namespace
+
+std::shared_ptr<exec::VectorFunction> makeICURegexExtract(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /* config */) {
+  const auto numArgs = inputArgs.size();
+  BOLT_USER_CHECK(
+      numArgs == 2 || numArgs == 3,
+      "{} requires 2 or 3 arguments, but got {}",
+      name,
+      numArgs);
+  BOLT_USER_CHECK(
+      inputArgs[0].type->isVarchar(),
+      "{} requires first argument of type VARCHAR, but got {}",
+      name,
+      inputArgs[0].type->toString());
+  BOLT_USER_CHECK(
+      inputArgs[1].type->isVarchar(),
+      "{} requires second argument of type VARCHAR, but got {}",
+      name,
+      inputArgs[1].type->toString());
+  BOLT_USER_CHECK(
+      inputArgs[1].constantValue != nullptr &&
+          inputArgs[1].constantValue->isConstantEncoding(),
+      "{} requires a constant pattern.",
+      name);
+
+  auto groupIdType = TypeKind::INTEGER;
+  if (numArgs == 3) {
+    groupIdType = inputArgs[2].type->kind();
+    BOLT_USER_CHECK(
+        groupIdType == TypeKind::INTEGER || groupIdType == TypeKind::BIGINT,
+        "{} requires third argument of type INTEGER or BIGINT, but got {}",
+        name,
+        mapTypeKindToName(groupIdType));
+  }
+
+  const auto* patternVector = inputArgs[1].constantValue.get();
+  if (patternVector->isNullAt(0)) {
+    if (groupIdType == TypeKind::INTEGER) {
+      return std::make_shared<
+          ICURegexpExtractConstantPatternFunction<int32_t>>();
+    }
+    return std::make_shared<ICURegexpExtractConstantPatternFunction<int64_t>>();
+  }
+
+  const auto pattern =
+      patternVector->as<ConstantVector<StringView>>()->valueAt(0);
+  if (groupIdType == TypeKind::INTEGER) {
+    return std::make_shared<ICURegexpExtractConstantPatternFunction<int32_t>>(
+        pattern);
+  }
+  return std::make_shared<ICURegexpExtractConstantPatternFunction<int64_t>>(
+      pattern);
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+icuRegexExtractSignatures() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .returnType("varchar")
+          .argumentType("varchar")
+          .argumentType("varchar")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("varchar")
+          .argumentType("varchar")
+          .argumentType("varchar")
+          .argumentType("integer")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("varchar")
+          .argumentType("varchar")
+          .argumentType("varchar")
+          .argumentType("bigint")
+          .build(),
+  };
+}
+
+} // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/ICURegexFunctions.h
+++ b/bolt/functions/flinksql/ICURegexFunctions.h
@@ -20,28 +20,15 @@
 #include <vector>
 
 #include "bolt/expression/Expr.h"
-#include "bolt/vector/BaseVector.h"
 
 namespace bytedance::bolt::functions::flinksql {
 
-// Flink rlike reuses the shared RE2 vector-function implementation in
-// lib/Re2Functions.h, but chooses an invalid-regex policy that returns false
-// instead of failing the task.
-std::shared_ptr<exec::VectorFunction> makeRLike(
+std::shared_ptr<exec::VectorFunction> makeICURegexExtract(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
 
-std::vector<std::shared_ptr<exec::FunctionSignature>> rlikeSignatures();
-
-// Flink 1.11 regexp_extract returns null for invalid regular expressions,
-// invalid group IDs, unmatched groups and inputs without a match. Native
-// Engine V2 only supports constant patterns.
-std::shared_ptr<exec::VectorFunction> makeRegexpExtract(
-    const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& config);
-
-std::vector<std::shared_ptr<exec::FunctionSignature>> regexpExtractSignatures();
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+icuRegexExtractSignatures();
 
 } // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/RegexFunctions.cpp
+++ b/bolt/functions/flinksql/RegexFunctions.cpp
@@ -32,4 +32,27 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> rlikeSignatures() {
   return re2SearchSignatures();
 }
 
+std::shared_ptr<exec::VectorFunction> makeRegexpExtract(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config) {
+  Re2ExtractOptions options;
+  options.invalidRegexPolicy = Re2ExtractErrorPolicy::kReturnNull;
+  options.invalidGroupPolicy = Re2ExtractErrorPolicy::kReturnNull;
+  options.unmatchedGroupPolicy = Re2ExtractResultPolicy::kReturnNull;
+
+  auto result = makeRe2ExtractWithOptions(name, inputArgs, config, options);
+  BOLT_USER_CHECK(
+      inputArgs[1].constantValue != nullptr &&
+          inputArgs[1].constantValue->isConstantEncoding(),
+      "{} requires a constant pattern.",
+      name);
+  return result;
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+regexpExtractSignatures() {
+  return re2ExtractSignatures();
+}
+
 } // namespace bytedance::bolt::functions::flinksql

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -21,6 +21,7 @@
 #include "bolt/functions/flinksql/DateTimeDiff.h"
 #include "bolt/functions/flinksql/DateTimeFunctions.h"
 #include "bolt/functions/flinksql/HashCodeFunction.h"
+#include "bolt/functions/flinksql/ICURegexFunctions.h"
 #include "bolt/functions/flinksql/Rand.h"
 #include "bolt/functions/flinksql/RegexFunctions.h"
 #include "bolt/functions/flinksql/String.h"
@@ -47,6 +48,12 @@ static void registerStringFunctions(const std::string& prefix) {
   registerFunction<IsDigitFunction, bool, Varchar>({prefix + "is_digit"});
   exec::registerStatefulVectorFunction(
       prefix + "rlike", rlikeSignatures(), makeRLike);
+  exec::registerStatefulVectorFunction(
+      prefix + "regexp_extract", regexpExtractSignatures(), makeRegexpExtract);
+  exec::registerStatefulVectorFunction(
+      prefix + "icu_regexp_extract",
+      icuRegexExtractSignatures(),
+      makeICURegexExtract);
   registerFunction<SplitIndex, Varchar, Varchar, Varchar, int64_t>(
       {prefix + "split_index"});
   registerFunction<SplitIndex, Varchar, Varchar, int32_t, int64_t>(

--- a/bolt/functions/flinksql/tests/RegexFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/RegexFunctionsTest.cpp
@@ -14,12 +14,38 @@
  * limitations under the License.
  */
 
+#include <limits>
+
+#include <fmt/format.h>
+
+#include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/flinksql/tests/FlinkFunctionBaseTest.h"
 
 namespace bytedance::bolt::functions::flinksql::test {
 namespace {
 
 class FlinkRegexFunctionsTest : public FlinkFunctionBaseTest {};
+
+class FlinkRegexpExtractTest : public FlinkFunctionBaseTest,
+                               public testing::WithParamInterface<std::string> {
+ protected:
+  const std::string& functionName() const {
+    return GetParam();
+  }
+
+  template <typename T>
+  std::optional<std::string> extract(
+      const std::optional<std::string>& input,
+      const std::string& pattern,
+      const std::optional<T>& groupId) {
+    return evaluateOnce<std::string>(
+        fmt::format("{}(c0, '{}', c1)", functionName(), pattern),
+        input,
+        groupId);
+  }
+};
+
+class FlinkICURegexpExtractTest : public FlinkFunctionBaseTest {};
 
 TEST_F(FlinkRegexFunctionsTest, invalidRegexReturnsFalse) {
   EXPECT_EQ(
@@ -95,6 +121,180 @@ TEST_F(FlinkRegexFunctionsTest, nullInputPreservesNullSemantics) {
                   std::vector<std::optional<std::string>>{std::nullopt}),
           })));
 }
+
+TEST_P(FlinkRegexpExtractTest, basicSemantics) {
+  EXPECT_EQ(
+      "bar",
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo(.*?)(bar)",
+          std::optional<int32_t>{2}));
+  EXPECT_EQ(
+      "foothebar",
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo(.*?)(bar)",
+          std::optional<int32_t>{0}));
+  EXPECT_EQ(
+      "the",
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo(.*?)(bar)",
+          std::optional<int32_t>{1}));
+  EXPECT_EQ(
+      "thebar",
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo([\\w]+)",
+          std::optional<int32_t>{1}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo([\\d]+)",
+          std::optional<int32_t>{1}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{std::nullopt},
+          "foo(.*?)(bar)",
+          std::optional<int32_t>{2}));
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<std::string>(
+          fmt::format("{}(c0, cast(null as varchar), c1)", functionName()),
+          std::optional<std::string>{"foothebar"},
+          std::optional<int32_t>{2}));
+  EXPECT_EQ(
+      "foothebar",
+      evaluateOnce<std::string>(
+          fmt::format("{}(c0, 'foo(.*?)(bar)')", functionName()),
+          std::optional<std::string>{"foothebar"}));
+}
+
+TEST_P(FlinkRegexpExtractTest, returnsNullOnFailure) {
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo([\\d]+)",
+          std::optional<int32_t>{1}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "*",
+          std::optional<int32_t>{0}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo(.*?)(bar)",
+          std::optional<int32_t>{-1}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo(.*?)(bar)",
+          std::optional<int32_t>{3}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"foothebar"},
+          "foo(.*?)(bar)",
+          std::optional<int64_t>{std::numeric_limits<int64_t>::max()}));
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"b"}, "(a)?b", std::optional<int32_t>{1}));
+  EXPECT_EQ(
+      "",
+      extract(
+          std::optional<std::string>{"b"}, "(a*)b", std::optional<int32_t>{1}));
+}
+
+TEST_P(FlinkRegexpExtractTest, hostnameNoMatch) {
+  EXPECT_EQ(
+      std::nullopt,
+      extract(
+          std::optional<std::string>{"dc05-p2-ta22-n146.byted.org:8052"},
+          "n\\d{1,3}\\-\\d{1,3}\\-\\d{1,3}",
+          std::optional<int32_t>{0}));
+}
+
+TEST_P(FlinkRegexpExtractTest, rejectsVariablePattern) {
+  auto input = makeRowVector({
+      makeFlatVector<std::string>({"foothebar"}),
+      makeFlatVector<std::string>({"foo(.*?)(bar)"}),
+  });
+  BOLT_ASSERT_THROW(
+      evaluate(fmt::format("{}(c0, c1, 2)", functionName()), input),
+      fmt::format("{} requires a constant pattern", functionName()));
+}
+
+TEST_P(FlinkRegexpExtractTest, preservesRowsAndInputBuffers) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<std::string>(
+          {"foothebar",
+           std::nullopt,
+           "foo123",
+           "foo_string_with_more_than_12_chars"}),
+  });
+  auto expected = makeNullableFlatVector<std::string>(
+      {"thebar", std::nullopt, "123", "_string_with_more_than_12_chars"});
+  bytedance::bolt::test::assertEqualVectors(
+      expected,
+      evaluate(fmt::format("{}(c0, 'foo([\\w]+)', 1)", functionName()), input));
+}
+
+TEST_F(FlinkICURegexpExtractTest, javaRegexSemantics) {
+  EXPECT_EQ(
+      "foo",
+      evaluateOnce<std::string>(
+          "icu_regexp_extract(c0, 'foo(?=bar)', 0)",
+          std::optional<std::string>{"foobar"}));
+  EXPECT_EQ(
+      "b",
+      evaluateOnce<std::string>(
+          "icu_regexp_extract(c0, '[a[b]]', 0)",
+          std::optional<std::string>{"b"}));
+}
+
+TEST_F(FlinkICURegexpExtractTest, bigintGroupIdUsesJavaNarrowing) {
+  constexpr int64_t kGroupOneAfterNarrowing = (int64_t{1} << 32) + 1;
+
+  EXPECT_EQ(
+      "foothebar",
+      evaluateOnce<std::string>(
+          "icu_regexp_extract(c0, 'foo(.*?)(bar)', "
+          "cast(4294967296 as bigint))",
+          std::optional<std::string>{"foothebar"}));
+  EXPECT_EQ(
+      "the",
+      evaluateOnce<std::string>(
+          "icu_regexp_extract(c0, 'foo(.*?)(bar)', c1)",
+          std::optional<std::string>{"foothebar"},
+          std::optional<int64_t>{kGroupOneAfterNarrowing}));
+}
+
+TEST_F(FlinkICURegexpExtractTest, unicode) {
+  EXPECT_EQ(
+      "一龥三",
+      evaluateOnce<std::string>(
+          "icu_regexp_extract(c0, '(.*)-(.*)', 1)",
+          std::optional<std::string>{"一龥三-一龥三"}));
+}
+
+std::string regexpExtractImplementationName(
+    const testing::TestParamInfo<std::string>& info) {
+  return info.param == "regexp_extract" ? "Re2" : "Icu";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Implementations,
+    FlinkRegexpExtractTest,
+    testing::Values("regexp_extract", "icu_regexp_extract"),
+    regexpExtractImplementationName);
 
 } // namespace
 } // namespace bytedance::bolt::functions::flinksql::test

--- a/bolt/functions/lib/Re2Functions.cpp
+++ b/bolt/functions/lib/Re2Functions.cpp
@@ -130,7 +130,7 @@ bool re2Extract(
     const exec::LocalDecodedVector& strs,
     std::vector<re2::StringPiece>& groups,
     int32_t groupId,
-    bool emptyNoMatch) {
+    const Re2ExtractOptions& options) {
   const StringView str = strs->valueAt<StringView>(row);
   DCHECK_GT(groups.size(), groupId);
   if (!re.Match(
@@ -140,15 +140,20 @@ bool re2Extract(
           RE2::UNANCHORED, // Full match not required.
           groups.data(),
           groupId + 1)) {
-    if (emptyNoMatch) {
+    if (options.noMatchPolicy == Re2ExtractResultPolicy::kReturnEmptyString) {
       result.setNoCopy(row, StringView(nullptr, 0));
-      return true;
+      return false;
     } else {
       result.setNull(row, true);
       return false;
     }
   } else {
     const re2::StringPiece extracted = groups[groupId];
+    if (groupId > 0 && extracted.data() == nullptr &&
+        options.unmatchedGroupPolicy == Re2ExtractResultPolicy::kReturnNull) {
+      result.setNull(row, true);
+      return false;
+    }
     result.setNoCopy(row, StringView(extracted.data(), extracted.size()));
     return !StringView::isInline(extracted.size());
   }
@@ -329,13 +334,44 @@ void checkForBadGroupId(int64_t groupId, const RE2& re) {
   }
 }
 
+bool validatePatternForExtract(const RE2& re, Re2ExtractErrorPolicy policy) {
+  if (LIKELY(re.ok())) {
+    return true;
+  }
+  if (policy == Re2ExtractErrorPolicy::kReturnNull) {
+    return false;
+  }
+  checkForBadPattern(re);
+  return false;
+}
+
+bool validateGroupIdForExtract(
+    int64_t groupId,
+    const RE2& re,
+    Re2ExtractErrorPolicy policy) {
+  if (LIKELY(groupId >= 0 && groupId <= re.NumberOfCapturingGroups())) {
+    return true;
+  }
+  if (policy == Re2ExtractErrorPolicy::kReturnNull) {
+    return false;
+  }
+  checkForBadGroupId(groupId, re);
+  return false;
+}
+
+void setNullForRows(
+    const SelectivityVector& rows,
+    FlatVector<StringView>& result) {
+  rows.applyToSelected([&](vector_size_t row) { result.setNull(row, true); });
+}
+
 template <typename T>
 class Re2SearchAndExtractConstantPattern final : public VectorFunction {
  public:
   explicit Re2SearchAndExtractConstantPattern(
       StringView pattern,
-      bool emptyNoMatch)
-      : re_(toStringPiece(pattern), RE2::Quiet), emptyNoMatch_(emptyNoMatch) {}
+      const Re2ExtractOptions& options)
+      : re_(toStringPiece(pattern), RE2::Quiet), options_(options) {}
 
   void apply(
       const SelectivityVector& rows,
@@ -350,8 +386,11 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
 
     // apply() will not be invoked if the selection is empty.
     try {
-      checkForBadPattern(re_);
-    } catch (const std::exception& e) {
+      if (!validatePatternForExtract(re_, options_.invalidRegexPolicy)) {
+        setNullForRows(rows, result);
+        return;
+      }
+    } catch (const std::exception& /* e */) {
       context.setErrors(rows, std::current_exception());
       return;
     }
@@ -364,7 +403,7 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
       groups.resize(1);
       context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         mustRefSourceStrings |=
-            re2Extract(result, i, re_, toSearch, groups, 0, emptyNoMatch_);
+            re2Extract(result, i, re_, toSearch, groups, 0, options_);
       });
       if (mustRefSourceStrings) {
         result.acquireSharedStringBuffers(toSearch->base());
@@ -374,16 +413,20 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
 
     if (const auto groupId = getIfConstant<T>(*args[2])) {
       try {
-        checkForBadGroupId(*groupId, re_);
-      } catch (const std::exception& e) {
+        if (!validateGroupIdForExtract(
+                *groupId, re_, options_.invalidGroupPolicy)) {
+          setNullForRows(rows, result);
+          return;
+        }
+      } catch (const std::exception& /* e */) {
         context.setErrors(rows, std::current_exception());
         return;
       }
 
       groups.resize(*groupId + 1);
       context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
-        mustRefSourceStrings |= re2Extract(
-            result, i, re_, toSearch, groups, *groupId, emptyNoMatch_);
+        mustRefSourceStrings |=
+            re2Extract(result, i, re_, toSearch, groups, *groupId, options_);
       });
       if (mustRefSourceStrings) {
         result.acquireSharedStringBuffers(toSearch->base());
@@ -398,9 +441,12 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
     groups.resize(re_.NumberOfCapturingGroups() + 1);
     context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
       T group = groupIds->valueAt<T>(i);
-      checkForBadGroupId(group, re_);
+      if (!validateGroupIdForExtract(group, re_, options_.invalidGroupPolicy)) {
+        result.setNull(i, true);
+        return;
+      }
       mustRefSourceStrings |=
-          re2Extract(result, i, re_, toSearch, groups, group, emptyNoMatch_);
+          re2Extract(result, i, re_, toSearch, groups, group, options_);
     });
     if (mustRefSourceStrings) {
       result.acquireSharedStringBuffers(toSearch->base());
@@ -409,7 +455,7 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
 
  private:
   RE2 re_;
-  const bool emptyNoMatch_;
+  const Re2ExtractOptions options_;
 }; // namespace
 
 // The factory function we provide returns a unique instance for each call, so
@@ -417,8 +463,8 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
 template <typename T>
 class Re2SearchAndExtract final : public VectorFunction {
  public:
-  explicit Re2SearchAndExtract(bool emptyNoMatch)
-      : emptyNoMatch_(emptyNoMatch) {}
+  explicit Re2SearchAndExtract(const Re2ExtractOptions& options)
+      : options_(options) {}
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -428,7 +474,7 @@ class Re2SearchAndExtract final : public VectorFunction {
     BOLT_CHECK(args.size() == 2 || args.size() == 3);
     // Handle the common case of a constant pattern.
     if (auto pattern = getIfConstant<StringView>(*args[1])) {
-      Re2SearchAndExtractConstantPattern<T>(*pattern, emptyNoMatch_)
+      Re2SearchAndExtractConstantPattern<T>(*pattern, options_)
           .apply(rows, args, outputType, context, resultRef);
       return;
     }
@@ -445,20 +491,27 @@ class Re2SearchAndExtract final : public VectorFunction {
       groups.resize(1);
       context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         RE2 re(toStringPiece(pattern->valueAt<StringView>(i)), RE2::Quiet);
-        checkForBadPattern(re);
+        if (!validatePatternForExtract(re, options_.invalidRegexPolicy)) {
+          result.setNull(i, true);
+          return;
+        }
         mustRefSourceStrings |=
-            re2Extract(result, i, re, toSearch, groups, 0, emptyNoMatch_);
+            re2Extract(result, i, re, toSearch, groups, 0, options_);
       });
     } else {
       exec::LocalDecodedVector groupIds(context, *args[2], rows);
       context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         const auto groupId = groupIds->valueAt<T>(i);
         RE2 re(toStringPiece(pattern->valueAt<StringView>(i)), RE2::Quiet);
-        checkForBadPattern(re);
-        checkForBadGroupId(groupId, re);
+        if (!validatePatternForExtract(re, options_.invalidRegexPolicy) ||
+            !validateGroupIdForExtract(
+                groupId, re, options_.invalidGroupPolicy)) {
+          result.setNull(i, true);
+          return;
+        }
         groups.resize(groupId + 1);
         mustRefSourceStrings |=
-            re2Extract(result, i, re, toSearch, groups, groupId, emptyNoMatch_);
+            re2Extract(result, i, re, toSearch, groups, groupId, options_);
       });
     }
     if (mustRefSourceStrings) {
@@ -467,7 +520,7 @@ class Re2SearchAndExtract final : public VectorFunction {
   }
 
  private:
-  const bool emptyNoMatch_;
+  const Re2ExtractOptions options_;
 };
 
 // Match string 'input' with a fixed pattern (with no wildcard characters).
@@ -1058,8 +1111,20 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2SearchSignatures() {
 std::shared_ptr<VectorFunction> makeRe2Extract(
     const std::string& name,
     const std::vector<VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& /*config*/,
+    const core::QueryConfig& config,
     const bool emptyNoMatch) {
+  Re2ExtractOptions options;
+  options.noMatchPolicy = emptyNoMatch
+      ? Re2ExtractResultPolicy::kReturnEmptyString
+      : Re2ExtractResultPolicy::kReturnNull;
+  return makeRe2ExtractWithOptions(name, inputArgs, config, options);
+}
+
+std::shared_ptr<VectorFunction> makeRe2ExtractWithOptions(
+    const std::string& name,
+    const std::vector<VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/,
+    const Re2ExtractOptions& options) {
   auto numArgs = inputArgs.size();
   BOLT_USER_CHECK(
       numArgs == 2 || numArgs == 3,
@@ -1098,10 +1163,10 @@ std::shared_ptr<VectorFunction> makeRe2Extract(
     switch (groupIdTypeKind) {
       case TypeKind::INTEGER:
         return std::make_shared<Re2SearchAndExtractConstantPattern<int32_t>>(
-            pattern, emptyNoMatch);
+            pattern, options);
       case TypeKind::BIGINT:
         return std::make_shared<Re2SearchAndExtractConstantPattern<int64_t>>(
-            pattern, emptyNoMatch);
+            pattern, options);
       default:
         BOLT_UNREACHABLE();
     }
@@ -1109,9 +1174,9 @@ std::shared_ptr<VectorFunction> makeRe2Extract(
 
   switch (groupIdTypeKind) {
     case TypeKind::INTEGER:
-      return std::make_shared<Re2SearchAndExtract<int32_t>>(emptyNoMatch);
+      return std::make_shared<Re2SearchAndExtract<int32_t>>(options);
     case TypeKind::BIGINT:
-      return std::make_shared<Re2SearchAndExtract<int64_t>>(emptyNoMatch);
+      return std::make_shared<Re2SearchAndExtract<int64_t>>(options);
     default:
       BOLT_UNREACHABLE();
   }

--- a/bolt/functions/lib/Re2Functions.h
+++ b/bolt/functions/lib/Re2Functions.h
@@ -46,6 +46,24 @@ enum class InvalidRegexPolicy {
   kReturnFalse,
 };
 
+enum class Re2ExtractResultPolicy {
+  kReturnNull,
+  kReturnEmptyString,
+};
+
+enum class Re2ExtractErrorPolicy {
+  kThrow,
+  kReturnNull,
+};
+
+struct Re2ExtractOptions {
+  Re2ExtractResultPolicy noMatchPolicy{Re2ExtractResultPolicy::kReturnNull};
+  Re2ExtractErrorPolicy invalidRegexPolicy{Re2ExtractErrorPolicy::kThrow};
+  Re2ExtractErrorPolicy invalidGroupPolicy{Re2ExtractErrorPolicy::kThrow};
+  Re2ExtractResultPolicy unmatchedGroupPolicy{
+      Re2ExtractResultPolicy::kReturnEmptyString};
+};
+
 /// Representation of different kinds of patterns.
 enum class PatternKind {
   /// Pattern containing wildcard character '_' only, such as _, __, ____.
@@ -136,6 +154,12 @@ std::shared_ptr<exec::VectorFunction> makeRe2Extract(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config,
     const bool emptyNoMatch);
+
+std::shared_ptr<exec::VectorFunction> makeRe2ExtractWithOptions(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config,
+    const Re2ExtractOptions& options);
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractSignatures();
 

--- a/bolt/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -245,6 +245,7 @@ TEST_F(RegexFunctionsTest, regexMatchRegistration) {
           "regexp_extract('a', c0)", std::optional<std::string>("a*")),
       BoltUserError);
   EXPECT_EQ(regexp_extract("abc", "a."), "ab");
+  EXPECT_EQ(regexp_extract("abc", "\\d+"), "");
   EXPECT_THROW(regexp_extract("[]", "[a[b]]"), BoltUserError);
 }
 


### PR DESCRIPTION
Register RE2- and ICU-backed regular expression extraction for Flink SQL. Return null for no match, invalid patterns or group IDs, and unmatched groups while preserving empty strings for successful zero-length matches.

Add configurable RE2 extraction policies so Flink semantics can be selected without changing existing Spark or Presto behavior. Require constant patterns and add coverage for Java regex semantics, Unicode, group ID narrowing, input buffer lifetime, and Spark no-match behavior.

### What problem does this PR solve?

Issue Number: close #793

The existing Spark-compatible `regexp_extract` returns an empty string when a
pattern does not match. For example:

```sql
REGEXP_EXTRACT(
    'dc05-p2-ta22-n146.byted.org:8052',
    'n\d{1,3}-\d{1,3}-\d{1,3}',
    0)
```

returns `""`, while Apache Flink returns `NULL`.

Flink SQL therefore needs its own extraction registration and result policies
instead of reusing Spark semantics. A Java-regex-compatible implementation is
also needed for patterns that RE2 does not support.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Register Flink SQL `regexp_extract` using RE2 with Flink-compatible `NULL`
  results for no matches, invalid patterns, invalid group IDs, and unmatched
  groups.
- Register `icu_regexp_extract` for Java-compatible regular expressions,
  including lookaheads, Java character-class semantics, Unicode input, and
  Java-style narrowing of `BIGINT` group IDs.
- Preserve empty strings for successful zero-length matches.
- Require constant regular expression patterns for both Flink implementations.
- Add configurable extraction policies to the shared RE2 implementation while
  preserving the existing Spark and Presto defaults.
- Add regression coverage for both Flink implementations and the existing
  Spark empty-string-on-no-match behavior.

### Validation

Configured and built inside the Bolt devcontainer:

```shell
make release_with_test BOLT_CONAN_CONFIGURE_ONLY=1

cmake --build --preset conan-release \
  --target bolt_functions_flink_test \
  --parallel 60

cmake --build --preset conan-release \
  --target bolt_functions_lib_test bolt_functions_spark_test \
  --parallel 60
```

Test results:

- `bolt_functions_flink_test`: 57/57 tests passed.
- `Re2FunctionsTest.regexExtract*` and `Re2FunctionsTest.tryException`:
  16/16 tests passed.
- `RegexFunctionsTest.regexMatchRegistration`: 1/1 test passed.
- clang-format 14 passed for all changed C++ sources and headers.
- `git diff --check` passed.

### Performance Impact

- [x] **No Impact**: This adds opt-in Flink registrations and preserves the
  existing RE2 extraction defaults for current Spark and Presto callers. No
  performance-focused changes or benchmarks were made.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Added Flink-compatible regexp_extract and icu_regexp_extract functions with NULL results for no-match and invalid extraction cases.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
