### PR TITLE
fix array_repeat above Presto repeat limit

### DIFF
--- a/bolt/functions/lib/Repeat.cpp
+++ b/bolt/functions/lib/Repeat.cpp
@@ -30,6 +30,9 @@
 
 #include "bolt/expression/DecodedArgs.h"
 #include "bolt/expression/VectorFunction.h"
+
+#include <limits>
+
 namespace bytedance::bolt::functions {
 namespace {
 // See documentation at https://prestodb.io/docs/current/functions/array.html
@@ -37,8 +40,11 @@ class RepeatFunction : public exec::VectorFunction {
  public:
   // @param allowNegativeCount If true, negative 'count' is allowed
   // and treated the same as zero (Spark's behavior).
-  explicit RepeatFunction(bool allowNegativeCount)
-      : allowNegativeCount_(allowNegativeCount) {}
+  // @param enforceMaxResultEntries If true, enforce Presto's 10,000 entries
+  // limit per row. Spark's array_repeat doesn't have this limit.
+  explicit RepeatFunction(bool allowNegativeCount, bool enforceMaxResultEntries)
+      : allowNegativeCount_(allowNegativeCount),
+        enforceMaxResultEntries_(enforceMaxResultEntries) {}
 
   static constexpr int32_t kMaxResultEntries = 10'000;
 
@@ -67,7 +73,10 @@ class RepeatFunction : public exec::VectorFunction {
 
  private:
   // Check count to make sure it is in valid range.
-  static int32_t checkCount(int32_t count, bool allowNegativeCount) {
+  static int32_t checkCount(
+      int32_t count,
+      bool allowNegativeCount,
+      bool enforceMaxResultEntries) {
     if (count < 0) {
       if (allowNegativeCount) {
         return 0;
@@ -77,11 +86,21 @@ class RepeatFunction : public exec::VectorFunction {
           count,
           0);
     }
-    BOLT_USER_CHECK_LE(
-        count,
-        kMaxResultEntries,
-        "Count argument of repeat function must be less than or equal to 10000");
+    if (enforceMaxResultEntries) {
+      BOLT_USER_CHECK_LE(
+          count,
+          kMaxResultEntries,
+          "Count argument of repeat function must be less than or equal to 10000");
+    }
     return count;
+  }
+
+  static vector_size_t checkTotalCount(int64_t totalCount) {
+    BOLT_USER_CHECK_LE(
+        totalCount,
+        std::numeric_limits<vector_size_t>::max(),
+        "Total entries of repeat result exceed the maximum vector size");
+    return static_cast<vector_size_t>(totalCount);
   }
 
   VectorPtr applyConstantCount(
@@ -99,13 +118,14 @@ class RepeatFunction : public exec::VectorFunction {
     }
 
     auto count = constantCount->valueAt(0);
+    vector_size_t totalCount;
     try {
-      count = checkCount(count, allowNegativeCount_);
+      count = checkCount(count, allowNegativeCount_, enforceMaxResultEntries_);
+      totalCount = checkTotalCount(static_cast<int64_t>(count) * numRows);
     } catch (const BoltUserError&) {
       context.setErrors(rows, std::current_exception());
       return nullptr;
     }
-    const auto totalCount = count * numRows;
 
     // Allocate new vectors for indices, lengths and offsets.
     BufferPtr indices = allocateIndices(totalCount, pool);
@@ -140,13 +160,14 @@ class RepeatFunction : public exec::VectorFunction {
       exec::EvalCtx& context) const {
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto countDecoded = decodedArgs.at(1);
-    int32_t totalCount = 0;
+    int64_t totalCount = 0;
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       auto count =
           countDecoded->isNullAt(row) ? 0 : countDecoded->valueAt<int32_t>(row);
-      count = checkCount(count, allowNegativeCount_);
+      count = checkCount(count, allowNegativeCount_, enforceMaxResultEntries_);
       totalCount += count;
     });
+    const auto totalEntries = checkTotalCount(totalCount);
 
     const auto numRows = rows.end();
     auto pool = context.pool();
@@ -160,7 +181,7 @@ class RepeatFunction : public exec::VectorFunction {
     }
 
     // Allocate new vectors for indices, lengths and offsets.
-    BufferPtr indices = allocateIndices(totalCount, pool);
+    BufferPtr indices = allocateIndices(totalEntries, pool);
     BufferPtr sizes = allocateSizes(numRows, pool);
     BufferPtr offsets = allocateOffsets(numRows, pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
@@ -196,10 +217,11 @@ class RepeatFunction : public exec::VectorFunction {
         numRows,
         offsets,
         sizes,
-        BaseVector::wrapInDictionary(nullptr, indices, totalCount, args[0]));
+        BaseVector::wrapInDictionary(nullptr, indices, totalEntries, args[0]));
   }
 
   const bool allowNegativeCount_;
+  const bool enforceMaxResultEntries_;
 };
 } // namespace
 
@@ -217,14 +239,14 @@ std::shared_ptr<exec::VectorFunction> makeRepeat(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& /* inputArgs */,
     const core::QueryConfig& /*config*/) {
-  return std::make_unique<RepeatFunction>(false);
+  return std::make_unique<RepeatFunction>(false, true);
 }
 
 std::shared_ptr<exec::VectorFunction> makeRepeatAllowNegativeCount(
     const std::string& /* name */,
     const std::vector<exec::VectorFunctionArg>& /* inputArgs */,
     const core::QueryConfig& /*config*/) {
-  return std::make_unique<RepeatFunction>(true);
+  return std::make_unique<RepeatFunction>(true, false);
 }
 
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/lib/tests/RepeatTest.cpp
+++ b/bolt/functions/lib/tests/RepeatTest.cpp
@@ -174,5 +174,22 @@ TEST_F(RepeatTest, repeatAllowNegativeCount) {
       {elementVector, countVector},
       expected);
 }
+
+TEST_F(RepeatTest, repeatAllowNegativeCountAbovePrestoLimit) {
+  constexpr int32_t repeatCount = 10'452;
+  const auto elementVector = makeFlatVector<int32_t>({repeatCount});
+  const auto countVector = makeFlatVector<int32_t>({repeatCount});
+  const auto expected = makeArrayVector<int32_t>(
+      {std::vector<int32_t>(repeatCount, repeatCount)});
+
+  testExpression(
+      "repeat_allow_negative_count(C0, C1)",
+      {elementVector, countVector},
+      expected);
+  testExpression(
+      "repeat_allow_negative_count(C0, '10452'::INTEGER)",
+      {elementVector},
+      expected);
+}
 } // namespace
 } // namespace bytedance::bolt::functions


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: #652

This PR fixes a compatibility issue in the Spark-compatible `array_repeat` implementation.

Previously, `repeat_allow_negative_count`, which is used to provide Spark-compatible behavior, reused the same 10,000-result-entry-per-row limit as Presto `repeat`. However, Spark `array_repeat` does not enforce this Presto-specific limit. As a result, valid Spark queries such as repeating an element more than 10,000 times could fail unexpectedly.

This PR separates the Presto `repeat` behavior from the Spark-compatible `repeat_allow_negative_count` behavior:
- Presto `repeat` still enforces the 10,000 entries per row limit.
- Spark-compatible `repeat_allow_negative_count` allows counts greater than 10,000.
- A total result size check is still kept to prevent exceeding the maximum vector size.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

This PR updates the implementation of the repeat array function to distinguish between Presto-compatible and Spark-compatible semantics.

Previously, `RepeatFunction::checkCount` always enforced `kMaxResultEntries = 10,000`, regardless of whether the function was used for Presto `repeat` or Spark-compatible `repeat_allow_negative_count`.

The change introduces a new `enforceMaxResultEntries` flag in `RepeatFunction`:
- `makeRepeat` creates `RepeatFunction(false, true)`, so Presto `repeat` keeps enforcing the 10,000 limit.
- `makeRepeatAllowNegativeCount` creates `RepeatFunction(true, false)`, so Spark-compatible `repeat_allow_negative_count` allows counts greater than 10,000.

In addition, this PR adds `checkTotalCount` to validate the total number of output entries before allocating result buffers. This prevents the total repeated result size from exceeding the maximum supported `vector_size_t` size.

The implementation also changes the accumulated total count in the non-constant count path from `int32_t` to `int64_t`, avoiding integer overflow when summing large repeat counts across rows.

A new unit test is added to verify that `repeat_allow_negative_count` works when the repeat count is above the Presto limit. The test covers both:
- non-constant count input
- constant count input

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This is a correctness fix for function semantics. It only adds a configuration flag and a total-size safety check, and does not introduce algorithmic changes to the repeat execution path.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

```text
Release Note:
- Fixed Spark-compatible array_repeat behavior to allow repeat counts greater than the Presto repeat limit of 10,000.
- Added safety validation for total repeat result size to avoid exceeding the maximum vector size.
```

### Checklist (For Author)                                                                                                                                                                                                                                                                                   
- [x] I have added/updated unit tests (ctest).                                                                                                          

### Breaking Changes                                                                                                                                                                                                                                                                                          
- [x] No                                                                                                                                                