### PR TITLE
fix(row): consume null bitmap for ARRAY<UNKNOWN>

### DIFF
--- a/bolt/row/CompactRow.cpp
+++ b/bolt/row/CompactRow.cpp
@@ -897,6 +897,11 @@ VectorPtr deserializeUnknownArrays(
   auto* rawSizes = sizes->as<vector_size_t>();
   const auto total = totalSize(rawSizes, numRows);
 
+  // UNKNOWN elements have no payload, but their null bitmap is still present.
+  for (auto i = 0; i < numRows; ++i) {
+    offsets[i] += bits::nbytes(rawSizes[i]);
+  }
+
   return BaseVector::createNullConstant(UNKNOWN(), total, pool);
 }
 

--- a/bolt/row/tests/CompactRowTest.cpp
+++ b/bolt/row/tests/CompactRowTest.cpp
@@ -371,6 +371,16 @@ TEST_F(CompactRowTest, unknown) {
   testRoundTrip(data);
 }
 
+TEST_F(CompactRowTest, arrayOfUnknownFollowedByFields) {
+  auto data = makeRowVector({
+      makeArrayVector({0, 1, 3, 3}, makeAllNullFlatVector<UnknownValue>(4)),
+      makeArrayVector<int64_t>({{10}, {20, 30}, {}, {40}}),
+      makeFlatVector<std::string>({"a", "bb", "ccc", "dddd"}),
+  });
+
+  testRoundTrip(data);
+}
+
 TEST_F(CompactRowTest, mix) {
   auto data = makeRowVector({
       makeFlatVector<std::string>({"a", "Abc", "", "Longer test string"}),


### PR DESCRIPTION
### What problem does this PR solve?

`CompactRow` deserialization did not advance row offsets past the element-null
bitmap of `ARRAY<UNKNOWN>`.

Although `UNKNOWN` elements have no value payload, a non-empty array still has
a null bitmap in the CompactRow wire format. Leaving the offset at that bitmap
caused the following field to be decoded one or more bytes early. A following
array could therefore receive a corrupted cardinality and fail during shuffle
read.

Issue Number: close #798

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR updates `deserializeUnknownArrays` to advance each row offset by
`bits::nbytes(arraySize)` before returning the null `UNKNOWN` elements vector.
This mirrors the existing behavior for arrays of fixed-width, string, and
complex elements.

A regression test adds the schema:

```text
ROW<ARRAY<UNKNOWN>, ARRAY<BIGINT>, VARCHAR>
```

The test includes empty and non-empty unknown arrays and verifies both
row-by-row and range serialization round trips. Keeping fields after
`ARRAY<UNKNOWN>` ensures that a stale offset cannot remain hidden.

Production validation on the original workload confirmed that the old offset
decoded the following array size as 257 while the corrected offset decoded it
as 1. Writer and payload integrity checks reported no errors, and the workload
completed successfully with the fix.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
- Fixed CompactRow shuffle deserialization for non-empty ARRAY<UNKNOWN> fields
  followed by other fields.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
