### PR TITLE
fix: support parquet INT32 as double and boolean

### DIFF
--- a/bolt/dwio/common/SelectiveColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveColumnReader.cpp
@@ -34,6 +34,13 @@ namespace bytedance::bolt::dwio::common {
 
 using dwio::common::TypeWithId;
 
+template <>
+void SelectiveColumnReader::getFlatValues<int32_t, bool>(
+    RowSet rows,
+    VectorPtr* result,
+    const TypePtr& type,
+    bool isFinal);
+
 bolt::common::AlwaysTrue& alwaysTrue() {
   static bolt::common::AlwaysTrue alwaysTrue;
   return alwaysTrue;
@@ -234,6 +241,26 @@ void SelectiveColumnReader::getIntValues(
           BOLT_FAIL("Unsupported value size: {}", valueSize_);
       }
       break;
+    case TypeKind::DOUBLE:
+      // Only Parquet INT32 widens to DOUBLE. INT64 -> DOUBLE is rejected in
+      // convertType due to precision loss.
+      switch (valueSize_) {
+        case 4:
+          getFlatValues<int32_t, double>(rows, result, requestedType);
+          break;
+        default:
+          BOLT_FAIL("Unsupported value size: {}", valueSize_);
+      }
+      break;
+    case TypeKind::BOOLEAN:
+      switch (valueSize_) {
+        case 4:
+          getFlatValues<int32_t, bool>(rows, result, requestedType);
+          break;
+        default:
+          BOLT_FAIL("Unsupported value size: {}", valueSize_);
+      }
+      break;
     case TypeKind::TIMESTAMP:
       getFlatValues<Timestamp, Timestamp>(rows, result, requestedType);
       break;
@@ -310,6 +337,41 @@ void SelectiveColumnReader::getUnsignedIntValues(
           "Not a valid type for unsigned integer reader: {}",
           requestedType->toString());
   }
+}
+
+template <>
+void SelectiveColumnReader::getFlatValues<int32_t, bool>(
+    RowSet rows,
+    VectorPtr* result,
+    const TypePtr& type,
+    bool isFinal) {
+  BOLT_CHECK_EQ(valueSize_, sizeof(int32_t));
+  if (allNull_) {
+    *result = std::make_shared<ConstantVector<bool>>(
+        &memoryPool_,
+        rows.size(),
+        true,
+        type,
+        false,
+        SimpleVectorStats<bool>{},
+        sizeof(bool) * rows.size());
+    return;
+  }
+  compactScalarValues<int32_t, int32_t>(rows, isFinal);
+  auto boolValues =
+      AlignedBuffer::allocate<bool>(numValues_, &memoryPool_, false);
+  auto rawInts = values_->as<int32_t>();
+  auto rawBits = boolValues->asMutable<uint64_t>();
+  for (auto i = 0; i < numValues_; ++i) {
+    bits::setBit(rawBits, i, rawInts[i] != 0);
+  }
+  *result = std::make_shared<FlatVector<bool>>(
+      &memoryPool_,
+      type,
+      resultNulls(),
+      numValues_,
+      std::move(boolValues),
+      std::move(stringBuffers_));
 }
 
 template <>

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -108,13 +108,29 @@ bool acceptsIntFileForReaderCast(const bytedance::bolt::TypePtr& t) {
 //     ShortType) is silently truncated at read time, matching Spark's
 //     vectorized reader. Covers HIVE-14294 where Hive 1.x writes
 //     TINYINT/SMALLINT as unannotated INT32 (SPARK-16632).
+//   - DOUBLE target. INT32 values are exactly representable as DOUBLE and
+//     SelectiveColumnReader::getIntValues performs the widening at read time.
+//     This covers Hive tables whose historical partitions were written as
+//     INT32 before the metastore type was widened to DOUBLE.
+//   - BOOLEAN target, using Spark SQL cast semantics for compatibility with
+//     tables that store boolean-like flags as unannotated INT32.
 //   - VARCHAR / VARBINARY target via IntegerColumnReader::makeCastExpr,
 //     which performs the int-to-string cast at read time.
 bool isInt32Compatible(const bytedance::bolt::TypePtr& type) {
   using TK = bytedance::bolt::TypeKind;
   const auto k = type->kind();
   return k == TK::TINYINT || k == TK::SMALLINT || k == TK::INTEGER ||
-      k == TK::BIGINT || acceptsIntFileForReaderCast(type);
+      k == TK::BIGINT || k == TK::DOUBLE || k == TK::BOOLEAN ||
+      acceptsIntFileForReaderCast(type);
+}
+
+// Compatibility predicate for UINT_* annotations. Keep this aligned with
+// SelectiveColumnReader::getUnsignedIntValues.
+bool isUInt32Compatible(const bytedance::bolt::TypePtr& type) {
+  using TK = bytedance::bolt::TypeKind;
+  const auto k = type->kind();
+  return k == TK::TINYINT || k == TK::SMALLINT || k == TK::INTEGER ||
+      k == TK::BIGINT || k == TK::HUGEINT || acceptsIntFileForReaderCast(type);
 }
 
 // Compatibility predicate for Parquet INT64-physical source columns.
@@ -1072,7 +1088,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_8 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
+        checkRequested([](const TypePtr& t) { return isUInt32Compatible(t); });
         return TINYINT();
 
       case thrift::ConvertedType::UINT_16:
@@ -1080,7 +1096,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_16 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
+        checkRequested([](const TypePtr& t) { return isUInt32Compatible(t); });
         return SMALLINT();
 
       case thrift::ConvertedType::UINT_32:
@@ -1088,7 +1104,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "UINT_32 converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
+        checkRequested([](const TypePtr& t) { return isUInt32Compatible(t); });
         return INTEGER();
 
       case thrift::ConvertedType::UINT_64:

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1501,10 +1501,17 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     {"integer_to_smallint",            INTEGER(),       SMALLINT(),         false},
     {"integer_to_tinyint",             INTEGER(),       TINYINT(),          false},
 
-    // ---- Reject: cross-family with no column-reader auto-cast ----
-    {"integer_to_double",              INTEGER(),       DOUBLE(),           true},
+    // ---- Accept: INT32 -> DOUBLE. INT32 is exactly representable as DOUBLE,
+    //      and Hive tables can have historical INT32 Parquet partitions after
+    //      the metastore column is widened to DOUBLE. ----
+    {"integer_to_double",              INTEGER(),       DOUBLE(),           false},
+
+    // ---- Reject: cross-family with no safe column-reader auto-cast ----
     {"bigint_to_double",               BIGINT(),        DOUBLE(),           true},
     {"integer_to_real",                INTEGER(),       REAL(),             true},
+
+    // ---- Accept: INT32 -> BOOLEAN for Spark/Hive compatibility. ----
+    {"integer_to_boolean",             INTEGER(),       BOOLEAN(),          false},
 
     // ---- Reject: float narrowing ----
     {"double_to_real",                 DOUBLE(),        REAL(),             true},
@@ -1657,7 +1664,61 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
     EXPECT_TRUE(assertEqualResults({expected}, {result}));
   }
 
-  // 2. Float widening: REAL [1.5, 2.5, 3.5] read as DOUBLE.
+  // 2. INT32 -> DOUBLE widening: file INT32 [1,2,3] read as DOUBLE.
+  {
+    auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {DOUBLE()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<double>({1.0, 2.0, 3.0})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  // 3. INT32 -> BOOLEAN compatibility: zero maps to false, non-zero maps to
+  //    true, and nulls are preserved.
+  {
+    auto data = makeRowVector(
+        {"c0"}, {makeNullableFlatVector<int32_t>({0, 1, -7, std::nullopt})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {BOOLEAN()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected = makeRowVector(
+        {"c0"},
+        {makeNullableFlatVector<bool>({false, true, true, std::nullopt})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  // INT32 -> BOOLEAN with all-null input uses the same null-only result shape
+  // as the generic fixed-width path.
+  {
+    auto data = makeRowVector({"c0"}, {makeAllNullFlatVector<int32_t>(3)});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {BOOLEAN()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected = makeRowVector({"c0"}, {makeAllNullFlatVector<bool>(3)});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  // 4. Float widening: REAL [1.5, 2.5, 3.5] read as DOUBLE.
   {
     auto data =
         makeRowVector({"c0"}, {makeFlatVector<float>({1.5f, 2.5f, 3.5f})});
@@ -1676,7 +1737,7 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
   }
 
 #ifdef SPARK_COMPATIBLE
-  // 3. Auto-cast VARCHAR -> BIGINT: ["100","200","300"] -> [100,200,300].
+  // 4. Auto-cast VARCHAR -> BIGINT: ["100","200","300"] -> [100,200,300].
   //    Skipped in non-Spark builds because matchType() at
   //    ParquetColumnReader.cpp:95 rejects VARCHAR-file -> INT-requested
   //    before the column-reader cast can run.


### PR DESCRIPTION
Allow Parquet INT32-backed columns to be read as DOUBLE or BOOLEAN when requested by the table schema. Keep UINT_* compatibility aligned with the unsigned reader so unsupported boolean/double targets are rejected during schema validation.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #796 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds Parquet schema-mismatch compatibility for reading INT32-backed columns as DOUBLE or BOOLEAN.

 - Allows Parquet INT32 columns to be read as DOUBLE.
      - INT32 values are exactly representable as DOUBLE.
      - INT64 -> DOUBLE remains rejected to avoid precision loss.

  - Allows Parquet INT32 columns to be read as BOOLEAN.
      - Uses Spark/Hive-compatible semantics: 0 maps to false, non-zero maps to true.
      - Preserves nulls, including all-null batches.

  - Keeps unsigned integer annotations separate from signed/plain INT32.
      - UINT_* columns no longer inherit the new DOUBLE / BOOLEAN compatibility unless the unsigned reader actually supports the target type.
      - This keeps schema validation aligned with the reader implementation.



### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: support parquet INT32 as double and boolean
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
