### PR TITLE
fix: support DATE parquet columns as int and varchar

### DIFF
--- a/bolt/dwio/common/SelectiveColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveColumnReader.cpp
@@ -541,9 +541,10 @@ void SelectiveColumnReader::addSkippedParentNulls(
   parentNullsRecordedTo_ = to;
 }
 
-void SelectiveColumnReader::makeCastExpr() {
+void SelectiveColumnReader::makeCastExpr(TypePtr castSourceType) {
+  castSourceType_ = castSourceType ? castSourceType : fileType_->type();
   auto inputField = std::make_shared<const core::FieldAccessTypedExpr>(
-      fileType_->type(), dummyColumnName);
+      castSourceType_, dummyColumnName);
   auto castExpr = std::make_shared<const core::CastTypedExpr>(
       requestedType_, inputField, false);
   castExprSet_ = scanSpec_->getExpressionEvaluator()->compile(castExpr);
@@ -552,7 +553,7 @@ void SelectiveColumnReader::makeCastExpr() {
 void SelectiveColumnReader::doCastEvaluate(VectorPtr* result) {
   SelectivityVector dummySelectivity((*result)->size(), true);
   VectorPtr convertedResult;
-  auto rowType = ROW({dummyColumnName}, {fileType_->type()});
+  auto rowType = ROW({dummyColumnName}, {castSourceType_});
   auto rowVector = std::make_shared<RowVector>(
       (*result)->pool(),
       rowType,

--- a/bolt/dwio/common/SelectiveColumnReader.h
+++ b/bolt/dwio/common/SelectiveColumnReader.h
@@ -475,7 +475,7 @@ class SelectiveColumnReader {
   // 'extraSpace' bits worth of space in the nulls buffer.
   void prepareNulls(const RowSet& rows, bool hasNulls, int32_t extraRows = 0);
 
-  void makeCastExpr();
+  void makeCastExpr(TypePtr castSourceType = nullptr);
 
   void doCastEvaluate(VectorPtr* result);
 
@@ -681,6 +681,7 @@ class SelectiveColumnReader {
   ScanState scanState_;
 
   std::unique_ptr<exec::ExprSet> castExprSet_;
+  TypePtr castSourceType_;
 
   const std::string dummyColumnName = "__innerc0__";
 };

--- a/bolt/dwio/parquet/reader/IntegerColumnReader.h
+++ b/bolt/dwio/parquet/reader/IntegerColumnReader.h
@@ -46,7 +46,10 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
             scanSpec,
             std::move(fileType)) {
     switch (requestedType->type()->kind()) {
-      case TypeKind::VARCHAR:
+      case TypeKind::VARCHAR: {
+        makeCastExpr(fileType_->type()->isDate() ? INTEGER() : nullptr);
+        break;
+      }
       case TypeKind::VARBINARY: {
         makeCastExpr();
         break;
@@ -78,7 +81,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
 
   void getValues(const RowSet& rows, VectorPtr* result) override {
     bool needConvertion = (castExprSet_ && castExprSet_->size() != 0);
-    auto& requestedType = needConvertion ? fileType_->type() : requestedType_;
+    auto& requestedType = needConvertion ? castSourceType_ : requestedType_;
     auto& fileType = static_cast<const ParquetTypeWithId&>(*fileType_);
     bool isUnsigned = false;
     if (fileType.logicalType_.has_value() &&

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -75,17 +75,35 @@ namespace {
 constexpr const char* kTypeMappingErrorFmtStr =
     "Schema mismatch, Column: [{}], From Kind: {}, To Kind: {}";
 
-// Predicates for the cross-family implicit cast that the column reader
-// layer performs at read time (Spark/Hive STRING<->INT compatibility):
-//   - StringColumnReader::makeCastExpr handles VARCHAR/VARBINARY file ->
-//     int family requested type
-//   - IntegerColumnReader::makeCastExpr handles int family file ->
-//     VARCHAR/VARBINARY requested type
-// Both makeCastExpr paths compile unconditionally so convertType keeps
-// these schema pairs uniform across build flavours. Non-Spark builds
-// still get the strict check at ParquetColumnReader.cpp:95 via
-// matchType() for the VARCHAR-file -> INT-requested direction, which
-// fires after convertType and throws with its existing error message.
+std::string parquetSourceTypeName(const thrift::SchemaElement& schemaElement) {
+  if (schemaElement.__isset.converted_type) {
+    return fmt::format(
+        "{}({})", schemaElement.type, schemaElement.converted_type);
+  }
+  if (schemaElement.__isset.logicalType) {
+    const auto& logicalType = schemaElement.logicalType;
+    if (logicalType.__isset.DATE) {
+      return fmt::format("{}(DATE)", schemaElement.type);
+    }
+    if (logicalType.__isset.INTEGER) {
+      return fmt::format("{}(INTEGER)", schemaElement.type);
+    }
+    if (logicalType.__isset.DECIMAL) {
+      return fmt::format("{}(DECIMAL)", schemaElement.type);
+    }
+    if (logicalType.__isset.STRING) {
+      return fmt::format("{}(STRING)", schemaElement.type);
+    }
+    if (logicalType.__isset.TIMESTAMP) {
+      return fmt::format("{}(TIMESTAMP)", schemaElement.type);
+    }
+    if (logicalType.__isset.TIME) {
+      return fmt::format("{}(TIME)", schemaElement.type);
+    }
+  }
+  return fmt::format("{}", schemaElement.type);
+}
+
 // Cross-family implicit cast for VARCHAR/VARBINARY file columns:
 // StringColumnReader::makeCastExpr handles VARCHAR/VARBINARY file -> int
 // family requested type. Non-Spark builds also get a strict check at
@@ -102,8 +120,13 @@ bool acceptsIntFileForReaderCast(const bytedance::bolt::TypePtr& t) {
       t->kind() == bytedance::bolt::TypeKind::VARBINARY;
 }
 
+bool acceptsDateFile(const bytedance::bolt::TypePtr& t) {
+  return t->isDate() || t->kind() == bytedance::bolt::TypeKind::INTEGER ||
+      t->kind() == bytedance::bolt::TypeKind::VARCHAR;
+}
+
 // Compatibility predicate for Parquet INT32-physical source columns
-// (INT_8 / INT_16 / INT_32 / UINT_* annotated, plus unannotated INT32).
+// (INT_8 / INT_16 / INT_32 annotated, plus unannotated INT32).
 // Accepts:
 //   - Any int-family target. Narrowing (file INT32 -> requested ByteType /
 //     ShortType) is silently truncated at read time, matching Spark's
@@ -1045,7 +1068,7 @@ TypePtr ReaderBase::convertType(
           BOLT_SCHEMA_MISMATCH_ERROR(fmt::format(
               kTypeMappingErrorFmtStr,
               schemaElement.name,
-              schemaElement.type,
+              parquetSourceTypeName(schemaElement),
               mapTypeKindToName(requestedType->kind())));
         }
         if (unannotatedArrayMatch) {
@@ -1127,7 +1150,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "DATE converted type can only be set for value of thrift::Type::INT32");
-        checkRequested([](const TypePtr& t) { return t->isDate(); });
+        checkRequested([](const TypePtr& t) { return acceptsDateFile(t); });
         return DATE();
 
       case thrift::ConvertedType::TIMESTAMP_MICROS:
@@ -1204,6 +1227,11 @@ TypePtr ReaderBase::convertType(
             [](const TypePtr& t) { return t->kind() == TypeKind::BOOLEAN; });
         return BOOLEAN();
       case thrift::Type::type::INT32:
+        if (schemaElement.__isset.logicalType &&
+            schemaElement.logicalType.__isset.DATE) {
+          checkRequested([](const TypePtr& t) { return acceptsDateFile(t); });
+          return DATE();
+        }
         checkRequested([](const TypePtr& t) { return isInt32Compatible(t); });
         return INTEGER();
       case thrift::Type::type::INT64:

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -30,12 +30,17 @@
 
 #include <folly/init/Init.h>
 #include <simdjson.h>
+#include <thrift/protocol/TCompactProtocol.h> //@manual
+#include <thrift/transport/TBufferTransports.h>
+#include <fstream>
+#include <iterator>
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/connectors/hive/HiveConfig.h"
 #include "bolt/dwio/common/tests/utils/DataFiles.h"
 #include "bolt/dwio/parquet/RegisterParquetReader.h"
 #include "bolt/dwio/parquet/reader/ParquetReader.h"
+#include "bolt/dwio/parquet/thrift/codegen/parquet_types.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
@@ -108,6 +113,73 @@ RowVectorPtr makeVariantParquetBatch(
       nullptr,
       groups.size(),
       std::vector<VectorPtr>{groupVector, variantStorageVector});
+}
+
+uint32_t readUint32LE(const char* data) {
+  return static_cast<uint8_t>(data[0]) | (static_cast<uint8_t>(data[1]) << 8) |
+      (static_cast<uint8_t>(data[2]) << 16) |
+      (static_cast<uint8_t>(data[3]) << 24);
+}
+
+void appendUint32LE(std::string& out, uint32_t value) {
+  out.push_back(static_cast<char>(value & 0xff));
+  out.push_back(static_cast<char>((value >> 8) & 0xff));
+  out.push_back(static_cast<char>((value >> 16) & 0xff));
+  out.push_back(static_cast<char>((value >> 24) & 0xff));
+}
+
+void rewriteDateConvertedTypeToLogicalTypeOnly(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  BOLT_CHECK(in.good(), "Failed to open Parquet file for read: {}", path);
+  std::string file(
+      (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  BOLT_CHECK_GE(file.size(), 12);
+  BOLT_CHECK_EQ(file.substr(file.size() - 4), "PAR1");
+
+  const auto footerLength = readUint32LE(file.data() + file.size() - 8);
+  BOLT_CHECK_LE(footerLength + 8, file.size());
+  const auto footerOffset = file.size() - 8 - footerLength;
+
+  thrift::FileMetaData metadata;
+  auto inputBuffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>(
+      reinterpret_cast<uint8_t*>(file.data() + footerOffset),
+      footerLength,
+      apache::thrift::transport::TMemoryBuffer::OBSERVE);
+  apache::thrift::protocol::TCompactProtocol inputProtocol(inputBuffer);
+  metadata.read(&inputProtocol);
+
+  bool removedDateConvertedType = false;
+  for (auto& schemaElement : metadata.schema) {
+    if (schemaElement.__isset.converted_type &&
+        schemaElement.converted_type == thrift::ConvertedType::DATE &&
+        schemaElement.__isset.logicalType &&
+        schemaElement.logicalType.__isset.DATE) {
+      schemaElement.__isset.converted_type = false;
+      removedDateConvertedType = true;
+    }
+  }
+  BOLT_CHECK(
+      removedDateConvertedType,
+      "Failed to find DATE converted_type in Parquet footer: {}",
+      path);
+
+  auto outputBuffer =
+      std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+  apache::thrift::protocol::TCompactProtocol outputProtocol(outputBuffer);
+  metadata.write(&outputProtocol);
+  uint8_t* serializedFooter{nullptr};
+  uint32_t serializedFooterLength{0};
+  outputBuffer->getBuffer(&serializedFooter, &serializedFooterLength);
+
+  file.resize(footerOffset);
+  file.append(
+      reinterpret_cast<const char*>(serializedFooter), serializedFooterLength);
+  appendUint32LE(file, serializedFooterLength);
+  file.append("PAR1", 4);
+
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  BOLT_CHECK(out.good(), "Failed to open Parquet file for write: {}", path);
+  out.write(file.data(), file.size());
 }
 
 } // namespace
@@ -1501,9 +1573,7 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     {"integer_to_smallint",            INTEGER(),       SMALLINT(),         false},
     {"integer_to_tinyint",             INTEGER(),       TINYINT(),          false},
 
-    // ---- Accept: INT32 -> DOUBLE. INT32 is exactly representable as DOUBLE,
-    //      and Hive tables can have historical INT32 Parquet partitions after
-    //      the metastore column is widened to DOUBLE. ----
+    // ---- Accept: INT32 -> DOUBLE. INT32 is exactly representable as DOUBLE. ----
     {"integer_to_double",              INTEGER(),       DOUBLE(),           false},
 
     // ---- Reject: cross-family with no safe column-reader auto-cast ----
@@ -1512,6 +1582,14 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
 
     // ---- Accept: INT32 -> BOOLEAN for Spark/Hive compatibility. ----
     {"integer_to_boolean",             INTEGER(),       BOOLEAN(),          false},
+
+    // ---- Accept: DATE annotation read as raw epoch-day INT or VARCHAR. ----
+    {"date_to_integer",                DATE(),          INTEGER(),          false},
+    {"date_to_varchar",                DATE(),          VARCHAR(),          false},
+
+    // ---- Reject: DATE annotation should not be treated as wider int family. ----
+    {"date_to_bigint",                 DATE(),          BIGINT(),           true,
+     "From Kind: INT32(DATE), To Kind: BIGINT"},
 
     // ---- Reject: float narrowing ----
     {"double_to_real",                 DOUBLE(),        REAL(),             true},
@@ -1584,6 +1662,10 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     if (fileType->isDecimal()) {
       return makeRowVector(
           {"c0"}, {makeFlatVector<int64_t>({100, 200, 300}, fileType)});
+    }
+    if (fileType->isDate()) {
+      return makeRowVector(
+          {"c0"}, {makeFlatVector<int32_t>({1, 2, 3}, DATE())});
     }
     switch (fileType->kind()) {
       case TypeKind::TINYINT:
@@ -1758,6 +1840,79 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
     EXPECT_TRUE(assertEqualResults({expected}, {result}));
   }
 #endif
+
+  // DATE annotation read as INTEGER: file INT32(DATE) [1,2,3]
+  // returns raw epoch-day integers when the Hive/Spark schema says INT.
+  {
+    auto data =
+        makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3}, DATE())});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {INTEGER()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  // Same behavior for files that carry only the newer logicalType.DATE
+  // annotation without the deprecated converted_type field.
+  {
+    auto data =
+        makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3}, DATE())});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+    rewriteDateConvertedTypeToLogicalTypeOnly(file->getPath());
+
+    auto declared = ROW({"c0"}, {INTEGER()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  {
+    auto data =
+        makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3}, DATE())});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+    rewriteDateConvertedTypeToLogicalTypeOnly(file->getPath());
+
+    auto declared = ROW({"c0"}, {BIGINT()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    BOLT_ASSERT_THROW(
+        AssertQueryBuilder(plan)
+            .split(makeSplit(file->getPath()))
+            .copyResults(pool()),
+        "From Kind: INT32(DATE), To Kind: BIGINT");
+  }
+
+  // DATE annotation read as VARCHAR: match Spark's INT32 physical read path
+  // and stringify the raw epoch-day integer, not the formatted DATE value.
+  {
+    auto data =
+        makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3}, DATE())});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {VARCHAR()});
+    auto plan =
+        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<StringView>({"1", "2", "3"})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
 
   // 3a/3b. INT32 narrowing: file INT32 read back as TINYINT and SMALLINT.
   //        Models HIVE-14294 / SPARK-16632 where Hive 1.x writes TINYINT/


### PR DESCRIPTION
Allow DATE-annotated INT32 Parquet columns to be read as raw epoch-day INTEGER or VARCHAR values. Treat converted_type=DATE and logicalType.DATE consistently so DATE columns do not fall through to the generic INT32 compatibility policy.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #796 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds compatibility for reading Parquet DATE-annotated INT32 columns as raw epoch-day INTEGER or VARCHAR values.

 - Allows INT32(DATE) -> INTEGER.
      - Returns the raw epoch-day integer.

  - Allows INT32(DATE) -> VARCHAR.
      - Stringifies the raw epoch-day integer, e.g. 1 -> "1".
      - Avoids formatting the value as a calendar date string.

  - Treats converted_type=DATE and logicalType.DATE consistently.
      - logicalType.DATE now uses the DATE compatibility policy instead of generic INT32.

  - Improves schema mismatch diagnostics for logical types.
      - Errors now show INT32(DATE) so users can identify DATE-annotated footer issues.

  - Keeps DATE stricter than generic INT32.
      - DATE -> BIGINT and other wider integer-family interpretations remain rejected.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: support DATE parquet columns as int and varchar
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
