### PR TITLE
fix(arrow): validate int32 offset overflow before allocating string buffer

### DIFF
--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -1081,11 +1081,18 @@ void exportStrings(
       bufSize += vec.valueAtFast(i).size();
     }
   });
+  if constexpr (std::is_same_v<T, int32_t>) {
+    BOLT_CHECK_LT(
+        bufSize,
+        std::numeric_limits<int32_t>::max(),
+        "Cannot export VARCHAR/VARBINARY to Arrow with int32 offsets: "
+        "rows={}, vectorSize={}, bufSize={}",
+        rows.count(),
+        vec.size(),
+        bufSize);
+  }
   holder.setBuffer(2, AlignedBuffer::allocate<char>(bufSize, pool));
   char* rawBuffer = holder.getBufferAs<char>(2);
-  if constexpr (std::is_same_v<T, int32_t>) {
-    BOLT_CHECK_LT(bufSize, std::numeric_limits<int32_t>::max());
-  }
   auto offsetLen = checkedPlus<size_t>(out.length, 1);
   holder.setBuffer(1, AlignedBuffer::allocate<T>(offsetLen, pool));
   auto* rawOffsets = holder.getBufferAs<T>(1);


### PR DESCRIPTION
When exporting VARCHAR/VARBINARY vectors to Arrow with int32 offsets, the total buffer size can exceed the int32 max, which previously only failed after the char buffer had already been allocated. Move the overflow check ahead of the allocation so it fails fast without the extra allocation, and enrich the message with rows, vectorSize and bufSize to make the failure actionable.


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
