### PR TITLE
misc: release old buffers before ensureCapacity growth

### DIFF
--- a/bolt/dwio/common/BufferUtil.h
+++ b/bolt/dwio/common/BufferUtil.h
@@ -40,6 +40,7 @@ inline void ensureCapacity(
     bolt::memory::MemoryPool* pool) {
   if (!data || !data->isMutable() ||
       data->capacity() < BaseVector::byteSize<T>(capacity)) {
+    data.reset();
     data = AlignedBuffer::allocate<T>(capacity, pool);
   }
 }

--- a/bolt/dwio/common/tests/DataBufferTests.cpp
+++ b/bolt/dwio/common/tests/DataBufferTests.cpp
@@ -33,6 +33,7 @@
 #include <gtest/gtest.h>
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/memory/Memory.h"
+#include "bolt/dwio/common/BufferUtil.h"
 #include "bolt/dwio/common/DataBuffer.h"
 namespace bytedance {
 namespace bolt {
@@ -187,6 +188,28 @@ TEST_F(DataBufferTest, Move) {
     ASSERT_EQ(usedBytes, pool_->currentBytes());
   }
   ASSERT_EQ(0, pool_->currentBytes());
+}
+
+TEST_F(DataBufferTest, EnsureCapacityReleasesOldBufferBeforeAllocatingNewOne) {
+  constexpr size_t kInitialSize = 4 << 20;
+  const auto oldAllocationBytes =
+      pool_->preferredSize(kInitialSize + AlignedBuffer::kPaddedSize);
+  const auto oldCapacity = oldAllocationBytes - AlignedBuffer::kPaddedSize;
+  const auto requestedCapacity = oldCapacity + 1;
+  const auto newAllocationBytes =
+      pool_->preferredSize(requestedCapacity + AlignedBuffer::kPaddedSize);
+
+  auto rootPool = memoryManager()->addRootPool(
+      "ensureCapacityReleaseBeforeAlloc", newAllocationBytes);
+  auto leafPool = rootPool->addLeafChild("leaf");
+  BufferPtr buffer =
+      AlignedBuffer::allocate<char>(kInitialSize, leafPool.get());
+  ASSERT_EQ(buffer->capacity(), oldCapacity);
+
+  dwio::common::ensureCapacity<char>(buffer, requestedCapacity, leafPool.get());
+
+  EXPECT_GE(buffer->capacity(), requestedCapacity);
+  EXPECT_LE(leafPool->currentBytes(), newAllocationBytes);
 }
 } // namespace common
 } // namespace dwio


### PR DESCRIPTION




### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Release the existing buffer before allocating a larger replacement in dwio::common::ensureCapacity(). The helper is used by Parquet decode buffers and other scan-side scratch buffers where growth can otherwise transiently hold both the old large allocation and the new larger allocation in the same memory pool.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This reduces short-lived scan memory spikes without changing the returned buffer contents contract: callers already request capacity growth and do not depend on preserving old contents through this helper.

Add a regression test with a constrained memory pool. The test derives the old and new capacities from the allocator preferred size, then requests one byte beyond the old capacity so ensureCapacity must reallocate. Without releasing the old buffer first, the constrained pool cannot hold the old and new allocations at the same time and the test fails with MEM_CAP_EXCEEDED.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
