### PR TITLE
misc: release parquet row group readers before prefetch

### DIFF
--- a/bolt/dwio/parquet/reader/ParquetData.cpp
+++ b/bolt/dwio/parquet/reader/ParquetData.cpp
@@ -437,6 +437,10 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
   return dwio::common::PositionProvider(empty);
 }
 
+void ParquetData::releaseRowGroupReader() {
+  reader_.reset();
+}
+
 std::pair<int64_t, int64_t> ParquetData::getRowGroupRegion(
     uint32_t index) const {
   auto& rowGroup = rowGroups_[index];

--- a/bolt/dwio/parquet/reader/ParquetData.h
+++ b/bolt/dwio/parquet/reader/ParquetData.h
@@ -147,6 +147,8 @@ class ParquetData : public dwio::common::FormatData {
   /// Other formats may use it.
   dwio::common::PositionProvider seekToRowGroup(int64_t index) override;
 
+  void releaseRowGroupReader();
+
   void filterRowGroups(
       const common::ScanSpec& scanSpec,
       uint64_t rowsPerRowGroup,

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1370,6 +1370,7 @@ void ReaderBase::scheduleRowGroups(
   // clear old RowGroup
   if (currentGroup >= 1) {
     inputs_.erase(rowGroupIds[currentGroup - 1]);
+    reader.releaseRowGroupReader();
   }
   // load current RowGroup and prefetch new RowGroup
   auto numRowGroupsToLoad = std::min(

--- a/bolt/dwio/parquet/reader/StructColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/StructColumnReader.cpp
@@ -172,6 +172,23 @@ StructColumnReader::findBestLeaf() {
   return best;
 }
 
+namespace {
+void releaseRowGroupReaderRecursive(
+    dwio::common::SelectiveColumnReader* reader) {
+  reader->scanState().clear();
+  reader->formatData().as<ParquetData>().releaseRowGroupReader();
+  for (auto* child : reader->children()) {
+    if (child != nullptr) {
+      releaseRowGroupReaderRecursive(child);
+    }
+  }
+}
+} // namespace
+
+void StructColumnReader::releaseRowGroupReader() {
+  releaseRowGroupReaderRecursive(this);
+}
+
 void StructColumnReader::read(
     int64_t offset,
     const RowSet& rows,

--- a/bolt/dwio/parquet/reader/StructColumnReader.h
+++ b/bolt/dwio/parquet/reader/StructColumnReader.h
@@ -57,6 +57,8 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
 
   void seekToRowGroup(int64_t index) override;
 
+  void releaseRowGroupReader();
+
   /// Creates the streams for 'rowGroup'. Checks whether row 'rowGroup'
   /// has been buffered in 'input'. If true, return the input. Or else creates
   /// the streams in a new input and loads.

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1459,6 +1459,91 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
   }
 }
 
+TEST_F(ParquetReaderTest, releasesRowGroupReaderStateBeforeLoadingNextWindow) {
+  constexpr int32_t kRowsPerGroup = 128;
+  constexpr int32_t kNumRowGroups = 4;
+  constexpr int32_t kStringBytes = 256 * 1024;
+  auto rowType = ROW({"payload"}, {VARCHAR()});
+
+  auto dataPool = rootPool_->addLeafChild("rowGroupReaderReleaseTestData");
+  BufferPtr values =
+      AlignedBuffer::allocate<StringView>(kRowsPerGroup, dataPool.get());
+  BufferPtr stringBuffer =
+      AlignedBuffer::allocate<char>(kStringBytes, dataPool.get());
+  auto rawString = stringBuffer->asMutable<char>();
+  for (int32_t i = 0; i < kStringBytes; ++i) {
+    rawString[i] = static_cast<char>('a' + (i % 26));
+  }
+  stringBuffer->setSize(kStringBytes);
+  auto rawValues = values->asMutable<StringView>();
+  for (int32_t i = 0; i < kRowsPerGroup; ++i) {
+    rawValues[i] = StringView(rawString, kStringBytes);
+  }
+  auto batch = std::make_shared<RowVector>(
+      dataPool.get(),
+      rowType,
+      nullptr,
+      kRowsPerGroup,
+      std::vector<VectorPtr>{std::make_shared<FlatVector<StringView>>(
+          dataPool.get(),
+          VARCHAR(),
+          nullptr,
+          kRowsPerGroup,
+          values,
+          std::vector<BufferPtr>{stringBuffer})});
+
+  auto tempFile = exec::test::TempFilePath::create();
+  {
+    auto writeFile =
+        std::make_unique<LocalWriteFile>(tempFile->getPath(), true, false);
+    auto sink = std::make_unique<dwio::common::WriteFileSink>(
+        std::move(writeFile), tempFile->getPath());
+    bytedance::bolt::parquet::WriterOptions writerOptions;
+    writerOptions.memoryPool = rootPool_.get();
+    writerOptions.dictionaryPageSizeLimit = kStringBytes * 2;
+    auto writer = std::make_unique<bytedance::bolt::parquet::Writer>(
+        std::move(sink), writerOptions, rowType);
+    for (int32_t i = 0; i < kNumRowGroups; ++i) {
+      writer->write(batch);
+      if (i + 1 < kNumRowGroups) {
+        writer->flush();
+      }
+    }
+    writer->close();
+  }
+
+  constexpr int64_t kReadMemoryLimit = 2 << 20;
+  auto readRootPool = memory::memoryManager()->addRootPool(
+      "rowGroupReaderReleaseRead", kReadMemoryLimit);
+  auto readPool = readRootPool->addLeafChild("leaf");
+
+  dwio::common::ReaderOptions readerOptions{readPool.get()};
+  readerOptions.setFilePreloadThreshold(0);
+  readerOptions.setPrefetchRowGroups(1);
+  auto reader = createReader(tempFile->getPath(), readerOptions);
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), kNumRowGroups);
+
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto parquetRowReader = dynamic_cast<ParquetRowReader*>(rowReader.get());
+  ASSERT_NE(parquetRowReader, nullptr);
+
+  VectorPtr result = BaseVector::create(rowType, 0, readPool.get());
+  uint64_t totalRows = 0;
+  for (;;) {
+    auto rows = parquetRowReader->next(kRowsPerGroup, result);
+    if (rows == 0) {
+      break;
+    }
+    totalRows += rows;
+    parquetRowReader->nextRowNumber();
+  }
+
+  EXPECT_EQ(totalRows, kRowsPerGroup * kNumRowGroups);
+  EXPECT_LT(readPool->peakBytes(), kReadMemoryLimit);
+}
+
 TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   // empty_row_groups.parquet contains empty row groups
   const std::string sample(getExampleFilePath("empty_row_groups.parquet"));


### PR DESCRIPTION



### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Release Parquet column reader state when a row group slides out of the prefetch window. Before loading the next current+prefetch window, the old row group's BufferedInput was erased, but PageReader state such as decompressed page buffers and dictionary string storage could remain attached to column readers until seekToRowGroup() replaced it later.


### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

That ordering can transiently overlap old row-group decode state with new DirectBufferedInput prefetch allocations. This is most visible for wide dictionary string columns where the dictionary page is held as both decompressed page data and dictionary string backing storage.

Add an explicit recursive release that clears ScanState and resets ParquetData's PageReader before the new row-group window is loaded. This keeps the steady row-group window bounded without changing read semantics; seekToRowGroup() still constructs the reader for the next active row group.

Add a regression test that writes multiple row groups with a large repeated string dictionary and reads them through a constrained memory pool. The test exercises row-group advancement and verifies the scan stays under the memory limit while reading all row groups.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
