### PR TITLE
perf: Optimize fused nested level conversion

### DIFF
--- a/bolt/dwio/parquet/arrow/LevelConversion.cpp
+++ b/bolt/dwio/parquet/arrow/LevelConversion.cpp
@@ -52,6 +52,73 @@ namespace {
 using ::arrow::internal::CpuInfo;
 using ::std::optional;
 
+optional<::arrow::internal::FirstTimeBitmapWriter> makeBitmapWriter(
+    ValidityBitmapInputOutput* output) {
+  if (output->valid_bits == nullptr) {
+    return std::nullopt;
+  }
+  return ::arrow::internal::FirstTimeBitmapWriter(
+      output->valid_bits,
+      output->valid_bits_offset,
+      output->values_read_upper_bound);
+}
+
+void writeValidityBit(
+    optional<::arrow::internal::FirstTimeBitmapWriter>& writer,
+    ValidityBitmapInputOutput* output,
+    bool isValid) {
+  if (!writer.has_value()) {
+    return;
+  }
+  if (isValid) {
+    writer->Set();
+  } else {
+    ++output->null_count;
+    writer->Clear();
+  }
+  writer->Next();
+}
+
+int64_t countContinuationRun(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    int64_t start,
+    LevelInfo level_info) {
+  int64_t run = 1;
+  while (start + run < num_def_levels &&
+         rep_levels[start + run] == level_info.rep_level &&
+         def_levels[start + run] >= level_info.repeated_ancestor_def_level) {
+    ++run;
+  }
+  return run;
+}
+
+bool isSupportedDirectStructList(
+    LevelInfo list_level_info,
+    LevelInfo struct_level_info) {
+  return struct_level_info.rep_level + 1 == list_level_info.rep_level &&
+      struct_level_info.def_level + 2 == list_level_info.def_level &&
+      struct_level_info.repeated_ancestor_def_level ==
+      list_level_info.repeated_ancestor_def_level;
+}
+
+void checkFusedValuesReadUpperBound(
+    int64_t values_read_for_bounds,
+    const ValidityBitmapInputOutput* list_output,
+    const ValidityBitmapInputOutput* struct_output) {
+  if (ARROW_PREDICT_FALSE(
+          values_read_for_bounds >= list_output->values_read_upper_bound ||
+          values_read_for_bounds >= struct_output->values_read_upper_bound)) {
+    std::stringstream ss;
+    ss << "Definition levels exceeded upper bound: "
+       << std::min(
+              list_output->values_read_upper_bound,
+              struct_output->values_read_upper_bound);
+    throw ParquetException(ss.str());
+  }
+}
+
 template <typename OffsetType>
 class OffsetListOutput {
  public:
@@ -177,12 +244,8 @@ void DefRepLevelsToListInfo(
     if (rep_levels[x] == level_info.rep_level) {
       // A continuation of an existing list. The list output handles whether
       // this extends cumulative offsets or the current list length.
-      int64_t run = 1;
-      while (x + run < num_def_levels &&
-             rep_levels[x + run] == level_info.rep_level &&
-             def_levels[x + run] >= level_info.repeated_ancestor_def_level) {
-        ++run;
-      }
+      const auto run = countContinuationRun(
+          def_levels, rep_levels, num_def_levels, x, level_info);
       list_output.OnContinuationRun(run);
       x += run - 1;
     } else {
@@ -303,6 +366,71 @@ void DefRepLevelsToListLengths(
   LengthListOutput listOutput(lengths);
   DefRepLevelsToListInfo(
       def_levels, rep_levels, num_def_levels, level_info, output, listOutput);
+}
+
+bool DefRepLevelsToListLengthsAndStructBitmap(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo list_level_info,
+    LevelInfo struct_level_info,
+    ValidityBitmapInputOutput* list_output,
+    int32_t* lengths,
+    ValidityBitmapInputOutput* struct_output) {
+  if (!isSupportedDirectStructList(list_level_info, struct_level_info)) {
+    return false;
+  }
+
+  auto list_valid_writer = makeBitmapWriter(list_output);
+  auto struct_valid_writer = makeBitmapWriter(struct_output);
+  LengthListOutput listLengths(lengths);
+
+  for (int64_t x = 0; x < num_def_levels; ++x) {
+    if (def_levels[x] < list_level_info.repeated_ancestor_def_level ||
+        rep_levels[x] > list_level_info.rep_level) {
+      continue;
+    }
+
+    if (rep_levels[x] == list_level_info.rep_level) {
+      const auto run = countContinuationRun(
+          def_levels, rep_levels, num_def_levels, x, list_level_info);
+      listLengths.OnContinuationRun(run);
+      x += run - 1;
+      continue;
+    }
+
+    checkFusedValuesReadUpperBound(
+        listLengths.valuesReadForBounds(), list_output, struct_output);
+    listLengths.OnNewList(def_levels[x], list_level_info);
+    writeValidityBit(
+        list_valid_writer,
+        list_output,
+        def_levels[x] >= list_level_info.def_level - 1);
+    writeValidityBit(
+        struct_valid_writer,
+        struct_output,
+        def_levels[x] >= struct_level_info.def_level);
+  }
+  listLengths.Finish();
+
+  if (list_valid_writer.has_value()) {
+    list_valid_writer->Finish();
+    list_output->values_read = list_valid_writer->position();
+  } else {
+    list_output->values_read = listLengths.valuesRead();
+  }
+  if (struct_valid_writer.has_value()) {
+    struct_valid_writer->Finish();
+    struct_output->values_read = struct_valid_writer->position();
+  } else {
+    struct_output->values_read = listLengths.valuesRead();
+  }
+  if (list_output->null_count > 0 && list_level_info.null_slot_usage > 1) {
+    throw ParquetException(
+        "Null values with null_slot_usage > 1 not supported."
+        "(i.e. FixedSizeLists with null values are not supported)");
+  }
+  return true;
 }
 
 void DefRepLevelsToBitmap(

--- a/bolt/dwio/parquet/arrow/LevelConversion.h
+++ b/bolt/dwio/parquet/arrow/LevelConversion.h
@@ -227,6 +227,20 @@ void PARQUET_EXPORT DefRepLevelsToListLengths(
     ValidityBitmapInputOutput* output,
     int32_t* lengths);
 
+// Reconstructs list lengths/list validity and the validity bitmap of a direct
+// nullable struct parent in one pass over the same def/rep levels. Returns
+// false if the two LevelInfo values do not describe a supported direct
+// struct -> list relationship.
+bool PARQUET_EXPORT DefRepLevelsToListLengthsAndStructBitmap(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo list_level_info,
+    LevelInfo struct_level_info,
+    ValidityBitmapInputOutput* list_output,
+    int32_t* lengths,
+    ValidityBitmapInputOutput* struct_output);
+
 // Reconstructs a validity bitmap for a struct every member is a list or has
 // a list descendant.  See documentation on DefLevelsToBitmap for when more
 // details on this method compared to the other ones defined above.

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
@@ -33,6 +33,9 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
+#include <algorithm>
+#include <map>
+#include <memory>
 #include <random>
 
 using namespace bytedance::bolt::parquet::arrow;
@@ -165,6 +168,167 @@ class LevelConversionBenchmark {
   ValidityBitmapInputOutput io_;
 };
 
+enum class FusedListShape {
+  kSingleElement,
+  kMixed,
+  kLong,
+};
+
+Levels makeFusedLevels(int32_t numLists, FusedListShape shape) {
+  std::mt19937 rng(kSeed);
+  std::uniform_int_distribution<int32_t> mixedLengthDist(0, 12);
+  std::uniform_int_distribution<int32_t> longLengthDist(32, 128);
+  std::uniform_int_distribution<int32_t> pct(0, 99);
+
+  Levels levels;
+  for (int32_t list = 0; list < numLists; ++list) {
+    if (list % 19 == 0) {
+      // Null struct and therefore null list.
+      levels.definitions.push_back(0);
+      levels.repetitions.push_back(0);
+      continue;
+    }
+    if (list % 17 == 0) {
+      // Present struct, empty list.
+      levels.definitions.push_back(2);
+      levels.repetitions.push_back(0);
+      continue;
+    }
+
+    int32_t length = 1;
+    if (shape == FusedListShape::kMixed) {
+      length = mixedLengthDist(rng);
+    } else if (shape == FusedListShape::kLong) {
+      length = longLengthDist(rng);
+    }
+    if (length == 0) {
+      levels.definitions.push_back(2);
+      levels.repetitions.push_back(0);
+      continue;
+    }
+
+    for (int32_t index = 0; index < length; ++index) {
+      levels.definitions.push_back(pct(rng) < 10 ? 3 : 4);
+      levels.repetitions.push_back(index == 0 ? 0 : 1);
+    }
+  }
+  return levels;
+}
+
+LevelInfo fusedListLevelInfo() {
+  LevelInfo info;
+  info.rep_level = 1;
+  info.def_level = 3;
+  return info;
+}
+
+LevelInfo fusedStructLevelInfo() {
+  LevelInfo info;
+  info.rep_level = 0;
+  info.def_level = 1;
+  return info;
+}
+
+LevelInfo unsupportedFusedStructLevelInfo() {
+  LevelInfo info = fusedStructLevelInfo();
+  info.rep_level = 1;
+  return info;
+}
+
+class FusedLevelConversionBenchmark {
+ public:
+  FusedLevelConversionBenchmark(int32_t numLists, FusedListShape shape)
+      : numLists_(numLists), levels_(makeFusedLevels(numLists, shape)) {
+    lengths_.resize(numLists);
+    listValidity_.resize(numLists);
+    structValidity_.resize(numLists);
+  }
+
+  int64_t separate() {
+    auto listOutput = makeOutput(listValidity_);
+    DefRepLevelsToListLengths(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        fusedListLevelInfo(),
+        &listOutput,
+        lengths_.data());
+
+    auto structOutput = makeOutput(structValidity_);
+    DefRepLevelsToBitmap(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        fusedStructLevelInfo(),
+        &structOutput);
+    return listOutput.values_read + structOutput.values_read;
+  }
+
+  int64_t fused() {
+    auto listOutput = makeOutput(listValidity_);
+    auto structOutput = makeOutput(structValidity_);
+    const auto converted = DefRepLevelsToListLengthsAndStructBitmap(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        fusedListLevelInfo(),
+        fusedStructLevelInfo(),
+        &listOutput,
+        lengths_.data(),
+        &structOutput);
+    folly::doNotOptimizeAway(converted);
+    return listOutput.values_read + structOutput.values_read;
+  }
+
+  int64_t fallback() {
+    auto listOutput = makeOutput(listValidity_);
+    auto structOutput = makeOutput(structValidity_);
+    const auto converted = DefRepLevelsToListLengthsAndStructBitmap(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        fusedListLevelInfo(),
+        unsupportedFusedStructLevelInfo(),
+        &listOutput,
+        lengths_.data(),
+        &structOutput);
+    folly::doNotOptimizeAway(converted);
+    if (!converted) {
+      DefRepLevelsToListLengths(
+          levels_.definitions.data(),
+          levels_.repetitions.data(),
+          levels_.definitions.size(),
+          fusedListLevelInfo(),
+          &listOutput,
+          lengths_.data());
+
+      structOutput = makeOutput(structValidity_);
+      DefRepLevelsToBitmap(
+          levels_.definitions.data(),
+          levels_.repetitions.data(),
+          levels_.definitions.size(),
+          fusedStructLevelInfo(),
+          &structOutput);
+    }
+    return listOutput.values_read + structOutput.values_read;
+  }
+
+ private:
+  ValidityBitmapInputOutput makeOutput(std::vector<uint8_t>& validity) {
+    std::fill(validity.begin(), validity.end(), 0);
+    ValidityBitmapInputOutput output;
+    output.valid_bits = validity.data();
+    output.values_read_upper_bound = numLists_;
+    return output;
+  }
+
+  int32_t numLists_;
+  Levels levels_;
+  std::vector<int32_t> lengths_;
+  std::vector<uint8_t> listValidity_;
+  std::vector<uint8_t> structValidity_;
+};
+
 LevelConversionBenchmark& benchmark(ListShape shape) {
   static LevelConversionBenchmark singleElement(ListShape::kSingleElement);
   static LevelConversionBenchmark mixed(ListShape::kMixed);
@@ -178,6 +342,20 @@ LevelConversionBenchmark& benchmark(ListShape shape) {
       return longLists;
   }
   return singleElement;
+}
+
+FusedLevelConversionBenchmark& fusedBenchmark(
+    int32_t numLists,
+    FusedListShape shape) {
+  using Key = std::pair<int32_t, FusedListShape>;
+  static std::map<Key, std::unique_ptr<FusedLevelConversionBenchmark>>
+      benchmarks;
+  const Key key{numLists, shape};
+  auto& instance = benchmarks[key];
+  if (!instance) {
+    instance = std::make_unique<FusedLevelConversionBenchmark>(numLists, shape);
+  }
+  return *instance;
 }
 
 void runOffsetsThenLengths(uint32_t iters, ListShape shape) {
@@ -195,6 +373,23 @@ void runDirectLengths(uint32_t iters, ListShape shape) {
   suspender.dismiss();
   while (iters--) {
     folly::doNotOptimizeAway(instance.directLengths());
+  }
+}
+
+void runFusedLevelConversion(
+    uint32_t iters,
+    int32_t numLists,
+    FusedListShape shape,
+    bool fused,
+    bool fallback = false) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = fusedBenchmark(numLists, shape);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(
+        fallback    ? instance.fallback()
+            : fused ? instance.fused()
+                    : instance.separate());
   }
 }
 
@@ -227,6 +422,30 @@ BENCHMARK(offsetsThenLengths_long, iters) {
 BENCHMARK_RELATIVE(directLengths_long, iters) {
   runDirectLengths(iters, ListShape::kLong);
 }
+
+BENCHMARK_DRAW_LINE();
+
+#define FUSED_LEVEL_CONVERSION_BENCHMARK(size, shape, name)                   \
+  BENCHMARK(separateStructAndList_##name##_##size, iters) {                   \
+    runFusedLevelConversion(iters, size, FusedListShape::shape, false);       \
+  }                                                                           \
+  BENCHMARK_RELATIVE(fusedStructAndList_##name##_##size, iters) {             \
+    runFusedLevelConversion(iters, size, FusedListShape::shape, true);        \
+  }                                                                           \
+  BENCHMARK_RELATIVE(fallbackStructAndList_##name##_##size, iters) {          \
+    runFusedLevelConversion(iters, size, FusedListShape::shape, false, true); \
+  }                                                                           \
+  BENCHMARK_DRAW_LINE()
+
+FUSED_LEVEL_CONVERSION_BENCHMARK(1024, kSingleElement, single);
+FUSED_LEVEL_CONVERSION_BENCHMARK(65536, kSingleElement, single);
+FUSED_LEVEL_CONVERSION_BENCHMARK(1048576, kSingleElement, single);
+FUSED_LEVEL_CONVERSION_BENCHMARK(1024, kMixed, mixed);
+FUSED_LEVEL_CONVERSION_BENCHMARK(65536, kMixed, mixed);
+FUSED_LEVEL_CONVERSION_BENCHMARK(1048576, kMixed, mixed);
+FUSED_LEVEL_CONVERSION_BENCHMARK(1024, kLong, long);
+FUSED_LEVEL_CONVERSION_BENCHMARK(65536, kLong, long);
+FUSED_LEVEL_CONVERSION_BENCHMARK(1048576, kLong, long);
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
@@ -38,6 +38,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <random>
 #include <string>
 #include <vector>
 
@@ -518,6 +519,358 @@ TEST(NestedListTest, DirectLengthsExactUpperBound) {
 
   EXPECT_EQ(io.values_read, 2);
   EXPECT_THAT(lengths, testing::ElementsAre(1, 1));
+}
+
+TEST(NestedListTest, FusedDirectStructListMatchesSeparateConversions) {
+  MultiLevelTestData test_data;
+  test_data.def_levels = std::vector<int16_t>{
+      0, // null struct and therefore null list.
+      1, // present struct, null list.
+      2, // present struct, empty list.
+      3, // present struct, list with null element.
+      4, // present struct, list with first non-null element.
+      4, // same list, second non-null element.
+      2, // present struct, another empty list.
+      0 // null struct.
+  };
+  test_data.rep_levels = std::vector<int16_t>{0, 0, 0, 0, 0, 1, 0, 0};
+
+  LevelInfo structInfo;
+  structInfo.rep_level = 0;
+  structInfo.def_level = 1;
+  structInfo.repeated_ancestor_def_level = 0;
+
+  LevelInfo listInfo;
+  listInfo.rep_level = 1;
+  listInfo.def_level = 3;
+  listInfo.repeated_ancestor_def_level = 0;
+
+  constexpr int32_t expectedValuesRead = 7;
+
+  std::vector<uint8_t> separateListValidity(expectedValuesRead, 0);
+  ValidityBitmapInputOutput separateListIo;
+  separateListIo.valid_bits = separateListValidity.data();
+  separateListIo.values_read_upper_bound = expectedValuesRead;
+  std::vector<int32_t> separateLengths(expectedValuesRead, -1);
+  DefRepLevelsToListLengths(
+      test_data.def_levels.data(),
+      test_data.rep_levels.data(),
+      test_data.def_levels.size(),
+      listInfo,
+      &separateListIo,
+      separateLengths.data());
+
+  std::vector<uint8_t> separateStructValidity(expectedValuesRead, 0);
+  ValidityBitmapInputOutput separateStructIo;
+  separateStructIo.valid_bits = separateStructValidity.data();
+  separateStructIo.values_read_upper_bound = expectedValuesRead;
+  DefRepLevelsToBitmap(
+      test_data.def_levels.data(),
+      test_data.rep_levels.data(),
+      test_data.def_levels.size(),
+      structInfo,
+      &separateStructIo);
+
+  std::vector<uint8_t> fusedListValidity(expectedValuesRead, 0);
+  ValidityBitmapInputOutput fusedListIo;
+  fusedListIo.valid_bits = fusedListValidity.data();
+  fusedListIo.values_read_upper_bound = expectedValuesRead;
+  std::vector<int32_t> fusedLengths(expectedValuesRead, -1);
+
+  std::vector<uint8_t> fusedStructValidity(expectedValuesRead, 0);
+  ValidityBitmapInputOutput fusedStructIo;
+  fusedStructIo.valid_bits = fusedStructValidity.data();
+  fusedStructIo.values_read_upper_bound = expectedValuesRead;
+
+  ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+      test_data.def_levels.data(),
+      test_data.rep_levels.data(),
+      test_data.def_levels.size(),
+      listInfo,
+      structInfo,
+      &fusedListIo,
+      fusedLengths.data(),
+      &fusedStructIo));
+
+  EXPECT_EQ(fusedListIo.values_read, separateListIo.values_read);
+  EXPECT_EQ(fusedListIo.null_count, separateListIo.null_count);
+  EXPECT_EQ(fusedStructIo.values_read, separateStructIo.values_read);
+  EXPECT_EQ(fusedStructIo.null_count, separateStructIo.null_count);
+  EXPECT_THAT(fusedLengths, testing::ElementsAreArray(separateLengths));
+  EXPECT_EQ(
+      BitmapToString(fusedListValidity, expectedValuesRead),
+      BitmapToString(separateListValidity, expectedValuesRead));
+  EXPECT_EQ(
+      BitmapToString(fusedStructValidity, expectedValuesRead),
+      BitmapToString(separateStructValidity, expectedValuesRead));
+}
+
+TEST(NestedListTest, FusedDirectStructListMatchesSeparateConversionOptions) {
+  MultiLevelTestData testData;
+  testData.def_levels = std::vector<int16_t>{
+      0, // Null repeated ancestor, ignored.
+      1, // Empty repeated ancestor, ignored.
+      2, // Null struct and therefore null list.
+      3, // Present struct, null list.
+      4, // Present struct, empty list.
+      5, // Present struct, list with a null element.
+      6, // Present struct, list with a non-null element.
+      6, // Same list, second non-null element.
+      6, // Deeper repeated descendant, ignored.
+      2 // Null struct.
+  };
+  testData.rep_levels = std::vector<int16_t>{0, 0, 1, 1, 1, 1, 1, 2, 3, 1};
+
+  LevelInfo structInfo;
+  structInfo.rep_level = 1;
+  structInfo.def_level = 3;
+  structInfo.repeated_ancestor_def_level = 2;
+  LevelInfo listInfo;
+  listInfo.rep_level = 2;
+  listInfo.def_level = 5;
+  listInfo.repeated_ancestor_def_level = 2;
+
+  constexpr int32_t kNumLists = 6;
+  constexpr int32_t kBitmapOffset = 3;
+  auto makeOutput = [](std::vector<uint8_t>* validity) {
+    ValidityBitmapInputOutput output;
+    output.valid_bits = validity ? validity->data() : nullptr;
+    output.valid_bits_offset = kBitmapOffset;
+    output.values_read_upper_bound = kNumLists;
+    output.null_count = 4;
+    return output;
+  };
+
+  std::vector<uint8_t> separateListValidity(2, 0xa5);
+  auto separateListIo = makeOutput(&separateListValidity);
+  std::vector<int32_t> separateLengths(kNumLists, -1);
+  DefRepLevelsToListLengths(
+      testData.def_levels.data(),
+      testData.rep_levels.data(),
+      testData.def_levels.size(),
+      listInfo,
+      &separateListIo,
+      separateLengths.data());
+
+  std::vector<uint8_t> separateStructValidity(2, 0xa5);
+  auto separateStructIo = makeOutput(&separateStructValidity);
+  DefRepLevelsToBitmap(
+      testData.def_levels.data(),
+      testData.rep_levels.data(),
+      testData.def_levels.size(),
+      structInfo,
+      &separateStructIo);
+
+  std::vector<uint8_t> fusedListValidity(2, 0xa5);
+  auto fusedListIo = makeOutput(&fusedListValidity);
+  std::vector<int32_t> fusedLengths(kNumLists, -1);
+  std::vector<uint8_t> fusedStructValidity(2, 0xa5);
+  auto fusedStructIo = makeOutput(&fusedStructValidity);
+
+  ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+      testData.def_levels.data(),
+      testData.rep_levels.data(),
+      testData.def_levels.size(),
+      listInfo,
+      structInfo,
+      &fusedListIo,
+      fusedLengths.data(),
+      &fusedStructIo));
+  EXPECT_EQ(fusedListIo.values_read, separateListIo.values_read);
+  EXPECT_EQ(fusedStructIo.values_read, separateStructIo.values_read);
+  EXPECT_EQ(fusedListIo.null_count, separateListIo.null_count);
+  EXPECT_EQ(fusedStructIo.null_count, separateStructIo.null_count);
+  EXPECT_THAT(fusedLengths, testing::ElementsAreArray(separateLengths));
+  EXPECT_EQ(fusedListValidity, separateListValidity);
+  EXPECT_EQ(fusedStructValidity, separateStructValidity);
+
+  auto separateLengthsOnlyIo = makeOutput(nullptr);
+  std::vector<int32_t> separateLengthsOnly(kNumLists, -1);
+  DefRepLevelsToListLengths(
+      testData.def_levels.data(),
+      testData.rep_levels.data(),
+      testData.def_levels.size(),
+      listInfo,
+      &separateLengthsOnlyIo,
+      separateLengthsOnly.data());
+
+  auto fusedLengthsOnlyIo = makeOutput(nullptr);
+  std::vector<int32_t> fusedLengthsOnly(kNumLists, -1);
+  std::vector<uint8_t> fusedStructOnlyValidity(2, 0xa5);
+  auto fusedStructOnlyIo = makeOutput(&fusedStructOnlyValidity);
+  ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+      testData.def_levels.data(),
+      testData.rep_levels.data(),
+      testData.def_levels.size(),
+      listInfo,
+      structInfo,
+      &fusedLengthsOnlyIo,
+      fusedLengthsOnly.data(),
+      &fusedStructOnlyIo));
+  EXPECT_EQ(fusedLengthsOnlyIo.values_read, separateLengthsOnlyIo.values_read);
+  EXPECT_EQ(fusedLengthsOnlyIo.null_count, separateLengthsOnlyIo.null_count);
+  EXPECT_THAT(fusedLengthsOnly, testing::ElementsAreArray(separateLengthsOnly));
+}
+
+TEST(NestedListTest, FusedDirectStructListRandomizedMatchesSeparate) {
+  constexpr uint32_t kSeed = 20260730;
+  std::mt19937 rng(kSeed);
+  std::uniform_int_distribution<int32_t> percent(0, 99);
+  std::uniform_int_distribution<int32_t> mixedLength(0, 12);
+  std::uniform_int_distribution<int32_t> longLength(32, 128);
+
+  LevelInfo structInfo;
+  structInfo.rep_level = 0;
+  structInfo.def_level = 1;
+  LevelInfo listInfo;
+  listInfo.rep_level = 1;
+  listInfo.def_level = 3;
+
+  for (const int32_t numLists : {1, 17, 1024, 65536}) {
+    for (const int32_t shape : {0, 1, 2}) {
+      MultiLevelTestData testData;
+      for (int32_t list = 0; list < numLists; ++list) {
+        const auto state = percent(rng);
+        if (state < 5) {
+          testData.def_levels.push_back(0);
+          testData.rep_levels.push_back(0);
+          continue;
+        }
+        if (state < 10) {
+          testData.def_levels.push_back(1);
+          testData.rep_levels.push_back(0);
+          continue;
+        }
+        if (state < 15) {
+          testData.def_levels.push_back(2);
+          testData.rep_levels.push_back(0);
+          continue;
+        }
+        int32_t length = shape == 0 ? 1
+            : shape == 1            ? mixedLength(rng)
+                                    : longLength(rng);
+        if (length == 0) {
+          testData.def_levels.push_back(2);
+          testData.rep_levels.push_back(0);
+          continue;
+        }
+        for (int32_t index = 0; index < length; ++index) {
+          testData.def_levels.push_back(percent(rng) < 10 ? 3 : 4);
+          testData.rep_levels.push_back(index == 0 ? 0 : 1);
+        }
+      }
+
+      std::vector<uint8_t> separateListValidity(numLists, 0);
+      ValidityBitmapInputOutput separateListIo;
+      separateListIo.valid_bits = separateListValidity.data();
+      separateListIo.values_read_upper_bound = numLists;
+      std::vector<int32_t> separateLengths(numLists, -1);
+      DefRepLevelsToListLengths(
+          testData.def_levels.data(),
+          testData.rep_levels.data(),
+          testData.def_levels.size(),
+          listInfo,
+          &separateListIo,
+          separateLengths.data());
+
+      std::vector<uint8_t> separateStructValidity(numLists, 0);
+      ValidityBitmapInputOutput separateStructIo;
+      separateStructIo.valid_bits = separateStructValidity.data();
+      separateStructIo.values_read_upper_bound = numLists;
+      DefRepLevelsToBitmap(
+          testData.def_levels.data(),
+          testData.rep_levels.data(),
+          testData.def_levels.size(),
+          structInfo,
+          &separateStructIo);
+
+      std::vector<uint8_t> fusedListValidity(numLists, 0);
+      ValidityBitmapInputOutput fusedListIo;
+      fusedListIo.valid_bits = fusedListValidity.data();
+      fusedListIo.values_read_upper_bound = numLists;
+      std::vector<int32_t> fusedLengths(numLists, -1);
+      std::vector<uint8_t> fusedStructValidity(numLists, 0);
+      ValidityBitmapInputOutput fusedStructIo;
+      fusedStructIo.valid_bits = fusedStructValidity.data();
+      fusedStructIo.values_read_upper_bound = numLists;
+
+      ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+          testData.def_levels.data(),
+          testData.rep_levels.data(),
+          testData.def_levels.size(),
+          listInfo,
+          structInfo,
+          &fusedListIo,
+          fusedLengths.data(),
+          &fusedStructIo));
+      ASSERT_EQ(fusedListIo.values_read, separateListIo.values_read);
+      ASSERT_EQ(fusedStructIo.values_read, separateStructIo.values_read);
+      EXPECT_EQ(fusedListIo.null_count, separateListIo.null_count);
+      EXPECT_EQ(fusedStructIo.null_count, separateStructIo.null_count);
+      EXPECT_THAT(fusedLengths, testing::ElementsAreArray(separateLengths));
+      EXPECT_EQ(
+          BitmapToString(fusedListValidity, numLists),
+          BitmapToString(separateListValidity, numLists));
+      EXPECT_EQ(
+          BitmapToString(fusedStructValidity, numLists),
+          BitmapToString(separateStructValidity, numLists));
+    }
+  }
+}
+
+TEST(NestedListTest, FusedDirectStructListRejectsUnsupportedLevels) {
+  LevelInfo structInfo;
+  structInfo.rep_level = 0;
+  structInfo.def_level = 1;
+  LevelInfo listInfo;
+  listInfo.rep_level = 2;
+  listInfo.def_level = 3;
+  std::vector<int16_t> definitions = {0};
+  std::vector<int16_t> repetitions = {0};
+  std::vector<int32_t> lengths(1);
+  ValidityBitmapInputOutput listOutput;
+  listOutput.values_read_upper_bound = 1;
+  ValidityBitmapInputOutput structOutput;
+  structOutput.values_read_upper_bound = 1;
+
+  EXPECT_FALSE(DefRepLevelsToListLengthsAndStructBitmap(
+      definitions.data(),
+      repetitions.data(),
+      definitions.size(),
+      listInfo,
+      structInfo,
+      &listOutput,
+      lengths.data(),
+      &structOutput));
+}
+
+TEST(NestedListTest, FusedDirectStructListUpperBound) {
+  LevelInfo structInfo;
+  structInfo.rep_level = 0;
+  structInfo.def_level = 1;
+  LevelInfo listInfo;
+  listInfo.rep_level = 1;
+  listInfo.def_level = 3;
+  std::vector<int16_t> definitions = {4, 4};
+  std::vector<int16_t> repetitions = {0, 0};
+  std::vector<int32_t> lengths(2, -1);
+  ValidityBitmapInputOutput listOutput;
+  listOutput.values_read_upper_bound = 1;
+  ValidityBitmapInputOutput structOutput;
+  structOutput.values_read_upper_bound = 1;
+
+  EXPECT_THROW(
+      DefRepLevelsToListLengthsAndStructBitmap(
+          definitions.data(),
+          repetitions.data(),
+          definitions.size(),
+          listInfo,
+          structInfo,
+          &listOutput,
+          lengths.data(),
+          &structOutput),
+      ParquetException);
+  EXPECT_EQ(lengths[1], -1);
 }
 
 TEST(TestOnlyExtractBitsSoftware, BasicTest) {

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -1356,6 +1356,25 @@ int32_t PageReader::getLengthsAndNulls(
   return static_cast<int32_t>(bits.values_read);
 }
 
+bool PageReader::getListLengthsAndStructNulls(
+    const arrow::LevelInfo& listInfo,
+    const arrow::LevelInfo& structInfo,
+    int32_t begin,
+    int32_t end,
+    arrow::ValidityBitmapInputOutput* listBits,
+    int32_t* lengths,
+    arrow::ValidityBitmapInputOutput* structBits) const {
+  return arrow::DefRepLevelsToListLengthsAndStructBitmap(
+      definitionLevels_.data() + begin,
+      repetitionLevels_.data() + begin,
+      end - begin,
+      listInfo,
+      structInfo,
+      listBits,
+      lengths,
+      structBits);
+}
+
 void PageReader::makeDecoder() {
   auto parquetType = type_->parquetType_.value();
   switch (encoding_) {

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -141,6 +141,15 @@ class PageReader {
       uint64_t* FOLLY_NULLABLE nulls,
       int64_t nullsStartIndex) const;
 
+  bool getListLengthsAndStructNulls(
+      const arrow::LevelInfo& listInfo,
+      const arrow::LevelInfo& structInfo,
+      int32_t begin,
+      int32_t end,
+      arrow::ValidityBitmapInputOutput* listBits,
+      int32_t* FOLLY_NONNULL lengths,
+      arrow::ValidityBitmapInputOutput* structBits) const;
+
   /// Applies 'visitor' to values in the ColumnChunk of 'this'. The
   /// operation to perform and The operand rows are given by
   /// 'visitor'. The rows are relative to the current position. The

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -37,10 +37,82 @@ namespace bytedance::bolt::parquet {
 class ParquetTypeWithId;
 
 namespace {
+arrow::ValidityBitmapInputOutput prepareRepeatedNulls(
+    BufferPtr& nulls,
+    int32_t maxItems,
+    memory::MemoryPool& memoryPool) {
+  dwio::common::ensureCapacity<uint64_t>(
+      nulls, bits::nwords(maxItems), &memoryPool);
+  arrow::ValidityBitmapInputOutput output;
+  output.values_read_upper_bound = maxItems;
+  output.values_read = 0;
+  output.null_count = 0;
+  output.valid_bits = reinterpret_cast<uint8_t*>(nulls->asMutable<uint64_t>());
+  output.valid_bits_offset = 0;
+  return output;
+}
+
+bool isArrayOrMap(const dwio::common::SelectiveColumnReader& reader) {
+  const auto kind = reader.fileType().type()->kind();
+  return kind == TypeKind::ARRAY || kind == TypeKind::MAP;
+}
+
+void setRepeatedRepDefsFromLeaf(
+    dwio::common::SelectiveColumnReader& reader,
+    PageReader& pageReader) {
+  if (auto* list = dynamic_cast<ListColumnReader*>(&reader)) {
+    list->setLengthsFromRepDefs(pageReader);
+  } else {
+    auto* map = dynamic_cast<MapColumnReader*>(&reader);
+    BOLT_CHECK_NOT_NULL(map);
+    map->setLengthsFromRepDefs(pageReader);
+  }
+}
+
+template <typename RepeatedReader>
+bool trySetFusedStructAndRepeatedRepDefs(
+    PageReader& pageReader,
+    StructColumnReader& structReader,
+    RepeatedReader& repeatedReader) {
+  const auto repDefRange = pageReader.repDefRange();
+  const int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  auto lengths = repeatedReader.prepareRepDefLengths(numRepDefs);
+  auto repeatedBits = repeatedReader.prepareRepDefNulls(numRepDefs);
+  auto structBits = structReader.prepareRepDefNulls(numRepDefs);
+  if (!pageReader.getListLengthsAndStructNulls(
+          repeatedReader.levelInfo(),
+          structReader.levelInfo(),
+          repDefRange.first,
+          repDefRange.second,
+          &repeatedBits,
+          lengths->template asMutable<int32_t>(),
+          &structBits)) {
+    return false;
+  }
+
+  repeatedReader.setLengthsFromRepDefOutput(std::move(lengths), repeatedBits);
+  structReader.setNullsFromRepDefOutput(structBits);
+  return true;
+}
+
+bool trySetFusedStructAndRepeatedRepDefs(
+    PageReader& pageReader,
+    StructColumnReader& structReader,
+    dwio::common::SelectiveColumnReader& repDefChild) {
+  if (auto* list = dynamic_cast<ListColumnReader*>(&repDefChild)) {
+    return trySetFusedStructAndRepeatedRepDefs(pageReader, structReader, *list);
+  }
+
+  auto* map = dynamic_cast<MapColumnReader*>(&repDefChild);
+  BOLT_CHECK_NOT_NULL(map);
+  return trySetFusedStructAndRepeatedRepDefs(pageReader, structReader, *map);
+}
+
 PageReader* FOLLY_NULLABLE readLeafRepDefs(
     dwio::common::SelectiveColumnReader* FOLLY_NONNULL reader,
     int32_t numTop,
-    bool mustRead) {
+    bool mustRead,
+    bool setRepeatedRepDefs = true) {
   auto children = reader->children();
   if (children.empty()) {
     if (!mustRead) {
@@ -57,26 +129,46 @@ PageReader* FOLLY_NULLABLE readLeafRepDefs(
   auto& type = *reinterpret_cast<const ParquetTypeWithId*>(&reader->fileType());
   if (type.type()->kind() == TypeKind::ARRAY) {
     pageReader = readLeafRepDefs(children[0], numTop, true);
-    auto list = dynamic_cast<ListColumnReader*>(reader);
-    assert(list);
-    list->setLengthsFromRepDefs(*pageReader);
+    if (setRepeatedRepDefs) {
+      setRepeatedRepDefsFromLeaf(*reader, *pageReader);
+    }
     return pageReader;
   }
   if (type.type()->kind() == TypeKind::MAP) {
     pageReader = readLeafRepDefs(children[0], numTop, true);
     readLeafRepDefs(children[1], numTop, false);
-    auto map = dynamic_cast<MapColumnReader*>(reader);
-    assert(map);
-    map->setLengthsFromRepDefs(*pageReader);
+    if (setRepeatedRepDefs) {
+      setRepeatedRepDefsFromLeaf(*reader, *pageReader);
+    }
     return pageReader;
   }
   if (auto structReader = dynamic_cast<StructColumnReader*>(reader)) {
-    pageReader = readLeafRepDefs(structReader->childForRepDefs(), numTop, true);
+    auto repDefChild = structReader->childForRepDefs();
+    if (repDefChild == nullptr) {
+      return nullptr;
+    }
+    const bool fuseStructAndRepeated = isArrayOrMap(*repDefChild);
+    pageReader =
+        readLeafRepDefs(repDefChild, numTop, true, !fuseStructAndRepeated);
     assert(pageReader);
+    if (fuseStructAndRepeated &&
+        trySetFusedStructAndRepeatedRepDefs(
+            *pageReader, *structReader, *repDefChild)) {
+      for (auto i = 0; i < children.size(); ++i) {
+        auto child = children[i];
+        if (child != repDefChild) {
+          readLeafRepDefs(child, numTop, false);
+        }
+      }
+      return pageReader;
+    }
+    if (fuseStructAndRepeated) {
+      setRepeatedRepDefsFromLeaf(*repDefChild, *pageReader);
+    }
     structReader->setNullsFromRepDefs(*pageReader);
     for (auto i = 0; i < children.size(); ++i) {
       auto child = children[i];
-      if (child != structReader->childForRepDefs()) {
+      if (child != repDefChild) {
         readLeafRepDefs(child, numTop, false);
       }
     }
@@ -218,6 +310,26 @@ void MapColumnReader::skipUnreadLengths() {
   }
 }
 
+BufferPtr MapColumnReader::prepareRepDefLengths(int32_t maxItems) {
+  BufferPtr lengths = std::move(lengths_.lengths());
+  dwio::common::ensureCapacity<int32_t>(lengths, maxItems + 1, &memoryPool_);
+  return lengths;
+}
+
+arrow::ValidityBitmapInputOutput MapColumnReader::prepareRepDefNulls(
+    int32_t maxItems) {
+  return prepareRepeatedNulls(nullsInReadRange_, maxItems, memoryPool_);
+}
+
+void MapColumnReader::setLengthsFromRepDefOutput(
+    BufferPtr lengths,
+    const arrow::ValidityBitmapInputOutput& bits) {
+  lengths->setSize(bits.values_read * sizeof(int32_t));
+  formatData_->as<ParquetData>().setNulls(
+      nullsInReadRange(), static_cast<int32_t>(bits.values_read));
+  setLengths(std::move(lengths));
+}
+
 void MapColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   auto repDefRange = pageReader.repDefRange();
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
@@ -327,6 +439,26 @@ void ListColumnReader::skipUnreadLengths() {
       skip(numPreviousLengths);
     }
   }
+}
+
+BufferPtr ListColumnReader::prepareRepDefLengths(int32_t maxItems) {
+  BufferPtr lengths = std::move(lengths_.lengths());
+  dwio::common::ensureCapacity<int32_t>(lengths, maxItems + 1, &memoryPool_);
+  return lengths;
+}
+
+arrow::ValidityBitmapInputOutput ListColumnReader::prepareRepDefNulls(
+    int32_t maxItems) {
+  return prepareRepeatedNulls(nullsInReadRange_, maxItems, memoryPool_);
+}
+
+void ListColumnReader::setLengthsFromRepDefOutput(
+    BufferPtr lengths,
+    const arrow::ValidityBitmapInputOutput& bits) {
+  lengths->setSize(bits.values_read * sizeof(int32_t));
+  formatData_->as<ParquetData>().setNulls(
+      nullsInReadRange(), static_cast<int32_t>(bits.values_read));
+  setLengths(std::move(lengths));
 }
 
 void ListColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -57,6 +57,18 @@ bool isArrayOrMap(const dwio::common::SelectiveColumnReader& reader) {
   return kind == TypeKind::ARRAY || kind == TypeKind::MAP;
 }
 
+bool isSupportedFusedStructAndRepeated(
+    const arrow::LevelInfo& repeated,
+    const arrow::LevelInfo& structure) {
+  // Required structs do not need a struct null conversion, so fusing would only
+  // add an all-valid bitmap that the old path never produced.
+  return structure.def_level > 0 &&
+      structure.rep_level + 1 == repeated.rep_level &&
+      structure.def_level + 2 == repeated.def_level &&
+      structure.repeated_ancestor_def_level ==
+      repeated.repeated_ancestor_def_level;
+}
+
 void setRepeatedRepDefsFromLeaf(
     dwio::common::SelectiveColumnReader& reader,
     PageReader& pageReader) {
@@ -74,6 +86,11 @@ bool trySetFusedStructAndRepeatedRepDefs(
     PageReader& pageReader,
     StructColumnReader& structReader,
     RepeatedReader& repeatedReader) {
+  if (!isSupportedFusedStructAndRepeated(
+          repeatedReader.levelInfo(), structReader.levelInfo())) {
+    return false;
+  }
+
   const auto repDefRange = pageReader.repDefRange();
   const int32_t numRepDefs = repDefRange.second - repDefRange.first;
   auto lengths = repeatedReader.prepareRepDefLengths(numRepDefs);

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.h
@@ -114,6 +114,14 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
   /// Sets nulls and lengths of 'this' for the range of top level rows for which
   /// these have been decoded in 'leaf'.
   void setLengthsFromRepDefs(PageReader& leaf);
+  const arrow::LevelInfo& levelInfo() const {
+    return levelInfo_;
+  }
+  BufferPtr prepareRepDefLengths(int32_t maxItems);
+  arrow::ValidityBitmapInputOutput prepareRepDefNulls(int32_t maxItems);
+  void setLengthsFromRepDefOutput(
+      BufferPtr lengths,
+      const arrow::ValidityBitmapInputOutput& bits);
 
   /// advances 'this' to the end of the previously provided lengths/nulls. This
   /// is needed if lists are conditionally read from different structs that all
@@ -173,6 +181,14 @@ class ListColumnReader : public dwio::common::SelectiveListColumnReader {
   /// Sets nulls and lengths of 'this' for the range of top level rows for which
   /// these have been decoded in 'leaf'.
   void setLengthsFromRepDefs(PageReader& leaf);
+  const arrow::LevelInfo& levelInfo() const {
+    return levelInfo_;
+  }
+  BufferPtr prepareRepDefLengths(int32_t maxItems);
+  arrow::ValidityBitmapInputOutput prepareRepDefNulls(int32_t maxItems);
+  void setLengthsFromRepDefOutput(
+      BufferPtr lengths,
+      const arrow::ValidityBitmapInputOutput& bits);
 
   /// advances 'this' to the end of the previously provided lengths/nulls. This
   /// is needed if lists are conditionally read from different structs that all

--- a/bolt/dwio/parquet/reader/StructColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/StructColumnReader.cpp
@@ -269,18 +269,37 @@ void StructColumnReader::setNullsFromRepDefs(PageReader& pageReader) {
   }
   auto repDefRange = pageReader.repDefRange();
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
-  dwio::common::ensureCapacity<uint64_t>(
-      nullsInReadRange_, bits::nwords(numRepDefs), &memoryPool_);
-  auto numStructs = pageReader.getLengthsAndNulls(
+  auto bits = prepareRepDefNulls(numRepDefs);
+  bits.values_read = pageReader.getLengthsAndNulls(
       levelMode_,
       levelInfo_,
       repDefRange.first,
       repDefRange.second,
       numRepDefs,
       nullptr,
-      nullsInReadRange()->asMutable<uint64_t>(),
+      reinterpret_cast<uint64_t*>(bits.valid_bits),
       0);
-  formatData_->as<ParquetData>().setNulls(nullsInReadRange(), numStructs);
+  setNullsFromRepDefOutput(bits);
+}
+
+arrow::ValidityBitmapInputOutput StructColumnReader::prepareRepDefNulls(
+    int32_t maxItems) {
+  dwio::common::ensureCapacity<uint64_t>(
+      nullsInReadRange_, bits::nwords(maxItems), &memoryPool_);
+  arrow::ValidityBitmapInputOutput output;
+  output.values_read_upper_bound = maxItems;
+  output.values_read = 0;
+  output.null_count = 0;
+  output.valid_bits =
+      reinterpret_cast<uint8_t*>(nullsInReadRange_->asMutable<uint64_t>());
+  output.valid_bits_offset = 0;
+  return output;
+}
+
+void StructColumnReader::setNullsFromRepDefOutput(
+    const arrow::ValidityBitmapInputOutput& bits) {
+  formatData_->as<ParquetData>().setNulls(
+      nullsInReadRange(), static_cast<int32_t>(bits.values_read));
 }
 
 void StructColumnReader::filterRowGroups(

--- a/bolt/dwio/parquet/reader/StructColumnReader.h
+++ b/bolt/dwio/parquet/reader/StructColumnReader.h
@@ -73,6 +73,11 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
       int64_t /*offset*/) override {}
 
   void setNullsFromRepDefs(PageReader& pageReader);
+  const arrow::LevelInfo& levelInfo() const {
+    return levelInfo_;
+  }
+  arrow::ValidityBitmapInputOutput prepareRepDefNulls(int32_t maxItems);
+  void setNullsFromRepDefOutput(const arrow::ValidityBitmapInputOutput& bits);
 
   dwio::common::SelectiveColumnReader* FOLLY_NULLABLE childForRepDefs() const {
     return childForRepDefs_;

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -33,6 +33,7 @@
 #include <type/Type.h>
 #include <cstdlib>
 #include <filesystem>
+#include <random>
 #ifdef SPARK_COMPATIBLE
 #include "bolt/common/base/tests/GTestUtils.h"
 #endif

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -138,6 +138,9 @@ struct PageReaderTestPeer {
 
 class ParquetReaderTest : public ParquetTestBase {
  public:
+  static constexpr vector_size_t kFusedLevelConversionRows = 12'000;
+  static constexpr uint32_t kFusedLevelConversionSeed = 20260730;
+
   std::unique_ptr<dwio::common::RowReader> createRowReader(
       const std::string& fileName,
       const RowTypePtr& rowType) {
@@ -173,6 +176,85 @@ class ParquetReaderTest : public ParquetTestBase {
     auto reader = createReader(filePath, readerOpts);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
+  }
+
+  RowVectorPtr makeFusedLevelConversionData() {
+    std::mt19937 rng(kFusedLevelConversionSeed);
+    std::uniform_int_distribution<int32_t> lengthDist(0, 12);
+    std::vector<int32_t> arrayLengths(kFusedLevelConversionRows);
+    std::vector<int32_t> mapLengths(kFusedLevelConversionRows);
+    for (vector_size_t row = 0; row < kFusedLevelConversionRows; ++row) {
+      arrayLengths[row] = lengthDist(rng);
+      mapLengths[row] = lengthDist(rng);
+    }
+
+    auto arrays = makeArrayVector<int64_t>(
+        kFusedLevelConversionRows,
+        [&](vector_size_t row) {
+          return row % 17 == 0 || row % 13 == 0 ? 0 : arrayLengths[row];
+        },
+        [&](vector_size_t row, vector_size_t index) {
+          return static_cast<int64_t>(row) * 100 + index;
+        },
+        [&](vector_size_t row) { return row % 17 == 0 || row % 13 == 0; });
+    auto maps = vectorMaker_.mapVector<int32_t, int64_t>(
+        kFusedLevelConversionRows,
+        [&](vector_size_t row) {
+          return row % 19 == 0 || row % 11 == 0 ? 0 : mapLengths[row];
+        },
+        [&](vector_size_t row, vector_size_t index) {
+          return static_cast<int32_t>(index);
+        },
+        [&](vector_size_t row, vector_size_t index) {
+          return static_cast<int64_t>(row) * 1000 + index;
+        },
+        [&](vector_size_t row) { return row % 19 == 0 || row % 11 == 0; });
+
+    auto arrayStruct = makeRowVector(
+        std::vector<std::string>{"items"},
+        std::vector<VectorPtr>{arrays},
+        [&](vector_size_t row) { return row % 13 == 0; });
+    auto mapStruct = makeRowVector(
+        std::vector<std::string>{"items"},
+        std::vector<VectorPtr>{maps},
+        [&](vector_size_t row) { return row % 11 == 0; });
+    return makeRowVector(
+        std::vector<std::string>{"id", "array_struct", "map_struct"},
+        std::vector<VectorPtr>{
+            makeFlatVector<int64_t>(
+                kFusedLevelConversionRows,
+                [](vector_size_t row) { return row; }),
+            arrayStruct,
+            mapStruct});
+  }
+
+  std::shared_ptr<exec::test::TempFilePath> writeFusedLevelConversionData(
+      const RowVectorPtr& data) {
+    auto file = exec::test::TempFilePath::create();
+    auto localWriteFile =
+        std::make_unique<LocalWriteFile>(file->path, true, false);
+    auto sink = std::make_unique<dwio::common::WriteFileSink>(
+        std::move(localWriteFile), file->path);
+    bytedance::bolt::parquet::WriterOptions options;
+    options.memoryPool = rootPool_.get();
+    options.dataPageSize = 4 * 1024;
+    bytedance::bolt::parquet::Writer writer(
+        std::move(sink), options, asRowType(data->type()));
+    writer.write(data);
+    writer.close();
+    return file;
+  }
+
+  std::unique_ptr<dwio::common::RowReader> makeFusedLevelConversionReader(
+      const std::string& filePath,
+      const RowVectorPtr& data,
+      std::shared_ptr<ScanSpec> scanSpec = nullptr) {
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    auto reader = createReader(filePath, readerOptions);
+    auto rowReaderOptions = getReaderOpts(asRowType(data->type()));
+    rowReaderOptions.setScanSpec(
+        scanSpec ? std::move(scanSpec) : makeScanSpec(asRowType(data->type())));
+    return reader->createRowReader(rowReaderOptions);
   }
 };
 
@@ -2414,6 +2496,64 @@ TEST_F(ParquetReaderTest, varcharToBigintSchemaMismatchCast) {
   EXPECT_EQ(decoded.valueAt<int64_t>(2), 300);
   EXPECT_EQ(decoded.valueAt<int64_t>(3), -42);
   EXPECT_EQ(decoded.valueAt<int64_t>(4), 0);
+}
+
+TEST_F(ParquetReaderTest, fusedLevelConversionContinuousReads) {
+  auto data = makeFusedLevelConversionData();
+  auto file = writeFusedLevelConversionData(data);
+
+  for (const vector_size_t batchSize : {1, 31, 1024, 4096}) {
+    auto reader = makeFusedLevelConversionReader(file->path, data);
+    VectorPtr result = BaseVector::create(data->type(), 0, leafPool_.get());
+    vector_size_t offset = 0;
+    while (reader->next(batchSize, result)) {
+      assertEqualVectorPart(data, result, offset);
+      offset += result->size();
+    }
+    EXPECT_EQ(offset, kFusedLevelConversionRows);
+  }
+}
+
+TEST_F(ParquetReaderTest, fusedLevelConversionNonContiguousReads) {
+  auto data = makeFusedLevelConversionData();
+  auto file = writeFusedLevelConversionData(data);
+  auto reader = makeFusedLevelConversionReader(file->path, data);
+  VectorPtr result = BaseVector::create(data->type(), 0, leafPool_.get());
+  vector_size_t offset = 0;
+  for (const auto& [skipSize, readSize] :
+       std::vector<std::pair<vector_size_t, vector_size_t>>{
+           {7, 3}, {101, 17}, {2'047, 33}, {4'096, 127}}) {
+    EXPECT_EQ(reader->skip(skipSize), skipSize);
+    offset += skipSize;
+    ASSERT_GT(reader->next(readSize, result), 0);
+    assertEqualVectorPart(data, result, offset);
+    offset += result->size();
+  }
+}
+
+TEST_F(ParquetReaderTest, fusedLevelConversionTopLevelFilter) {
+  auto data = makeFusedLevelConversionData();
+  auto file = writeFusedLevelConversionData(data);
+  auto scanSpec = makeScanSpec(asRowType(data->type()));
+  scanSpec->getOrCreateChild("id")->setFilter(
+      exec::bigintOr(exec::between(1'000, 1'999), exec::between(7'000, 7'999)));
+  auto reader = makeFusedLevelConversionReader(file->path, data, scanSpec);
+  VectorPtr result = BaseVector::create(data->type(), 0, leafPool_.get());
+  vector_size_t totalRows = 0;
+  while (reader->next(257, result)) {
+    auto* rows = result->as<RowVector>();
+    auto* ids = rows->childAt(0)->as<FlatVector<int64_t>>();
+    for (vector_size_t row = 0; row < rows->size(); ++row) {
+      const auto originalRow = static_cast<vector_size_t>(ids->valueAt(row));
+      ASSERT_TRUE(
+          (originalRow >= 1'000 && originalRow <= 1'999) ||
+          (originalRow >= 7'000 && originalRow <= 7'999));
+      ASSERT_TRUE(data->equalValueAt(result.get(), originalRow, row))
+          << "original row " << originalRow;
+    }
+    totalRows += result->size();
+  }
+  EXPECT_EQ(totalRows, 2'000);
 }
 
 TEST_F(ParquetReaderTest, readVariantParquet) {


### PR DESCRIPTION
### What problem does this PR solve?

Parquet nested reads currently convert the same DataPage def/rep levels separately when a nullable struct directly wraps a list or map child: once for repeated list/map lengths and validity, and once for the parent struct null bitmap. This repeats the same level traversal on a hot nested-read path.

This PR adds a fused conversion path for the direct nullable struct -> list/map case. The reader now attempts to populate the repeated lengths/list validity and parent struct null bitmap in one pass, then falls back to the existing separate conversions when the level relationship is not supported.

Issue Number: N/A

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds:

- `DefRepLevelsToListLengthsAndStructBitmap`, which fuses direct list/map length conversion with direct parent struct bitmap conversion.
- A `PageReader::getListLengthsAndStructNulls` wrapper used by nested Parquet readers.
- Reader-side wiring for direct struct -> list/map children, with fallback to the original separate conversion path when the fused level relationship is not supported.
- Oracle-based level conversion tests comparing fused output against the existing separate conversions.
- End-to-end Parquet reader coverage in `ParquetReaderTest` for continuous reads, non-contiguous `skip + next` reads, and top-level filtering.
- Level conversion microbenchmarks for fused fast path and unsupported fallback path.

The fused reader path avoids setting repeated lengths twice by delaying the old repeated setup until the fused path either succeeds or explicitly falls back.

### Performance Impact
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Benchmark: bolt_dwio_parquet_level_conversion_benchmark
    Comparison: separateStructAndList_* vs fusedStructAndList_*

    Fast-path fused conversion speedups:
    - single lists: ~1.50x to 1.74x
    - mixed lists:  ~1.85x to 2.17x
    - long lists:   ~1.98x to 1.99x

    Unsupported fallback path:
    - fallbackStructAndList_* vs separateStructAndList_* stayed within ~99.0% to 101.1%
    - no systematic regression observed when the fused fast path is not applicable
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
- Optimized Parquet nested level conversion for direct nullable struct -> list/map reads by fusing repeated length and struct null bitmap generation.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation run locally:

```text
cmake --build --preset conan-release --target bolt_dwio_parquet_level_conversion_benchmark bolt_dwio_parquet_arrow_test bolt_dwio_parquet_reader_test --parallel 16

bolt_dwio_parquet_arrow_test --gtest_filter='NestedListTest.*'
bolt_dwio_parquet_reader_test --gtest_filter='ParquetReaderTest.fusedLevelConversion*'
bolt_dwio_parquet_level_conversion_benchmark --bm_regex='(separateStructAndList|fallbackStructAndList)_'
clang-format --dry-run --Werror on touched C++ files
git diff --check
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - N/A
    ```
    </details>
