### PR TITLE
fix(parquet): limit rows per data page to prevent overflow

### DIFF
--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -1623,6 +1623,15 @@ inline void DoInBatchesNonRepeated(
     int64_t max_batch_size = std::min(batch_size, num_levels - offset);
     max_batch_size =
         std::min(max_batch_size, max_rows_per_page - page_buffered_rows);
+    if (max_batch_size <= 0) {
+      throw ParquetException(
+          "Non-repeated column batching cannot make progress: batch size ",
+          batch_size,
+          ", buffered rows ",
+          page_buffered_rows,
+          ", maximum rows per page ",
+          max_rows_per_page);
+    }
     const int64_t end_offset = offset + max_batch_size;
 
     DCHECK_LE(offset, end_offset);
@@ -1645,6 +1654,11 @@ inline void DoInBatchesRepeated(
   int64_t offset = 0;
   while (offset < num_levels) {
     const int64_t max_batch_size = std::min(batch_size, num_levels - offset);
+    if (max_batch_size <= 0) {
+      throw ParquetException(
+          "Repeated column batching cannot make progress: batch size ",
+          batch_size);
+    }
     int64_t end_offset = num_levels;
     int64_t check_page_limit_end_offset = -1;
     int64_t page_buffered_rows = current_page_buffered_rows();
@@ -1696,7 +1710,7 @@ inline void DoInBatches(
     bool pages_change_on_record_boundaries,
     Action&& action,
     GetBufferedRows&& current_page_buffered_rows) {
-  if (rep_levels == nullptr || !pages_change_on_record_boundaries) {
+  if (rep_levels == nullptr) {
     DoInBatchesNonRepeated(
         num_levels,
         batch_size,
@@ -2280,7 +2294,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     num_buffered_encoded_values_ += num_values;
     num_buffered_nulls_ += num_nulls;
 
-    if (check_page_limit &&
+    if (num_buffered_values_ > 0 && check_page_limit &&
         (current_encoder_->EstimatedDataEncodedSize() >= data_pagesize_ ||
          num_buffered_rows_ >= properties_->max_rows_per_page())) {
       AddDataPage();

--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -100,6 +100,8 @@ using util::CodecOptions;
 namespace {
 
 constexpr int64_t kMaxPageHeaderSize = std::numeric_limits<int32_t>::max();
+constexpr int64_t kDataPageValueCountFlushThreshold =
+    std::numeric_limits<int32_t>::max() / 2;
 
 int32_t checkPageHeaderSize(std::string_view size_name, int64_t size) {
   if (size < 0 || size > kMaxPageHeaderSize) {
@@ -2154,6 +2156,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       int64_t num_values,
       const int16_t* def_levels,
       const int16_t* rep_levels) {
+    CheckPageValueCountCanBeBuffered(num_values);
     int64_t values_to_write = 0;
     // If the field is required and non-repeated, there are no definition levels
     if (descr_->max_definition_level() > 0) {
@@ -2263,6 +2266,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       int64_t num_levels,
       const int16_t* def_levels,
       const int16_t* rep_levels) {
+    CheckPageValueCountCanBeBuffered(num_levels);
     // If the field is required and non-repeated, there are no definition levels
     if (descr_->max_definition_level() > 0) {
       WriteDefinitionLevels(num_levels, def_levels);
@@ -2296,8 +2300,21 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
 
     if (num_buffered_values_ > 0 && check_page_limit &&
         (current_encoder_->EstimatedDataEncodedSize() >= data_pagesize_ ||
-         num_buffered_rows_ >= properties_->max_rows_per_page())) {
+         num_buffered_rows_ >= properties_->max_rows_per_page() ||
+         num_buffered_values_ >= kDataPageValueCountFlushThreshold)) {
       AddDataPage();
+    }
+  }
+
+  void CheckPageValueCountCanBeBuffered(int64_t num_levels) const {
+    if (num_levels < 0 ||
+        num_levels > kMaxPageHeaderSize - num_buffered_values_) {
+      throw ParquetException(
+          "DataPage num_values cannot be represented in a Parquet page "
+          "header int32 field: buffered ",
+          num_buffered_values_,
+          ", incoming ",
+          num_levels);
     }
   }
 

--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -112,6 +112,16 @@ int32_t checkPageHeaderSize(std::string_view size_name, int64_t size) {
   return static_cast<int32_t>(size);
 }
 
+int32_t checkPageHeaderCount(std::string_view count_name, int64_t count) {
+  if (count < 0 || count > std::numeric_limits<int32_t>::max()) {
+    throw ParquetException(
+        std::string(count_name),
+        " cannot be represented in a Parquet page header int32 field: ",
+        count);
+  }
+  return static_cast<int32_t>(count);
+}
+
 int64_t bufferAllocatedBytes(const std::shared_ptr<Buffer>& buffer) {
   return buffer != nullptr ? buffer->capacity() : 0;
 }
@@ -1442,7 +1452,8 @@ void ColumnWriterImpl::BuildDataPageV1(
     compressed_data = std::move(combined);
   }
 
-  int32_t num_values = static_cast<int32_t>(num_buffered_values_);
+  const int32_t num_values =
+      checkPageHeaderCount("DataPageV1 num_values", num_buffered_values_);
   int64_t first_row_index = rows_written_ - num_buffered_rows_;
 
   // Write the page to OutputStream eagerly if there is no dictionary or
@@ -1507,13 +1518,16 @@ void ColumnWriterImpl::BuildDataPageV2(
   page_stats.set_is_signed(SortOrder::SIGNED == descr_->sort_order());
   ResetPageStatistics();
 
-  int32_t num_values = static_cast<int32_t>(num_buffered_values_);
-  int32_t null_count = static_cast<int32_t>(num_buffered_nulls_);
-  int32_t num_rows = static_cast<int32_t>(num_buffered_rows_);
-  int32_t def_levels_byte_length =
-      static_cast<int32_t>(definition_levels_rle_size);
-  int32_t rep_levels_byte_length =
-      static_cast<int32_t>(repetition_levels_rle_size);
+  const int32_t num_values =
+      checkPageHeaderCount("DataPageV2 num_values", num_buffered_values_);
+  const int32_t null_count =
+      checkPageHeaderCount("DataPageV2 null_count", num_buffered_nulls_);
+  const int32_t num_rows =
+      checkPageHeaderCount("DataPageV2 num_rows", num_buffered_rows_);
+  const int32_t def_levels_byte_length =
+      checkPageHeaderSize("Definition levels", definition_levels_rle_size);
+  const int32_t rep_levels_byte_length =
+      checkPageHeaderSize("Repetition levels", repetition_levels_rle_size);
   int64_t first_row_index = rows_written_ - num_buffered_rows_;
 
   // page_stats.null_count is not set when page_statistics_ is nullptr. It is
@@ -1594,71 +1608,111 @@ void ColumnWriterImpl::FlushBufferedDataPages() {
 // ----------------------------------------------------------------------
 // TypedColumnWriter
 
-template <typename Action>
-inline void DoInBatches(int64_t total, int64_t batch_size, Action&& action) {
-  int64_t num_batches = static_cast<int>(total / batch_size);
-  for (int round = 0; round < num_batches; round++) {
-    action(round * batch_size, batch_size, /*check_page_size=*/true);
-  }
-  // Write the remaining values
-  if (total % batch_size > 0) {
-    action(
-        num_batches * batch_size, total % batch_size, /*check_page_size=*/true);
+template <typename Action, typename GetBufferedRows>
+inline void DoInBatchesNonRepeated(
+    int64_t num_levels,
+    int64_t batch_size,
+    int64_t max_rows_per_page,
+    Action&& action,
+    GetBufferedRows&& current_page_buffered_rows) {
+  int64_t offset = 0;
+  while (offset < num_levels) {
+    const int64_t page_buffered_rows = current_page_buffered_rows();
+    DCHECK_LE(page_buffered_rows, max_rows_per_page);
+
+    int64_t max_batch_size = std::min(batch_size, num_levels - offset);
+    max_batch_size =
+        std::min(max_batch_size, max_rows_per_page - page_buffered_rows);
+    const int64_t end_offset = offset + max_batch_size;
+
+    DCHECK_LE(offset, end_offset);
+    DCHECK_LE(end_offset, num_levels);
+    action(offset, end_offset - offset, /*check_page_limit=*/true);
+    offset = end_offset;
   }
 }
 
-template <typename Action>
+template <typename Action, typename GetBufferedRows>
+inline void DoInBatchesRepeated(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_levels,
+    int64_t batch_size,
+    int64_t max_rows_per_page,
+    bool pages_change_on_record_boundaries,
+    Action&& action,
+    GetBufferedRows&& current_page_buffered_rows) {
+  int64_t offset = 0;
+  while (offset < num_levels) {
+    const int64_t max_batch_size = std::min(batch_size, num_levels - offset);
+    int64_t end_offset = num_levels;
+    int64_t check_page_limit_end_offset = -1;
+    int64_t page_buffered_rows = current_page_buffered_rows();
+    DCHECK_LE(page_buffered_rows, max_rows_per_page);
+
+    // Find a batch ending at a record boundary. A single repeated record may
+    // exceed the row limit in values, but it must not be split across pages
+    // when page indexes or DataPageV2 require record-aligned pages.
+    for (int64_t i = offset; i < num_levels; ++i) {
+      if (rep_levels[i] == 0) {
+        check_page_limit_end_offset = i;
+        if (i - offset >= max_batch_size ||
+            page_buffered_rows >= max_rows_per_page) {
+          end_offset = i;
+          break;
+        }
+        ++page_buffered_rows;
+      }
+    }
+
+    DCHECK_LE(offset, end_offset);
+    DCHECK_LE(check_page_limit_end_offset, end_offset);
+
+    if (check_page_limit_end_offset >= 0) {
+      action(
+          offset,
+          check_page_limit_end_offset - offset,
+          /*check_page_limit=*/true);
+      offset = check_page_limit_end_offset;
+    }
+    if (end_offset > offset) {
+      DCHECK_EQ(end_offset, num_levels);
+      action(
+          offset,
+          end_offset - offset,
+          /*check_page_limit=*/!pages_change_on_record_boundaries);
+    }
+    offset = end_offset;
+  }
+}
+
+template <typename Action, typename GetBufferedRows>
 inline void DoInBatches(
     const int16_t* def_levels,
     const int16_t* rep_levels,
     int64_t num_levels,
     int64_t batch_size,
+    int64_t max_rows_per_page,
+    bool pages_change_on_record_boundaries,
     Action&& action,
-    bool pages_change_on_record_boundaries) {
-  if (!pages_change_on_record_boundaries || !rep_levels) {
-    // If rep_levels is null, then we are writing a non-repeated column.
-    // In this case, every record contains only one level.
-    return DoInBatches(num_levels, batch_size, std::forward<Action>(action));
-  }
-
-  int64_t offset = 0;
-  while (offset < num_levels) {
-    int64_t end_offset = std::min(offset + batch_size, num_levels);
-
-    // Find next record boundary (i.e. ref_level = 0)
-    while (end_offset < num_levels && rep_levels[end_offset] != 0) {
-      end_offset++;
-    }
-
-    if (end_offset < num_levels) {
-      // This is not the last chunk of batch and end_offset is a record
-      // boundary. It is a good chance to check the page size.
-      action(offset, end_offset - offset, /*check_page_size=*/true);
-    } else {
-      DCHECK_EQ(end_offset, num_levels);
-      // This is the last chunk of batch, and we do not know whether end_offset
-      // is a record boundary. Find the offset to beginning of last record in
-      // this chunk, so we can check page size.
-      int64_t last_record_begin_offset = num_levels - 1;
-      while (last_record_begin_offset >= offset &&
-             rep_levels[last_record_begin_offset] != 0) {
-        last_record_begin_offset--;
-      }
-
-      if (offset < last_record_begin_offset) {
-        // We have found the beginning of last record and can check page size.
-        action(
-            offset,
-            last_record_begin_offset - offset,
-            /*check_page_size=*/true);
-        offset = last_record_begin_offset;
-      }
-
-      // There is no record boundary in this chunk and cannot check page size.
-      action(offset, end_offset - offset, /*check_page_size=*/false);
-    }
-
-    offset = end_offset;
+    GetBufferedRows&& current_page_buffered_rows) {
+  if (rep_levels == nullptr || !pages_change_on_record_boundaries) {
+    DoInBatchesNonRepeated(
+        num_levels,
+        batch_size,
+        max_rows_per_page,
+        std::forward<Action>(action),
+        std::forward<GetBufferedRows>(current_page_buffered_rows));
+  } else {
+    DoInBatchesRepeated(
+        def_levels,
+        rep_levels,
+        num_levels,
+        batch_size,
+        max_rows_per_page,
+        pages_change_on_record_boundaries,
+        std::forward<Action>(action),
+        std::forward<GetBufferedRows>(current_page_buffered_rows));
   }
 }
 
@@ -1780,8 +1834,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
         rep_levels,
         num_values,
         properties_->write_batch_size(),
+        properties_->max_rows_per_page(),
+        pages_change_on_record_boundaries(),
         WriteChunk,
-        pages_change_on_record_boundaries());
+        [this]() { return num_buffered_rows_; });
     return value_offset;
   }
 
@@ -1841,8 +1897,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
         rep_levels,
         num_values,
         properties_->write_batch_size(),
+        properties_->max_rows_per_page(),
+        pages_change_on_record_boundaries(),
         WriteChunk,
-        pages_change_on_record_boundaries());
+        [this]() { return num_buffered_rows_; });
   }
 
   Status WriteArrow(
@@ -2217,13 +2275,14 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       int64_t num_levels,
       int64_t num_values,
       int64_t num_nulls,
-      bool check_page_size) {
+      bool check_page_limit) {
     num_buffered_values_ += num_levels;
     num_buffered_encoded_values_ += num_values;
     num_buffered_nulls_ += num_nulls;
 
-    if (check_page_size &&
-        current_encoder_->EstimatedDataEncodedSize() >= data_pagesize_) {
+    if (check_page_limit &&
+        (current_encoder_->EstimatedDataEncodedSize() >= data_pagesize_ ||
+         num_buffered_rows_ >= properties_->max_rows_per_page())) {
       AddDataPage();
     }
   }
@@ -2468,8 +2527,10 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
       rep_levels,
       num_levels,
       properties_->write_batch_size(),
+      properties_->max_rows_per_page(),
+      pages_change_on_record_boundaries(),
       WriteIndicesChunk,
-      pages_change_on_record_boundaries()));
+      [this]() { return num_buffered_rows_; }));
   return Status::OK();
 }
 
@@ -3338,8 +3399,10 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
       rep_levels,
       num_levels,
       properties_->write_batch_size(),
+      properties_->max_rows_per_page(),
+      pages_change_on_record_boundaries(),
       WriteChunk,
-      pages_change_on_record_boundaries()));
+      [this]() { return num_buffered_rows_; }));
   return Status::OK();
 }
 

--- a/bolt/dwio/parquet/arrow/Encoding.cpp
+++ b/bolt/dwio/parquet/arrow/Encoding.cpp
@@ -4377,8 +4377,8 @@ class IncrementalLevelRleEncoder::Impl {
   void FlushRepeatedRun() {
     DCHECK_GT(repeat_count_, 0);
     bool result = true;
-    int32_t indicator_value = repeat_count_ << 1;
-    result &= bit_writer_.PutVlqInt(static_cast<uint32_t>(indicator_value));
+    const uint32_t indicator_value = static_cast<uint32_t>(repeat_count_) << 1;
+    result &= bit_writer_.PutVlqInt(indicator_value);
     result &= bit_writer_.PutAligned(
         current_value_, static_cast<int>(bit_util::CeilDiv(bit_width_, 8)));
     DCHECK(result);

--- a/bolt/dwio/parquet/arrow/Properties.h
+++ b/bolt/dwio/parquet/arrow/Properties.h
@@ -458,6 +458,10 @@ class PARQUET_EXPORT WriterProperties {
     /// Specify the write batch size while writing batches of Arrow values into
     /// Parquet. Default 1024.
     Builder* write_batch_size(int64_t write_batch_size) {
+      if (write_batch_size <= 0) {
+        throw ParquetException(
+            "Write batch size must be positive: ", write_batch_size);
+      }
       write_batch_size_ = write_batch_size;
       return this;
     }

--- a/bolt/dwio/parquet/arrow/Properties.h
+++ b/bolt/dwio/parquet/arrow/Properties.h
@@ -238,6 +238,7 @@ class PARQUET_EXPORT ReaderProperties {
 ReaderProperties PARQUET_EXPORT default_reader_properties();
 
 static constexpr int64_t kDefaultDataPageSize = 1024 * 1024;
+static constexpr int64_t kDefaultMaxRowsPerPage = 20'000;
 static constexpr bool DEFAULT_IS_DICTIONARY_ENABLED = true;
 static constexpr int64_t DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT =
     kDefaultDataPageSize;
@@ -377,6 +378,7 @@ class PARQUET_EXPORT WriterProperties {
         : pool_(::arrow::default_memory_pool()),
           write_batch_size_(DEFAULT_WRITE_BATCH_SIZE),
           max_row_group_length_(DEFAULT_MAX_ROW_GROUP_LENGTH),
+          max_rows_per_page_(kDefaultMaxRowsPerPage),
           version_(ParquetVersion::PARQUET_2_6),
           data_page_version_(ParquetDataPageVersion::V1),
           created_by_(DEFAULT_CREATED_BY),
@@ -487,6 +489,17 @@ class PARQUET_EXPORT WriterProperties {
         const std::shared_ptr<schema::ColumnPath>& path,
         int64_t pg_size) {
       return this->data_pagesize(path->ToDotString(), pg_size);
+    }
+
+    /// Specify the maximum number of rows per data page.
+    /// Default 20K rows.
+    Builder* max_rows_per_page(int64_t max_rows) {
+      if (max_rows <= 0) {
+        throw ParquetException(
+            "Maximum rows per data page must be positive: ", max_rows);
+      }
+      max_rows_per_page_ = max_rows;
+      return this;
     }
 
     /// Specify the data page version.
@@ -858,6 +871,7 @@ class PARQUET_EXPORT WriterProperties {
           pool_,
           write_batch_size_,
           max_row_group_length_,
+          max_rows_per_page_,
           parquet_block_size_,
           version_,
           created_by_,
@@ -874,6 +888,7 @@ class PARQUET_EXPORT WriterProperties {
     MemoryPool* pool_;
     int64_t write_batch_size_;
     int64_t max_row_group_length_;
+    int64_t max_rows_per_page_;
     int64_t parquet_block_size_{-1};
     ParquetVersion::type version_;
     ParquetDataPageVersion data_page_version_;
@@ -909,6 +924,10 @@ class PARQUET_EXPORT WriterProperties {
 
   inline int64_t max_row_group_length() const {
     return max_row_group_length_;
+  }
+
+  inline int64_t max_rows_per_page() const {
+    return max_rows_per_page_;
   }
 
   inline int64_t parquet_block_size() const {
@@ -1049,6 +1068,7 @@ class PARQUET_EXPORT WriterProperties {
       MemoryPool* pool,
       int64_t write_batch_size,
       int64_t max_row_group_length,
+      int64_t max_rows_per_page,
       int64_t parquet_block_size,
       ParquetVersion::type version,
       const std::string& created_by,
@@ -1063,6 +1083,7 @@ class PARQUET_EXPORT WriterProperties {
       : pool_(pool),
         write_batch_size_(write_batch_size),
         max_row_group_length_(max_row_group_length),
+        max_rows_per_page_(max_rows_per_page),
         parquet_block_size_(parquet_block_size),
         parquet_data_page_version_(data_page_version),
         parquet_version_(version),
@@ -1078,6 +1099,7 @@ class PARQUET_EXPORT WriterProperties {
   int64_t dictionary_pagesize_limit_;
   int64_t write_batch_size_;
   int64_t max_row_group_length_;
+  int64_t max_rows_per_page_;
   int64_t pagesize_;
   int64_t parquet_block_size_;
   ParquetDataPageVersion parquet_data_page_version_;

--- a/bolt/dwio/parquet/arrow/Properties.h
+++ b/bolt/dwio/parquet/arrow/Properties.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -238,7 +240,12 @@ class PARQUET_EXPORT ReaderProperties {
 ReaderProperties PARQUET_EXPORT default_reader_properties();
 
 static constexpr int64_t kDefaultDataPageSize = 1024 * 1024;
-static constexpr int64_t kDefaultMaxRowsPerPage = 20'000;
+// Keep enough headroom for encoded level counts while minimizing changes to
+// existing page layouts. Page count fields are signed int32 in the Parquet
+// format, and RLE run headers encode the count shifted left by one bit.
+static constexpr int64_t kMaxRowsPerPage =
+    std::numeric_limits<int32_t>::max() / 2;
+static constexpr int64_t kDefaultMaxRowsPerPage = kMaxRowsPerPage;
 static constexpr bool DEFAULT_IS_DICTIONARY_ENABLED = true;
 static constexpr int64_t DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT =
     kDefaultDataPageSize;
@@ -496,11 +503,14 @@ class PARQUET_EXPORT WriterProperties {
     }
 
     /// Specify the maximum number of rows per data page.
-    /// Default 20K rows.
+    /// Default INT32_MAX / 2 rows.
     Builder* max_rows_per_page(int64_t max_rows) {
-      if (max_rows <= 0) {
+      if (max_rows <= 0 || max_rows > kMaxRowsPerPage) {
         throw ParquetException(
-            "Maximum rows per data page must be positive: ", max_rows);
+            "Maximum rows per data page must be in range [1, ",
+            kMaxRowsPerPage,
+            "]: ",
+            max_rows);
       }
       max_rows_per_page_ = max_rows;
       return this;

--- a/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
@@ -55,6 +55,7 @@
 #include "bolt/dwio/parquet/arrow/FileWriter.h"
 #include "bolt/dwio/parquet/arrow/Metadata.h"
 #include "bolt/dwio/parquet/arrow/PageBufferArena.h"
+#include "bolt/dwio/parquet/arrow/PageIndex.h"
 #include "bolt/dwio/parquet/arrow/Platform.h"
 #include "bolt/dwio/parquet/arrow/Properties.h"
 #include "bolt/dwio/parquet/arrow/Statistics.h"
@@ -2550,6 +2551,114 @@ TEST(
     EXPECT_EQ(1, dictionary_page_count);
     EXPECT_EQ(page_value_counts, (std::vector<int64_t>{3, 3, 3, 1}));
   }
+}
+
+TEST(
+    TestColumnWriter,
+    RepeatedDictionaryColumnDoesNotWriteEmptyPageWithPageIndex) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema",
+      Repetition::REQUIRED,
+      {schema::Int32("repeated", Repetition::REPEATED)}));
+  auto properties = WriterProperties::Builder()
+                        .enable_dictionary()
+                        ->enable_write_page_index()
+                        ->data_page_version(ParquetDataPageVersion::V1)
+                        ->data_pagesize(1)
+                        ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto row_group_writer = file_writer->AppendRowGroup();
+  auto column_writer =
+      static_cast<Int32Writer*>(row_group_writer->NextColumn());
+
+  const int16_t definition_level = 1;
+  const int16_t repetition_level = 0;
+  for (const int32_t value : {7, 8}) {
+    column_writer->WriteBatch(1, &definition_level, &repetition_level, &value);
+  }
+  ASSERT_NO_THROW(file_writer->Close());
+
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      default_reader_properties());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  int64_t dictionary_page_count = 0;
+  std::vector<int64_t> data_page_value_counts;
+  auto page_reader = row_group_reader->GetColumnPageReader(0);
+  while (auto page = page_reader->NextPage()) {
+    if (page->type() == PageType::DICTIONARY_PAGE) {
+      ++dictionary_page_count;
+      continue;
+    }
+    auto data_page = std::static_pointer_cast<DataPage>(page);
+    data_page_value_counts.push_back(data_page->num_values());
+    EXPECT_GT(data_page->num_values(), 0);
+  }
+  EXPECT_EQ(1, dictionary_page_count);
+  EXPECT_EQ(data_page_value_counts, (std::vector<int64_t>{1, 1}));
+
+  auto page_index_reader = file_reader->GetPageIndexReader();
+  ASSERT_NE(nullptr, page_index_reader);
+  auto row_group_page_index = page_index_reader->RowGroup(0);
+  ASSERT_NE(nullptr, row_group_page_index);
+  auto offset_index = row_group_page_index->GetOffsetIndex(0);
+  ASSERT_NE(nullptr, offset_index);
+  const auto& page_locations = offset_index->page_locations();
+  ASSERT_EQ(data_page_value_counts.size(), page_locations.size());
+  for (size_t i = 1; i < page_locations.size(); ++i) {
+    EXPECT_LT(
+        page_locations[i - 1].first_row_index,
+        page_locations[i].first_row_index);
+  }
+}
+
+TEST(
+    TestColumnWriter,
+    DataPageV1RepeatedColumnCountsRowsInsteadOfLevelsWithoutPageIndex) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema",
+      Repetition::REQUIRED,
+      {schema::Int32("repeated", Repetition::REPEATED)}));
+  auto properties = WriterProperties::Builder()
+                        .disable_dictionary()
+                        ->disable_write_page_index()
+                        ->data_page_version(ParquetDataPageVersion::V1)
+                        ->data_pagesize(1 << 20)
+                        ->max_rows_per_page(1)
+                        ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto row_group_writer = file_writer->AppendRowGroup();
+  auto column_writer =
+      static_cast<Int32Writer*>(row_group_writer->NextColumn());
+
+  const std::vector<int16_t> definition_levels(8, 1);
+  const std::vector<int16_t> repetition_levels = {0, 1, 1, 1, 1, 0, 1, 1};
+  const std::vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6, 7};
+  column_writer->WriteBatch(
+      values.size(),
+      definition_levels.data(),
+      repetition_levels.data(),
+      values.data());
+  ASSERT_NO_THROW(file_writer->Close());
+
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      default_reader_properties());
+  auto page_reader = file_reader->RowGroup(0)->GetColumnPageReader(0);
+
+  std::vector<int64_t> data_page_value_counts;
+  while (auto page = page_reader->NextPage()) {
+    ASSERT_EQ(PageType::DATA_PAGE, page->type());
+    auto data_page = std::static_pointer_cast<DataPage>(page);
+    data_page_value_counts.push_back(data_page->num_values());
+    EXPECT_GT(data_page->num_values(), 0);
+  }
+  EXPECT_EQ(data_page_value_counts, (std::vector<int64_t>{5, 3}));
 }
 
 TEST(PageBufferArenaTest, FixedCapacityAllocationAndReset) {

--- a/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
@@ -528,6 +528,48 @@ void TestPrimitiveWriter<FLBAType>::ReadColumnFully(
   this->SyncValuesOut();
 }
 
+template <>
+void TestPrimitiveWriter<ByteArrayType>::ReadColumnFully(
+    Compression::type compression,
+    bool page_checksum_verify) {
+  int64_t total_values = static_cast<int64_t>(this->values_out_.size());
+  BuildReader(total_values, compression, page_checksum_verify);
+  this->data_buffer_.clear();
+
+  values_read_ = 0;
+  while (values_read_ < total_values) {
+    int64_t values_read_recently = 0;
+    reader_->ReadBatch(
+        static_cast<int>(this->values_out_.size()) -
+            static_cast<int>(values_read_),
+        definition_levels_out_.data() + values_read_,
+        repetition_levels_out_.data() + values_read_,
+        this->values_out_ptr_ + values_read_,
+        &values_read_recently);
+
+    // ByteArray values point into the reader's current page buffer, which is
+    // reused when the next compressed page is decoded. Preserve every batch
+    // before advancing to the next page.
+    int64_t total_length = 0;
+    for (int64_t i = 0; i < values_read_recently; ++i) {
+      total_length += this->values_out_[i + values_read_].len;
+    }
+
+    std::vector<uint8_t> data(total_length);
+    uint8_t* data_ptr = data.data();
+    for (int64_t i = 0; i < values_read_recently; ++i) {
+      const ByteArray& value = this->values_out_[i + values_read_];
+      memcpy(data_ptr, value.ptr, value.len);
+      this->values_out_[i + values_read_].ptr = data_ptr;
+      data_ptr += value.len;
+    }
+    data_buffer_.emplace_back(std::move(data));
+
+    values_read_ += values_read_recently;
+  }
+  this->SyncValuesOut();
+}
+
 typedef ::testing::Types<
     Int32Type,
     Int64Type,
@@ -2005,7 +2047,7 @@ TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundariesWithSmallBatches) {
 
   // Check if pages are changed on record boundaries.
   const std::array<int64_t, num_cols> expect_num_pages_by_col = {
-      5, 201, 397, 201};
+      5, 201, 397, 400};
   const std::array<int64_t, num_cols> expect_num_rows_1st_page_by_col = {
       99, 1, 1, 1};
   const std::array<int64_t, num_cols> expect_num_vals_1st_page_by_col = {
@@ -2384,6 +2426,130 @@ TEST_F(
 
   EXPECT_LT(writer->memory_stats().columnScratchAllocatedBytes, 1 << 20);
   writer->Close();
+}
+
+TEST(TestColumnWriter, AllNullOptionalColumnRespectsMaxRowsPerPage) {
+  constexpr int64_t kNumRows = 10;
+  constexpr int64_t kMaxRowsPerPage = 3;
+  const std::vector<int16_t> definition_levels(kNumRows, 0);
+  const std::vector<uint8_t> valid_bits(bit_util::BytesForBits(kNumRows), 0);
+  const std::vector<int32_t> values(kNumRows, 0);
+
+  for (const auto page_version :
+       {ParquetDataPageVersion::V1, ParquetDataPageVersion::V2}) {
+    auto sink = CreateOutputStream();
+    auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+        "schema",
+        Repetition::REQUIRED,
+        {schema::Int32("all_null", Repetition::OPTIONAL)}));
+    auto properties = WriterProperties::Builder()
+                          .compression(Compression::ZSTD)
+                          ->data_page_version(page_version)
+                          ->data_pagesize(1 << 20)
+                          ->max_rows_per_page(kMaxRowsPerPage)
+                          ->build();
+    auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+    auto row_group_writer = file_writer->AppendRowGroup();
+    auto column_writer =
+        static_cast<Int32Writer*>(row_group_writer->NextColumn());
+
+    column_writer->WriteBatchSpaced(
+        kNumRows,
+        definition_levels.data(),
+        nullptr,
+        valid_bits.data(),
+        0,
+        values.data());
+    ASSERT_NO_THROW(file_writer->Close());
+
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+    auto file_reader = ParquetFileReader::Open(
+        std::make_shared<::arrow::io::BufferReader>(buffer),
+        default_reader_properties());
+    auto metadata = file_reader->metadata();
+    ASSERT_EQ(1, metadata->num_row_groups());
+    ASSERT_EQ(kNumRows, metadata->RowGroup(0)->num_rows());
+    ASSERT_EQ(kNumRows, metadata->RowGroup(0)->ColumnChunk(0)->num_values());
+
+    auto page_reader = file_reader->RowGroup(0)->GetColumnPageReader(0);
+    std::vector<int64_t> page_value_counts;
+    while (auto page = page_reader->NextPage()) {
+      if (page->type() == PageType::DICTIONARY_PAGE) {
+        continue;
+      }
+      auto data_page = std::static_pointer_cast<DataPage>(page);
+      page_value_counts.push_back(data_page->num_values());
+      EXPECT_GT(data_page->num_values(), 0);
+      EXPECT_LE(data_page->num_values(), kMaxRowsPerPage);
+      if (page_version == ParquetDataPageVersion::V2) {
+        auto data_page_v2 = std::static_pointer_cast<DataPageV2>(page);
+        EXPECT_EQ(data_page_v2->num_values(), data_page_v2->num_rows());
+        EXPECT_EQ(data_page_v2->num_values(), data_page_v2->num_nulls());
+      }
+    }
+    EXPECT_EQ(page_value_counts, (std::vector<int64_t>{3, 3, 3, 1}));
+  }
+}
+
+TEST(
+    TestColumnWriter,
+    LowCardinalityDictionaryByteArrayRespectsMaxRowsPerPage) {
+  constexpr int64_t kNumRows = 10;
+  constexpr int64_t kMaxRowsPerPage = 3;
+  const std::string constant_value = "same-highly-compressible-value";
+  const std::vector<ByteArray> values(kNumRows, ByteArray(constant_value));
+
+  for (const auto page_version :
+       {ParquetDataPageVersion::V1, ParquetDataPageVersion::V2}) {
+    auto sink = CreateOutputStream();
+    auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+        "schema",
+        Repetition::REQUIRED,
+        {schema::ByteArray("low_cardinality", Repetition::REQUIRED)}));
+    auto properties = WriterProperties::Builder()
+                          .compression(Compression::ZSTD)
+                          ->data_page_version(page_version)
+                          ->data_pagesize(1 << 20)
+                          ->max_rows_per_page(kMaxRowsPerPage)
+                          ->build();
+    auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+    auto row_group_writer = file_writer->AppendRowGroup();
+    auto column_writer =
+        static_cast<ByteArrayWriter*>(row_group_writer->NextColumn());
+
+    column_writer->WriteBatch(kNumRows, nullptr, nullptr, values.data());
+    ASSERT_NO_THROW(file_writer->Close());
+
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+    auto file_reader = ParquetFileReader::Open(
+        std::make_shared<::arrow::io::BufferReader>(buffer),
+        default_reader_properties());
+    auto metadata = file_reader->metadata();
+    ASSERT_EQ(1, metadata->num_row_groups());
+    ASSERT_EQ(kNumRows, metadata->RowGroup(0)->num_rows());
+    ASSERT_EQ(kNumRows, metadata->RowGroup(0)->ColumnChunk(0)->num_values());
+
+    auto page_reader = file_reader->RowGroup(0)->GetColumnPageReader(0);
+    int64_t dictionary_page_count = 0;
+    std::vector<int64_t> page_value_counts;
+    while (auto page = page_reader->NextPage()) {
+      if (page->type() == PageType::DICTIONARY_PAGE) {
+        ++dictionary_page_count;
+        continue;
+      }
+      auto data_page = std::static_pointer_cast<DataPage>(page);
+      page_value_counts.push_back(data_page->num_values());
+      EXPECT_GT(data_page->num_values(), 0);
+      EXPECT_LE(data_page->num_values(), kMaxRowsPerPage);
+      if (page_version == ParquetDataPageVersion::V2) {
+        auto data_page_v2 = std::static_pointer_cast<DataPageV2>(page);
+        EXPECT_EQ(data_page_v2->num_values(), data_page_v2->num_rows());
+        EXPECT_EQ(0, data_page_v2->num_nulls());
+      }
+    }
+    EXPECT_EQ(1, dictionary_page_count);
+    EXPECT_EQ(page_value_counts, (std::vector<int64_t>{3, 3, 3, 1}));
+  }
 }
 
 TEST(PageBufferArenaTest, FixedCapacityAllocationAndReset) {

--- a/bolt/dwio/parquet/arrow/tests/PropertiesTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/PropertiesTest.cpp
@@ -56,6 +56,7 @@ TEST(TestWriterProperties, Basics) {
   std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
 
   ASSERT_EQ(kDefaultDataPageSize, props->data_pagesize());
+  ASSERT_EQ(kDefaultMaxRowsPerPage, props->max_rows_per_page());
   ASSERT_EQ(
       DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT, props->dictionary_pagesize_limit());
   ASSERT_EQ(ParquetVersion::PARQUET_2_6, props->version());
@@ -87,6 +88,16 @@ TEST(TestWriterProperties, AdvancedHandling) {
       Encoding::DELTA_LENGTH_BYTE_ARRAY,
       props->encoding(ColumnPath::FromDotString("delta-length")));
   ASSERT_EQ(ParquetDataPageVersion::V2, props->data_page_version());
+}
+
+TEST(TestWriterProperties, MaxRowsPerPage) {
+  auto props = WriterProperties::Builder().max_rows_per_page(123)->build();
+  ASSERT_EQ(123, props->max_rows_per_page());
+
+  EXPECT_THROW(
+      WriterProperties::Builder().max_rows_per_page(0), ParquetException);
+  EXPECT_THROW(
+      WriterProperties::Builder().max_rows_per_page(-1), ParquetException);
 }
 
 TEST(TestReaderProperties, GetStreamInsufficientData) {

--- a/bolt/dwio/parquet/arrow/tests/PropertiesTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/PropertiesTest.cpp
@@ -100,6 +100,16 @@ TEST(TestWriterProperties, MaxRowsPerPage) {
       WriterProperties::Builder().max_rows_per_page(-1), ParquetException);
 }
 
+TEST(TestWriterProperties, WriteBatchSizeMustBePositive) {
+  auto props = WriterProperties::Builder().write_batch_size(1)->build();
+  ASSERT_EQ(1, props->write_batch_size());
+
+  EXPECT_THROW(
+      WriterProperties::Builder().write_batch_size(0), ParquetException);
+  EXPECT_THROW(
+      WriterProperties::Builder().write_batch_size(-1), ParquetException);
+}
+
 TEST(TestReaderProperties, GetStreamInsufficientData) {
   // ARROW-6058
   std::string data = "shorter than expected";

--- a/bolt/dwio/parquet/arrow/tests/PropertiesTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/PropertiesTest.cpp
@@ -94,10 +94,17 @@ TEST(TestWriterProperties, MaxRowsPerPage) {
   auto props = WriterProperties::Builder().max_rows_per_page(123)->build();
   ASSERT_EQ(123, props->max_rows_per_page());
 
+  props =
+      WriterProperties::Builder().max_rows_per_page(kMaxRowsPerPage)->build();
+  ASSERT_EQ(kMaxRowsPerPage, props->max_rows_per_page());
+
   EXPECT_THROW(
       WriterProperties::Builder().max_rows_per_page(0), ParquetException);
   EXPECT_THROW(
       WriterProperties::Builder().max_rows_per_page(-1), ParquetException);
+  EXPECT_THROW(
+      WriterProperties::Builder().max_rows_per_page(kMaxRowsPerPage + 1),
+      ParquetException);
 }
 
 TEST(TestWriterProperties, WriteBatchSizeMustBePositive) {

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -564,6 +564,8 @@ TEST_F(ParquetWriterTest, allNulls) {
   auto sinkPtr = sink.get();
   vp::WriterOptions writerOptions;
   writerOptions.memoryPool = leafPool_.get();
+  writerOptions.enableDictionary = false;
+  writerOptions.maxRowsPerDataPage = 1'000;
 
   auto writer = std::make_unique<vp::Writer>(
       std::move(sink),
@@ -578,6 +580,15 @@ TEST_F(ParquetWriterTest, allNulls) {
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
   ASSERT_EQ(reader->numberOfRows(), kRows);
   ASSERT_EQ(*reader->rowType(), *schema);
+  int32_t dataPageCount = 0;
+  for (const auto& stats :
+       reader->fileMetaData().rowGroup(0).columnChunk(0).pageEncodingStats()) {
+    if (stats.page_type == thrift::PageType::DATA_PAGE ||
+        stats.page_type == thrift::PageType::DATA_PAGE_V2) {
+      dataPageCount += stats.count;
+    }
+  }
+  ASSERT_EQ(dataPageCount, 5);
 
   auto rowReader = createRowReaderWithSchema(std::move(reader), schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -180,6 +180,7 @@ std::shared_ptr<WriterProperties::Builder> getArrowParquetWriterOptionsBuilder(
   }
   properties = properties->encoding(options.encoding);
   properties = properties->data_pagesize(options.dataPageSize);
+  properties = properties->max_rows_per_page(options.maxRowsPerDataPage);
   for (const auto& [path, dataPageSize] : options.columnDataPageSizeMap) {
     properties = properties->data_pagesize(path, dataPageSize);
   }
@@ -232,6 +233,7 @@ std::string WriterOptionsToString(const WriterOptions& options) {
   oss << "]" << std::endl;
 
   oss << "  dataPageSize: " << options.dataPageSize << std::endl;
+  oss << "  maxRowsPerDataPage: " << options.maxRowsPerDataPage << std::endl;
   oss << "  columnDataPageSizeMap: {";
   for (const auto& [key, value] : options.columnDataPageSizeMap) {
     oss << key << ": " << value << ", ";

--- a/bolt/dwio/parquet/writer/Writer.h
+++ b/bolt/dwio/parquet/writer/Writer.h
@@ -155,6 +155,10 @@ struct WriterOptions {
   int64_t parquet_block_size = -1;
   std::vector<int32_t> expectedRowsInEachBlock;
   int64_t dataPageSize = 1'024 * 1'024;
+  // A page is flushed when either dataPageSize or this logical row limit is
+  // reached. The row limit protects highly compressible and all-null columns,
+  // whose encoded byte size may otherwise stay small for billions of values.
+  int64_t maxRowsPerDataPage = arrow::kDefaultMaxRowsPerPage;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
   // Growth ratio passed to ArrowDataBufferSink. The default value is a
   // heuristic borrowed from


### PR DESCRIPTION
### What problem does this PR solve?

Bolt's Parquet writer could generate a file that completed successfully during
write but failed later during read with an error like:

```text
Expected -1509661479 values in column chunk at offset 32065246
but got 0 values instead over 0 pages ending at file offset 32065223
```

The invalid negative value came from an overflowing DataPage count. The writer
previously used the estimated encoded byte size as the main DataPage flush
condition. For highly compressible data, especially dictionary-encoded
low-cardinality `BYTE_ARRAY` values and all-null columns, billions of logical
values could accumulate in one page while the encoded buffer remained below the
configured byte limit.

Issue Number: close #800 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR:

- adds `WriterProperties::max_rows_per_page` with an initial conservative
  default of `INT32_MAX / 2` (`1,073,741,823`) rows;
- exposes the limit as Bolt `WriterOptions::maxRowsPerDataPage` and passes it
  into the Arrow-derived Parquet writer properties;
- makes block-size-based buffered writes honor the row count carried by an
  existing custom `flushPolicyFactory`, without adding another
  `WriterOptions` field; this lets existing integrations enforce both row and
  compressed-byte RowGroup limits;
- changes all relevant column-writing paths to split work according to both
  the internal write-batch size and the remaining row capacity of the current
  DataPage;
- preserves record boundaries for repeated/nested columns where page-index or
  DataPageV2 semantics require record-aligned pages;
- flushes a DataPage when the encoded byte threshold, logical row threshold,
  or internal value-count safety threshold is reached;
- validates the configured row limit against the safe range and uses unsigned
  arithmetic when serializing RLE run lengths;
- validates DataPage V1/V2 counts before narrowing them to the Parquet
  page-header `int32` fields, providing a fail-fast safety net;
- adds property validation and regression coverage for:
  - default and custom row limits;
  - limits outside the supported range;
  - all-null optional columns with DataPage V1 and V2;
  - ZSTD-compressed, dictionary-encoded, low-cardinality `BYTE_ARRAY` columns;
  - repeated columns and record-boundary page splitting;
  - the high-level Bolt writer round trip.

The incoming Spark/Gluten RecordBatch split is intentionally not used as the
correctness boundary. Multiple input batches can be appended to the same open
DataPage, so the limit must be enforced inside `ColumnWriter`.

The initial default is deliberately set to a high value. The purpose of this PR
is to prevent an `int32` overflow without aggressively changing the DataPage
layout of existing workloads. 

This value is a correctness-oriented initial threshold, not a claim that it is
the optimal DataPage row count. Apache Arrow C++, Arrow Rust, and parquet-java
use a much smaller 20K row default to balance page-index pruning, cache behavior,
metadata size, and compression overhead. Selecting a lower Bolt default and
quantifying its write/read performance impact are intentionally left to a
follow-up change with representative benchmarks.

- https://github.com/apache/arrow/issues/47030
- https://github.com/apache/arrow/pull/47090
- https://github.com/apache/parquet-java/commit/910bcc4edc2d

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

No performance improvement is claimed by this correctness fix. The initial
`INT32_MAX / 2` threshold is intentionally high, so ordinary columns and even
very large but valid pages continue to be governed by the existing encoded-byte
threshold. Only pages approaching the Parquet `int32` representation boundary
are split by the new count limits.

The exact row threshold can affect page count, metadata size, compression
finalization overhead, peak memory, cache behavior, and page-index pruning.
Choosing a lower default therefore requires dedicated write/read benchmarks on
representative normal, all-null, low-cardinality dictionary, and nested data.
That tuning and performance evaluation will be handled separately rather than
mixed into this correctness fix.

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
Fix the Parquet writer so highly compressible columns cannot overflow DataPage
row/value count fields. DataPages now use a high `INT32_MAX / 2` default row
limit plus an internal value-count safety threshold, and page-header counts are
validated before serialization.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
