### PR TITLE
fix: handle float-to-integer overflow boundary

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -368,7 +368,7 @@ class Converter {
         constexpr TypeKind originKind = ToKind::storage;
         using LimitType = typename util::
             Converter<originKind, void, util::TruncateCastPolicy>::LimitType;
-        if (from > LimitType::maxLimit()) {
+        if (LimitType::isPositiveOverflow(from)) {
           to = LimitType::max();
           return ConvertStatus::INTEGER_OVERFLOW;
         }

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -655,6 +655,18 @@ TEST_F(SparkCastExprTest, overflow) {
   testCast<double, int8_t>("tinyint", {127.8}, {127});
   testCast<double, int8_t>("tinyint", {129.9}, {-127});
   testCast<double, int16_t>("smallint", {1234567.89}, {-10617});
+  testCast<float, int32_t>(
+      "integer",
+      {0x1.fffffep30f, 0x1p31f, -0x1p31f},
+      {2'147'483'520,
+       std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min()});
+  testCast<double, int64_t>(
+      "bigint",
+      {0x1.fffffffffffffp62, 0x1p63, -0x1p63},
+      {9'223'372'036'854'774'784LL,
+       std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min()});
   testCast<double, int64_t>(
       "bigint", {std::numeric_limits<double>::max()}, {9223372036854775807});
   testCast<double, int64_t>(

--- a/bolt/type/Conversions.h
+++ b/bolt/type/Conversions.h
@@ -323,6 +323,17 @@ struct Converter<
   struct LimitType {
     static constexpr bool kByteOrSmallInt =
         std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t>;
+    using FirstStageType = std::conditional_t<kByteOrSmallInt, int32_t, T>;
+
+    template <typename FP>
+    static bool isPositiveOverflow(const FP& value) {
+      // Integer max may round up to the first out-of-range value when it is
+      // converted to FP. The negative minimum is a power of two, so its
+      // negation gives an exact exclusive upper bound.
+      return value >=
+          -static_cast<FP>(std::numeric_limits<FirstStageType>::min());
+    }
+
     static int64_t minLimit() {
       if (kByteOrSmallInt) {
         return std::numeric_limits<int32_t>::min();
@@ -363,7 +374,7 @@ struct Converter<
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::max();
-      } else if (v > LimitType::maxLimit()) {
+      } else if (LimitType::isPositiveOverflow(v)) {
         return LimitType::max();
       }
       if constexpr (std::is_same_v<T, int128_t>) {
@@ -392,7 +403,7 @@ struct Converter<
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::max();
-      } else if (v > LimitType::maxLimit()) {
+      } else if (LimitType::isPositiveOverflow(v)) {
         return LimitType::max();
       }
       if constexpr (std::is_same_v<T, int128_t>) {

--- a/bolt/type/tests/ConversionsTest.cpp
+++ b/bolt/type/tests/ConversionsTest.cpp
@@ -369,6 +369,12 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
             12345,
         },
         /*truncate*/ true);
+    testConversion<double, int64_t>(
+        {0x1.fffffffffffffp62, 0x1p63, -0x1p63},
+        {9'223'372'036'854'774'784LL,
+         std::numeric_limits<int64_t>::max(),
+         std::numeric_limits<int64_t>::min()},
+        /*truncate*/ true);
     testConversion<double, int32_t>(
         {
             1.888,
@@ -385,6 +391,16 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
             -100,
         },
         /*truncate*/ true);
+    testConversion<double, int32_t>(
+        {0x1.fffffffffffffp30, 0x1p31, -0x1p31},
+        {std::numeric_limits<int32_t>::max(),
+         std::numeric_limits<int32_t>::max(),
+         std::numeric_limits<int32_t>::min()},
+        /*truncate*/ true);
+    testConversion<double, int16_t>(
+        {0x1.fffffffffffffp30, 0x1p31, -0x1p31},
+        {-1, -1, 0},
+        /*truncate*/ true);
     testConversion<double, int8_t>(
         {
             12345.67,
@@ -396,6 +412,10 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
             -57,
             127,
         },
+        /*truncate*/ true);
+    testConversion<double, int8_t>(
+        {0x1.fffffffffffffp30, 0x1p31, -0x1p31},
+        {-1, -1, 0},
         /*truncate*/ true);
     testConversion<double, int8_t>(
         {
@@ -440,9 +460,27 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
     // When TRUNCATE = true.
     testConversion<float, int64_t>(
         {kInf, kNan}, {9223372036854775807, 0}, /*truncate*/ true);
-    testConversion<float, int32_t>({kNan}, {0}, /*truncate*/ true);
-    testConversion<float, int16_t>({kNan}, {0}, /*truncate*/ true);
-    testConversion<float, int8_t>({kNan}, {0}, /*truncate*/ true);
+    testConversion<float, int64_t>(
+        {0x1.fffffep62f, 0x1p63f, -0x1p63f},
+        {9'223'371'487'098'961'920LL,
+         std::numeric_limits<int64_t>::max(),
+         std::numeric_limits<int64_t>::min()},
+        /*truncate*/ true);
+    testConversion<float, int32_t>(
+        {kNan, 0x1.fffffep30f, 0x1p31f, -0x1p31f},
+        {0,
+         2'147'483'520,
+         std::numeric_limits<int32_t>::max(),
+         std::numeric_limits<int32_t>::min()},
+        /*truncate*/ true);
+    testConversion<float, int16_t>(
+        {kNan, 0x1.fffffep30f, 0x1p31f, -0x1p31f},
+        {0, -128, -1, 0},
+        /*truncate*/ true);
+    testConversion<float, int8_t>(
+        {kNan, 0x1.fffffep30f, 0x1p31f, -0x1p31f},
+        {0, -128, -1, 0},
+        /*truncate*/ true);
   }
 
   // From string.


### PR DESCRIPTION
### What problem does this PR solve?

Spark-compatible floating-point-to-integer casts currently compare the input
against the target's maximum after converting that maximum to the floating-point
source type. `INT_MAX` rounds to `2^31` as a `float`, and `INT64_MAX` rounds to
`2^63` as a `double`. Equality therefore misses the first positive out-of-range
value and lets it enter an undefined C++ conversion, which can produce the
target's minimum value.

Issue Number: close #809

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Derive an exactly representable exclusive upper bound from the negative
  integer minimum and use `>=` against that boundary.
- Keep `int32_t` as the first-stage type for tinyint and smallint so Spark's
  Java-style two-stage narrowing behavior remains unchanged.
- Share the boundary helper between the general conversion utility and the
  Spark Cast expression path.
- Cover the last in-range floating-point value, the positive overflow boundary,
  and the negative minimum for float/double conversions to all integral widths.

Using `>= max()` would reject a valid `double(INT_MAX)`. In contrast, the
negated minimum is a power of two and is exactly representable in the relevant
floating-point type, so it identifies the first positive out-of-range value
without narrowing the valid range.

Current-main verification (2026-08-29):

- Reapplied the exact four-file `+67/-6` change to upstream `main` at
  `d5d50bb2a430fb52ccaaecb277fa076163eb3ff2`; it applies without conflicts.
- The targeted Release build completed all 675 compile/link steps for
  `bolt_type_test` and `bolt_functions_spark_test`. The macOS-only generated
  build shim used for current main is outside the repository and the source diff
  remains limited to the four PR files.
- `ConversionsTest.*`: 5 passed.
- `SparkCastExprTest.*`: 23 passed, including the new overflow boundaries.
- Full `bolt_type_test`: 213 passed, 1 skipped, 0 failed (214 total).
- Spark SQL test binary excluding two data-dependent performance tests:
  716 passed, 4 skipped, 0 failed (720 total).
- The two excluded tests fail before their test logic because this checkout does
  not contain `data/large_slow_parse.json`; no Cast or conversion test was
  excluded.
- Repository pre-commit checks, including clang-format, C++ lint, license
  headers, secret detection, and codespell, passed; `git diff --check` passed.
- Independent final review reported no Critical, Important, or Minor findings
  and marked the change ready.
- A standalone UBSan reproduction confirms that the previous `2^31f`
  conversion enters undefined behavior.

### Performance Impact

- [x] **No Impact**: The hot path still performs one comparison against a
  compile-time-derived boundary; no allocation, loop, or additional branch is
  introduced.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Fixed Spark-compatible float and double casts at positive integer overflow boundaries.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with a local Release build.
- [x] I have run clang-format / linters.
- [x] (Optional) I have run UBSan locally on the boundary reproduction.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
