### PR TITLE
fix: support parquet floating point columns as varchar

### DIFF
--- a/bolt/connectors/hive/SplitReader.cpp
+++ b/bolt/connectors/hive/SplitReader.cpp
@@ -41,6 +41,7 @@
 #include "bolt/dwio/common/ReaderFactory.h"
 #include "bolt/dwio/paimon/deletionvectors/DeletionFileReader.h"
 #include "bolt/type/Conversions.h"
+#include "bolt/type/filter/MapSubscriptFilter.h"
 
 namespace bytedance::bolt::connector::hive {
 
@@ -104,6 +105,91 @@ bool applyPartitionFilter(
     default:
       BOLT_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
       break;
+  }
+}
+
+void checkFloatingPointToVarcharFilterCompatibility(
+    const TypePtr& fileType,
+    const TypePtr& requestedType,
+    const common::Filter* filter,
+    const std::string& path) {
+  if ((fileType->isReal() || fileType->isDouble()) &&
+      requestedType->isVarchar()) {
+    if (filter && !filter->isValueIndependent()) {
+      BOLT_USER_FAIL(
+          "Cannot apply VARCHAR filter to physical {} Parquet column {}",
+          fileType->kindName(),
+          path);
+    }
+  }
+}
+
+void checkFloatingPointToVarcharFilter(
+    const TypePtr& fileType,
+    const TypePtr& requestedType,
+    const common::ScanSpec& scanSpec,
+    const std::string& path) {
+  auto* filter = scanSpec.filter();
+  checkFloatingPointToVarcharFilterCompatibility(
+      fileType, requestedType, filter, path);
+  if ((fileType->isReal() || fileType->isDouble()) &&
+      requestedType->isVarchar()) {
+    return;
+  }
+  if (fileType->kind() != requestedType->kind()) {
+    return;
+  }
+
+  if (fileType->isMap() && filter &&
+      filter->kind() == common::FilterKind::kMapSubscript) {
+    const auto* mapFilter =
+        dynamic_cast<const common::MapSubscriptFilter*>(filter);
+    BOLT_CHECK_NOT_NULL(mapFilter);
+    const auto keyPath = path.empty()
+        ? common::ScanSpec::kMapKeysFieldName
+        : path + "." + common::ScanSpec::kMapKeysFieldName;
+    checkFloatingPointToVarcharFilterCompatibility(
+        fileType->childAt(0),
+        requestedType->childAt(0),
+        mapFilter->keyFilter(),
+        keyPath);
+    const auto valuePath = path.empty()
+        ? common::ScanSpec::kMapValuesFieldName
+        : path + "." + common::ScanSpec::kMapValuesFieldName;
+    checkFloatingPointToVarcharFilterCompatibility(
+        fileType->childAt(1),
+        requestedType->childAt(1),
+        mapFilter->valueFilter(),
+        valuePath);
+  }
+
+  for (const auto& child : scanSpec.children()) {
+    std::optional<uint32_t> fileChildIndex;
+    std::optional<uint32_t> requestedChildIndex;
+    if (fileType->isRow()) {
+      fileChildIndex =
+          fileType->asRow().getChildIdxIfExists(child->fieldName());
+      requestedChildIndex =
+          requestedType->asRow().getChildIdxIfExists(child->fieldName());
+      if (!fileChildIndex || !requestedChildIndex) {
+        continue;
+      }
+    } else if (fileType->isArray()) {
+      fileChildIndex = requestedChildIndex = 0;
+    } else if (fileType->isMap()) {
+      fileChildIndex = requestedChildIndex =
+          child->fieldName() == common::ScanSpec::kMapKeysFieldName ? 0 : 1;
+    } else {
+      continue;
+    }
+
+    const auto childPath =
+        path.empty() ? child->fieldName() : path + "." + child->fieldName();
+    checkFloatingPointToVarcharFilter(
+        fileType->childAt(*fileChildIndex),
+        requestedType->childAt(*requestedChildIndex),
+        *child,
+        childPath);
   }
 }
 
@@ -295,6 +381,10 @@ void SplitReader::prepareSplit(
     throw std::runtime_error(
         FLAGS_testing_only_set_scan_exception_mesg_for_prepare);
   }
+
+  validateFloatingPointToVarcharFilters();
+  baseRowReaderOpts_.setDisableFloatingPointToVarcharMetadataFilter(
+      !isPartOfPaimonSplit_);
 
   // Note that this doesn't apply to Hudi tables.
   emptySplit_ = false;
@@ -562,9 +652,22 @@ void SplitReader::populatePaimonMetadataColumns(VectorPtr& output) {
 }
 
 void SplitReader::resetFilterCaches() {
+  validateFloatingPointToVarcharFilters();
   if (baseRowReader_) {
     baseRowReader_->resetFilterCaches();
   }
+}
+
+void SplitReader::validateFloatingPointToVarcharFilters() const {
+  if (isPartOfPaimonSplit_ || !baseReader_ ||
+      baseReaderOpts_.getFileFormat() != dwio::common::FileFormat::PARQUET) {
+    return;
+  }
+  const auto requestedType = hiveTableHandle_->dataColumns()
+      ? hiveTableHandle_->dataColumns()
+      : readerOutputType_;
+  checkFloatingPointToVarcharFilter(
+      baseReader_->rowType(), requestedType, *scanSpec_, "");
 }
 
 bool SplitReader::emptySplit() const {

--- a/bolt/connectors/hive/SplitReader.h
+++ b/bolt/connectors/hive/SplitReader.h
@@ -201,6 +201,8 @@ class SplitReader : public HiveSplitReaderBase {
       metadataColumns_{};
 
  private:
+  void validateFloatingPointToVarcharFilters() const;
+
   bool emptySplit_;
   bool isPartOfPaimonSplit_;
 };

--- a/bolt/dwio/common/Options.h
+++ b/bolt/dwio/common/Options.h
@@ -173,6 +173,7 @@ class RowReaderOptions {
   /// against query filters. This can significantly improve performance for
   /// selective queries. Defaults to true.
   bool enableDictionaryFilter_ = false;
+  bool disableFloatingPointToVarcharMetadataFilter_{false};
 
   int32_t decodeRepDefPageCount_{10};
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
@@ -475,6 +476,14 @@ class RowReaderOptions {
     return enableDictionaryFilter_;
   }
 
+  void setDisableFloatingPointToVarcharMetadataFilter(bool disable) {
+    disableFloatingPointToVarcharMetadataFilter_ = disable;
+  }
+
+  bool disableFloatingPointToVarcharMetadataFilter() const {
+    return disableFloatingPointToVarcharMetadataFilter_;
+  }
+
   void setDecodeRepDefPageCount(int32_t pageCount) {
     decodeRepDefPageCount_ = pageCount;
   }
@@ -556,7 +565,9 @@ class RowReaderOptions {
        << ", ";
     ss << "fileName_=" << fileName_ << ", ";
     ss << "fileId_=" << fileId_ << ", ";
-    ss << "enableDictionaryFilter_=" << enableDictionaryFilter_;
+    ss << "enableDictionaryFilter_=" << enableDictionaryFilter_ << ", ";
+    ss << "disableFloatingPointToVarcharMetadataFilter_="
+       << disableFloatingPointToVarcharMetadataFilter_ << ", ";
     ss << "decodeRepDefPageCount_=" << decodeRepDefPageCount_;
     ss << "parquetRepDefMemoryLimit_=" << parquetRepDefMemoryLimit_ << ", ";
     ss << "maxBatchBytes_=" << maxBatchBytes_ << ", ";

--- a/bolt/dwio/parquet/reader/DictionaryFilter.cpp
+++ b/bolt/dwio/parquet/reader/DictionaryFilter.cpp
@@ -76,15 +76,7 @@ DictionaryFilter::MatchResult DictionaryFilter::tryMatch() {
 }
 
 bool DictionaryFilter::isDictionaryFriendly() const {
-  switch (filter_->kind()) {
-    case bolt::common::FilterKind::kIsNull:
-    case bolt::common::FilterKind::kIsNotNull:
-    case bolt::common::FilterKind::kAlwaysFalse:
-    case bolt::common::FilterKind::kAlwaysTrue:
-      return false;
-    default:
-      return true;
-  }
+  return !filter_->isValueIndependent();
 }
 
 template <typename T, typename U>

--- a/bolt/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/bolt/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -47,7 +47,8 @@ class FloatingPointColumnReader
       const TypePtr& requestedType,
       std::shared_ptr<const dwio::common::TypeWithId> fileType,
       ParquetParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      TypePtr castSourceType = nullptr);
 
   // Parquet floating point reader always supports a bulk path
   static constexpr bool kHasBulkPath = true;
@@ -74,6 +75,18 @@ class FloatingPointColumnReader
 
   template <typename TVisitor>
   void readWithVisitor(const RowSet& rows, TVisitor visitor);
+
+  void getValues(const RowSet& rows, VectorPtr* result) override {
+    const bool needConversion =
+        this->castExprSet_ && this->castExprSet_->size() != 0;
+    auto& requestedType =
+        needConversion ? this->castSourceType_ : this->requestedType_;
+    this->template getFlatValues<TData, TRequested>(
+        rows, result, requestedType);
+    if (needConversion) {
+      this->doCastEvaluate(result);
+    }
+  }
 };
 
 template <typename TData, typename TRequested>
@@ -81,20 +94,29 @@ FloatingPointColumnReader<TData, TRequested>::FloatingPointColumnReader(
     const TypePtr& requestedType,
     std::shared_ptr<const dwio::common::TypeWithId> fileType,
     ParquetParams& params,
-    common::ScanSpec& scanSpec)
+    common::ScanSpec& scanSpec,
+    TypePtr castSourceType)
     : dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>(
           requestedType,
           std::move(fileType),
           params,
           scanSpec) {
+  const auto& decodedType = castSourceType ? castSourceType : requestedType;
   BOLT_DCHECK(
-      (this->requestedType_->kind() == TypeKind::REAL &&
+      (decodedType->kind() == TypeKind::REAL &&
        std::is_same_v<TRequested, float>) ||
-          (this->requestedType_->kind() == TypeKind::DOUBLE &&
+          (decodedType->kind() == TypeKind::DOUBLE &&
            std::is_same_v<TRequested, double>),
       "TRequested type mismatch: template parameter is {}, but requestedType is {}",
       folly::demangle(typeid(TRequested)),
       this->requestedType_->toString());
+  if (castSourceType) {
+    this->makeCastExpr(castSourceType);
+    if (params.disableFloatingPointToVarcharMetadataFilter()) {
+      this->formatData_->template as<ParquetData>()
+          .disableTypeDependentMetadataFilters();
+    }
+  }
 }
 
 template <typename TData, typename TRequested>

--- a/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -49,17 +49,19 @@
 namespace bytedance::bolt::parquet {
 
 /* type matching restriction, only allow following type convert
- * real -> real/double
- * double -> double
+ * real -> real/double/varchar
+ * double -> double/varchar
  * varchar/varbinary -> varchar/varbinary
  * timestamp -> timestamp
  */
 bool matchType(TypeKind schemaType, TypeKind requestType) {
   switch (schemaType) {
     case TypeKind::REAL:
-      return requestType == TypeKind::REAL || requestType == TypeKind::DOUBLE;
+      return requestType == TypeKind::REAL || requestType == TypeKind::DOUBLE ||
+          requestType == TypeKind::VARCHAR;
     case TypeKind::DOUBLE:
-      return requestType == TypeKind::DOUBLE;
+      return requestType == TypeKind::DOUBLE ||
+          requestType == TypeKind::VARCHAR;
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
       if (requestType == TypeKind::VARCHAR ||
@@ -110,7 +112,10 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
           requestedType, fileType, params, scanSpec);
 
     case TypeKind::REAL:
-      if (requestedType->type()->kind() == TypeKind::REAL) {
+      if (requestedType->type()->kind() == TypeKind::VARCHAR) {
+        return std::make_unique<FloatingPointColumnReader<float, float>>(
+            requestedType->type(), fileType, params, scanSpec, REAL());
+      } else if (requestedType->type()->kind() == TypeKind::REAL) {
         return std::make_unique<FloatingPointColumnReader<float, float>>(
             requestedType->type(), fileType, params, scanSpec);
       } else {
@@ -118,6 +123,10 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
             requestedType->type(), fileType, params, scanSpec);
       }
     case TypeKind::DOUBLE:
+      if (requestedType->type()->kind() == TypeKind::VARCHAR) {
+        return std::make_unique<FloatingPointColumnReader<double, double>>(
+            requestedType->type(), fileType, params, scanSpec, DOUBLE());
+      }
       return std::make_unique<FloatingPointColumnReader<double, double>>(
           requestedType->type(), fileType, params, scanSpec);
 

--- a/bolt/dwio/parquet/reader/ParquetData.cpp
+++ b/bolt/dwio/parquet/reader/ParquetData.cpp
@@ -47,6 +47,7 @@ std::unique_ptr<dwio::common::FormatData> ParquetParams::toFormatData(
       fileDecryptor_,
       scanSpec.getRuntimeStatistics(),
       schemaHelper_,
+      enableMetadataFilter_,
       enableDictionaryFilter_,
       decodeRepDefPageCount_,
       parquetRepDefMemoryLimit_);
@@ -64,10 +65,29 @@ void ParquetData::filterRowGroups(
     result.filterResult.resize(nwords);
   }
   auto metadataFiltersStartIndex = result.metadataFilterResults.size();
-  for (int i = 0; i < scanSpec.numMetadataFilters(); ++i) {
-    result.metadataFilterResults.emplace_back(
-        scanSpec.metadataFilterNodeAt(i), std::vector<uint64_t>(nwords));
+  const auto numScanSpecMetadataFilters =
+      enableMetadataFilter_ ? scanSpec.numMetadataFilters() : 0;
+  std::vector<int> metadataFilterIndices;
+  if (typeDependentMetadataFiltersEnabled_) {
+    for (int i = 0; i < numScanSpecMetadataFilters; ++i) {
+      result.metadataFilterResults.emplace_back(
+          scanSpec.metadataFilterNodeAt(i), std::vector<uint64_t>(nwords));
+    }
+  } else {
+    metadataFilterIndices.reserve(numScanSpecMetadataFilters);
+    for (int i = 0; i < numScanSpecMetadataFilters; ++i) {
+      auto* filter = scanSpec.metadataFilterAt(i);
+      if (!filter->isValueIndependent()) {
+        continue;
+      }
+      metadataFilterIndices.push_back(i);
+      result.metadataFilterResults.emplace_back(
+          scanSpec.metadataFilterNodeAt(i), std::vector<uint64_t>(nwords));
+    }
   }
+  const auto numMetadataFilters = typeDependentMetadataFiltersEnabled_
+      ? numScanSpecMetadataFilters
+      : metadataFilterIndices.size();
   auto isVarchar = type_->type()->isVarchar();
   auto lt = scanSpec.logicalTypeName();
   auto ct = scanSpec.convertedTypeName();
@@ -76,15 +96,17 @@ void ParquetData::filterRowGroups(
         << "Skipping row group filter for VARCHAR column without logical type";
     return;
   }
-  if (scanSpec.filter() || scanSpec.numMetadataFilters() > 0) {
+  if (scanSpec.filter() || numMetadataFilters > 0) {
     for (auto i = 0; i < rowGroups_.size(); ++i) {
       if (scanSpec.filter() && !rowGroupMatches(i, scanSpec.filter(), input)) {
         bits::setBit(result.filterResult.data(), i);
         continue;
       }
-      for (int j = 0; j < scanSpec.numMetadataFilters(); ++j) {
-        auto* metadataFilter = scanSpec.metadataFilterAt(j);
-        if (!rowGroupMatches(i, metadataFilter, input)) {
+      for (int j = 0; j < numMetadataFilters; ++j) {
+        const auto filterIndex =
+            typeDependentMetadataFiltersEnabled_ ? j : metadataFilterIndices[j];
+        if (!rowGroupMatches(
+                i, scanSpec.metadataFilterAt(filterIndex), input)) {
           bits::setBit(
               result.metadataFilterResults[metadataFiltersStartIndex + j]
                   .second.data(),

--- a/bolt/dwio/parquet/reader/ParquetData.h
+++ b/bolt/dwio/parquet/reader/ParquetData.h
@@ -59,6 +59,8 @@ class ParquetParams : public dwio::common::FormatParams {
       TimestampPrecision timestampPrecision,
       const std::shared_ptr<InternalFileDecryptor>& fileDecryptor,
       const SchemaHelper& schemaHelper,
+      bool enableMetadataFilter,
+      bool disableFloatingPointToVarcharMetadataFilter,
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
       int32_t parquetRepDefMemoryLimit)
@@ -67,6 +69,9 @@ class ParquetParams : public dwio::common::FormatParams {
         timestampPrecision_(timestampPrecision),
         fileDecryptor_(fileDecryptor),
         schemaHelper_(schemaHelper),
+        enableMetadataFilter_(enableMetadataFilter),
+        disableFloatingPointToVarcharMetadataFilter_(
+            disableFloatingPointToVarcharMetadataFilter),
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
         parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {}
@@ -83,11 +88,17 @@ class ParquetParams : public dwio::common::FormatParams {
     return enableDictionaryFilter_;
   }
 
+  bool disableFloatingPointToVarcharMetadataFilter() const {
+    return disableFloatingPointToVarcharMetadataFilter_;
+  }
+
  private:
   const thrift::FileMetaData& metaData_;
   const TimestampPrecision timestampPrecision_;
   const std::shared_ptr<InternalFileDecryptor>& fileDecryptor_;
   const SchemaHelper& schemaHelper_;
+  const bool enableMetadataFilter_;
+  const bool disableFloatingPointToVarcharMetadataFilter_;
   const bool enableDictionaryFilter_;
   const int32_t decodeRepDefPageCount_;
   const int32_t parquetRepDefMemoryLimit_;
@@ -103,6 +114,7 @@ class ParquetData : public dwio::common::FormatData {
       const std::shared_ptr<InternalFileDecryptor>& fileDecryptor,
       dwio::common::RuntimeStatistics* statis,
       const SchemaHelper& schemaHelper,
+      bool enableMetadataFilter,
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
       int32_t parquetRepDefMemoryLimit)
@@ -115,6 +127,7 @@ class ParquetData : public dwio::common::FormatData {
         fileDecryptor_(fileDecryptor),
         statis_(statis),
         schemaHelper_(schemaHelper),
+        enableMetadataFilter_(enableMetadataFilter),
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
         parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {
@@ -140,6 +153,10 @@ class ParquetData : public dwio::common::FormatData {
       const dwio::common::StatsContext& writerContext,
       FilterRowGroupsResult&,
       dwio::common::BufferedInput& input) override;
+
+  void disableTypeDependentMetadataFilters() {
+    typeDependentMetadataFiltersEnabled_ = false;
+  }
 
   PageReader* FOLLY_NONNULL reader() const {
     return reader_.get();
@@ -329,6 +346,8 @@ class ParquetData : public dwio::common::FormatData {
 
   dwio::common::RuntimeStatistics* statis_{nullptr};
   const SchemaHelper& schemaHelper_;
+  const bool enableMetadataFilter_;
+  bool typeDependentMetadataFiltersEnabled_{true};
   const bool enableDictionaryFilter_;
   const int32_t decodeRepDefPageCount_;
   const int32_t parquetRepDefMemoryLimit_;

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -125,6 +125,10 @@ bool acceptsDateFile(const bytedance::bolt::TypePtr& t) {
       t->kind() == bytedance::bolt::TypeKind::VARCHAR;
 }
 
+bool acceptsFloatingPointFileForReaderCast(const bytedance::bolt::TypePtr& t) {
+  return t->kind() == bytedance::bolt::TypeKind::VARCHAR;
+}
+
 // Compatibility predicate for Parquet INT32-physical source columns
 // (INT_8 / INT_16 / INT_32 annotated, plus unannotated INT32).
 // Accepts:
@@ -1274,12 +1278,15 @@ TypePtr ReaderBase::convertType(
         return TIMESTAMP(); // INT96 only maps to a timestamp
       case thrift::Type::type::FLOAT:
         checkRequested([](const TypePtr& t) {
-          return t->kind() == TypeKind::REAL || t->kind() == TypeKind::DOUBLE;
+          return t->kind() == TypeKind::REAL || t->kind() == TypeKind::DOUBLE ||
+              acceptsFloatingPointFileForReaderCast(t);
         });
         return REAL();
       case thrift::Type::type::DOUBLE:
-        checkRequested(
-            [](const TypePtr& t) { return t->kind() == TypeKind::DOUBLE; });
+        checkRequested([](const TypePtr& t) {
+          return t->kind() == TypeKind::DOUBLE ||
+              acceptsFloatingPointFileForReaderCast(t);
+        });
         return DOUBLE();
       case thrift::Type::type::BYTE_ARRAY:
       case thrift::Type::type::FIXED_LEN_BYTE_ARRAY:
@@ -1585,6 +1592,8 @@ class ParquetRowReader::Impl {
         options_.timestampPrecision(),
         readerBase->fileDecryptor(),
         schemaHelper_,
+        options_.getMetadataFilter() != nullptr,
+        options_.disableFloatingPointToVarcharMetadataFilter(),
         options_.isDictionaryFilterEnabled(),
         options_.getDecodeRepDefPageCount(),
         options_.getParquetRepDefMemoryLimit());

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -161,6 +161,18 @@ MapColumnReader::MapColumnReader(
   DWIO_ENSURE_EQ(fileType_->id(), fileType->id(), "working on the same node");
   auto& keyChildType = requestedType->childAt(0);
   auto& elementChildType = requestedType->childAt(1);
+  if (params.disableFloatingPointToVarcharMetadataFilter()) {
+    const auto hasMismatch = [&](int childIndex) {
+      const auto& fileChildType = fileType_->childAt(childIndex)->type();
+      const auto& requestedChildType =
+          requestedType->childAt(childIndex)->type();
+      return (fileChildType->isReal() || fileChildType->isDouble()) &&
+          requestedChildType->isVarchar();
+    };
+    if (hasMismatch(0) || hasMismatch(1)) {
+      formatData_->as<ParquetData>().disableTypeDependentMetadataFilters();
+    }
+  }
   keyReader_ = ParquetColumnReader::build(
       columnReaderOptions,
       keyChildType,

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -34,6 +34,7 @@
 #include <thrift/transport/TBufferTransports.h>
 #include <fstream>
 #include <iterator>
+#include <limits>
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/connectors/hive/HiveConfig.h"
@@ -41,11 +42,15 @@
 #include "bolt/dwio/parquet/RegisterParquetReader.h"
 #include "bolt/dwio/parquet/reader/ParquetReader.h"
 #include "bolt/dwio/parquet/thrift/codegen/parquet_types.h"
+#include "bolt/exec/PlanNodeStats.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/expression/ExprToSubfieldFilter.h"
 #include "bolt/functions/sparksql/VariantEncoding.h"
 #include "bolt/functions/sparksql/registration/Register.h"
+#include "bolt/type/filter/FilterUtil.h"
+#include "bolt/type/filter/MapSubscriptFilter.h"
 #include "bolt/type/tests/SubfieldFiltersBuilder.h"
 
 #include "bolt/connectors/hive/HiveConfig.h"
@@ -181,6 +186,49 @@ void rewriteDateConvertedTypeToLogicalTypeOnly(const std::string& path) {
   BOLT_CHECK(out.good(), "Failed to open Parquet file for write: {}", path);
   out.write(file.data(), file.size());
 }
+
+class MapSubscriptMetadataFilterParser final
+    : public exec::PrestoExprToSubfieldFilterParser {
+ public:
+  std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
+  leafCallToSubfieldFilter(
+      const core::CallTypedExpr& call,
+      core::ExpressionEvaluator* evaluator,
+      bool negated) override {
+    if (!negated && call.name() == "eq" && call.inputs().size() == 2) {
+      auto mapAccess = std::dynamic_pointer_cast<const core::CallTypedExpr>(
+          call.inputs()[0]);
+      if (mapAccess && mapAccess->name() == "element_at") {
+        std::shared_ptr<const common::Filter> valueFilter =
+            common::createBytesRange("1.25", true, "1.25", true, false);
+        std::shared_ptr<const common::Filter> keyFilter =
+            common::createBytesRange("key", true, "key", true, false);
+        return std::make_pair(
+            common::Subfield("c0"),
+            common::createMapSubscriptFilter(
+                "key", std::move(valueFilter), std::move(keyFilter)));
+      }
+    }
+    return PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
+        call, evaluator, negated);
+  }
+};
+
+class ScopedExprToSubfieldFilterParser {
+ public:
+  explicit ScopedExprToSubfieldFilterParser(
+      std::shared_ptr<exec::ExprToSubfieldFilterParser> parser)
+      : previous_(exec::ExprToSubfieldFilterParser::getInstance()) {
+    exec::ExprToSubfieldFilterParser::registerParser(std::move(parser));
+  }
+
+  ~ScopedExprToSubfieldFilterParser() {
+    exec::ExprToSubfieldFilterParser::registerParser(std::move(previous_));
+  }
+
+ private:
+  std::shared_ptr<exec::ExprToSubfieldFilterParser> previous_;
+};
 
 } // namespace
 
@@ -1591,6 +1639,10 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     {"date_to_bigint",                 DATE(),          BIGINT(),           true,
      "From Kind: INT32(DATE), To Kind: BIGINT"},
 
+    // ---- Accept: column-reader auto-cast floating point -> VARCHAR. ----
+    {"real_to_varchar",                REAL(),          VARCHAR(),          false},
+    {"double_to_varchar",              DOUBLE(),        VARCHAR(),          false},
+
     // ---- Reject: float narrowing ----
     {"double_to_real",                 DOUBLE(),        REAL(),             true},
 
@@ -1966,6 +2018,267 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
     auto expected =
         makeRowVector({"c0"}, {makeFlatVector<StringView>({"1", "2", "3"})});
     EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+}
+
+TEST_F(ParquetTableScanTest, floatingPointToVarcharValueFilters) {
+  // Floating point -> VARCHAR follows Spark's vectorized Parquet reader
+  // conversion. Value filters cannot run against the physical floating-point
+  // values; residual predicates run after conversion.
+  auto data = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<double>(
+          {1.25,
+           2.5,
+           0.00012,
+           std::numeric_limits<double>::quiet_NaN(),
+           std::nullopt})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {VARCHAR()});
+  auto plan =
+      PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+  auto result = AssertQueryBuilder(plan)
+                    .split(makeSplit(file->getPath()))
+                    .copyResults(pool());
+  auto expected = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<StringView>(
+          {"1.25", "2.5", "1.2E-4", "NaN", std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({expected}, {result}));
+
+  // A logical VARCHAR value filter cannot be evaluated against physical
+  // DOUBLE values.
+  auto pushdownOnlyPlan =
+      PlanBuilder(pool())
+          .tableScan(declared, {"c0 = '1.25'"}, "", declared)
+          .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(pushdownOnlyPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical DOUBLE Parquet column c0");
+
+  auto extractedFilterPlan =
+      PlanBuilder(pool())
+          .tableScan(declared, {}, "c0 = '1.25'", declared)
+          .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(extractedFilterPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical DOUBLE Parquet column c0");
+
+  auto isNullPlan = PlanBuilder(pool())
+                        .tableScan(declared, {"c0 IS NULL"}, "", declared)
+                        .planNode();
+  auto isNullResult = AssertQueryBuilder(isNullPlan)
+                          .split(makeSplit(file->getPath()))
+                          .copyResults(pool());
+  auto nullExpected = makeRowVector(
+      {"c0"}, {makeNullableFlatVector<StringView>({std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({nullExpected}, {isNullResult}));
+
+  // Merging mutually exclusive VARCHAR filters produces an AlwaysFalse
+  // filter, which is safe to evaluate against the physical DOUBLE values.
+  auto alwaysFalsePlan =
+      PlanBuilder(pool())
+          .tableScan(declared, {"c0 < '2'"}, "c0 >= '2'", declared)
+          .planNode();
+  auto alwaysFalseResult = AssertQueryBuilder(alwaysFalsePlan)
+                               .split(makeSplit(file->getPath()))
+                               .copyResults(pool());
+  EXPECT_EQ(alwaysFalseResult->size(), 0);
+}
+
+TEST_F(ParquetTableScanTest, floatingPointToVarcharFilterOnlyColumn) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<double>({1.25, 2.5}), makeFlatVector<int64_t>({10, 20})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto outputType = ROW({"c1"}, {BIGINT()});
+  auto dataColumns = ROW({"c0", "c1"}, {VARCHAR(), BIGINT()});
+  auto plan = PlanBuilder(pool())
+                  .tableScan(outputType, {"c0 = '1.25'"}, "", dataColumns)
+                  .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical DOUBLE Parquet column c0");
+}
+
+TEST_F(ParquetTableScanTest, floatingPointToVarcharMapValueFilter) {
+  auto data = makeRowVector(
+      {"c0"},
+      {makeMapVector<StringView, double>({{{"key", 1.25}}, {{"key", 2.5}}})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {MAP(VARCHAR(), VARCHAR())});
+  auto filters =
+      common::test::SubfieldFiltersBuilder()
+          .add(
+              "c0",
+              common::createMapSubscriptFilter(
+                  "key",
+                  common::createBytesRange("1.25", true, "1.25", true, false),
+                  common::createBytesRange("key", true, "key", true, false)))
+          .build();
+  auto tableHandle =
+      makeTableHandle(std::move(filters), nullptr, "hive_table", declared);
+  auto plan = PlanBuilder(pool())
+                  .tableScan(declared, tableHandle, allRegularColumns(declared))
+                  .planNode();
+
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical DOUBLE Parquet column c0.values");
+}
+
+TEST_F(ParquetTableScanTest, floatingPointToVarcharMapMetadataFilter) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {makeMapVector<StringView, double>(
+           {{{"key", 1.25}}, {{"key", 2.5}}, {{"key", 1.25}}, {{"key", 2.5}}}),
+       makeFlatVector<int64_t>({0, 0, 100, 100})});
+  auto file = exec::test::TempFilePath::create();
+  WriterOptions writerOptions;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<DefaultFlushPolicy>(
+        2, std::numeric_limits<int64_t>::max());
+  };
+  writeToParquetFile(file->getPath(), {data}, writerOptions);
+
+  ScopedExprToSubfieldFilterParser parser(
+      std::make_shared<MapSubscriptMetadataFilterParser>());
+  auto declared = ROW({"c0", "c1"}, {MAP(VARCHAR(), VARCHAR()), BIGINT()});
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder(pool())
+                  .tableScan(
+                      "hive_table",
+                      declared,
+                      {},
+                      {},
+                      "element_at(c0, 'key') = '1.25' AND c1 >= 100",
+                      declared,
+                      false)
+                  .capturePlanNodeId(scanNodeId)
+                  .planNode();
+  std::shared_ptr<exec::Task> task;
+  auto result =
+      AssertQueryBuilder(plan)
+          .config(core::QueryConfig::kMapSubscriptFilterPushdown, "true")
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool(), task);
+  auto expected = makeRowVector(
+      {"c0", "c1"},
+      {makeMapVector<StringView, StringView>({{{"key", "1.25"}}}),
+       makeFlatVector<int64_t>({100})});
+  EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  EXPECT_EQ(
+      exec::toPlanStats(task->taskStats())
+          .at(scanNodeId)
+          .customStats.at("skippedStrides")
+          .sum,
+      1);
+}
+
+TEST_F(ParquetTableScanTest, floatingPointToVarcharMetadataFilter) {
+  // Without filter extraction, the predicate remains a residual expression.
+  // The physical DOUBLE statistics are present, but its metadata filter must
+  // be ignored and the predicate evaluated after conversion.
+  {
+    auto data = makeRowVector({"c0"}, {makeFlatVector<double>({1.25, 2.5})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {VARCHAR()});
+    auto plan =
+        PlanBuilder(pool())
+            .tableScan(
+                "hive_table", declared, {}, {}, "c0 = '1.25'", declared, false)
+            .planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<StringView>({"1.25"})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  {
+    auto data =
+        makeRowVector({"c0"}, {makeFlatVector<float>({1.25F, 0.00012F})});
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto declared = ROW({"c0"}, {VARCHAR()});
+    auto plan = PlanBuilder(pool())
+                    .tableScan(
+                        "hive_table",
+                        declared,
+                        {},
+                        {},
+                        "c0 = '1.2E-4'",
+                        declared,
+                        false)
+                    .planNode();
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool());
+    auto expected =
+        makeRowVector({"c0"}, {makeFlatVector<StringView>({"1.2E-4"})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  }
+
+  // A type mismatch on one metadata-filter leaf must not disable row-group
+  // pruning for compatible leaves in the same AND expression.
+  {
+    auto data = makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<double>({1.25, 2.5, 1.25, 2.5}),
+         makeFlatVector<int64_t>({0, 0, 100, 100})});
+    auto file = exec::test::TempFilePath::create();
+    WriterOptions writerOptions;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<DefaultFlushPolicy>(
+          2, std::numeric_limits<int64_t>::max());
+    };
+    writeToParquetFile(file->getPath(), {data}, writerOptions);
+
+    auto declared = ROW({"c0", "c1"}, {VARCHAR(), BIGINT()});
+    core::PlanNodeId scanNodeId;
+    auto plan = PlanBuilder(pool())
+                    .tableScan(
+                        "hive_table",
+                        declared,
+                        {},
+                        {},
+                        "c0 = '1.25' AND c1 >= 100",
+                        declared,
+                        false)
+                    .capturePlanNodeId(scanNodeId)
+                    .planNode();
+    std::shared_ptr<exec::Task> task;
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool(), task);
+    auto expected = makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<StringView>({"1.25"}), makeFlatVector<int64_t>({100})});
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+    EXPECT_EQ(
+        exec::toPlanStats(task->taskStats())
+            .at(scanNodeId)
+            .customStats.at("skippedStrides")
+            .sum,
+        1);
   }
 }
 

--- a/bolt/type/filter/FilterBase.h
+++ b/bolt/type/filter/FilterBase.h
@@ -142,6 +142,18 @@ class Filter : public bolt::ISerializable {
     return kind_;
   }
 
+  bool isValueIndependent() const {
+    switch (kind_) {
+      case FilterKind::kIsNull:
+      case FilterKind::kIsNotNull:
+      case FilterKind::kAlwaysTrue:
+      case FilterKind::kAlwaysFalse:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   bool nullAllowed() const {
     return nullAllowed_;
   }


### PR DESCRIPTION
Allow REAL and DOUBLE Parquet columns to be read as VARCHAR. For ordinary Hive Parquet splits, reject incompatible VARCHAR value filters before they reach floating-point readers. When only metadata pruning is involved, disable the metadata filter and evaluate the residual predicate after conversion. Keep IS NULL and IS NOT NULL pushdown unchanged, and exclude Paimon splits from this handling.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #796 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

 - Support reading Parquet FLOAT and DOUBLE columns as VARCHAR.
 - Reject incompatible VARCHAR value filters before they reach floating-point readers.
 - Skip incompatible metadata-filter leaves while preserving null checks and compatible row-group pruning.
 - Cover scalar, filter-only, nested map, and metadata-filter scenarios.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: support parquet floating point columns as varchar
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
