### PR TITLE
feat(sparksql): support bitmap_bit_position

### DIFF
--- a/bolt/functions/sparksql/Bitmap.h
+++ b/bolt/functions/sparksql/Bitmap.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <folly/Portability.h>
+
+namespace bytedance::bolt::functions::sparksql {
+
+inline constexpr int64_t kBitmapNumBits = 32768;
+
+template <typename T>
+struct BitmapBitPositionFunction {
+  FOLLY_ALWAYS_INLINE void call(int64_t& result, int64_t value) {
+    if (value > 0) {
+      result = (value - 1) % kBitmapNumBits;
+      return;
+    }
+
+    // Calculate the magnitude as unsigned to avoid signed overflow for
+    // INT64_MIN while preserving Java's two's-complement behavior.
+    const auto magnitude = uint64_t{0} - static_cast<uint64_t>(value);
+    result = static_cast<int64_t>(magnitude % kBitmapNumBits);
+  }
+};
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/registration/CMakeLists.txt
+++ b/bolt/functions/sparksql/registration/CMakeLists.txt
@@ -31,6 +31,7 @@ bolt_add_library(
   bolt_functions_spark
   Register.cpp
   RegisterArray.cpp
+  RegisterBitmap.cpp
   RegisterBinary.cpp
   RegisterBitwise.cpp
   RegisterCharVarchar.cpp

--- a/bolt/functions/sparksql/registration/Register.cpp
+++ b/bolt/functions/sparksql/registration/Register.cpp
@@ -35,6 +35,7 @@
 namespace bytedance::bolt::functions::sparksql {
 
 extern void registerArrayFunctions(const std::string& prefix);
+extern void registerBitmapFunctions(const std::string& prefix);
 extern void registerBinaryFunctions(const std::string& prefix);
 extern void registerBitwiseFunctions(const std::string& prefix);
 extern void registerCharVarcharFunctions(const std::string& prefix);
@@ -53,6 +54,7 @@ extern void registerVariantFunctions(const std::string& prefix);
 void registerFunctions(const std::string& prefix) {
   registerTimestampWithTimeZoneType();
   registerArrayFunctions(prefix);
+  registerBitmapFunctions(prefix);
   registerBinaryFunctions(prefix);
   registerBitwiseFunctions(prefix);
   registerCharVarcharFunctions(prefix);

--- a/bolt/functions/sparksql/registration/RegisterBitmap.cpp
+++ b/bolt/functions/sparksql/registration/RegisterBitmap.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/lib/RegistrationHelpers.h"
+#include "bolt/functions/sparksql/Bitmap.h"
+
+namespace bytedance::bolt::functions::sparksql {
+
+void registerBitmapFunctions(const std::string& prefix) {
+  registerFunction<BitmapBitPositionFunction, int64_t, int64_t>(
+      {prefix + "bitmap_bit_position"});
+}
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/tests/BitmapTest.cpp
+++ b/bolt/functions/sparksql/tests/BitmapTest.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include <optional>
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class BitmapTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<int64_t> bitPosition(std::optional<int64_t> value) {
+    return evaluateOnce<int64_t>("bitmap_bit_position(c0)", value);
+  }
+
+  std::optional<int64_t> bitPositionFromInt(std::optional<int32_t> value) {
+    return evaluateOnce<int64_t>(
+        "bitmap_bit_position(cast(c0 as bigint))", value);
+  }
+};
+
+TEST_F(BitmapTest, bitPositionPositive) {
+  EXPECT_EQ(bitPosition(1), 0);
+  EXPECT_EQ(bitPosition(2), 1);
+  EXPECT_EQ(bitPosition(32768), 32767);
+  EXPECT_EQ(bitPosition(32769), 0);
+  EXPECT_EQ(bitPosition(65536), 32767);
+  EXPECT_EQ(bitPosition(65537), 0);
+  EXPECT_EQ(bitPosition(std::numeric_limits<int64_t>::max()), 32766);
+}
+
+TEST_F(BitmapTest, bitPositionNonPositive) {
+  EXPECT_EQ(bitPosition(0), 0);
+  EXPECT_EQ(bitPosition(-1), 1);
+  EXPECT_EQ(bitPosition(-32767), 32767);
+  EXPECT_EQ(bitPosition(-32768), 0);
+  EXPECT_EQ(bitPosition(-32769), 1);
+  EXPECT_EQ(bitPosition(std::numeric_limits<int64_t>::min()), 0);
+  EXPECT_EQ(bitPosition(std::numeric_limits<int64_t>::min() + 1), 32767);
+}
+
+TEST_F(BitmapTest, bitPositionNullAndCast) {
+  EXPECT_EQ(bitPosition(std::nullopt), std::nullopt);
+  EXPECT_EQ(bitPositionFromInt(32769), 0);
+  EXPECT_EQ(bitPositionFromInt(std::nullopt), std::nullopt);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/BitmapTest.cpp
+++ b/bolt/functions/sparksql/tests/BitmapTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstdint>
 #include <limits>
 #include <optional>
 

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   ArraysZipTest.cpp
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
+  BitmapTest.cpp
   BitwiseTest.cpp
   CharVarcharTest.cpp
   ComparisonsTest.cpp


### PR DESCRIPTION
### What problem does this PR solve?

Bolt does not currently register Spark 3.5's `bitmap_bit_position`, so queries using the bitmap aggregation pipeline cannot execute this scalar step natively.

Issue Number: close #758

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature which changes existing behavior)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- add a Spark-compatible `bitmap_bit_position(BIGINT) -> BIGINT` scalar function
- register it through the Spark SQL function registry
- preserve NULL propagation and BIGINT cast behavior
- handle `INT64_MIN` through unsigned magnitude arithmetic, avoiding signed-overflow undefined behavior while matching Java/Spark results
- cover positive, zero, negative, bucket-boundary, integer-limit, NULL, and cast inputs

### Performance Impact

- [x] **No Impact**: this only adds a new scalar function and does not alter existing execution paths.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below.

### Release Note

```text
Release Note:
- Added Spark SQL `bitmap_bit_position` support.
```

### Validation

- `clang-format 14.0.6 --dry-run --Werror` on all changed C++ files
- `git diff --check`
- standalone Clang 17 build with ASan and UBSan exercising the same Spark boundary cases, including `INT64_MIN` and `INT64_MAX`
- the native Bolt test target is included for CI; a full local build was not completed because a clean macOS/ARM64 setup requires building the full LLVM/Arrow/Folly dependency graph from source

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes