### PR TITLE
fix: correct shuffle compression buffer capacity

### DIFF
--- a/bolt/shuffle/sparksql/Payload.cpp
+++ b/bolt/shuffle/sparksql/Payload.cpp
@@ -54,6 +54,7 @@ static const Payload::Mode kRowVectorMode = BlockPayload::kRowVector;
 static constexpr int64_t kZeroLengthBuffer = 0;
 static constexpr int64_t kNullBuffer = -1;
 static constexpr int64_t kUncompressedBuffer = -2;
+static constexpr int64_t kCompressedBufferHeaderLength = 2 * sizeof(int64_t);
 
 using RowSizeType = int32_t;
 static constexpr int32_t kRowSizeBytes = sizeof(RowSizeType);
@@ -133,7 +134,7 @@ arrow::Result<std::tuple<uint32_t, uint8_t>> readRowsAndMode(
 arrow::Result<int64_t> compressBuffer(
     const std::shared_ptr<arrow::Buffer>& buffer,
     uint8_t* output,
-    int64_t outputLength,
+    int64_t outputRemainingLength,
     Codec* codec) {
   auto outputPtr = &output;
   if (!buffer) {
@@ -144,11 +145,13 @@ arrow::Result<int64_t> compressBuffer(
     write<int64_t>(outputPtr, kZeroLengthBuffer);
     return sizeof(int64_t);
   }
-  static const int64_t kCompressedBufferHeaderLength = 2 * sizeof(int64_t);
   auto* compressedLengthPtr = advance<int64_t>(outputPtr);
   write(outputPtr, static_cast<int64_t>(buffer->size()));
-  auto compressedLength =
-      codec->compress(buffer->data(), buffer->size(), *outputPtr, outputLength);
+  auto compressedLength = codec->compress(
+      buffer->data(),
+      buffer->size(),
+      *outputPtr,
+      outputRemainingLength - kCompressedBufferHeaderLength);
   if (compressedLength >= buffer->size()) {
     // Write uncompressed buffer.
     memcpy(*outputPtr, buffer->data(), buffer->size());
@@ -184,11 +187,15 @@ arrow::Status compressAndFlush(
     ARROW_ASSIGN_OR_RAISE(
         compressed,
         arrow::AllocateResizableBuffer(
-            sizeof(int64_t) * 2 + maxCompressedLength, pool));
+            kCompressedBufferHeaderLength + maxCompressedLength, pool));
     auto output = compressed->mutable_data();
     ARROW_ASSIGN_OR_RAISE(
         compressedSize,
-        compressBuffer(buffer, output, maxCompressedLength, codec));
+        compressBuffer(
+            buffer,
+            output,
+            kCompressedBufferHeaderLength + maxCompressedLength,
+            codec));
   }
 
   {

--- a/bolt/shuffle/sparksql/tests/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/tests/CMakeLists.txt
@@ -180,6 +180,21 @@ add_test(
     COMMAND bolt_shuffle_reader_test
 )
 
+add_executable(bolt_shuffle_payload_test PayloadTest.cpp)
+
+target_link_libraries(
+    bolt_shuffle_payload_test
+    PRIVATE
+        bolt_shuffle_spark_impl
+        bolt_testutils
+        GTest::gtest
+)
+
+add_test(
+    NAME bolt_shuffle_payload_test
+    COMMAND bolt_shuffle_payload_test
+)
+
 add_executable(
     bolt_shuffle_local_partition_writer_test
     LocalPartitionWriterTest.cpp

--- a/bolt/shuffle/sparksql/tests/PayloadTest.cpp
+++ b/bolt/shuffle/sparksql/tests/PayloadTest.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <arrow/buffer.h>
+#include <arrow/memory_pool.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "bolt/common/memory/Memory.h"
+#include "bolt/shuffle/sparksql/Payload.h"
+
+namespace bytedance::bolt::shuffle::sparksql::test {
+namespace {
+
+class CheckingMemoryPool final : public arrow::MemoryPool {
+ public:
+  static constexpr int64_t kPaddingSize = 64;
+
+  explicit CheckingMemoryPool(
+      std::shared_ptr<bytedance::bolt::memory::MemoryPool> pool)
+      : pool_(std::move(pool)) {}
+
+  using arrow::MemoryPool::Allocate;
+  using arrow::MemoryPool::Free;
+  using arrow::MemoryPool::Reallocate;
+
+  arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out)
+      override {
+    if (size < 0 || size > std::numeric_limits<int64_t>::max() - kPaddingSize) {
+      return arrow::Status::Invalid("Invalid allocation size: ", size);
+    }
+
+    *out =
+        static_cast<uint8_t*>(pool_->allocate(size + kPaddingSize, alignment));
+    initializePadding(*out, size);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!allocations_.emplace(*out, Allocation{size, alignment}).second) {
+      pool_->free(*out, size + kPaddingSize, alignment);
+      *out = nullptr;
+      return arrow::Status::Invalid("Duplicate allocation address");
+    }
+    bytesAllocated_ += size;
+    maxMemory_ = std::max(maxMemory_, bytesAllocated_);
+    totalBytesAllocated_ += size;
+    ++numAllocations_;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Reallocate(
+      int64_t oldSize,
+      int64_t newSize,
+      int64_t alignment,
+      uint8_t** ptr) override {
+    if (ptr == nullptr || *ptr == nullptr) {
+      return arrow::Status::Invalid("Cannot reallocate a null allocation");
+    }
+    if (newSize < 0 ||
+        newSize > std::numeric_limits<int64_t>::max() - kPaddingSize) {
+      return arrow::Status::Invalid("Invalid reallocation size: ", newSize);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto allocation = allocations_.find(*ptr);
+    if (allocation == allocations_.end()) {
+      return arrow::Status::Invalid("Cannot reallocate an unknown allocation");
+    }
+    if (oldSize != allocation->second.size) {
+      return arrow::Status::Invalid(
+          "Reallocation size mismatch: expected ",
+          allocation->second.size,
+          ", got ",
+          oldSize);
+    }
+    if (alignment != allocation->second.alignment) {
+      return arrow::Status::Invalid(
+          "Reallocation alignment mismatch: expected ",
+          allocation->second.alignment,
+          ", got ",
+          alignment);
+    }
+
+    checkPaddingLocked(*ptr, allocation->second);
+    auto* oldPtr = *ptr;
+    *ptr = static_cast<uint8_t*>(pool_->reallocate(
+        *ptr, oldSize + kPaddingSize, newSize + kPaddingSize, alignment));
+
+    allocations_.erase(oldPtr);
+    initializePadding(*ptr, newSize);
+    allocations_.emplace(*ptr, Allocation{newSize, alignment});
+    bytesAllocated_ += newSize - oldSize;
+    maxMemory_ = std::max(maxMemory_, bytesAllocated_);
+    if (newSize > oldSize) {
+      totalBytesAllocated_ += newSize - oldSize;
+    }
+    ++numAllocations_;
+    return arrow::Status::OK();
+  }
+
+  void Free(uint8_t* buffer, int64_t size, int64_t alignment) override {
+    if (buffer == nullptr) {
+      return;
+    }
+
+    Allocation allocation;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto it = allocations_.find(buffer);
+      if (it == allocations_.end()) {
+        recordErrorLocked("Cannot free an unknown allocation");
+        return;
+      }
+
+      allocation = it->second;
+      checkPaddingLocked(buffer, allocation);
+      if (size != allocation.size) {
+        recordErrorLocked(
+            "Free size mismatch: expected " + std::to_string(allocation.size) +
+            ", got " + std::to_string(size));
+      }
+      if (alignment != allocation.alignment) {
+        recordErrorLocked(
+            "Free alignment mismatch: expected " +
+            std::to_string(allocation.alignment) + ", got " +
+            std::to_string(alignment));
+      }
+      allocations_.erase(it);
+      bytesAllocated_ -= allocation.size;
+    }
+
+    pool_->free(buffer, allocation.size + kPaddingSize, allocation.alignment);
+  }
+
+  void ReleaseUnused() override {
+    pool_->release();
+  }
+
+  int64_t bytes_allocated() const override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return bytesAllocated_;
+  }
+
+  int64_t max_memory() const override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return maxMemory_;
+  }
+
+  int64_t total_bytes_allocated() const override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return totalBytesAllocated_;
+  }
+
+  int64_t num_allocations() const override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return numAllocations_;
+  }
+
+  std::string backend_name() const override {
+    return "bolt-checking-memory-pool";
+  }
+
+  arrow::Status check() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& [buffer, allocation] : allocations_) {
+      checkPaddingLocked(buffer, allocation);
+    }
+    if (!firstError_.empty()) {
+      return arrow::Status::Invalid(firstError_);
+    }
+    return arrow::Status::OK();
+  }
+
+  int64_t numActiveAllocations() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return allocations_.size();
+  }
+
+ private:
+  struct Allocation {
+    int64_t size;
+    int64_t alignment;
+  };
+
+  static uint8_t paddingByte(int64_t offset) {
+    return static_cast<uint8_t>(0xA5U ^ (offset * 0x9DU));
+  }
+
+  static void initializePadding(uint8_t* buffer, int64_t size) {
+    for (int64_t i = 0; i < kPaddingSize; ++i) {
+      buffer[size + i] = paddingByte(i);
+    }
+  }
+
+  void checkPaddingLocked(const uint8_t* buffer, const Allocation& allocation)
+      const {
+    for (int64_t i = 0; i < kPaddingSize; ++i) {
+      if (buffer[allocation.size + i] != paddingByte(i)) {
+        recordErrorLocked(
+            "Allocation padding was modified at offset " +
+            std::to_string(allocation.size + i));
+        return;
+      }
+    }
+  }
+
+  void recordErrorLocked(std::string error) const {
+    if (firstError_.empty()) {
+      firstError_ = std::move(error);
+    }
+  }
+
+  std::shared_ptr<bytedance::bolt::memory::MemoryPool> pool_;
+  mutable std::mutex mutex_;
+  std::unordered_map<uint8_t*, Allocation> allocations_;
+  mutable std::string firstError_;
+  int64_t bytesAllocated_{0};
+  int64_t maxMemory_{0};
+  int64_t totalBytesAllocated_{0};
+  int64_t numAllocations_{0};
+};
+
+class PayloadTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = bytedance::bolt::memory::memoryManager()->addLeafPool();
+  }
+
+  std::shared_ptr<bytedance::bolt::memory::MemoryPool> pool_;
+};
+
+TEST_F(PayloadTest, CheckingMemoryPoolTracksEveryAllocation) {
+  CheckingMemoryPool checkingPool(pool_);
+  auto first = arrow::AllocateResizableBuffer(37, &checkingPool).ValueOrDie();
+  auto second = arrow::AllocateResizableBuffer(129, &checkingPool).ValueOrDie();
+
+  EXPECT_EQ(checkingPool.numActiveAllocations(), 2);
+  EXPECT_EQ(
+      checkingPool.bytes_allocated(), first->capacity() + second->capacity());
+  EXPECT_TRUE(checkingPool.check().ok());
+
+  ASSERT_TRUE(first->Resize(257).ok());
+  EXPECT_EQ(checkingPool.numActiveAllocations(), 2);
+  EXPECT_EQ(
+      checkingPool.bytes_allocated(), first->capacity() + second->capacity());
+  EXPECT_TRUE(checkingPool.check().ok());
+
+  second.reset();
+  first.reset();
+  EXPECT_EQ(checkingPool.numActiveAllocations(), 0);
+  EXPECT_EQ(checkingPool.bytes_allocated(), 0);
+  EXPECT_EQ(pool_->usedBytes(), 0);
+  EXPECT_TRUE(checkingPool.check().ok());
+}
+
+TEST_F(PayloadTest, CheckingMemoryPoolPreservesCorruptionDetectedOnFree) {
+  CheckingMemoryPool checkingPool(pool_);
+  uint8_t* buffer = nullptr;
+  constexpr int64_t kSize = 32;
+  ASSERT_TRUE(checkingPool.Allocate(kSize, &buffer).ok());
+
+  buffer[kSize + CheckingMemoryPool::kPaddingSize - 1] ^= 1;
+  checkingPool.Free(buffer, kSize);
+
+  auto status = checkingPool.check();
+  EXPECT_FALSE(status.ok());
+  EXPECT_NE(
+      status.ToString().find("Allocation padding was modified"),
+      std::string::npos);
+  EXPECT_EQ(pool_->usedBytes(), 0);
+}
+
+TEST_F(PayloadTest, CompressedBufferCapacityExcludesHeader) {
+  CodecOptions codecOptions{};
+  codecOptions.backend = CodecBackend::NONE;
+  auto codec = Codec::create(CodecType::ZSTD, codecOptions);
+  std::vector<uint8_t> input(290);
+  uint32_t state = 1266;
+  for (auto& byte : input) {
+    state = state * 1664525U + 1013904223U;
+    byte = static_cast<uint8_t>(state >> 24);
+  }
+  CheckingMemoryPool outputPool(pool_);
+  std::vector<bool> isValidityBuffer{false};
+  std::vector<std::shared_ptr<arrow::Buffer>> buffers{
+      arrow::Buffer::FromVector(std::move(input))};
+
+  auto payload = BlockPayload::fromBuffers(
+                     Payload::Type::kCompressed,
+                     /*numRows=*/1,
+                     std::move(buffers),
+                     &isValidityBuffer,
+                     &outputPool,
+                     codec.get(),
+                     Payload::Mode::kBuffer,
+                     /*hasComplexType=*/false)
+                     .ValueOrDie();
+  ASSERT_NE(payload, nullptr);
+  auto status = outputPool.check();
+  EXPECT_TRUE(status.ok()) << status.ToString();
+}
+
+} // namespace
+} // namespace bytedance::bolt::shuffle::sparksql::test
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  bytedance::bolt::memory::MemoryManager::initialize({});
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #817 

Spark-on-Bolt executors could crash during shuffle compression even when task
retries allowed the Spark application to finish as `Completed`.

`BlockPayload::fromBuffers` allocates a 16-byte record header for each
nonempty compressed buffer. `compressBuffer` advances the codec output pointer
past that header, but the caller previously still included the consumed 16
bytes in the destination capacity passed to the codec. For the final nonempty
buffer, the advertised destination interval therefore ended 16 bytes beyond
the real output allocation, allowing a legal codec store to corrupt adjacent
heap memory.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR contains only the production fix and its deterministic unit test:

- `bolt/shuffle/sparksql/Payload.cpp`
  - Moves the existing two-`int64_t` compressed-buffer header length to shared
    local scope.
  - Subtracts that header from the destination capacity after the output
    pointer advances past it.
- `bolt/shuffle/sparksql/tests/BoltShuffleReaderTest.cpp`
  - Adds `CompressedBufferCapacityExcludesHeader`.
  - Uses a tracking Arrow memory pool to measure the bytes actually available
    from the codec destination pointer to the allocation end.
  - Uses a recording fake codec to capture the advertised destination
    capacity without performing an out-of-bounds write.

Before the fix, the test observes:

```text
advertised codec capacity = 64
actual bytes available    = 48
```

After the fix, both values are 48.

#### Validation

- Built `bolt_shuffle_reader_test` with the Conan Release preset.
- `BoltShuffleReaderTest.CompressedBufferCapacityExcludesHeader`: 1/1 passed.
- Complete `bolt_shuffle_reader_test`: 5/5 passed.
- Clang-format 14.0.6 dry-run passed for both changed files.
- `git diff --check` passed.
- A fixed-package run covered 3,075 Stage 2 task attempts with zero failed
  attempts, 3,260 diagnostic watchpoint arms, zero overwrite hits, zero core
  dumps, and zero fatal native markers.
- A ten-application concurrent run covered 29,882 Stage 2 task attempts and
  9,530 diagnostic watchpoint arms. The original crash signatures remained
  absent: zero `checkCopyValue:fastCopy` occurrences, native fatal signals,
  JVM fatal errors, core dumps, problematic frames, or overwrite hits.
- The ten-application run did have 29 task-attempt failures in two
  applications caused by container memory-cgroup OOM; all were recovered by
  retry. Those resource failures are separate from the overwrite fixed here,
  so this validation does not claim that Stage 2 had zero errors.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    No benchmark was run.
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

No material performance impact is expected. The compression critical path
adds one integer subtraction per nonempty buffer compression call and adds no
allocation, copy, branch, lock, or codec invocation. No benchmark was run.

### Release Note

```text
Release Note:
- Fixed a Spark shuffle compression buffer-capacity overstatement that could
  corrupt adjacent memory and crash executors.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - None.
    ```
    </details>