### PR TITLE
misc: increase spark bloom filter max bits

### DIFF
--- a/bolt/common/base/BloomFilter.h
+++ b/bolt/common/base/BloomFilter.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <vector>
 
@@ -126,6 +128,34 @@ class BloomFilter {
     }
   }
 
+  /// Computes m (total bits of Bloom filter) which is expected to achieve,
+  /// for the specified expected insertions, the required false positive
+  /// probability.
+  ///
+  /// See
+  /// http://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives
+  /// for the formula.
+  ///
+  /// @param n expected insertions (must be positive).
+  /// @param p false positive rate (must be 0 < p < 1).
+  static int64_t optimalNumOfBits(int64_t n, double p) {
+    return static_cast<int64_t>(
+        -n * std::log(p) / (std::log(2.0) * std::log(2.0)));
+  }
+
+  /// Computes m (total bits of Bloom filter) which is expected to achieve.
+  /// The smaller the expectedNumItems, the smaller the fpp.
+  ///
+  /// @param expectedNumItems expected number of items to insert.
+  /// @param maxNumItems maximum number of items.
+  static int64_t optimalNumOfBits(
+      int64_t expectedNumItems,
+      int64_t maxNumItems) {
+    double ratio = static_cast<double>(expectedNumItems) / maxNumItems;
+    double fpp = kDefaultFpp * std::min(ratio, 1.0);
+    return optimalNumOfBits(expectedNumItems, fpp);
+  }
+
  private:
   // We use 4 independent hash functions by taking 24 bits of
   // the hash code and breaking these up into 4 groups of 6 bits. Each group
@@ -160,6 +190,8 @@ class BloomFilter {
   }
 
   static constexpr int8_t kBloomFilterV1 = 1;
+  static constexpr double kDefaultFpp = 0.03;
+
   std::vector<uint64_t, Allocator> bits_;
 };
 

--- a/bolt/common/base/tests/BloomFilterTest.cpp
+++ b/bolt/common/base/tests/BloomFilterTest.cpp
@@ -135,6 +135,31 @@ TEST_F(BloomFilterTest, merge) {
   EXPECT_EQ(bloom.serializedSize(), merge.serializedSize());
 }
 
+TEST_F(BloomFilterTest, optimalNumOfBitsWithFpp) {
+  EXPECT_EQ(BloomFilter<>::optimalNumOfBits(1000, 0.03), 7298);
+  EXPECT_EQ(BloomFilter<>::optimalNumOfBits(1000000, 0.01), 9585058);
+  EXPECT_EQ(BloomFilter<>::optimalNumOfBits(1, 0.5), 1);
+  EXPECT_EQ(BloomFilter<>::optimalNumOfBits(1000, 0.001), 14377);
+}
+
+TEST_F(BloomFilterTest, optimalNumOfBitsWithMaxItems) {
+  constexpr int64_t kMaxNumItems = 4'000'000L;
+
+  EXPECT_EQ(
+      BloomFilter<>::optimalNumOfBits(kMaxNumItems, kMaxNumItems), 29'193'763);
+
+  EXPECT_EQ(
+      BloomFilter<>::optimalNumOfBits(1'000'000L, kMaxNumItems), 10'183'830);
+
+  EXPECT_EQ(BloomFilter<>::optimalNumOfBits(100L, kMaxNumItems), 2935);
+
+  EXPECT_EQ(
+      BloomFilter<>::optimalNumOfBits(5'000'000L, kMaxNumItems), 36'492'204);
+
+  EXPECT_EQ(
+      BloomFilter<>::optimalNumOfBits(10'000'000L, kMaxNumItems), 72'984'408);
+}
+
 TEST(NGramBloomFilterTest, basic) {
   constexpr int32_t kSize = 512;
   constexpr int32_t kHashes = 3;

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -422,6 +422,10 @@ class QueryConfig {
   static constexpr const char* kSparkBloomFilterMaxNumBits =
       "spark.bloom_filter.max_num_bits";
 
+  /// The max number of items to use for the bloom filter.
+  static constexpr const char* kSparkBloomFilterMaxNumItems =
+      "spark.bloom_filter.max_num_items";
+
   // The policy to deduplicate map keys in builtin function: CreateMap,
   // MapFromArrays, MapFromEntries, StringToMap, MapConcat and TransformKeys.
   // When EXCEPTION, the query fails if duplicated map keys are detected. When
@@ -1350,6 +1354,11 @@ class QueryConfig {
   int64_t sparkBloomFilterMaxNumBits() const {
     constexpr int64_t kDefault = 64 * 1024 * 1024;
     return get<int64_t>(kSparkBloomFilterMaxNumBits, kDefault);
+  }
+
+  int64_t sparkBloomFilterMaxNumItems() const {
+    constexpr int64_t kDefault = 4'000'000L;
+    return get<int64_t>(kSparkBloomFilterMaxNumItems, kDefault);
   }
 
   std::string sparkMapKeyDedupPolicy() const {

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -1349,13 +1349,7 @@ class QueryConfig {
   // Spark kMaxNumBits is 67'108'864.
   int64_t sparkBloomFilterMaxNumBits() const {
     constexpr int64_t kDefault = 64 * 1024 * 1024;
-    auto value = get<int64_t>(kSparkBloomFilterMaxNumBits, kDefault);
-    BOLT_USER_CHECK_LE(
-        value,
-        kDefault,
-        "{} cannot exceed the default value",
-        kSparkBloomFilterMaxNumBits);
-    return value;
+    return get<int64_t>(kSparkBloomFilterMaxNumBits, kDefault);
   }
 
   std::string sparkMapKeyDedupPolicy() const {

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -1346,10 +1346,9 @@ class QueryConfig {
     return get<int64_t>(kSparkBloomFilterNumBits, kDefault);
   }
 
-  // Spark kMaxNumBits is 67'108'864, but bolt has memory limit sizeClassSizes
-  // 256, so decrease it to not over memory limit.
+  // Spark kMaxNumBits is 67'108'864.
   int64_t sparkBloomFilterMaxNumBits() const {
-    constexpr int64_t kDefault = 4'096 * 1024;
+    constexpr int64_t kDefault = 64 * 1024 * 1024;
     auto value = get<int64_t>(kSparkBloomFilterMaxNumBits, kDefault);
     BOLT_USER_CHECK_LE(
         value,

--- a/bolt/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -79,7 +79,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       : Aggregate(resultType),
         defaultExpectedNumItems_(config.sparkBloomFilterExpectedNumItems()),
         defaultNumBits_(config.sparkBloomFilterNumBits()),
-        maxNumBits_(config.sparkBloomFilterMaxNumBits()) {}
+        maxNumBits_(config.sparkBloomFilterMaxNumBits()),
+        maxNumItems_(config.sparkBloomFilterMaxNumItems()) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(BloomFilterAccumulator);
@@ -234,7 +235,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
         DecodedVector decodedNumBits(*args[2], rows);
         setConstantArgument("numBits", numBits_, decodedNumBits);
       } else {
-        numBits_ = estimatedNumItems_ * 8;
+        numBits_ =
+            BloomFilter<>::optimalNumOfBits(estimatedNumItems_, maxNumItems_);
       }
     } else {
       estimatedNumItems_ = defaultExpectedNumItems_;
@@ -290,6 +292,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   const int64_t defaultExpectedNumItems_;
   const int64_t defaultNumBits_;
   const int64_t maxNumBits_;
+  const int64_t maxNumItems_;
 
   // Reusable instance of DecodedVector for decoding input vectors.
   DecodedVector decodedRaw_;

--- a/bolt/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -70,12 +70,15 @@ TEST_F(BloomFilterAggAggregateTest, bloomFilterAggArgument) {
   auto vectors = {makeRowVector({makeFlatVector<int64_t>(
       100, [](vector_size_t row) { return row % 9; })})};
 
-  auto expected1 = {makeRowVector({getSerializedBloomFilter(3)})};
+  auto expected1 = {makeRowVector({getSerializedBloomFilter(13)})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 6)"}, expected1);
 
-  // This capacity is kMaxNumBits / 16.
-  auto expected2 = {makeRowVector({getSerializedBloomFilter(262144)})};
+  auto expected2 = {makeRowVector({getSerializedBloomFilter(524288)})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0)"}, expected2);
+
+  // Max bits case: bloom filter is at its largest possible size.
+  auto expected3 = {makeRowVector({getSerializedBloomFilter(4194304)})};
+  testAggregations(vectors, {}, {"bloom_filter_agg(c0, 10000000)"}, expected3);
 }
 
 TEST_F(BloomFilterAggAggregateTest, emptyInput) {


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Raise the default spark.bloom_filter.max_num_bits from 4M bits to 64M bits so the default aligns with Spark's 67,108,864-bit limit.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Raise the default spark.bloom_filter.max_num_bits from 4M bits to 64M bits so the default aligns with Spark's 67,108,864-bit limit.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
