### PR TITLE
fix: keep sliced bool buffers word aligned

### DIFF
--- a/bolt/buffer/Buffer.cpp
+++ b/bolt/buffer/Buffer.cpp
@@ -76,7 +76,7 @@ BufferPtr Buffer::slice<bool>(
     memory::MemoryPool* pool) {
   BOLT_CHECK_NOT_NULL(buffer, "Buffer must not be null.");
 
-  if (offset % 8 == 0) {
+  if (offset % (sizeof(uint64_t) * 8) == 0) {
     return sliceBufferZeroCopy(
         1, true, buffer, bits::nbytes(offset), bits::nbytes(length));
   }

--- a/bolt/buffer/tests/BufferTest.cpp
+++ b/bolt/buffer/tests/BufferTest.cpp
@@ -30,6 +30,10 @@
 
 #include "bolt/buffer/Buffer.h"
 
+#if defined(__SSE2__)
+#include <emmintrin.h>
+#endif
+
 #include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -372,23 +376,64 @@ TEST_F(BufferTest, sliceBigintBuffer) {
 }
 
 TEST_F(BufferTest, sliceBooleanBuffer) {
-  auto bufferPtr = AlignedBuffer::allocate<bool>(16, pool_.get());
+  auto bufferPtr = AlignedBuffer::allocate<bool>(80, pool_.get());
   auto data = bufferPtr->asMutableRange<bool>();
-  for (int i = 0; i < 16; ++i) {
+  for (int i = 0; i < 80; ++i) {
     data[i] = (i % 2 != 0);
   }
-  auto sliceBufferPtr = Buffer::slice<bool>(bufferPtr, 8, 8, pool_.get());
+  auto sliceBufferPtr = Buffer::slice<bool>(bufferPtr, 64, 8, pool_.get());
   ASSERT_TRUE(sliceBufferPtr->isView());
-  ASSERT_EQ(sliceBufferPtr->as<bool>(), bufferPtr->as<bool>() + 1);
+  ASSERT_EQ(sliceBufferPtr->as<bool>(), bufferPtr->as<bool>() + 8);
+
+  sliceBufferPtr = Buffer::slice<bool>(bufferPtr, 8, 8, pool_.get());
+  ASSERT_FALSE(sliceBufferPtr->isView());
+  auto sliceData = sliceBufferPtr->asRange<bool>();
+  for (int i = 0; i < 8; ++i) {
+    ASSERT_EQ(sliceData[i], i % 2 != 0);
+  }
 
   sliceBufferPtr = Buffer::slice<bool>(bufferPtr, 5, 5, pool_.get());
   ASSERT_FALSE(sliceBufferPtr->isView());
-  auto sliceData = sliceBufferPtr->asRange<bool>();
+  sliceData = sliceBufferPtr->asRange<bool>();
   for (int i = 0; i < 5; ++i) {
     ASSERT_EQ(sliceData[i], i % 2 == 0);
   }
   BOLT_ASSERT_THROW(
       Buffer::slice<bool>(bufferPtr, 5, 6, nullptr), "Pool must not be null.");
+}
+
+TEST_F(BufferTest, sliceBooleanBufferWordUnalignedCoredumpRepro) {
+#if !defined(__SSE2__)
+  GTEST_SKIP() << "SSE2 is required to reproduce the original SIGSEGV.";
+#else
+  // This reproduces the original crash scenario described in
+  // https://meego.larkoffice.com/spark_on_bolt/issue/detail/7359777330:
+  // offset=10920 bits -> bits::nbytes(offset)=1365 bytes (byte-aligned but not
+  // uint64_t-word-aligned). In the buggy implementation this would create a
+  // zero-copy view with a misaligned bitmap pointer.
+  constexpr size_t kSliceStart = 10920;
+  constexpr size_t kSliceLength = 256;
+  constexpr size_t kPadding = 64;
+  constexpr size_t kBufferSize = kSliceStart + kSliceLength + kPadding;
+
+  auto bufferPtr = AlignedBuffer::allocate<bool>(kBufferSize, pool_.get());
+  auto data = bufferPtr->asMutableRange<bool>();
+  for (size_t i = 0; i < kBufferSize; ++i) {
+    data[i] = true;
+  }
+
+  auto sliceBufferPtr =
+      Buffer::slice<bool>(bufferPtr, kSliceStart, kSliceLength, pool_.get());
+
+  // Force a 16-byte aligned load from the bitmap pointer. With the old buggy
+  // zero-copy condition (byte alignment only), this triggers SIGSEGV.
+  const auto* bitmap = reinterpret_cast<const __m128i*>(
+      sliceBufferPtr->as<uint64_t>()); // NOLINT
+  const __m128i loaded = _mm_load_si128(bitmap);
+  EXPECT_EQ(_mm_movemask_epi8(loaded), 0xFFFF);
+
+  EXPECT_FALSE(sliceBufferPtr->isView());
+#endif
 }
 
 } // namespace bolt


### PR DESCRIPTION
### What problem does this PR solve?

`HashAggregation` over a sliced `RowVector` could crash with `SIGSEGV` in `SumAggregateBase::addIntermediateResults`.

`Buffer::slice<bool>` allowed a zero-copy slice whenever `offset % 8 == 0`, which only guarantees **byte** alignment. But `rawNulls()` exposes the null bitmap as `uint64_t*`, and `BitUtil` / `SumAggregateBase` read it as `uint64_t` words, so the zero-copy slice must start on a **64-bit word** boundary. Otherwise the bitmap pointer is misaligned and word-sized aligned loads segfault. The reproduced case had `sliceStart = 10920`, `bits::nbytes(10920) = 1365`, and `1365 % 8 = 5` (byte-aligned but not word-aligned).

Issue Number: close #820

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Call chain that reaches the bug: `RowVector::slice` -> `FlatVector::slice` -> `BaseVector::sliceNulls` -> `Buffer::slice<bool>`.

Changes:
- In `Buffer::slice<bool>`, require `offset % (sizeof(uint64_t) * 8) == 0` for the zero-copy path (was `offset % 8 == 0`). This guarantees the sliced null-bitmap pointer stays 64-bit-word aligned so word-sized reads in `BitUtil` / aggregation are safe.
- Otherwise fall back to copying into a new aligned bool buffer (existing `AlignedBuffer::allocate` + `bits::copyBits` path).
- Extend `BufferTest.sliceBooleanBuffer` to cover: aligned zero-copy (offset 64), byte-aligned-but-not-word-aligned copy (offset 8), and unaligned copy (offset 5).
- Add `BufferTest.sliceBooleanBufferWordUnalignedCoredumpRepro`, which reproduces the original crash (`sliceStart = 10920`) and forces a 16-byte aligned load from the bitmap pointer; it is guarded by `#if defined(__SSE2__)` and skipped otherwise.

### Performance Impact
- [x] **No Impact**: This change only tightens the zero-copy alignment condition for bool buffer slicing; the common word-aligned case still takes the zero-copy path, and only byte-aligned-but-not-word-aligned slices now take an already-existing copy fallback (correctness fix).

### Release Note

```text
Release Note:
- Fixed a SIGSEGV in aggregation caused by zero-copy slicing of bool (null) buffers at byte-aligned but not 64-bit-word-aligned offsets.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)