### PR TITLE
fix: prevent crash casting dictionary/constant-wrapped complex type to VARCHAR

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -1079,6 +1079,61 @@ void doCast(
     VectorPtr& result,
     CastErrorPolicy errorPolicy);
 
+// Casts a complex (ARRAY/MAP/ROW) vector to VARCHAR when the input arrives
+// wrapped in a dictionary/constant encoding, so `input.as<ArrayVector>()` (and
+// the map/row equivalents) return nullptr. Decodes the input down to its flat
+// complex base vector, casts the base, then copies the results back through the
+// decoded indices while re-applying nulls introduced by the wrapper layers.
+void doCastWrappedComplexToVarchar(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& fromType,
+    VectorPtr& result,
+    CastErrorPolicy errorPolicy) {
+  LocalDecodedVector decodedHolder(context, input, rows);
+  auto* decoded = decodedHolder.get();
+  auto* base = decoded->base();
+  BOLT_CHECK_NOT_NULL(
+      base, "Decoded vector for {} has no base vector.", fromType->toString());
+  BOLT_CHECK(
+      (fromType->isArray() && base->as<ArrayVector>() != nullptr) ||
+          (fromType->isMap() && base->as<MapVector>() != nullptr) ||
+          (fromType->isRow() && base->as<RowVector>() != nullptr),
+      "Decoded vector for {} has unexpected base encoding {}.",
+      fromType->toString(),
+      VectorEncoding::mapSimpleToName(base->encoding()));
+
+  LocalSelectivityVector nonNullRows(context, rows);
+  auto* rawNulls = decoded->nulls(nonNullRows.get());
+  if (rawNulls) {
+    nonNullRows->deselectNulls(
+        rawNulls, nonNullRows->begin(), nonNullRows->end());
+  }
+
+  context.ensureWritable(rows, VARCHAR(), result);
+  result->clearNulls(rows);
+
+  if (!nonNullRows->hasSelections()) {
+    result->addNulls(rows);
+    return;
+  }
+
+  SelectivityVector baseRows(base->size(), false);
+  nonNullRows->applyToSelected(
+      [&](auto row) { baseRows.setValid(decoded->index(row), true); });
+  baseRows.updateBounds();
+
+  VectorPtr baseResult;
+  doCast(
+      baseRows, *base, context, fromType, VARCHAR(), baseResult, errorPolicy);
+
+  result->copy(baseResult.get(), *nonNullRows, decoded->indices(), false);
+  if (rawNulls) {
+    result->addNulls(rawNulls, rows);
+  }
+}
+
 void doCastArrayToVarchar(
     const SelectivityVector& rows,
     const ArrayVector& input,
@@ -1431,19 +1486,32 @@ void doCast(
   } else if (
       !fromType->isPrimitiveType() && toType->kind() == TypeKind::VARCHAR) {
     if (fromType->isArray()) {
-      doCastArrayToVarchar(
-          rows,
-          *input.as<ArrayVector>(),
-          context,
-          fromType,
-          result,
-          errorPolicy);
+      auto* arrayVector = input.as<ArrayVector>();
+      if (arrayVector == nullptr) {
+        doCastWrappedComplexToVarchar(
+            rows, input, context, fromType, result, errorPolicy);
+      } else {
+        doCastArrayToVarchar(
+            rows, *arrayVector, context, fromType, result, errorPolicy);
+      }
     } else if (fromType->isMap()) {
-      doCastMapToVarchar(
-          rows, *input.as<MapVector>(), context, fromType, result, errorPolicy);
+      auto* mapVector = input.as<MapVector>();
+      if (mapVector == nullptr) {
+        doCastWrappedComplexToVarchar(
+            rows, input, context, fromType, result, errorPolicy);
+      } else {
+        doCastMapToVarchar(
+            rows, *mapVector, context, fromType, result, errorPolicy);
+      }
     } else if (fromType->isRow()) {
-      doCastRowToVarchar(
-          rows, *input.as<RowVector>(), context, fromType, result, errorPolicy);
+      auto* rowVector = input.as<RowVector>();
+      if (rowVector == nullptr) {
+        doCastWrappedComplexToVarchar(
+            rows, input, context, fromType, result, errorPolicy);
+      } else {
+        doCastRowToVarchar(
+            rows, *rowVector, context, fromType, result, errorPolicy);
+      }
     }
   } else {
     BOLT_FAIL(

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -3592,5 +3592,93 @@ TEST_F(CastExprTest, skipCastEvaluation) {
     assertEqualVectors(result, expected);
   }
 }
+
+// Regression test for casting a complex type to VARCHAR when a nested complex
+// child arrives wrapped in a dictionary encoding. Top-level encodings are
+// peeled by CastExpr::apply, and casting an outer ARRAY to VARCHAR recurses
+// (via doCastArrayToVarchar) into its element vector while it is still
+// dictionary-encoded. Before the fix, doCast() dereferenced
+// input.as<RowVector>()/MapVector/ArrayVector unconditionally, which returned
+// nullptr for a dictionary-encoded child and crashed. Results are compared
+// against a deeply-flattened copy of the same logical input so the assertions
+// do not depend on the (build-specific) string format.
+TEST_F(CastExprTest, complexTypeToStringWrappedNestedInput) {
+  auto castWrappedAndFlat = [&](const VectorPtr& elements,
+                                const std::vector<vector_size_t>& offsets,
+                                const std::vector<vector_size_t>& nullArrays) {
+    // Wrap the nested element vector (the child of the outer array) in a
+    // reversing dictionary so it is dictionary-encoded when doCast() recurses
+    // into it while casting the outer array to VARCHAR.
+    auto indices = test::makeIndicesInReverse(elements->size(), pool());
+    auto wrappedElements = BaseVector::wrapInDictionary(
+        nullptr, indices, elements->size(), elements);
+    auto wrappedArray = makeArrayVector(offsets, wrappedElements, nullArrays);
+
+    // Build the logically-equivalent flat input by deep-flattening a copy of
+    // the same reversed elements.
+    VectorPtr flatElements = wrappedElements;
+    BaseVector::flattenVector(flatElements);
+    auto flatArray = makeArrayVector(offsets, flatElements, nullArrays);
+
+    auto wrappedResult =
+        evaluate("cast(c0 as VARCHAR)", makeRowVector({wrappedArray}));
+    auto flatResult =
+        evaluate("cast(c0 as VARCHAR)", makeRowVector({flatArray}));
+    assertEqualVectors(flatResult, wrappedResult);
+  };
+
+  // ARRAY<ROW<...>> where the ROW child is dictionary-encoded.
+  {
+    auto rows = makeRowVector({
+        makeNullableFlatVector<int64_t>({1, std::nullopt, 3, 4, 5}),
+        makeNullableFlatVector<StringView>(
+            {"a", "b", std::nullopt, "d", "e"}),
+    });
+    castWrappedAndFlat(rows, {0, 2, 2, 5}, {1});
+  }
+
+  // ARRAY<MAP<...>> where the MAP child is dictionary-encoded.
+  {
+    auto maps = makeNullableMapVector<int32_t, double>(
+        {{{{1, 1.25}, {2, std::nullopt}}},
+         std::nullopt,
+         {{{3, 4.5}}},
+         {{}},
+         {{{5, 13.25}, {6, 1e7}}}},
+        MAP(INTEGER(), DOUBLE()));
+    castWrappedAndFlat(maps, {0, 2, 3, 5}, {});
+  }
+
+  // ARRAY<ARRAY<...>> where the inner ARRAY child is dictionary-encoded.
+  {
+    auto inner = makeNullableArrayVector<int32_t>(
+        {{{0, 1}}, {{}}, {{2, std::nullopt, 3}}, std::nullopt, {{4}}});
+    castWrappedAndFlat(inner, {0, 2, 5, 5}, {2});
+  }
+}
+
+// Regression test for casting a complex type to VARCHAR when a nested complex
+// child is constant-encoded (all outer array elements reference the same inner
+// complex element). Exercises the constant-mapping branch of
+// doCastWrappedComplexToVarchar.
+TEST_F(CastExprTest, complexTypeToStringConstantNestedInput) {
+  auto rowElement = makeRowVector({
+      makeNullableFlatVector<int64_t>({7, std::nullopt, 9}),
+      makeFlatVector<StringView>({"x", "y", "z"}),
+  });
+  // Constant-encode the ROW child so all outer array elements point to row 1.
+  auto constElements = BaseVector::wrapInConstant(3, 1, rowElement);
+  auto wrappedArray = makeArrayVector({0, 2, 3}, constElements);
+
+  VectorPtr flatElements = constElements;
+  BaseVector::flattenVector(flatElements);
+  auto flatArray = makeArrayVector({0, 2, 3}, flatElements);
+
+  auto wrappedResult =
+      evaluate("cast(c0 as VARCHAR)", makeRowVector({wrappedArray}));
+  auto flatResult =
+      evaluate("cast(c0 as VARCHAR)", makeRowVector({flatArray}));
+  assertEqualVectors(flatResult, wrappedResult);
+}
 } // namespace
 } // namespace bytedance::bolt::test

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -3631,8 +3631,7 @@ TEST_F(CastExprTest, complexTypeToStringWrappedNestedInput) {
   {
     auto rows = makeRowVector({
         makeNullableFlatVector<int64_t>({1, std::nullopt, 3, 4, 5}),
-        makeNullableFlatVector<StringView>(
-            {"a", "b", std::nullopt, "d", "e"}),
+        makeNullableFlatVector<StringView>({"a", "b", std::nullopt, "d", "e"}),
     });
     castWrappedAndFlat(rows, {0, 2, 2, 5}, {1});
   }
@@ -3676,8 +3675,7 @@ TEST_F(CastExprTest, complexTypeToStringConstantNestedInput) {
 
   auto wrappedResult =
       evaluate("cast(c0 as VARCHAR)", makeRowVector({wrappedArray}));
-  auto flatResult =
-      evaluate("cast(c0 as VARCHAR)", makeRowVector({flatArray}));
+  auto flatResult = evaluate("cast(c0 as VARCHAR)", makeRowVector({flatArray}));
   assertEqualVectors(flatResult, wrappedResult);
 }
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?

Casting a complex type (`ARRAY`/`MAP`/`ROW`) to `VARCHAR` crashed with `SIGSEGV`
when the complex child arrived wrapped in a dictionary/constant encoding.
`CastExpr::apply` only peels the top-level encoding, so a complex child nested
inside another complex column can still be dictionary/constant-encoded when
`doCast()` recurses into it. In that case `input.as<ArrayVector>()` (and the
`MapVector`/`RowVector` equivalents) return `nullptr`, and `doCast()`
dereferenced the null pointer unconditionally.

Issue Number: close #822

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add `doCastWrappedComplexToVarchar()` which handles the case where the complex
input to a `... -> VARCHAR` cast is dictionary/constant-encoded:

- **Why**: `input.as<ArrayVector>()` / `MapVector` / `RowVector` return `nullptr`
  for a wrapped (non-flat) complex vector, so the previous unconditional
  dereference crashed. This only surfaces for nested complex children, because
  top-level encodings are already peeled by `CastExpr::apply`.
- **How**: The new helper decodes the wrapped input down to its flat complex
  base vector, casts the base to `VARCHAR`, then copies the results back through
  the decoded indices (`decoded->indices()`) while re-applying the nulls
  introduced by the wrapper layers (`decoded->nulls()`). It validates the
  decoded base encoding with `BOLT_CHECK`/`BOLT_CHECK_NOT_NULL` and short-circuits
  when every selected row is null.

The dispatch in `doCast()` for `array/map/row -> VARCHAR` now checks for the
`nullptr` case and routes through the new helper, keeping the fast flat path
unchanged.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path. The new
  branch is only taken when the complex input is non-flat (dictionary/constant
  wrapped); the existing flat path is unchanged.

### Release Note

```text
Release Note:
- Fixed a SIGSEGV crash when casting a dictionary/constant-encoded complex type
  (ARRAY/MAP/ROW), typically nested inside another complex column, to VARCHAR.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Verification detail: the two added tests
(`complexTypeToStringWrappedNestedInput`, `complexTypeToStringConstantNestedInput`)
crash with `SIGSEGV` on the pre-fix dispatch and pass with the fix; the full
`CastExprTest` suite (51 tests) passes.

### Breaking Changes

- [x] No
