### PR TITLE
fix: support parquet double columns as bigint

### DIFF
--- a/bolt/connectors/hive/SplitReader.cpp
+++ b/bolt/connectors/hive/SplitReader.cpp
@@ -40,6 +40,7 @@
 #include "bolt/connectors/hive/TableHandle.h"
 #include "bolt/dwio/common/ReaderFactory.h"
 #include "bolt/dwio/paimon/deletionvectors/DeletionFileReader.h"
+#include "bolt/dwio/parquet/reader/ParquetReaderCast.h"
 #include "bolt/type/Conversions.h"
 #include "bolt/type/filter/MapSubscriptFilter.h"
 
@@ -108,32 +109,30 @@ bool applyPartitionFilter(
   }
 }
 
-void checkFloatingPointToVarcharFilterCompatibility(
+void checkReaderCastFilter(
     const TypePtr& fileType,
     const TypePtr& requestedType,
     const common::Filter* filter,
     const std::string& path) {
-  if ((fileType->isReal() || fileType->isDouble()) &&
-      requestedType->isVarchar()) {
+  if (parquet::isReaderCastFilterMismatch(fileType, requestedType)) {
     if (filter && !filter->isValueIndependent()) {
       BOLT_USER_FAIL(
-          "Cannot apply VARCHAR filter to physical {} Parquet column {}",
+          "Cannot apply {} filter to physical {} Parquet column {}",
+          requestedType->kindName(),
           fileType->kindName(),
           path);
     }
   }
 }
 
-void checkFloatingPointToVarcharFilter(
+void validateReaderCastFilterRecursive(
     const TypePtr& fileType,
     const TypePtr& requestedType,
     const common::ScanSpec& scanSpec,
     const std::string& path) {
   auto* filter = scanSpec.filter();
-  checkFloatingPointToVarcharFilterCompatibility(
-      fileType, requestedType, filter, path);
-  if ((fileType->isReal() || fileType->isDouble()) &&
-      requestedType->isVarchar()) {
+  checkReaderCastFilter(fileType, requestedType, filter, path);
+  if (parquet::isReaderCastFilterMismatch(fileType, requestedType)) {
     return;
   }
   if (fileType->kind() != requestedType->kind()) {
@@ -148,7 +147,7 @@ void checkFloatingPointToVarcharFilter(
     const auto keyPath = path.empty()
         ? common::ScanSpec::kMapKeysFieldName
         : path + "." + common::ScanSpec::kMapKeysFieldName;
-    checkFloatingPointToVarcharFilterCompatibility(
+    checkReaderCastFilter(
         fileType->childAt(0),
         requestedType->childAt(0),
         mapFilter->keyFilter(),
@@ -156,7 +155,7 @@ void checkFloatingPointToVarcharFilter(
     const auto valuePath = path.empty()
         ? common::ScanSpec::kMapValuesFieldName
         : path + "." + common::ScanSpec::kMapValuesFieldName;
-    checkFloatingPointToVarcharFilterCompatibility(
+    checkReaderCastFilter(
         fileType->childAt(1),
         requestedType->childAt(1),
         mapFilter->valueFilter(),
@@ -185,7 +184,7 @@ void checkFloatingPointToVarcharFilter(
 
     const auto childPath =
         path.empty() ? child->fieldName() : path + "." + child->fieldName();
-    checkFloatingPointToVarcharFilter(
+    validateReaderCastFilterRecursive(
         fileType->childAt(*fileChildIndex),
         requestedType->childAt(*requestedChildIndex),
         *child,
@@ -382,7 +381,7 @@ void SplitReader::prepareSplit(
         FLAGS_testing_only_set_scan_exception_mesg_for_prepare);
   }
 
-  validateFloatingPointToVarcharFilters();
+  validateReaderCastFilter();
   baseRowReaderOpts_.setDisableFloatingPointToVarcharMetadataFilter(
       !isPartOfPaimonSplit_);
 
@@ -652,13 +651,13 @@ void SplitReader::populatePaimonMetadataColumns(VectorPtr& output) {
 }
 
 void SplitReader::resetFilterCaches() {
-  validateFloatingPointToVarcharFilters();
+  validateReaderCastFilter();
   if (baseRowReader_) {
     baseRowReader_->resetFilterCaches();
   }
 }
 
-void SplitReader::validateFloatingPointToVarcharFilters() const {
+void SplitReader::validateReaderCastFilter() const {
   if (isPartOfPaimonSplit_ || !baseReader_ ||
       baseReaderOpts_.getFileFormat() != dwio::common::FileFormat::PARQUET) {
     return;
@@ -666,7 +665,7 @@ void SplitReader::validateFloatingPointToVarcharFilters() const {
   const auto requestedType = hiveTableHandle_->dataColumns()
       ? hiveTableHandle_->dataColumns()
       : readerOutputType_;
-  checkFloatingPointToVarcharFilter(
+  validateReaderCastFilterRecursive(
       baseReader_->rowType(), requestedType, *scanSpec_, "");
 }
 

--- a/bolt/connectors/hive/SplitReader.h
+++ b/bolt/connectors/hive/SplitReader.h
@@ -201,7 +201,7 @@ class SplitReader : public HiveSplitReaderBase {
       metadataColumns_{};
 
  private:
-  void validateFloatingPointToVarcharFilters() const;
+  void validateReaderCastFilter() const;
 
   bool emptySplit_;
   bool isPartOfPaimonSplit_;

--- a/bolt/dwio/parquet/reader/IntegerColumnReader.h
+++ b/bolt/dwio/parquet/reader/IntegerColumnReader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "bolt/dwio/common/SelectiveIntegerColumnReader.h"
+#include "bolt/dwio/parquet/reader/ParquetReaderCast.h"
 namespace bytedance::bolt::parquet {
 
 class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
@@ -56,6 +57,10 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
       }
       default:
         break;
+    }
+    if (params.disableFloatingPointToVarcharMetadataFilter() &&
+        isReaderCastFilterMismatch(fileType_->type(), requestedType->type())) {
+      formatData_->as<ParquetData>().disableTypeDependentMetadataFilters();
     }
   }
 

--- a/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -123,7 +123,11 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
             requestedType->type(), fileType, params, scanSpec);
       }
     case TypeKind::DOUBLE:
-      if (requestedType->type()->kind() == TypeKind::VARCHAR) {
+      if (
+#ifdef SPARK_COMPATIBLE
+          requestedType->type()->kind() == TypeKind::BIGINT ||
+#endif
+          requestedType->type()->kind() == TypeKind::VARCHAR) {
         return std::make_unique<FloatingPointColumnReader<double, double>>(
             requestedType->type(), fileType, params, scanSpec, DOUBLE());
       }

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -125,8 +125,17 @@ bool acceptsDateFile(const bytedance::bolt::TypePtr& t) {
       t->kind() == bytedance::bolt::TypeKind::VARCHAR;
 }
 
-bool acceptsFloatingPointFileForReaderCast(const bytedance::bolt::TypePtr& t) {
+bool acceptsRealFileForReaderCast(const bytedance::bolt::TypePtr& t) {
   return t->kind() == bytedance::bolt::TypeKind::VARCHAR;
+}
+
+bool acceptsDoubleFileForReaderCast(const bytedance::bolt::TypePtr& t) {
+#ifdef SPARK_COMPATIBLE
+  return t->kind() == bytedance::bolt::TypeKind::BIGINT ||
+      acceptsRealFileForReaderCast(t);
+#else
+  return acceptsRealFileForReaderCast(t);
+#endif
 }
 
 // Compatibility predicate for Parquet INT32-physical source columns
@@ -1279,13 +1288,13 @@ TypePtr ReaderBase::convertType(
       case thrift::Type::type::FLOAT:
         checkRequested([](const TypePtr& t) {
           return t->kind() == TypeKind::REAL || t->kind() == TypeKind::DOUBLE ||
-              acceptsFloatingPointFileForReaderCast(t);
+              acceptsRealFileForReaderCast(t);
         });
         return REAL();
       case thrift::Type::type::DOUBLE:
         checkRequested([](const TypePtr& t) {
           return t->kind() == TypeKind::DOUBLE ||
-              acceptsFloatingPointFileForReaderCast(t);
+              acceptsDoubleFileForReaderCast(t);
         });
         return DOUBLE();
       case thrift::Type::type::BYTE_ARRAY:

--- a/bolt/dwio/parquet/reader/ParquetReaderCast.h
+++ b/bolt/dwio/parquet/reader/ParquetReaderCast.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/type/Type.h"
+
+namespace bytedance::bolt::parquet {
+
+inline bool isReaderCastFilterMismatch(
+    const TypePtr& fileType,
+    const TypePtr& requestedType) {
+  const auto fileKind = fileType->kind();
+  return ((fileType->isReal() || fileType->isDouble()) &&
+          requestedType->isVarchar()) ||
+      (fileType->isDouble() && requestedType->kind() == TypeKind::BIGINT) ||
+      ((fileKind == TypeKind::TINYINT || fileKind == TypeKind::SMALLINT ||
+        fileKind == TypeKind::INTEGER) &&
+       requestedType->kind() == TypeKind::DOUBLE) ||
+      (fileType->isDate() && requestedType->isVarchar());
+}
+
+} // namespace bytedance::bolt::parquet

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -30,6 +30,7 @@
 
 #include "bolt/dwio/parquet/reader/RepeatedColumnReader.h"
 #include "bolt/dwio/parquet/reader/ParquetColumnReader.h"
+#include "bolt/dwio/parquet/reader/ParquetReaderCast.h"
 #include "bolt/dwio/parquet/reader/StructColumnReader.h"
 namespace bytedance::bolt::parquet {
 
@@ -162,14 +163,10 @@ MapColumnReader::MapColumnReader(
   auto& keyChildType = requestedType->childAt(0);
   auto& elementChildType = requestedType->childAt(1);
   if (params.disableFloatingPointToVarcharMetadataFilter()) {
-    const auto hasMismatch = [&](int childIndex) {
-      const auto& fileChildType = fileType_->childAt(childIndex)->type();
-      const auto& requestedChildType =
-          requestedType->childAt(childIndex)->type();
-      return (fileChildType->isReal() || fileChildType->isDouble()) &&
-          requestedChildType->isVarchar();
-    };
-    if (hasMismatch(0) || hasMismatch(1)) {
+    if (isReaderCastFilterMismatch(
+            fileType_->childAt(0)->type(), requestedType->childAt(0)->type()) ||
+        isReaderCastFilterMismatch(
+            fileType_->childAt(1)->type(), requestedType->childAt(1)->type())) {
       formatData_->as<ParquetData>().disableTypeDependentMetadataFilters();
     }
   }

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -190,6 +190,11 @@ void rewriteDateConvertedTypeToLogicalTypeOnly(const std::string& path) {
 class MapSubscriptMetadataFilterParser final
     : public exec::PrestoExprToSubfieldFilterParser {
  public:
+  explicit MapSubscriptMetadataFilterParser(
+      std::unique_ptr<common::Filter> valueFilter =
+          common::createBytesRange("1.25", true, "1.25", true, false))
+      : valueFilter_(std::move(valueFilter)) {}
+
   std::optional<std::pair<common::Subfield, std::unique_ptr<common::Filter>>>
   leafCallToSubfieldFilter(
       const core::CallTypedExpr& call,
@@ -199,19 +204,20 @@ class MapSubscriptMetadataFilterParser final
       auto mapAccess = std::dynamic_pointer_cast<const core::CallTypedExpr>(
           call.inputs()[0]);
       if (mapAccess && mapAccess->name() == "element_at") {
-        std::shared_ptr<const common::Filter> valueFilter =
-            common::createBytesRange("1.25", true, "1.25", true, false);
         std::shared_ptr<const common::Filter> keyFilter =
             common::createBytesRange("key", true, "key", true, false);
         return std::make_pair(
             common::Subfield("c0"),
             common::createMapSubscriptFilter(
-                "key", std::move(valueFilter), std::move(keyFilter)));
+                "key", valueFilter_->clone(), std::move(keyFilter)));
       }
     }
     return PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
         call, evaluator, negated);
   }
+
+ private:
+  const std::shared_ptr<const common::Filter> valueFilter_;
 };
 
 class ScopedExprToSubfieldFilterParser {
@@ -1643,6 +1649,13 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     {"real_to_varchar",                REAL(),          VARCHAR(),          false},
     {"double_to_varchar",              DOUBLE(),        VARCHAR(),          false},
 
+    // ---- Hive SerDe-compatible floating point -> BIGINT cast. ----
+#ifdef SPARK_COMPATIBLE
+    {"double_to_bigint",               DOUBLE(),        BIGINT(),           false},
+#else
+    {"double_to_bigint",               DOUBLE(),        BIGINT(),           true},
+#endif
+
     // ---- Reject: float narrowing ----
     {"double_to_real",                 DOUBLE(),        REAL(),             true},
 
@@ -2092,6 +2105,135 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharValueFilters) {
   EXPECT_EQ(alwaysFalseResult->size(), 0);
 }
 
+#ifdef SPARK_COMPATIBLE
+TEST_F(ParquetTableScanTest, doubleToBigintValueChecks) {
+  auto data = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<double>({1.0, 1.2, -1.8, 0.0, std::nullopt})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {BIGINT()});
+  auto plan =
+      PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+  auto result = AssertQueryBuilder(plan)
+                    .split(makeSplit(file->getPath()))
+                    .copyResults(pool());
+  auto expected = makeRowVector(
+      {"c0"}, {makeNullableFlatVector<int64_t>({1, 1, -1, 0, std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({expected}, {result}));
+
+  auto isNullPlan = PlanBuilder(pool())
+                        .tableScan(declared, {"c0 IS NULL"}, "", declared)
+                        .planNode();
+  auto isNullResult = AssertQueryBuilder(isNullPlan)
+                          .split(makeSplit(file->getPath()))
+                          .copyResults(pool());
+  auto nullExpected =
+      makeRowVector({"c0"}, {makeNullableFlatVector<int64_t>({std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({nullExpected}, {isNullResult}));
+
+  auto pushdownOnlyPlan = PlanBuilder(pool())
+                              .tableScan(declared, {"c0 = 1"}, "", declared)
+                              .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(pushdownOnlyPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply BIGINT filter to physical DOUBLE Parquet column c0");
+}
+#endif
+
+TEST_F(ParquetTableScanTest, integerToDoubleValueFilters) {
+  auto declared = ROW({"c0"}, {DOUBLE()});
+  auto test = [&](const RowVectorPtr& data, const std::string& physicalType) {
+    auto file = exec::test::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+    auto pushdownOnlyPlan = PlanBuilder(pool())
+                                .tableScan(declared, {"c0 > 1.0"}, "", declared)
+                                .planNode();
+    BOLT_ASSERT_THROW(
+        AssertQueryBuilder(pushdownOnlyPlan)
+            .split(makeSplit(file->getPath()))
+            .copyResults(pool()),
+        fmt::format(
+            "Cannot apply DOUBLE filter to physical {} Parquet column c0",
+            physicalType));
+  };
+
+  test(
+      makeRowVector(
+          {"c0"}, {makeNullableFlatVector<int8_t>({1, 2, std::nullopt})}),
+      "TINYINT");
+  test(
+      makeRowVector(
+          {"c0"}, {makeNullableFlatVector<int16_t>({1, 2, std::nullopt})}),
+      "SMALLINT");
+
+  auto data = makeRowVector(
+      {"c0"}, {makeNullableFlatVector<int32_t>({1, 2, 3, std::nullopt})});
+  test(data, "INTEGER");
+
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+  auto extractedFilterPlan = PlanBuilder(pool())
+                                 .tableScan(declared, {}, "c0 > 1.0", declared)
+                                 .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(extractedFilterPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply DOUBLE filter to physical INTEGER Parquet column c0");
+
+  auto isNullPlan = PlanBuilder(pool())
+                        .tableScan(declared, {"c0 IS NULL"}, "", declared)
+                        .planNode();
+  auto isNullResult = AssertQueryBuilder(isNullPlan)
+                          .split(makeSplit(file->getPath()))
+                          .copyResults(pool());
+  auto expected =
+      makeRowVector({"c0"}, {makeNullableFlatVector<double>({std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({expected}, {isNullResult}));
+}
+
+TEST_F(ParquetTableScanTest, dateToVarcharValueFilters) {
+  auto data = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<int32_t>({1, 2, 3, std::nullopt}, DATE())});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {VARCHAR()});
+  auto pushdownOnlyPlan = PlanBuilder(pool())
+                              .tableScan(declared, {"c0 = '1'"}, "", declared)
+                              .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(pushdownOnlyPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical INTEGER Parquet column c0");
+
+  auto extractedFilterPlan = PlanBuilder(pool())
+                                 .tableScan(declared, {}, "c0 = '1'", declared)
+                                 .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(extractedFilterPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical INTEGER Parquet column c0");
+
+  auto isNullPlan = PlanBuilder(pool())
+                        .tableScan(declared, {"c0 IS NULL"}, "", declared)
+                        .planNode();
+  auto isNullResult = AssertQueryBuilder(isNullPlan)
+                          .split(makeSplit(file->getPath()))
+                          .copyResults(pool());
+  auto expected = makeRowVector(
+      {"c0"}, {makeNullableFlatVector<StringView>({std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({expected}, {isNullResult}));
+}
+
 TEST_F(ParquetTableScanTest, floatingPointToVarcharFilterOnlyColumn) {
   auto data = makeRowVector(
       {"c0", "c1"},
@@ -2109,6 +2251,25 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharFilterOnlyColumn) {
           .split(makeSplit(file->getPath()))
           .copyResults(pool()),
       "Cannot apply VARCHAR filter to physical DOUBLE Parquet column c0");
+}
+
+TEST_F(ParquetTableScanTest, integerToDoubleFilterOnlyColumn) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int64_t>({10, 20})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto outputType = ROW({"c1"}, {BIGINT()});
+  auto dataColumns = ROW({"c0", "c1"}, {DOUBLE(), BIGINT()});
+  auto plan = PlanBuilder(pool())
+                  .tableScan(outputType, {"c0 > 1.0"}, "", dataColumns)
+                  .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply DOUBLE filter to physical INTEGER Parquet column c0");
 }
 
 TEST_F(ParquetTableScanTest, floatingPointToVarcharMapValueFilter) {
@@ -2139,6 +2300,136 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharMapValueFilter) {
           .split(makeSplit(file->getPath()))
           .copyResults(pool()),
       "Cannot apply VARCHAR filter to physical DOUBLE Parquet column c0.values");
+}
+
+TEST_F(ParquetTableScanTest, integerToDoubleMapValueFilter) {
+  auto data = makeRowVector(
+      {"c0"},
+      {makeMapVector<StringView, int32_t>({{{"key", 1}}, {{"key", 2}}})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {MAP(VARCHAR(), DOUBLE())});
+  auto filters =
+      common::test::SubfieldFiltersBuilder()
+          .add(
+              "c0",
+              common::createMapSubscriptFilter(
+                  "key",
+                  std::make_unique<common::DoubleRange>(
+                      1.0, false, false, 1.0, false, false, false),
+                  common::createBytesRange("key", true, "key", true, false)))
+          .build();
+  auto tableHandle =
+      makeTableHandle(std::move(filters), nullptr, "hive_table", declared);
+  auto plan = PlanBuilder(pool())
+                  .tableScan(declared, tableHandle, allRegularColumns(declared))
+                  .planNode();
+
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply DOUBLE filter to physical INTEGER Parquet column c0.values");
+}
+
+TEST_F(ParquetTableScanTest, dateToVarcharMapValueFilter) {
+  auto map = makeMapVector<StringView, int32_t>(
+      {{{"key", 1}}, {{"key", 2}}}, MAP(VARCHAR(), DATE()));
+  auto data = makeRowVector({"c0"}, {map});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {MAP(VARCHAR(), VARCHAR())});
+  auto filters =
+      common::test::SubfieldFiltersBuilder()
+          .add(
+              "c0",
+              common::createMapSubscriptFilter(
+                  "key",
+                  common::createBytesRange("1", true, "1", true, false),
+                  common::createBytesRange("key", true, "key", true, false)))
+          .build();
+  auto tableHandle =
+      makeTableHandle(std::move(filters), nullptr, "hive_table", declared);
+  auto plan = PlanBuilder(pool())
+                  .tableScan(declared, tableHandle, allRegularColumns(declared))
+                  .planNode();
+
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical INTEGER Parquet column c0.values");
+}
+
+TEST_F(ParquetTableScanTest, integerReaderCastMapMetadataFilters) {
+  auto test = [&](const RowVectorPtr& data,
+                  const RowTypePtr& declared,
+                  const std::string& filter,
+                  std::unique_ptr<common::Filter> valueFilter,
+                  const RowVectorPtr& expected) {
+    auto file = exec::test::TempFilePath::create();
+    WriterOptions writerOptions;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<DefaultFlushPolicy>(
+          2, std::numeric_limits<int64_t>::max());
+    };
+    writeToParquetFile(file->getPath(), {data}, writerOptions);
+
+    ScopedExprToSubfieldFilterParser parser(
+        std::make_shared<MapSubscriptMetadataFilterParser>(
+            std::move(valueFilter)));
+    core::PlanNodeId scanNodeId;
+    auto plan =
+        PlanBuilder(pool())
+            .tableScan("hive_table", declared, {}, {}, filter, declared, false)
+            .capturePlanNodeId(scanNodeId)
+            .planNode();
+    std::shared_ptr<exec::Task> task;
+    auto result =
+        AssertQueryBuilder(plan)
+            .config(core::QueryConfig::kMapSubscriptFilterPushdown, "true")
+            .split(makeSplit(file->getPath()))
+            .copyResults(pool(), task);
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+    EXPECT_EQ(
+        exec::toPlanStats(task->taskStats())
+            .at(scanNodeId)
+            .customStats.at("skippedStrides")
+            .sum,
+        1);
+  };
+
+  test(
+      makeRowVector(
+          {"c0", "c1"},
+          {makeMapVector<StringView, int32_t>(
+               {{{"key", 1}}, {{"key", 2}}, {{"key", 1}}, {{"key", 2}}}),
+           makeFlatVector<int64_t>({0, 0, 100, 100})}),
+      ROW({"c0", "c1"}, {MAP(VARCHAR(), DOUBLE()), BIGINT()}),
+      "element_at(c0, 'key') = 1.0 AND c1 >= 100",
+      std::make_unique<common::DoubleRange>(
+          1.0, false, false, 1.0, false, false, false),
+      makeRowVector(
+          {"c0", "c1"},
+          {makeMapVector<StringView, double>({{{"key", 1.0}}}),
+           makeFlatVector<int64_t>({100})}));
+
+  test(
+      makeRowVector(
+          {"c0", "c1"},
+          {makeMapVector<StringView, int32_t>(
+               {{{"key", 1}}, {{"key", 2}}, {{"key", 1}}, {{"key", 2}}},
+               MAP(VARCHAR(), DATE())),
+           makeFlatVector<int64_t>({0, 0, 100, 100})}),
+      ROW({"c0", "c1"}, {MAP(VARCHAR(), VARCHAR()), BIGINT()}),
+      "element_at(c0, 'key') = '1' AND c1 >= 100",
+      common::createBytesRange("1", true, "1", true, false),
+      makeRowVector(
+          {"c0", "c1"},
+          {makeMapVector<StringView, StringView>({{{"key", "1"}}}),
+           makeFlatVector<int64_t>({100})}));
 }
 
 TEST_F(ParquetTableScanTest, floatingPointToVarcharMapMetadataFilter) {
@@ -2187,6 +2478,112 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharMapMetadataFilter) {
           .customStats.at("skippedStrides")
           .sum,
       1);
+}
+
+#ifdef SPARK_COMPATIBLE
+TEST_F(ParquetTableScanTest, doubleToBigintMapMetadataFilter) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {makeMapVector<StringView, double>(
+           {{{"key", 1.2}}, {{"key", 2.5}}, {{"key", 1.8}}, {{"key", 2.5}}}),
+       makeFlatVector<int64_t>({0, 0, 100, 100})});
+  auto file = exec::test::TempFilePath::create();
+  WriterOptions writerOptions;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<DefaultFlushPolicy>(
+        2, std::numeric_limits<int64_t>::max());
+  };
+  writeToParquetFile(file->getPath(), {data}, writerOptions);
+
+  ScopedExprToSubfieldFilterParser parser(
+      std::make_shared<MapSubscriptMetadataFilterParser>(
+          common::createBigintRange(1, 1, false, false)));
+  auto declared = ROW({"c0", "c1"}, {MAP(VARCHAR(), BIGINT()), BIGINT()});
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder(pool())
+                  .tableScan(
+                      "hive_table",
+                      declared,
+                      {},
+                      {},
+                      "element_at(c0, 'key') = 1 AND c1 >= 100",
+                      declared,
+                      false)
+                  .capturePlanNodeId(scanNodeId)
+                  .planNode();
+  std::shared_ptr<exec::Task> task;
+  auto result =
+      AssertQueryBuilder(plan)
+          .config(core::QueryConfig::kMapSubscriptFilterPushdown, "true")
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool(), task);
+  auto expected = makeRowVector(
+      {"c0", "c1"},
+      {makeMapVector<StringView, int64_t>({{{"key", 1}}}),
+       makeFlatVector<int64_t>({100})});
+  EXPECT_TRUE(assertEqualResults({expected}, {result}));
+  EXPECT_EQ(
+      exec::toPlanStats(task->taskStats())
+          .at(scanNodeId)
+          .customStats.at("skippedStrides")
+          .sum,
+      1);
+}
+#endif
+
+TEST_F(ParquetTableScanTest, integerReaderCastMetadataFilters) {
+  auto test = [&](const RowVectorPtr& data,
+                  const RowTypePtr& declared,
+                  const std::string& filter,
+                  const RowVectorPtr& expected) {
+    auto file = exec::test::TempFilePath::create();
+    WriterOptions writerOptions;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<DefaultFlushPolicy>(
+          2, std::numeric_limits<int64_t>::max());
+    };
+    writeToParquetFile(file->getPath(), {data}, writerOptions);
+
+    core::PlanNodeId scanNodeId;
+    auto plan =
+        PlanBuilder(pool())
+            .tableScan("hive_table", declared, {}, {}, filter, declared, false)
+            .capturePlanNodeId(scanNodeId)
+            .planNode();
+    std::shared_ptr<exec::Task> task;
+    auto result = AssertQueryBuilder(plan)
+                      .split(makeSplit(file->getPath()))
+                      .copyResults(pool(), task);
+    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+    EXPECT_EQ(
+        exec::toPlanStats(task->taskStats())
+            .at(scanNodeId)
+            .customStats.at("skippedStrides")
+            .sum,
+        1);
+  };
+
+  test(
+      makeRowVector(
+          {"c0", "c1"},
+          {makeFlatVector<int32_t>({1, 2, 1, 2}),
+           makeFlatVector<int64_t>({0, 0, 100, 100})}),
+      ROW({"c0", "c1"}, {DOUBLE(), BIGINT()}),
+      "c0 = 1.0 AND c1 >= 100",
+      makeRowVector(
+          {"c0", "c1"},
+          {makeFlatVector<double>({1.0}), makeFlatVector<int64_t>({100})}));
+
+  test(
+      makeRowVector(
+          {"c0", "c1"},
+          {makeFlatVector<int32_t>({1, 2, 1, 2}, DATE()),
+           makeFlatVector<int64_t>({0, 0, 100, 100})}),
+      ROW({"c0", "c1"}, {VARCHAR(), BIGINT()}),
+      "c0 = '1' AND c1 >= 100",
+      makeRowVector(
+          {"c0", "c1"},
+          {makeFlatVector<StringView>({"1"}), makeFlatVector<int64_t>({100})}));
 }
 
 TEST_F(ParquetTableScanTest, floatingPointToVarcharMetadataFilter) {


### PR DESCRIPTION
Allow Parquet DOUBLE columns to be read as BIGINT through the reader-side Spark cast path.

Reject value-dependent filter pushdown when reader casts make the logical filter type incompatible with physical Parquet values, including floating point to VARCHAR, DOUBLE to BIGINT, signed INT32 types to DOUBLE, and DATE to VARCHAR. Disable incompatible metadata filters while preserving value-independent filters and compatible pruning for scalar and nested map columns, including dynamic filters.

Add coverage for scalar reads, filter-only columns, null filters, nested maps, and metadata pruning.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #796 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

  Support reading Parquet `DOUBLE` columns as `BIGINT` through the existing reader-side cast path, matching Spark behavior.

  Reader casts can make logical filters incompatible with physical Parquet values and statistics. This change:

  - Rejects value-dependent filter pushdown for incompatible reader casts.
  - Preserves value-independent filters such as `IS NULL`, `IS NOT NULL`, `AlwaysTrue`, and `AlwaysFalse`.
  - Disables type-dependent metadata filtering where physical and requested types use different value domains.
  - Applies the same handling to scalar columns, filter-only columns, nested maps, and dynamic filters.

  The shared compatibility check covers:

  - `DOUBLE -> BIGINT`
  - Signed `INT32 -> DOUBLE`
  - `DATE -> VARCHAR`
  - `REAL/DOUBLE -> VARCHAR`

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- fix: support parquet double columns as bigint
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
