### PR TITLE
feat: implement bitmap_count scalar function for Spark compatibility

### DIFF
--- a/bolt/functions/sparksql/Bitmap.h
+++ b/bolt/functions/sparksql/Bitmap.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "bolt/functions/Macros.h"
+#include "bolt/functions/sparksql/BitmapUtil.h"
+
+namespace bytedance::bolt::functions::sparksql {
+
+/// Spark-compatible bitmap_count(BINARY) -> BIGINT.
+/// Matches Spark 3.5 BitmapExpressionUtils.bitmapCount.
+template <typename T>
+struct BitmapCountFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<Varbinary>& input) {
+    result = bitmapPopcount(input.data(), input.size());
+  }
+};
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/BitmapUtil.h
+++ b/bolt/functions/sparksql/BitmapUtil.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+namespace bytedance::bolt::functions::sparksql {
+
+// Spark's BitmapExpressionUtils.NUM_BYTES (4 KiB, 32768 bits).
+inline constexpr int32_t kBitmapNumBytes = 4096;
+inline constexpr int32_t kBitmapNumBits = kBitmapNumBytes * 8;
+
+/// Popcount over arbitrary byte buffer. memcpy avoids UB from misaligned
+/// data (the input may not be 8-byte aligned). Returns 0 for null/empty.
+inline int64_t bitmapPopcount(const char* data, size_t size) {
+  if (data == nullptr || size == 0) {
+    return 0;
+  }
+  int64_t count = 0;
+  const size_t numFullWords = size / sizeof(uint64_t);
+  for (size_t i = 0; i < numFullWords; ++i) {
+    uint64_t word;
+    memcpy(&word, data + (i * sizeof(uint64_t)), sizeof(uint64_t));
+    count += __builtin_popcountll(word);
+  }
+  // Tail: remaining bytes that don't fill a full 64-bit word.
+  const size_t tailStart = numFullWords * sizeof(uint64_t);
+  const auto* tail = reinterpret_cast<const uint8_t*>(data);
+  for (size_t i = tailStart; i < size; ++i) {
+    count += __builtin_popcount(tail[i]);
+  }
+  return count;
+}
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/aggregates/BitmapUtil.h
+++ b/bolt/functions/sparksql/aggregates/BitmapUtil.h
@@ -22,12 +22,13 @@
 #include <xsimd/xsimd.hpp>
 
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/functions/sparksql/BitmapUtil.h"
 
 namespace bytedance::bolt::functions::aggregate::sparksql {
 
-// Matching Spark's BitmapExpressionUtils.NUM_BYTES (4 KiB, 32768 bits).
-inline constexpr int32_t kBitmapNumBytes = 4096;
-inline constexpr int32_t kBitmapNumBits = kBitmapNumBytes * 8;
+// Re-export shared wire-format constants.
+using ::bytedance::bolt::functions::sparksql::kBitmapNumBits;
+using ::bytedance::bolt::functions::sparksql::kBitmapNumBytes;
 
 // Inline 4096-byte bitmap accumulator. Trivially constructible/destructible so
 // Bolt's RowContainer group reuse is safe. uint8_t ensures portable unsigned

--- a/bolt/functions/sparksql/registration/CMakeLists.txt
+++ b/bolt/functions/sparksql/registration/CMakeLists.txt
@@ -32,6 +32,7 @@ bolt_add_library(
   Register.cpp
   RegisterArray.cpp
   RegisterBinary.cpp
+  RegisterBitmap.cpp
   RegisterBitwise.cpp
   RegisterCharVarchar.cpp
   RegisterComparison.cpp

--- a/bolt/functions/sparksql/registration/Register.cpp
+++ b/bolt/functions/sparksql/registration/Register.cpp
@@ -36,6 +36,7 @@ namespace bytedance::bolt::functions::sparksql {
 
 extern void registerArrayFunctions(const std::string& prefix);
 extern void registerBinaryFunctions(const std::string& prefix);
+extern void registerBitmapFunctions(const std::string& prefix);
 extern void registerBitwiseFunctions(const std::string& prefix);
 extern void registerCharVarcharFunctions(const std::string& prefix);
 extern void registerCompareFunctions(const std::string& prefix);
@@ -54,6 +55,7 @@ void registerFunctions(const std::string& prefix) {
   registerTimestampWithTimeZoneType();
   registerArrayFunctions(prefix);
   registerBinaryFunctions(prefix);
+  registerBitmapFunctions(prefix);
   registerBitwiseFunctions(prefix);
   registerCharVarcharFunctions(prefix);
   registerCompareFunctions(prefix);

--- a/bolt/functions/sparksql/registration/RegisterBitmap.cpp
+++ b/bolt/functions/sparksql/registration/RegisterBitmap.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/functions/lib/RegistrationHelpers.h"
+#include "bolt/functions/sparksql/Bitmap.h"
+
+namespace bytedance::bolt::functions::sparksql {
+
+void registerBitmapFunctions(const std::string& prefix) {
+  registerFunction<BitmapCountFunction, int64_t, Varbinary>(
+      {prefix + "bitmap_count"});
+}
+
+} // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/tests/BitmapCountTest.cpp
+++ b/bolt/functions/sparksql/tests/BitmapCountTest.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/functions/sparksql/Bitmap.h"
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+using namespace bytedance::bolt::functions::sparksql;
+
+class BitmapCountTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<int64_t> bitmapCount(const std::optional<std::string>& bitmap) {
+    return evaluateOnce<int64_t, std::string>(
+        "bitmap_count(cast(c0 as varbinary))", bitmap);
+  }
+
+  /// Evaluate bitmap_count for a binary value. Uses FunctionBaseTest::evaluate
+  /// like other Spark tests (avoids manual ExprSet construction issues).
+  int64_t evalBitmapCount(const std::string& serialized) {
+    auto vec = makeConstant(StringView(serialized), 1, VARBINARY());
+    auto result = evaluate<SimpleVector<int64_t>>(
+        "bitmap_count(c0)", makeRowVector({vec}));
+    return result->valueAt(0);
+  }
+
+  void assertNullResult() {
+    auto vec = makeNullConstant(TypeKind::VARBINARY, 1);
+    auto result = evaluate<SimpleVector<int64_t>>(
+        "bitmap_count(c0)", makeRowVector({vec}));
+    EXPECT_TRUE(result->isNullAt(0));
+  }
+
+  std::string makeAllZeroBitmap() {
+    return std::string(kBitmapNumBytes, '\0');
+  }
+
+  std::string makeAllOnesBitmap() {
+    return std::string(kBitmapNumBytes, '\xff');
+  }
+
+  std::string makeBitmapWithBit(int32_t bitPosition) {
+    std::string bitmap(kBitmapNumBytes, '\0');
+    int32_t byteIdx = bitPosition / 8;
+    int32_t bitIdx = bitPosition % 8;
+    bitmap[byteIdx] = static_cast<char>(1 << bitIdx);
+    return bitmap;
+  }
+};
+
+TEST_F(BitmapCountTest, nullInput) {
+  auto result = bitmapCount(std::nullopt);
+  EXPECT_EQ(result, std::nullopt);
+}
+
+TEST_F(BitmapCountTest, emptyBinary) {
+  EXPECT_EQ(bitmapPopcount(nullptr, 0), 0);
+  EXPECT_EQ(bitmapPopcount("", 0), 0);
+}
+
+TEST_F(BitmapCountTest, nullBinaryConstant) {
+  assertNullResult();
+}
+
+TEST_F(BitmapCountTest, allZeroBitmap) {
+  EXPECT_EQ(evalBitmapCount(makeAllZeroBitmap()), 0);
+}
+
+TEST_F(BitmapCountTest, allOnesBitmap) {
+  EXPECT_EQ(evalBitmapCount(makeAllOnesBitmap()), 32768);
+}
+
+TEST_F(BitmapCountTest, singleBit) {
+  EXPECT_EQ(evalBitmapCount(makeBitmapWithBit(0)), 1);
+  EXPECT_EQ(evalBitmapCount(makeBitmapWithBit(32767)), 1);
+}
+
+TEST_F(BitmapCountTest, multipleBits) {
+  auto bitmap = makeAllZeroBitmap();
+  auto setBit = [&](int32_t pos) {
+    bitmap[pos / 8] |= static_cast<char>(1 << (pos % 8));
+  };
+  setBit(0);
+  setBit(100);
+  setBit(1000);
+  setBit(10000);
+  setBit(32767);
+  EXPECT_EQ(evalBitmapCount(bitmap), 5);
+}
+
+TEST_F(BitmapCountTest, mixedBits) {
+  std::string bitmap(kBitmapNumBytes, static_cast<char>(0xAA));
+  EXPECT_EQ(evalBitmapCount(bitmap), 16384);
+}
+
+TEST_F(BitmapCountTest, misalignedData) {
+  constexpr int32_t kBufSize = kBitmapNumBytes + 1;
+  auto padded = AlignedBuffer::allocate<char>(kBufSize, pool());
+  std::memset(padded->asMutable<char>() + 1, 0xFF, kBitmapNumBytes);
+  EXPECT_EQ(
+      evalBitmapCount(std::string(padded->as<char>() + 1, kBitmapNumBytes)),
+      32768);
+}
+
+TEST_F(BitmapCountTest, sparkHexFFFF) {
+  std::string bytes(2, '\0');
+  bytes[0] = static_cast<char>(0xFF);
+  bytes[1] = static_cast<char>(0xFF);
+  EXPECT_EQ(evalBitmapCount(bytes), 16);
+}
+
+TEST_F(BitmapCountTest, nonFullWord) {
+  std::string bytes(3, '\0');
+  bytes[0] = static_cast<char>(0xAA);
+  bytes[1] = static_cast<char>(0x55);
+  bytes[2] = static_cast<char>(0x0F);
+  EXPECT_EQ(evalBitmapCount(bytes), 12);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   ArraysZipTest.cpp
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
+  BitmapCountTest.cpp
   BitwiseTest.cpp
   CharVarcharTest.cpp
   ComparisonsTest.cpp


### PR DESCRIPTION
Add Spark-compatible bitmap_count(BINARY) -> BIGINT that returns the population count of set bits across every byte of a bitmap produced by bitmap_construct_agg or bitmap_or_agg.

Core design:
- BitmapUtil.h: shared constants (4096 bytes, 32768 bits) and bitmapPopcount() utility with memcpy-based 64-bit word popcount to avoid UB from misaligned data
- Bitmap.h: domain-grouped scalar function header
- RegisterBitmap.cpp: dedicated registration file for bitmap scalars

11 unit tests: null, empty, all-zero/all-ones, boundary single bits, multiple bits, alternating 0xAA, misaligned buffer, Spark hex FFFF reference case, and non-full-word tail coverage.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #760 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
