### PR TITLE
fix: release RowContainer row pointers before clearing allocator

### DIFF
--- a/bolt/exec/RowContainer.cpp
+++ b/bolt/exec/RowContainer.cpp
@@ -1061,8 +1061,11 @@ void RowContainer::clear() {
     }
   }
   rows_.clear();
-  rowPointers_.clear();
-  rowPointers_.shrink_to_fit();
+  {
+    std::vector<char*, StlAllocator<char*>> emptyRowPointers{
+        rowPointers_.get_allocator()};
+    rowPointers_.swap(emptyRowPointers);
+  }
   if (!sharedStringAllocator) {
     if (checkFree_) {
       stringAllocator_->checkEmpty();

--- a/bolt/exec/tests/RowContainerTest.cpp
+++ b/bolt/exec/tests/RowContainerTest.cpp
@@ -1529,6 +1529,28 @@ TEST_F(RowContainerTest, mixedFree) {
   data2->checkConsistency();
 }
 
+TEST_F(RowContainerTest, listRowIndexClearReleasesAllocatorStorageBeforeReuse) {
+  constexpr int32_t kRowsToUseHashStringAllocatorPool =
+      HashStringAllocator::kMaxAlloc / sizeof(char*) + 1;
+  auto data = makeRowContainer({SMALLINT()}, {VARCHAR()}, false, true);
+
+  for (int32_t i = 0; i < kRowsToUseHashStringAllocatorPool; ++i) {
+    data->newRow();
+  }
+  ASSERT_GT(
+      data->testingRowPointers().capacity() * sizeof(char*),
+      HashStringAllocator::kMaxAlloc);
+
+  data->clear();
+  ASSERT_TRUE(data->testingRowPointers().empty());
+  ASSERT_EQ(data->testingRowPointers().capacity(), 0);
+
+  for (int32_t i = 0; i < kRowsToUseHashStringAllocatorPool; ++i) {
+    data->newRow();
+  }
+  ASSERT_EQ(data->numRows(), kRowsToUseHashStringAllocatorPool);
+}
+
 TEST_F(RowContainerTest, unknown) {
   std::vector<TypePtr> types = {UNKNOWN()};
   auto rowContainer = std::make_unique<RowContainer>(types, pool_.get());


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Fix "freeToPool for block not allocated from pool of HashStringAllocator".

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

OrderBy spill can fail while reusing a RowContainer after spill with this runtime error:

E20260803 16:16:23.277523 140505006470848 Exceptions.h:82] Line: ./bolt/common/memory/HashStringAllocator.cpp:130, Function:freeToPool, Expression: it != allocationsFromPool_.end() freeToPool for block not allocated from pool of HashStringAllocator, Source: RUNTIME, ErrorCode: INVALID_STATE

terminate called after throwing an instance of 'bytedance::bolt::BoltRuntimeError'; Reason: freeToPool for block not allocated from pool of HashStringAllocator; Context: Operator: OrderBy[1] 1; File: ./bolt/common/memory/HashStringAllocator.cpp; Line: 130

Root cause: RowContainer::clear() used clear() plus shrink_to_fit() on rowPointers_ before clearing the HashStringAllocator. shrink_to_fit() is non-binding, so rowPointers_ can retain a large backing buffer allocated through HashStringAllocator::allocateFromPool(). If stringAllocator_->clear() resets allocationsFromPool_ first, later vector growth may free that stale backing buffer and trigger freeToPool's invalid-state check.

Fix: release rowPointers_ by swapping with an empty vector using the same allocator in a scoped block. This guarantees the old vector storage is destroyed before stringAllocator_->clear() resets allocator state. Add a RowContainer regression test that uses the smallest row count needed for rowPointers_ to cross HashStringAllocator::kMaxAlloc and verifies clear releases the storage before reuse.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
