### PR TITLE
misc: Remove unused deprecated APIs

### DIFF
--- a/bolt/common/memory/Memory.cpp
+++ b/bolt/common/memory/Memory.cpp
@@ -38,11 +38,9 @@
 #include "bolt/common/memory/MemoryPoolForGluten.h"
 #include "bolt/common/memory/MmapAllocator.h"
 
-DECLARE_int32(bolt_memory_num_shared_leaf_pools);
 namespace bytedance::bolt::memory {
 namespace {
 constexpr std::string_view kSysRootName{"__sys_root__"};
-constexpr std::string_view kSysSharedLeafNamePrefix{"__sys_shared_leaf__"};
 
 struct SingletonState {
   ~SingletonState() {
@@ -86,20 +84,6 @@ std::unique_ptr<MemoryArbitrator> createArbitrator(
            std::min(options.arbitratorCapacity, options.allocatorCapacity),
        .arbitrationStateCheckCb = options.arbitrationStateCheckCb,
        .extraConfigs = options.extraArbitratorConfigs});
-}
-
-std::vector<std::shared_ptr<MemoryPool>> createSharedLeafMemoryPools(
-    MemoryPool& sysPool) {
-  BOLT_CHECK_EQ(sysPool.name(), kSysRootName);
-  std::vector<std::shared_ptr<MemoryPool>> leafPools;
-  const size_t numSharedPools =
-      std::max(1, FLAGS_bolt_memory_num_shared_leaf_pools);
-  leafPools.reserve(numSharedPools);
-  for (size_t i = 0; i < numSharedPools; ++i) {
-    leafPools.emplace_back(
-        sysPool.addLeafChild(fmt::format("{}{}", kSysSharedLeafNamePrefix, i)));
-  }
-  return leafPools;
 }
 
 // Used by sys root memory pool for use case that expect a memory reclaimer to
@@ -211,8 +195,7 @@ MemoryManager::MemoryManager(const MemoryManager::Options& options)
                             options.enableDynamicMemoryQuotaManager})},
       spillPool_{addLeafPool("__sys_spilling__")},
       cachePool_{addLeafPool("__sys_caching__")},
-      tracePool_{addLeafPool("__sys_tracing__")},
-      sharedLeafPools_(createSharedLeafMemoryPools(*sysRoot_)) {
+      tracePool_{addLeafPool("__sys_tracing__")} {
   sysRoot_->setReclaimer(SysMemoryReclaimer::create());
   BOLT_CHECK_NOT_NULL(allocator_);
   BOLT_CHECK_NOT_NULL(arbitrator_);
@@ -225,9 +208,6 @@ MemoryManager::MemoryManager(const MemoryManager::Options& options)
       "Failed to set max capacity {} for {}",
       succinctBytes(sysRoot_->maxCapacity()),
       sysRoot_->name());
-  BOLT_CHECK_EQ(
-      sharedLeafPools_.size(),
-      std::max(1, FLAGS_bolt_memory_num_shared_leaf_pools));
 }
 
 MemoryManager::~MemoryManager() {
@@ -246,24 +226,6 @@ MemoryManager::~MemoryManager() {
       LOG(ERROR) << errMsg;
     }
   }
-}
-
-// static
-MemoryManager& MemoryManager::deprecatedGetInstance(
-    const MemoryManager::Options& options) {
-  auto& state = singletonState();
-  if (auto* instance = state.instance.load(std::memory_order_acquire)) {
-    return *instance;
-  }
-
-  std::lock_guard<std::mutex> l(state.mutex);
-  auto* instance = state.instance.load(std::memory_order_acquire);
-  if (instance != nullptr) {
-    return *instance;
-  }
-  instance = new MemoryManager(options);
-  state.instance.store(instance, std::memory_order_release);
-  return *instance;
 }
 
 // static
@@ -420,12 +382,6 @@ void MemoryManager::dropPool(MemoryPool* pool) {
   pools_.erase(it);
 }
 
-MemoryPool& MemoryManager::deprecatedSharedLeafPool() {
-  const auto idx = std::hash<std::thread::id>{}(std::this_thread::get_id());
-  std::shared_lock guard{mutex_};
-  return *sharedLeafPools_.at(idx % sharedLeafPools_.size());
-}
-
 int64_t MemoryManager::getTotalBytes() const {
   return allocator_->totalUsedBytes();
 }
@@ -434,7 +390,7 @@ size_t MemoryManager::numPools() const {
   size_t numPools = sysRoot_->getChildCount();
   {
     std::shared_lock guard{mutex_};
-    numPools += pools_.size() - sharedLeafPools_.size();
+    numPools += pools_.size();
   }
   return numPools;
 }
@@ -508,25 +464,6 @@ void initializeMemoryManager(const MemoryManager::Options& options) {
 
 MemoryManager* memoryManager() {
   return MemoryManager::getInstance();
-}
-
-MemoryManager& deprecatedDefaultMemoryManager() {
-  return MemoryManager::deprecatedGetInstance();
-}
-
-std::shared_ptr<MemoryPool> deprecatedAddDefaultLeafMemoryPool(
-    const std::string& name,
-    bool threadSafe) {
-  auto& memoryManager = deprecatedDefaultMemoryManager();
-  return memoryManager.addLeafPool(name, threadSafe);
-}
-
-MemoryPool& deprecatedSharedLeafPool() {
-  return deprecatedDefaultMemoryManager().deprecatedSharedLeafPool();
-}
-
-MemoryPool& deprecatedRootPool() {
-  return deprecatedDefaultMemoryManager().deprecatedSysRootPool();
 }
 
 memory::MemoryPool* spillMemoryPool() {

--- a/bolt/common/memory/Memory.h
+++ b/bolt/common/memory/Memory.h
@@ -214,12 +214,6 @@ class MemoryManager {
   /// called yet.
   static MemoryManager* getInstance();
 
-  /// Deprecated. Do not use. Remove once existing call sites are updated.
-  /// Returns the process-wide default memory manager instance if exists,
-  /// otherwise creates one based on the specified 'options'.
-  FOLLY_EXPORT static MemoryManager& deprecatedGetInstance(
-      const Options& options = Options{});
-
   /// Returns true if the memory manager has been set.
   static bool testInstance();
 
@@ -265,14 +259,6 @@ class MemoryManager {
       bool allowSpill = true,
       bool allowAbort = false);
 
-  /// Default unmanaged leaf pool with no threadsafe stats support. Libraries
-  /// using this method can get a pool that is shared with other threads. The
-  /// goal is to minimize lock contention while supporting such use cases.
-  ///
-  /// TODO: deprecate this API after all the use cases are able to manage the
-  /// lifecycle of the allocated memory pools properly.
-  MemoryPool& deprecatedSharedLeafPool();
-
   /// Returns the current total memory usage under this memory manager.
   int64_t getTotalBytes() const;
 
@@ -315,10 +301,6 @@ class MemoryManager {
     return tracePool_.get();
   }
 
-  const std::vector<std::shared_ptr<MemoryPool>>& testingSharedLeafPools() {
-    return sharedLeafPools_;
-  }
-
  private:
   std::shared_ptr<MemoryPoolImpl> createRootPool(
       std::string poolName,
@@ -356,8 +338,6 @@ class MemoryManager {
   const std::shared_ptr<MemoryPool> spillPool_;
   const std::shared_ptr<MemoryPool> cachePool_;
   const std::shared_ptr<MemoryPool> tracePool_;
-  const std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;
-
   mutable folly::SharedMutex mutex_;
   // All user root pools allocated from 'this'.
   std::unordered_map<std::string, std::weak_ptr<MemoryPool>> pools_;
@@ -375,28 +355,6 @@ void initializeMemoryManager(const MemoryManager::Options& options);
 /// NOTE: user should have already initialized memory manager by calling.
 /// Otherwise, the function throws.
 MemoryManager* memoryManager();
-
-/// Deprecated. Do not use.
-MemoryManager& deprecatedDefaultMemoryManager();
-
-/// Deprecated. Do not use.
-/// Creates a leaf memory pool from the default memory manager for memory
-/// allocation use. If 'threadSafe' is true, then creates a leaf memory pool
-/// with thread-safe memory usage tracking.
-std::shared_ptr<MemoryPool> deprecatedAddDefaultLeafMemoryPool(
-    const std::string& name = "",
-    bool threadSafe = true);
-
-/// Default unmanaged leaf pool with no threadsafe stats support. Libraries
-/// using this method can get a pool that is shared with other threads. The goal
-/// is to minimize lock contention while supporting such use cases.
-///
-/// TODO: deprecate this API after all the use cases are able to manage the
-/// lifecycle of the allocated memory pools properly.
-MemoryPool& deprecatedSharedLeafPool();
-
-/// Returns the sys root memory pool from the default memory manager.
-MemoryPool& deprecatedRootPool();
 
 /// Returns the system-wide memory pool for spilling memory usage.
 memory::MemoryPool* spillMemoryPool();

--- a/bolt/common/memory/tests/MemoryManagerTest.cpp
+++ b/bolt/common/memory/tests/MemoryManagerTest.cpp
@@ -39,7 +39,6 @@
 #include "bolt/common/memory/Memory.h"
 #include "bolt/common/memory/SharedArbitrator.h"
 
-DECLARE_int32(bolt_memory_num_shared_leaf_pools);
 DECLARE_bool(bolt_enable_memory_usage_track_in_default_memory_pool);
 
 using namespace ::testing;
@@ -48,9 +47,6 @@ namespace bytedance::bolt::memory {
 namespace {
 constexpr folly::StringPiece kSysRootName{"__sys_root__"};
 
-MemoryManager& toMemoryManager(MemoryManager& manager) {
-  return *static_cast<MemoryManager*>(&manager);
-}
 } // namespace
 
 class MemoryManagerTest : public testing::Test {
@@ -63,7 +59,6 @@ class MemoryManagerTest : public testing::Test {
 };
 
 TEST_F(MemoryManagerTest, ctor) {
-  const auto kSharedPoolCount = FLAGS_bolt_memory_num_shared_leaf_pools;
   {
     MemoryManager manager{};
     ASSERT_EQ(manager.numPools(), 3);
@@ -114,8 +109,7 @@ TEST_F(MemoryManagerTest, ctor) {
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMinAlignment);
     ASSERT_EQ(manager.deprecatedSysRootPool().alignment(), manager.alignment());
     // TODO: replace with root pool memory tracker quota check.
-    ASSERT_EQ(
-        kSharedPoolCount + 3, manager.deprecatedSysRootPool().getChildCount());
+    ASSERT_EQ(3, manager.deprecatedSysRootPool().getChildCount());
     ASSERT_EQ(kCapacity, manager.capacity());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
@@ -300,108 +294,6 @@ TEST_F(MemoryManagerTest, addPoolWithArbitrator) {
   ASSERT_EQ(aggregationPool->capacity(), initialPoolCapacity);
 }
 
-// TODO: remove this test when remove deprecatedDefaultMemoryManager.
-TEST_F(MemoryManagerTest, defaultMemoryManager) {
-  auto& managerA = toMemoryManager(deprecatedDefaultMemoryManager());
-  auto& managerB = toMemoryManager(deprecatedDefaultMemoryManager());
-  const auto kSharedPoolCount = FLAGS_bolt_memory_num_shared_leaf_pools + 3;
-  ASSERT_EQ(managerA.numPools(), 3);
-  ASSERT_EQ(managerA.deprecatedSysRootPool().getChildCount(), kSharedPoolCount);
-  ASSERT_EQ(managerB.numPools(), 3);
-  ASSERT_EQ(managerB.deprecatedSysRootPool().getChildCount(), kSharedPoolCount);
-
-  auto child1 = managerA.addLeafPool("child_1");
-  ASSERT_EQ(child1->parent()->name(), managerA.deprecatedSysRootPool().name());
-  auto child2 = managerB.addLeafPool("child_2");
-  ASSERT_EQ(child2->parent()->name(), managerA.deprecatedSysRootPool().name());
-  EXPECT_EQ(
-      kSharedPoolCount + 2, managerA.deprecatedSysRootPool().getChildCount());
-  EXPECT_EQ(
-      kSharedPoolCount + 2, managerB.deprecatedSysRootPool().getChildCount());
-  ASSERT_EQ(managerA.numPools(), 5);
-  ASSERT_EQ(managerB.numPools(), 5);
-  auto pool = managerB.addRootPool();
-  ASSERT_EQ(managerA.numPools(), 6);
-  ASSERT_EQ(managerB.numPools(), 6);
-  ASSERT_EQ(
-      managerA.toString(),
-      "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 6\nList of root pools:\n\t__sys_root__\n\tdefault_root_0\n\trefcount 2\nMemory Allocator[MALLOC capacity UNLIMITED allocated bytes 0 allocated pages 0 mapped pages 0]\nARBIRTATOR[NOOP CAPACITY[UNLIMITED]]]");
-  ASSERT_EQ(
-      managerB.toString(),
-      "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 6\nList of root pools:\n\t__sys_root__\n\tdefault_root_0\n\trefcount 2\nMemory Allocator[MALLOC capacity UNLIMITED allocated bytes 0 allocated pages 0 mapped pages 0]\nARBIRTATOR[NOOP CAPACITY[UNLIMITED]]]");
-  child1.reset();
-  EXPECT_EQ(
-      kSharedPoolCount + 1, managerA.deprecatedSysRootPool().getChildCount());
-  child2.reset();
-  EXPECT_EQ(kSharedPoolCount, managerB.deprecatedSysRootPool().getChildCount());
-  ASSERT_EQ(managerA.numPools(), 4);
-  ASSERT_EQ(managerB.numPools(), 4);
-  pool.reset();
-  ASSERT_EQ(managerA.numPools(), 3);
-  ASSERT_EQ(managerB.numPools(), 3);
-  ASSERT_EQ(
-      managerA.toString(),
-      "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__sys_root__\nMemory Allocator[MALLOC capacity UNLIMITED allocated bytes 0 allocated pages 0 mapped pages 0]\nARBIRTATOR[NOOP CAPACITY[UNLIMITED]]]");
-  ASSERT_EQ(
-      managerB.toString(),
-      "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__sys_root__\nMemory Allocator[MALLOC capacity UNLIMITED allocated bytes 0 allocated pages 0 mapped pages 0]\nARBIRTATOR[NOOP CAPACITY[UNLIMITED]]]");
-  const std::string detailedManagerStr = managerA.toString(true);
-  ASSERT_THAT(
-      detailedManagerStr,
-      testing::HasSubstr(
-          "Memory Manager[capacity UNLIMITED alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n__sys_root__ usage 0B reserved 0B peak 0B\n"));
-  ASSERT_THAT(
-      detailedManagerStr,
-      testing::HasSubstr("__sys_spilling__ usage 0B reserved 0B peak 0B\n"));
-  ASSERT_THAT(
-      detailedManagerStr,
-      testing::HasSubstr("__sys_tracing__ usage 0B reserved 0B peak 0B\n"));
-  for (int i = 0; i < 32; ++i) {
-    ASSERT_THAT(
-        managerA.toString(true),
-        testing::HasSubstr(fmt::format(
-            "__sys_shared_leaf__{} usage 0B reserved 0B peak 0B\n", i)));
-  }
-}
-
-// TODO: remove this test when remove deprecatedAddDefaultLeafMemoryPool.
-TEST(MemoryHeaderTest, addDefaultLeafMemoryPool) {
-  auto& manager = toMemoryManager(deprecatedDefaultMemoryManager());
-  const auto kSharedPoolCount = FLAGS_bolt_memory_num_shared_leaf_pools + 3;
-  ASSERT_EQ(manager.deprecatedSysRootPool().getChildCount(), kSharedPoolCount);
-  {
-    auto poolA = deprecatedAddDefaultLeafMemoryPool();
-    ASSERT_EQ(poolA->kind(), MemoryPool::Kind::kLeaf);
-    auto poolB = deprecatedAddDefaultLeafMemoryPool();
-    ASSERT_EQ(poolB->kind(), MemoryPool::Kind::kLeaf);
-    EXPECT_EQ(
-        kSharedPoolCount + 2, manager.deprecatedSysRootPool().getChildCount());
-    {
-      auto poolC = deprecatedAddDefaultLeafMemoryPool();
-      ASSERT_EQ(poolC->kind(), MemoryPool::Kind::kLeaf);
-      EXPECT_EQ(
-          kSharedPoolCount + 3,
-          manager.deprecatedSysRootPool().getChildCount());
-      {
-        auto poolD = deprecatedAddDefaultLeafMemoryPool();
-        ASSERT_EQ(poolD->kind(), MemoryPool::Kind::kLeaf);
-        EXPECT_EQ(
-            kSharedPoolCount + 4,
-            manager.deprecatedSysRootPool().getChildCount());
-      }
-      EXPECT_EQ(
-          kSharedPoolCount + 3,
-          manager.deprecatedSysRootPool().getChildCount());
-    }
-    EXPECT_EQ(
-        kSharedPoolCount + 2, manager.deprecatedSysRootPool().getChildCount());
-  }
-  EXPECT_EQ(kSharedPoolCount, manager.deprecatedSysRootPool().getChildCount());
-
-  auto namedPool = deprecatedAddDefaultLeafMemoryPool("namedPool");
-  ASSERT_EQ(namedPool->name(), "namedPool");
-}
-
 TEST_F(MemoryManagerTest, defaultMemoryUsageTracking) {
   for (bool trackDefaultMemoryUsage : {false, true}) {
     MemoryManager::Options options;
@@ -474,21 +366,21 @@ TEST_F(MemoryManagerTest, globalMemoryManager) {
   ASSERT_NE(manager, globalManager);
   ASSERT_EQ(manager, memoryManager());
   auto* managerII = memoryManager();
-  const auto kSharedPoolCount = FLAGS_bolt_memory_num_shared_leaf_pools + 3;
+  constexpr int32_t kSystemPoolCount = 3;
   {
     auto& rootI = manager->deprecatedSysRootPool();
     const std::string childIName("some_child");
     auto childI = rootI.addLeafChild(childIName);
-    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 1);
+    ASSERT_EQ(rootI.getChildCount(), kSystemPoolCount + 1);
 
     auto& rootII = managerII->deprecatedSysRootPool();
-    ASSERT_EQ(kSharedPoolCount + 1, rootII.getChildCount());
+    ASSERT_EQ(kSystemPoolCount + 1, rootII.getChildCount());
     std::vector<MemoryPool*> pools{};
     rootII.visitChildren([&pools](MemoryPool* child) {
       pools.emplace_back(child);
       return true;
     });
-    ASSERT_EQ(pools.size(), kSharedPoolCount + 1);
+    ASSERT_EQ(pools.size(), kSystemPoolCount + 1);
     int matchedCount = 0;
     for (const auto* pool : pools) {
       if (pool->name() == childIName) {
@@ -499,15 +391,15 @@ TEST_F(MemoryManagerTest, globalMemoryManager) {
 
     auto childII = manager->addLeafPool("another_child");
     ASSERT_EQ(childII->kind(), MemoryPool::Kind::kLeaf);
-    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 2);
+    ASSERT_EQ(rootI.getChildCount(), kSystemPoolCount + 2);
     ASSERT_EQ(childII->parent()->name(), kSysRootName.str());
     childII.reset();
-    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 1);
-    ASSERT_EQ(rootII.getChildCount(), kSharedPoolCount + 1);
+    ASSERT_EQ(rootI.getChildCount(), kSystemPoolCount + 1);
+    ASSERT_EQ(rootII.getChildCount(), kSystemPoolCount + 1);
     auto userRootChild = manager->addRootPool("rootChild");
     ASSERT_EQ(userRootChild->kind(), MemoryPool::Kind::kAggregate);
-    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 1);
-    ASSERT_EQ(rootII.getChildCount(), kSharedPoolCount + 1);
+    ASSERT_EQ(rootI.getChildCount(), kSystemPoolCount + 1);
+    ASSERT_EQ(rootII.getChildCount(), kSystemPoolCount + 1);
     ASSERT_EQ(manager->numPools(), 2 + 3);
   }
   ASSERT_EQ(manager->numPools(), 3);

--- a/bolt/common/memory/tests/MemoryPoolTest.cpp
+++ b/bolt/common/memory/tests/MemoryPoolTest.cpp
@@ -44,7 +44,6 @@
 
 DECLARE_bool(bolt_memory_leak_check_enabled);
 DECLARE_bool(bolt_memory_pool_debug_enabled);
-DECLARE_int32(bolt_memory_num_shared_leaf_pools);
 
 using namespace ::testing;
 using namespace bytedance::bolt::cache;
@@ -2381,37 +2380,6 @@ TEST_P(MemoryPoolTest, concurrentUpdatesToTheSamePool) {
   childPools.clear();
   ASSERT_LE(root->stats().peakBytes, root->stats().cumulativeBytes);
   ASSERT_EQ(root->stats().currentBytes, 0);
-}
-
-TEST_P(MemoryPoolTest, DISABLED_concurrentUpdateToSharedPools) {
-  // under some conditions bug.
-  constexpr int64_t kMaxMemory = 10 * GB;
-  MemoryManager& manager = *getMemoryManager();
-  const int32_t kNumThreads = FLAGS_bolt_memory_num_shared_leaf_pools;
-
-  folly::Random::DefaultGenerator rng;
-  rng.seed(1234);
-
-  const int32_t kNumOpsPerThread = 200;
-  std::vector<std::thread> threads;
-  threads.reserve(kNumThreads);
-  for (size_t i = 0; i < kNumThreads; ++i) {
-    threads.emplace_back([&, i]() {
-      auto& sharedPool = manager.deprecatedSharedLeafPool();
-      MemoryPoolTester tester(i, kMaxMemory, sharedPool);
-      for (int32_t iter = 0; iter < kNumOpsPerThread; ++iter) {
-        tester.run();
-      }
-    });
-  }
-
-  for (auto& th : threads) {
-    th.join();
-  }
-
-  for (auto pool : manager.testingSharedLeafPools()) {
-    EXPECT_EQ(pool->currentBytes(), 0);
-  }
 }
 
 TEST_P(MemoryPoolTest, concurrentPoolStructureAccess) {

--- a/bolt/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/bolt/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -39,6 +39,10 @@ using namespace bytedance::bolt::duckdb;
 
 class BaseDuckWrapperTest : public testing::Test {
  public:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   template <class T>
   void verifyUnaryResult(
       const std::string& query,
@@ -108,7 +112,7 @@ class BaseDuckWrapperTest : public testing::Test {
 
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::deprecatedAddDefaultLeafMemoryPool()};
+      memory::memoryManager()->addLeafPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   std::unique_ptr<DuckDBWrapper> db_{

--- a/bolt/dwio/common/fuzzer/DwioFuzzer.cpp
+++ b/bolt/dwio/common/fuzzer/DwioFuzzer.cpp
@@ -132,8 +132,7 @@ DwioFuzzer::DwioFuzzer(
     : tempPath_(exec::test::TempDirectoryPath::create()),
       options_(options),
       fileFormat_{fileFormat},
-      aggregatePool_(
-          memory::MemoryManager::deprecatedGetInstance().addRootPool()),
+      aggregatePool_(memory::memoryManager()->addRootPool()),
       pool_(aggregatePool_->addLeafChild("leaf")),
       vectorFuzzer_(std::make_shared<VectorFuzzer>(
           options_.vectorFuzzerOptions,

--- a/bolt/dwio/parquet/fuzzer/ParquetFuzzerRunner.cpp
+++ b/bolt/dwio/parquet/fuzzer/ParquetFuzzerRunner.cpp
@@ -69,7 +69,7 @@ DwioFuzzer::Options getDwioFuzzerOptions() {
 
 // static
 int ParquetFuzzerRunner::run() {
-  memory::MemoryManager::deprecatedGetInstance({});
+  memory::MemoryManager::initialize({});
   size_t seed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   DwioFuzzer(seed, getDwioFuzzerOptions(), common::FileFormat::PARQUET).go();
   return RUN_ALL_TESTS();

--- a/bolt/dwio/parquet/tests/encryption/InternalFileDecryptorTest.cpp
+++ b/bolt/dwio/parquet/tests/encryption/InternalFileDecryptorTest.cpp
@@ -66,13 +66,18 @@ std::vector<uint8_t> encryptGcm(
   return ciphertext;
 }
 
+class InternalFileDecryptorTest : public testing::Test {
+ protected:
+  memory::MemoryManager memoryManager_;
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memoryManager_.addLeafPool("bolt_dwio_parquet_encryption_test")};
+};
+
 } // namespace
 
-TEST(InternalFileDecryptorTest, FooterDecryptorDecryptsAndCaches) {
+TEST_F(InternalFileDecryptorTest, FooterDecryptorDecryptsAndCaches) {
   const std::string footerKey(16, 'k');
   const std::string fileAad(8, 'f');
-  auto pool = memory::deprecatedAddDefaultLeafMemoryPool(
-      "bolt_dwio_parquet_encryption_test");
 
   auto properties = ::parquet::FileDecryptionProperties::Builder()
                         .footer_key(footerKey)
@@ -83,7 +88,7 @@ TEST(InternalFileDecryptorTest, FooterDecryptorDecryptsAndCaches) {
       fileAad,
       bytedance::bolt::parquet::ParquetCipher::AES_GCM_V1,
       "",
-      pool.get());
+      pool_.get());
 
   auto decryptor1 = fileDecryptor.GetFooterDecryptor();
   ASSERT_NE(decryptor1, nullptr);
@@ -106,13 +111,10 @@ TEST(InternalFileDecryptorTest, FooterDecryptorDecryptsAndCaches) {
   EXPECT_EQ(decrypted, plaintext);
 }
 
-TEST(InternalFileDecryptorTest, ColumnMetaDecryptorCachesAndUpdatesAad) {
+TEST_F(InternalFileDecryptorTest, ColumnMetaDecryptorCachesAndUpdatesAad) {
   const std::string footerKey(16, 'k');
   const std::string columnKey(16, 'c');
   const std::string fileAad(8, 'f');
-  auto pool = memory::deprecatedAddDefaultLeafMemoryPool(
-      "bolt_dwio_parquet_encryption_test");
-
   ::parquet::ColumnPathToDecryptionPropertiesMap columnKeys;
   columnKeys["col"] = ::parquet::ColumnDecryptionProperties::Builder("col")
                           .key(columnKey)
@@ -128,7 +130,7 @@ TEST(InternalFileDecryptorTest, ColumnMetaDecryptorCachesAndUpdatesAad) {
       fileAad,
       bytedance::bolt::parquet::ParquetCipher::AES_GCM_V1,
       "",
-      pool.get());
+      pool_.get());
 
   const std::string aad1 = parquet_encryption::createFooterAad(fileAad);
   const std::string aad2 = aad1 + "x";
@@ -162,12 +164,9 @@ TEST(InternalFileDecryptorTest, ColumnMetaDecryptorCachesAndUpdatesAad) {
       BoltRuntimeError);
 }
 
-TEST(InternalFileDecryptorTest, MissingColumnKeyThrows) {
+TEST_F(InternalFileDecryptorTest, MissingColumnKeyThrows) {
   const std::string footerKey(16, 'k');
   const std::string fileAad(8, 'f');
-  auto pool = memory::deprecatedAddDefaultLeafMemoryPool(
-      "bolt_dwio_parquet_encryption_test");
-
   auto properties = ::parquet::FileDecryptionProperties::Builder()
                         .footer_key(footerKey)
                         ->build();
@@ -177,7 +176,7 @@ TEST(InternalFileDecryptorTest, MissingColumnKeyThrows) {
       fileAad,
       bytedance::bolt::parquet::ParquetCipher::AES_GCM_V1,
       "",
-      pool.get());
+      pool_.get());
 
   EXPECT_THROW(
       fileDecryptor.GetColumnDataDecryptor("missing", "", "aad"),

--- a/bolt/expression/fuzzer/ExpressionFuzzerVerifier.h
+++ b/bolt/expression/fuzzer/ExpressionFuzzerVerifier.h
@@ -209,7 +209,7 @@ class ExpressionFuzzerVerifier {
   std::shared_ptr<core::QueryCtx> queryCtx_;
 
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::deprecatedAddDefaultLeafMemoryPool()};
+      memory::memoryManager()->addLeafPool()};
 
   core::ExecCtx execCtx_;
 

--- a/bolt/expression/tests/ExpressionRunner.cpp
+++ b/bolt/expression/tests/ExpressionRunner.cpp
@@ -132,8 +132,7 @@ void ExpressionRunner::run(
   BOLT_CHECK(!sql.empty());
 
   auto queryCtx = core::QueryCtx::create();
-  std::shared_ptr<memory::MemoryPool> pool{
-      memory::deprecatedAddDefaultLeafMemoryPool()};
+  auto pool = memory::memoryManager()->addLeafPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   RowVectorPtr inputVector;

--- a/bolt/flag_definitions/flags.cpp
+++ b/bolt/flag_definitions/flags.cpp
@@ -30,12 +30,10 @@
 
 #include <gflags/gflags.h>
 
-// Used in bolt/common/memory/MappedMemory.cpp
-
 DEFINE_int32(
     bolt_memory_num_shared_leaf_pools,
     32,
-    "Number of shared leaf memory pools per process");
+    "Deprecated compatibility flag; no longer used");
 
 DEFINE_bool(
     bolt_time_allocations,

--- a/bolt/functions/prestosql/JsonFunctions.h
+++ b/bolt/functions/prestosql/JsonFunctions.h
@@ -50,9 +50,8 @@ struct IsJsonScalarFunction {
 
 // jsonExtractScalar(json, json_path) -> varchar
 // Current implementation support UTF-8 in json, but not in json_path.
-// Like jsonExtract(), but returns the result value as a string (as opposed
-// to being encoded as JSON). The value referenced by json_path must be a scalar
-// (boolean, number or string)
+// Returns the result value as a string rather than JSON-encoded text. The value
+// referenced by json_path must be a scalar (boolean, number or string).
 template <typename T>
 struct JsonExtractScalarFunction {
   BOLT_DEFINE_FUNCTION_TYPES(T);
@@ -135,30 +134,6 @@ struct JsonExtractScalarFunctionWithDetected {
         return false;
       }
     }
-  }
-};
-
-template <typename T>
-struct JsonExtractFunction {
-  BOLT_DEFINE_FUNCTION_TYPES(T);
-
-  FOLLY_ALWAYS_INLINE bool call(
-      out_type<Json>& result,
-      const arg_type<Json>& json,
-      const arg_type<Varchar>& jsonPath) {
-    auto extractResult =
-        jsonExtract(folly::StringPiece(json), folly::StringPiece(jsonPath));
-    if (!extractResult.hasValue() || extractResult.value().isNull()) {
-      return false;
-    }
-
-    folly::json::serialization_opts opts;
-    opts.sort_keys = true;
-    folly::json::serialize(*extractResult, opts);
-
-    UDFOutputString::assign(
-        result, folly::json::serialize(*extractResult, opts));
-    return true;
   }
 };
 

--- a/bolt/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/bolt/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -65,10 +65,6 @@ class JsonBenchmark : public bolt::functions::test::FunctionBenchmarkBase {
         {"folly_json_extract_scalar"});
     registerFunction<WrapperJsonExtractScalarFunction, Varchar, Json, Varchar>(
         {"simd_json_extract_scalar"});
-    registerFunction<JsonExtractFunction, Varchar, Json, Varchar>(
-        {"folly_json_extract"});
-    registerFunction<WrapperJsonExtractFunction, Varchar, Json, Varchar>(
-        {"simd_json_extract"});
     registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
         {"folly_json_size"});
     registerFunction<WrapperJsonSizeFunction, int64_t, Json, Varchar>(
@@ -225,22 +221,13 @@ void SIMDJsonExtractScalar(int iter, int vectorSize, int jsonSize) {
       iter, vectorSize, "simd_json_extract_scalar", json, "$.key[7].k1");
 }
 
-void FollyJsonExtract(int iter, int vectorSize, int jsonSize) {
+void JsonExtract(int iter, int vectorSize, int jsonSize) {
   folly::BenchmarkSuspender suspender;
   JsonBenchmark benchmark;
   auto json = benchmark.prepareData(jsonSize);
   suspender.dismiss();
   benchmark.runWithJsonExtract(
-      iter, vectorSize, "folly_json_extract", json, "$.key[*].k1");
-}
-
-void SIMDJsonExtract(int iter, int vectorSize, int jsonSize) {
-  folly::BenchmarkSuspender suspender;
-  JsonBenchmark benchmark;
-  auto json = benchmark.prepareData(jsonSize);
-  suspender.dismiss();
-  benchmark.runWithJsonExtract(
-      iter, vectorSize, "simd_json_extract", json, "$.key[*].k1");
+      iter, vectorSize, "json_extract", json, "$.key[*].k1");
 }
 
 void FollyJsonSize(int iter, int vectorSize, int jsonSize) {
@@ -426,37 +413,16 @@ BENCHMARK_RELATIVE_NAMED_PARAM(
     10000);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_DRAW_LINE();
-BENCHMARK_NAMED_PARAM(FollyJsonExtract, 100_iters_10bytes_size, 100, 10);
-BENCHMARK_RELATIVE_NAMED_PARAM(
-    SIMDJsonExtract,
-    100_iters_10bytes_size,
-    100,
-    10);
+BENCHMARK_NAMED_PARAM(JsonExtract, 100_iters_10bytes_size, 100, 10);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(FollyJsonExtract, 100_iters_100bytes_size, 100, 100);
-BENCHMARK_RELATIVE_NAMED_PARAM(
-    SIMDJsonExtract,
-    100_iters_100bytes_size,
-    100,
-    100);
+BENCHMARK_NAMED_PARAM(JsonExtract, 100_iters_100bytes_size, 100, 100);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(FollyJsonExtract, 100_iters_1000bytes_size, 100, 1000);
-BENCHMARK_RELATIVE_NAMED_PARAM(
-    SIMDJsonExtract,
-    100_iters_1000bytes_size,
-    100,
-    1000);
+BENCHMARK_NAMED_PARAM(JsonExtract, 100_iters_1000bytes_size, 100, 1000);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(FollyJsonExtract, 100_iters_10000bytes_size, 100, 10000);
-BENCHMARK_RELATIVE_NAMED_PARAM(
-    SIMDJsonExtract,
-    100_iters_10000bytes_size,
-    100,
-    10000);
+BENCHMARK_NAMED_PARAM(JsonExtract, 100_iters_10000bytes_size, 100, 10000);
 BENCHMARK_DRAW_LINE();
 
 BENCHMARK_DRAW_LINE();

--- a/bolt/functions/prestosql/json/JsonExtractor.cpp
+++ b/bolt/functions/prestosql/json/JsonExtractor.cpp
@@ -31,9 +31,7 @@
 #include "bolt/functions/prestosql/json/JsonExtractor.h"
 
 #include <string_view>
-#include "folly/Optional.h"
 #include "folly/String.h"
-#include "folly/json.h"
 
 #define SONIC_EXPONENT_ALWAYS_DOT 1
 #define SONIC_EXPONENT_UPPERCASE 1
@@ -59,13 +57,7 @@ static constexpr double EXPAND_FACTOR{1.5};
 
 namespace {
 
-using JsonVector = std::vector<const folly::dynamic*>;
 using SimdJsonVector = std::vector<simdjson::ondemand::value>;
-
-bool isScalarType(const folly::Optional<folly::dynamic>& json) {
-  return json.has_value() && !json->isObject() && !json->isArray() &&
-      !json->isNull();
-}
 // can't escape whole json, such as {\n "name": "xxx"} can't be parsed
 static void escapeControlCharInJsonStr(
     folly::StringPiece::const_iterator it,
@@ -145,10 +137,6 @@ class JsonExtractor {
     }
     return *op;
   }
-
-  [[deprecated("Use simdExtract(const folly::StringPiece json)")]] folly::
-      Optional<folly::dynamic>
-      extract(const folly::dynamic& json);
 
   [[nodiscard]] size_t tokensSize() {
     return this->tokens_.size();
@@ -418,107 +406,6 @@ thread_local std::unordered_map<std::string, std::shared_ptr<JsonExtractor>>
     JsonExtractor::kExtractorCache;
 thread_local JsonPathTokenizer JsonExtractor::kTokenizer;
 
-[[deprecated("Use simdjson")]] void extractObject(
-    const folly::dynamic* jsonObj,
-    const std::string& key,
-    JsonVector& ret) {
-  auto val = jsonObj->get_ptr(key);
-  if (val) {
-    ret.push_back(val);
-  }
-}
-
-[[deprecated("Use simdjson")]] void extractArray(
-    const folly::dynamic* jsonArray,
-    const std::string& key,
-    JsonVector& ret) {
-  auto arrayLen = jsonArray->size();
-  if (key == "*") {
-    for (size_t i = 0; i < arrayLen; ++i) {
-      ret.push_back(jsonArray->get_ptr(i));
-    }
-  } else {
-    auto rv = folly::tryTo<int32_t>(key);
-    if (rv.hasValue()) {
-      auto idx = rv.value();
-      if (idx >= 0 && idx < arrayLen) {
-        ret.push_back(jsonArray->get_ptr(idx));
-      }
-    }
-  }
-}
-
-[[deprecated("Use simdjson")]] folly::Optional<folly::dynamic>
-JsonExtractor::extract(const folly::dynamic& json) {
-  JsonVector input;
-  // Temporary extraction result holder, swap with input after
-  // each iteration.
-  JsonVector result;
-  input.push_back(&json);
-
-  for (auto& token : tokens_) {
-    for (auto& jsonObj : input) {
-      if (jsonObj->isObject()) {
-        extractObject(jsonObj, token, result);
-      } else if (jsonObj->isArray()) {
-        extractArray(jsonObj, token, result);
-      }
-    }
-    if (result.empty()) {
-      return folly::none;
-    }
-    input.clear();
-    result.swap(input);
-  }
-
-  auto len = input.size();
-  if (0 == len) {
-    return folly::none;
-  } else if (1 == len) {
-    return *input.front();
-  } else {
-    folly::dynamic array = folly::dynamic::array;
-    for (auto obj : input) {
-      array.push_back(*obj);
-    }
-    return array;
-  }
-}
-
-folly::Optional<folly::dynamic> jsonExtract(
-    folly::StringPiece json,
-    folly::StringPiece path) {
-  try {
-    // If extractor fails to parse the path, this will throw a BoltUserError,
-    // and we want to let this exception bubble up to the client. We only catch
-    // json parsing failures (in which cases we return folly::none instead of
-    // throw).
-    auto& extractor = JsonExtractor::getInstance(path);
-    return extractor.extract(folly::parseJson(json));
-  } catch (const folly::json::parse_error&) {
-  } catch (const folly::ConversionError&) {
-    // Folly might throw a conversion error while parsing the input json. In
-    // this case, let it return null.
-  }
-  return folly::none;
-}
-
-folly::Optional<folly::dynamic> jsonExtract(
-    const std::string& json,
-    const std::string& path) {
-  return jsonExtract(folly::StringPiece(json), folly::StringPiece(path));
-}
-
-folly::Optional<folly::dynamic> jsonExtract(
-    const folly::dynamic& json,
-    folly::StringPiece path) {
-  try {
-    return JsonExtractor::getInstance(path).extract(json);
-  } catch (const folly::json::parse_error&) {
-  }
-  return folly::none;
-}
-
 folly::Optional<std::string_view> jsonExtractScalar(
     folly::StringPiece json,
     folly::StringPiece path,
@@ -543,32 +430,6 @@ folly::Optional<std::string_view> jsonExtractScalar(
     VLOG(100) << "simdjson error: " << e.what();
   }
 
-  return folly::none;
-}
-
-// [[deprecated]], for benchmark
-folly::Optional<std::string> follyJsonExtractScalar(
-    const std::string& json,
-    const std::string& path) {
-  folly::StringPiece jsonPiece{json};
-  folly::StringPiece pathPiece{path};
-
-  auto& extractor = JsonExtractor::getInstance(pathPiece);
-  try {
-    auto res = extractor.extract(folly::parseJson(jsonPiece));
-
-    if (isScalarType(res)) {
-      if (res->isBool()) {
-        return res->asBool() ? std::string{"true"} : std::string{"false"};
-      } else {
-        return res->asString();
-      }
-    }
-  } catch (const folly::json::parse_error&) {
-  } catch (const folly::ConversionError&) {
-    // Folly might throw a conversion error while parsing the input json. In
-    // this case, let it return null.
-  }
   return folly::none;
 }
 
@@ -604,7 +465,6 @@ folly::Optional<size_t> jsonExtractSize(
     return extractor.simdJsonSize<false>(json);
   } catch (simdjson::simdjson_error& e) {
     // e.error()
-    // Just follow previous behivor in jsonExtract()
     // simdjson might throw a conversion error while parsing the input json. In
     // this case, let it return null.
   }
@@ -631,7 +491,6 @@ folly::Optional<size_t> jsonArrayLength(folly::StringPiece json) {
     return extractor.simdJsonSize<true>(json);
   } catch (simdjson::simdjson_error& e) {
     // e.error()
-    // Just follow previous behivor in jsonExtract()
     // simdjson might throw a conversion error while parsing the input json. In
     // this case, let it return null.
   }
@@ -652,7 +511,6 @@ folly::Optional<bool> jsonArrayContains(folly::StringPiece json, const T& t) {
     return extractor.simdJsonArrayContains<T>(json);
   } catch (simdjson::simdjson_error& e) {
     // e.error()
-    // Just follow previous behivor in jsonExtract()
     // simdjson might throw a conversion error while parsing the input json. In
     // this case, let it return null.
   }

--- a/bolt/functions/prestosql/json/JsonExtractor.h
+++ b/bolt/functions/prestosql/json/JsonExtractor.h
@@ -32,42 +32,11 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
+#include "folly/Optional.h"
 #include "folly/Range.h"
-#include "folly/dynamic.h"
 namespace bytedance::bolt::functions {
-
-/**
- * Extract a json object from path
- * @param json: A json object
- * @param path: Path to locate a json object. Following operators are supported
- *              "$"      Root member of a json structure no matter it's an
- *                       object or an array
- *              "./[]"   Child operator to get a children object
- *              "[]"     Subscript operator for array and map
- *              "*"      Wildcard for [], get all the elements of an array
- * @return Return json string object on success.
- *         On invalid json path, returns folly::none (not json null) value
- *         On non-json value, returns the original value.
- * Example:
- * For the following example: ,
- * "{\"store\":,
- *   {\"fruit\":\\[{\"weight\":8,\"type\":\"apple\"},
- *                 {\"weight\":9,\"type\":\"pear\"}],
- *    \"bicycle\":{\"price\":19.95,\"color\":\"red\"}
- *   },
- *  \"email\":\"amy@only_for_json_udf_test.net\",
- *  \"owner\":\"amy\",
- * }",
- * jsonExtract(json, "$.owner") = "amy",
- * jsonExtract(json, "$.store.fruit[0]") =
- *    "{\"weight\":8,\"type\":\"apple\"}",
- * jsonExtract(json, "$.non_exist_key") = NULL
- * jsonExtract(json, "$.store.fruit[*].type") = "[\"apple\", \"pear\"]"
- */
-folly::Optional<folly::dynamic> jsonExtract(
-    folly::StringPiece json,
-    folly::StringPiece path);
 
 // The legacy flag mainly controls the behavior of the return results when
 // encountering illegal characters If true, the already parsed portion of the
@@ -79,10 +48,6 @@ std::vector<folly::Optional<std::string>> jsonExtractTuple(
     bool legacy = true,
     const bool useSonicLibrary = true);
 
-folly::Optional<folly::dynamic> jsonExtract(
-    const folly::dynamic& json,
-    folly::StringPiece path);
-
 // Currently, bolt does not throw exception,
 folly::Optional<std::string_view> jsonExtractScalar(
     folly::StringPiece json,
@@ -92,10 +57,6 @@ folly::Optional<std::string_view> jsonExtractScalar(
     const bool getJsonObjectEscapeEmoji = true,
     const bool parsePath = true,
     const bool useSonicJson = false);
-
-folly::Optional<folly::dynamic> jsonExtract(
-    const std::string& json,
-    const std::string& path);
 
 folly::Optional<std::string_view> jsonExtractScalar(
     const std::string& json,
@@ -116,9 +77,5 @@ folly::Optional<size_t> jsonExtractSize(
 
 // For json_array_length()
 folly::Optional<size_t> jsonArrayLength(folly::StringPiece json);
-
-folly::Optional<std::string> follyJsonExtractScalar(
-    const std::string& json,
-    const std::string& path);
 
 } // namespace bytedance::bolt::functions

--- a/bolt/functions/prestosql/json/tests/JsonExtractorTest.cpp
+++ b/bolt/functions/prestosql/json/tests/JsonExtractorTest.cpp
@@ -31,20 +31,13 @@
 #include "bolt/functions/prestosql/json/JsonExtractor.h"
 
 #include <folly/Benchmark.h>
-#include <folly/json.h>
 #include <gtest/gtest.h>
 
-#include "bolt/common/base/BoltException.h"
 #include "bolt/functions/prestosql/json/SIMDJsonWrapper.h"
 
-using bytedance::bolt::functions::follyJsonExtractScalar;
-
-using bytedance::bolt::BoltUserError;
-using bytedance::bolt::functions::jsonExtract;
 using bytedance::bolt::functions::jsonExtractScalar;
 using bytedance::bolt::functions::jsonExtractSize;
 using bytedance::bolt::functions::jsonExtractTuple;
-using folly::json::parse_error;
 using namespace std::string_literals;
 
 #define EXPECT_SCALAR_VALUE_EQ(json, path, ret) \
@@ -64,171 +57,6 @@ using namespace std::string_literals;
 #define EXPECT_SCALAR_VALUE_NULL(json, path) \
   EXPECT_FALSE(jsonExtractScalar(json, path).hasValue())
 
-#define EXPECT_JSON_VALUE_EQ(json, path, ret)        \
-  {                                                  \
-    auto val = json_format(jsonExtract(json, path)); \
-    EXPECT_TRUE(val.hasValue());                     \
-    EXPECT_EQ(val.value(), ret);                     \
-  }
-
-#define EXPECT_JSON_VALUE_NULL(json, path) \
-  EXPECT_FALSE(json_format(jsonExtract(json, path)).hasValue())
-
-#define EXPECT_THROW_INVALID_ARGUMENT(json, path) \
-  EXPECT_THROW(jsonExtract(json, path), BoltUserError)
-
-namespace {
-folly::Optional<std::string> json_format(
-    const folly::Optional<folly::dynamic>& json) {
-  if (json.has_value()) {
-    return folly::toJson(json.value());
-  }
-  return folly::none;
-}
-} // namespace
-
-TEST(JsonExtractorTest, generalJsonTest) {
-  // clang-format off
-  std::string json = R"DELIM(
-      {"store":
-        {"fruit":[
-          {"weight":8, "type":"apple"},
-          {"weight":9, "type":"pear"}],
-         "basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],
-         "book":[
-            {"author":"Nigel Rees",
-             "title":"Sayings of the Century",
-             "category":"reference",
-             "price":8.95},
-            {"author":"Herman Melville",
-             "title":"Moby Dick",
-             "category":"fiction",
-             "price":8.99,
-             "isbn":"0-553-21311-3"},
-            {"author":"J. R. R. Tolkien",
-             "title":"The Lord of the Rings",
-             "category":"fiction",
-             "reader":[
-                {"age":25,
-                 "name":"bob"},
-                {"age":26,
-                 "name":"jack"}],
-             "price":22.99,
-             "isbn":"0-395-19395-8"}],
-          "bicycle":{"price":19.95, "color":"red"}},
-        "e mail":"amy@only_for_json_udf_test.net",
-        "owner":"amy"})DELIM";
-  // clang-format on
-  std::replace(json.begin(), json.end(), '\'', '\"');
-  auto res = json_format(jsonExtract(json, "$.store.fruit[0].weight"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("8", res.value());
-  res = json_format(jsonExtract(json, "$.store.fruit[1].weight"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("9", res.value());
-  EXPECT_FALSE(
-      json_format(jsonExtract(json, "$.store.fruit[2].weight"s)).has_value());
-  res = json_format(jsonExtract(json, "$.store.fruit[*].weight"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("[8,9]", res.value());
-  res = json_format(jsonExtract(json, "$.store.fruit[*].type"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("[\"apple\",\"pear\"]", res.value());
-  res = json_format(jsonExtract(json, "$.store.book[0].price"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("8.95", res.value());
-  res = json_format(jsonExtract(json, "$.store.book[2].category"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("\"fiction\"", res.value());
-  res = json_format(jsonExtract(json, "$.store.basket[1]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("[3,4]", res.value());
-  res = json_format(jsonExtract(json, "$.store.basket[0]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ(
-      folly::parseJson("[1,2,{\"a\":\"x\",\"b\":\"y\"}]"),
-      folly::parseJson(res.value()));
-  EXPECT_FALSE(
-      json_format(jsonExtract(json, "$.store.baskets[1]"s)).has_value());
-  res = json_format(jsonExtract(json, "$[\"e mail\"]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("\"amy@only_for_json_udf_test.net\"", res.value());
-  res = json_format(jsonExtract(json, "$.owner"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("\"amy\"", res.value());
-  res = json_format(
-      jsonExtract("[[1.1,[2.1,2.2]],2,{\"a\":\"b\"}]"s, "$[0][1][1]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("2.2", res.value());
-  res = json_format(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[1]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("2", res.value());
-  res = json_format(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[2]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("{\"a\":\"b\"}", res.value());
-  EXPECT_FALSE(
-      json_format(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[3]"s)).has_value());
-  res = json_format(jsonExtract("[{\"a\":\"b\"}]"s, "$[0]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("{\"a\":\"b\"}", res.value());
-  EXPECT_FALSE(
-      json_format(jsonExtract("[{\"a\":\"b\"}]"s, "$[2]"s)).has_value());
-  res = json_format(jsonExtract("{\"a\":\"b\"}"s, " $ "s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("{\"a\":\"b\"}", res.value());
-
-  std::string json2 =
-      "[[{\"key\": 1, \"value\": 2},"
-      "{\"key\": 2, \"value\": 4}],"
-      "[{\"key\": 3, \"value\": 6},"
-      "{\"key\": 4, \"value\": 8},"
-      "{\"key\": 5, \"value\": 10}]]";
-
-  // Key value pair order of a JsonMap may be changed after folly::toJson
-  std::string expected("[[{\"key\":1,\"value\":2},{\"key\":2,\"value\":4}],");
-  expected.append("[{\"key\":3,\"value\":6},{\"key\":4,\"value\":8},")
-      .append("{\"key\":5,\"value\":10}]]");
-  auto expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
-
-  expected.clear();
-  expected.append("[{\"key\":1,\"value\":2},{\"key\":2,\"value\":4},")
-      .append("{\"key\":3,\"value\":6},")
-      .append("{\"key\":4,\"value\":8},{\"value\":10,\"key\":5}]");
-  expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*][*]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
-
-  res = json_format(jsonExtract(json2, "$[*][*].key"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("[1,2,3,4,5]", res.value());
-
-  expected = "[{\"key\":1,\"value\":2},{\"key\":3,\"value\":6}]";
-  expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*][0]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
-
-  expected = "{\"key\":5,\"value\":10}";
-  expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*][2]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
-
-  // TEST whitespaces in Path and Json
-  res = json_format(jsonExtract(json2, "$[*][*].key"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("[1,2,3,4,5]", res.value());
-  res = json_format(
-      jsonExtract(" [ [1.1,[2.1,2.2]],2, {\"a\": \"b\"}]"s, "$[0][1][1]"s));
-  EXPECT_TRUE(res.has_value());
-  EXPECT_EQ("2.2", res.value());
-  EXPECT_SCALAR_VALUE_NULL(json2, "  \t\n "s);
-}
-
 // Test compatibility with Presto
 // Reference: from https://github.com/prestodb/presto
 // presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -242,56 +70,9 @@ TEST(JsonExtractorTest, scalarValueTest) {
   // Test character escaped values
   EXPECT_SCALAR_VALUE_EQ("\"ab\\u0001c\""s, "$"s, "ab\001c"s);
   EXPECT_SCALAR_VALUE_EQ("\"ab\\u0002c\""s, "$"s, "ab\002c"s);
-
-  EXPECT_JSON_VALUE_EQ("[1,2,3]"s, "$"s, "[1,2,3]"s);
-  EXPECT_JSON_VALUE_EQ("[1,   2,   3]"s, "$"s, "[1,2,3]"s);
-  EXPECT_JSON_VALUE_EQ("{\"a\": 1}"s, "$"s, "{\"a\":1}"s);
-  EXPECT_JSON_VALUE_EQ("{\"a\":        1}"s, "$"s, "{\"a\":1}"s);
-}
-
-TEST(JsonExtractorTest, jsonValueTest) {
-  // Check scalar values
-  EXPECT_JSON_VALUE_EQ("123"s, "$"s, "123"s);
-  EXPECT_JSON_VALUE_EQ("-1"s, "$"s, "-1"s);
-  EXPECT_JSON_VALUE_EQ("0.01"s, "$"s, "0.01"s);
-  EXPECT_JSON_VALUE_EQ("\"abc\""s, "$"s, "\"abc\""s);
-  EXPECT_JSON_VALUE_EQ("\"\""s, "$"s, "\"\""s);
-  EXPECT_JSON_VALUE_EQ("null"s, "$"s, "null"s);
-
-  // Test character escaped values
-  EXPECT_JSON_VALUE_EQ("\"ab\\u0001c\""s, "$"s, "\"ab\\u0001c\""s);
-  EXPECT_JSON_VALUE_EQ("\"ab\\u0002c\""s, "$"s, "\"ab\\u0002c\""s);
-
-  // Complex types should return json values
-  EXPECT_JSON_VALUE_EQ("[1, 2, 3]"s, "$"s, "[1,2,3]"s);
-  EXPECT_JSON_VALUE_EQ("{\"a\": 1}"s, "$"s, "{\"a\":1}"s);
-}
-
-TEST(JsonExtractorTest, arrayJsonValueTest) {
-  EXPECT_JSON_VALUE_NULL("[]"s, "$[0]"s);
-  EXPECT_JSON_VALUE_EQ("[1, 2, 3]"s, "$[0]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("[1, 2]"s, "$[1]"s, "2"s);
-  EXPECT_JSON_VALUE_EQ("[1, null]"s, "$[1]"s, "null"s);
-  // Out of bounds
-  EXPECT_JSON_VALUE_NULL("[1]"s, "$[1]"s);
-  // Check skipping complex structures
-  EXPECT_JSON_VALUE_EQ("[{\"a\": 1}, 2, 3]"s, "$[1]"s, "2"s);
-}
-
-TEST(JsonExtractorTest, objectJsonValueTest) {
-  EXPECT_JSON_VALUE_NULL("{}"s, "$.fuu"s);
-  EXPECT_JSON_VALUE_NULL("{\"a\": 1}"s, "$.fuu"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": 1}"s, "$.fuu"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"a\": 0, \"fuu\": 1}"s, "$.fuu"s, "1"s);
-  // Check skipping complex structures
-  EXPECT_JSON_VALUE_EQ("{\"a\": [1, 2, 3], \"fuu\": 1}"s, "$.fuu"s, "1"s);
 }
 
 TEST(JsonExtractorTest, fullScalarTest) {
-  EXPECT_JSON_VALUE_EQ("{}"s, "$"s, "{}");
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": {\"bar\":1}}"s, "$.fuu"s, "{\"bar\":1}");
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": {\"bar\":          1}}"s, "$.fuu"s, "{\"bar\":1}");
   EXPECT_SCALAR_VALUE_EQ("{\"fuu\": 1}"s, "$.fuu"s, "1"s);
   EXPECT_SCALAR_VALUE_EQ("{\"fuu\": 1}"s, "$[fuu]"s, "1"s);
   EXPECT_SCALAR_VALUE_EQ("{\"fuu\": 1}"s, "$[\"fuu\"]"s, "1"s);
@@ -305,8 +86,6 @@ TEST(JsonExtractorTest, fullScalarTest) {
       "\001"s); // Test escaped characters
   EXPECT_SCALAR_VALUE_EQ("{\"fuu\": 1, \"bar\": \"abc\"}"s, "$.bar"s, "abc"s);
   EXPECT_SCALAR_VALUE_EQ("{\"fuu\": [0.1, 1, 2]}"s, "$.fuu[0]"s, "0.1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [0, [100, 101], 2]}"s, "$.fuu[1]"s, "[100,101]");
   EXPECT_SCALAR_VALUE_EQ(
       "{\"fuu\": [0, [100, 101], 2]}"s, "$.fuu[1][1]"s, "101"s);
   EXPECT_SCALAR_VALUE_EQ(
@@ -338,111 +117,6 @@ TEST(JsonExtractorTest, fullScalarTest) {
       "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }"s, "$[\"30day\"]"s, "1"s);
 }
 
-TEST(JsonExtractorTest, fullJsonValueTest) {
-  EXPECT_JSON_VALUE_EQ("{}"s, "$"s, "{}"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": {\"bar\": 1}}"s, "$.fuu"s, "{\"bar\":1}"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": 1}"s, "$.fuu"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": 1}"s, "$[fuu]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": 1}"s, "$[\"fuu\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": null}"s, "$.fuu"s, "null"s);
-  EXPECT_JSON_VALUE_NULL("{\"fuu\": 1}"s, "$.bar"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [\"\\u0001\"]}"s,
-      "$.fuu[0]"s,
-      "\"\\u0001\""s); // Test escaped characters
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": 1, \"bar\": \"abc\"}"s, "$.bar"s, "\"abc\""s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": [0.1, 1, 2]}"s, "$.fuu[0]"s, "0.1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [0, [100, 101], 2]}"s, "$.fuu[1]"s, "[100,101]"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [0, [100, 101], 2]}"s, "$.fuu[1][1]"s, "101"s);
-
-  // Test non-object extraction
-  EXPECT_JSON_VALUE_EQ("[0, 1, 2]"s, "$[0]"s, "0"s);
-  EXPECT_JSON_VALUE_EQ("\"abc\""s, "$"s, "\"abc\""s);
-  EXPECT_JSON_VALUE_EQ("123"s, "$"s, "123"s);
-  EXPECT_JSON_VALUE_EQ("null"s, "$"s, "null"s);
-
-  // Test extraction using bracket json path
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": {\"bar\": 1}}"s, "$[\"fuu\"]"s, "{\"bar\":1}"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": {\"bar\": 1}}"s, "$[\"fuu\"][\"bar\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": 1}"s, "$[\"fuu\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": null}"s, "$[\"fuu\"]"s, "null"s);
-  EXPECT_JSON_VALUE_NULL("{\"fuu\": 1}"s, "$[\"bar\"]"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [\"\\u0001\"]}"s,
-      "$[\"fuu\"][0]"s,
-      "\"\\u0001\""s); // Test escaped characters
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": 1, \"bar\": \"abc\"}"s, "$[\"bar\"]"s, "\"abc\""s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": [0.1, 1, 2]}"s, "$[\"fuu\"][0]"s, "0.1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [0, [100, 101], 2]}"s, "$[\"fuu\"][1]"s, "[100,101]"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [0, [100, 101], 2]}"s, "$[\"fuu\"][1][1]"s, "101"s);
-
-  // Test extraction using bracket json path with special json characters in
-  // path
-  EXPECT_JSON_VALUE_EQ(
-      "{\"@$fuu\": {\".b.ar\": 1}}"s, "$[\"@$fuu\"]"s, "{\".b.ar\":1}"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu..\": 1}"s, "$[\"fuu..\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fu*u\": null}"s, "$[\"fu*u\"]"s, "null"s);
-  EXPECT_JSON_VALUE_NULL("{\",fuu\": 1}"s, "$[\"bar\"]"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\",fuu\": [\"\\u0001\"]}"s,
-      "$[\",fuu\"][0]"s,
-      "\"\\u0001\""s); // Test escaped characters
-  EXPECT_JSON_VALUE_EQ(
-      "{\":fu:u:\": 1, \":b:ar:\": \"abc\"}"s, "$[\":b:ar:\"]"s, "\"abc\""s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"?()fuu\": [0.1, 1, 2]}"s, "$[\"?()fuu\"][0]"s, "0.1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"f?uu\": [0, [100, 101], 2]}"s, "$[\"f?uu\"][1]"s, "[100,101]"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu()\": [0, [100, 101], 2]}"s, "$[\"fuu()\"][1][1]"s, "101"s);
-
-  // Test extraction using mix of bracket and dot notation json path
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": {\"bar\": 1}}"s, "$[\"fuu\"].bar"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"fuu\": {\"bar\": 1}}"s, "$.fuu[\"bar\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [\"\\u0001\"]}"s,
-      "$[\"fuu\"][0]"s,
-      "\"\\u0001\""s); // Test escaped characters
-  EXPECT_JSON_VALUE_EQ(
-      "{\"fuu\": [\"\\u0001\"]}"s,
-      "$.fuu[0]"s,
-      "\"\\u0001\""s); // Test escaped characters
-
-  // Test extraction using  mix of bracket and dot notation json path with
-  // special json characters in path
-  EXPECT_JSON_VALUE_EQ("{\"@$fuu\": {\"bar\": 1}}"s, "$[\"@$fuu\"].bar"s, "1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\",fuu\": {\"bar\": [\"\\u0001\"]}}"s,
-      "$[\",fuu\"].bar[0]"s,
-      "\"\\u0001\""s); // Test escaped characters
-
-  // Test numeric path expression matches arrays and objects
-  EXPECT_JSON_VALUE_EQ("[0, 1, 2]"s, "$.1"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("[0, 1, 2]"s, "$[1]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("[0, 1, 2]"s, "$[\"1\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }"s, "$.1"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }"s, "$[1]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"0\" : 0, \"1\" : 1, \"2\" : 2 }"s, "$[\"1\"]"s, "1"s);
-
-  // Test fields starting with a digit
-  EXPECT_JSON_VALUE_EQ(
-      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }"s, "$.30day"s, "1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }"s, "$[30day]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ(
-      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }"s, "$[\"30day\"]"s, "1"s);
-  EXPECT_JSON_VALUE_EQ("{\"a\\\\b\": 4}"s, "$[\"a\\\\b\"]"s, "4"s);
-  EXPECT_JSON_VALUE_NULL("{\"fuu\" : null}"s, "$.a.b"s);
-}
-
 TEST(JsonExtractorTest, invalidJsonPathTest) {
   EXPECT_SCALAR_VALUE_NULL(""s, ""s);
   EXPECT_SCALAR_VALUE_NULL("{}"s, "$.bar[2][-1]"s);
@@ -454,81 +128,6 @@ TEST(JsonExtractorTest, invalidJsonPathTest) {
   EXPECT_SCALAR_VALUE_NULL(
       "{ \"store\": { \"book\": [{ \"title\": \"title\" }] } }"s,
       "$.store.book["s);
-}
-
-TEST(JsonExtractorTest, reextractJsonTest) {
-  std::string json = R"DELIM(
-      {"store":
-        {"fruit":[
-          {"weight":8, "type":"apple"},
-          {"weight":9, "type":"pear"}],
-         "basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],
-         "book":[
-            {"author":"Nigel Rees",
-             "title":"Sayings of the Century",
-             "category":"reference",
-             "price":8.95},
-            {"author":"Herman Melville",
-             "title":"Moby Dick",
-             "category":"fiction",
-             "price":8.99,
-             "isbn":"0-553-21311-3"},
-            {"author":"J. R. R. Tolkien",
-             "title":"The Lord of the Rings",
-             "category":"fiction",
-             "reader":[
-                {"age":25,
-                 "name":"bob"},
-                {"age":26,
-                 "name":"jack"}],
-             "price":22.99,
-             "isbn":"0-395-19395-8"}],
-          "bicycle":{"price":19.95, "color":"red"}},
-        "e mail":"amy@only_for_json_udf_test.net",
-        "owner":"amy"})DELIM";
-  auto originalJsonObj = jsonExtract(json, "$");
-  // extract the same json json by giving the root path
-  auto reExtractedJsonObj = jsonExtract(originalJsonObj.value(), "$");
-  ASSERT_TRUE(reExtractedJsonObj.hasValue());
-  // expect the re-extracted json object to be the same as the original jsonObj
-  EXPECT_EQ(originalJsonObj.value(), reExtractedJsonObj.value());
-}
-
-TEST(JsonExtractorTest, jsonMultipleExtractsTest) {
-  std::string json = R"DELIM(
-      {"store":
-        {"fruit":[
-          {"weight":8, "type":"apple"},
-          {"weight":9, "type":"pear"}],
-         "basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],
-         "book":[
-            {"author":"Nigel Rees",
-             "title":"Sayings of the Century",
-             "category":"reference",
-             "price":8.95},
-            {"author":"Herman Melville",
-             "title":"Moby Dick",
-             "category":"fiction",
-             "price":8.99,
-             "isbn":"0-553-21311-3"},
-            {"author":"J. R. R. Tolkien",
-             "title":"The Lord of the Rings",
-             "category":"fiction",
-             "reader":[
-                {"age":25,
-                 "name":"bob"},
-                {"age":26,
-                 "name":"jack"}],
-             "price":22.99,
-             "isbn":"0-395-19395-8"}],
-          "bicycle":{"price":19.95, "color":"red"}},
-        "e mail":"amy@only_for_json_udf_test.net",
-        "owner":"amy"})DELIM";
-  auto extract1 = jsonExtract(json, "$.store");
-  ASSERT_TRUE(extract1.hasValue());
-  auto extract2 = jsonExtract(extract1.value(), "$.fruit");
-  ASSERT_TRUE(extract2.hasValue());
-  EXPECT_EQ(jsonExtract(json, "$.store.fruit").value(), extract2.value());
 }
 
 TEST(JsonExtractorTest, simdJsonScalarValueTest) {
@@ -558,16 +157,6 @@ TEST(JsonExtractorTest, simdJsonSimpleArrayTest) {
   EXPECT_SCALAR_VALUE_NULL("[1, null]"s, "$[1]"s);
   EXPECT_SCALAR_VALUE_NULL("[1, null]"s, "$[2]"s); // Out of bounds
   EXPECT_SCALAR_VALUE_NULL("[1]"s, "$[1]"s);
-}
-
-TEST(JsonExtractorTest, quotedUnicode) {
-  // unicode control character quoted
-  std::string json2 =
-      R"( {"category":{"origin_string":"=\u0007mEs\u000fA���%חk�9ded06cd author: John Doe"},"server_uuid":"1234"} )";
-  std::string path2 = "$.category";
-  std::string expect2 =
-      "{\"origin_string\":\"=\\u0007mEs\\u000FA���%חk�9ded06cd author: John Doe\"}";
-  EXPECT_JSON_VALUE_EQ(json2, path2, expect2);
 }
 
 TEST(JsonExtractorTest, simdJsonTypesTest) {
@@ -701,46 +290,6 @@ TEST(JsonExtractorTest, benchmark) {
     auto val = jsonExtractScalar(json, paths[j]);
     EXPECT_TRUE(val.hasValue());
   }
-
-  // std::random_device rd;
-  // std::mt19937 mt(rd());
-  // std::uniform_real_distribution<double> dist(1, 100);
-
-  constexpr size_t rounds = 1024 * 256;
-  size_t rnd = 0; // ((size_t)dist(mt)) % 2;   // To stop optimization
-
-  // simdJSON
-  // auto start = std::chrono::high_resolution_clock::now();
-
-  // for (size_t i = 0; i < rounds; i++) {
-  //   for (size_t j = 0; j < paths.size() - rnd; j++) {
-  //     auto val = jsonExtractScalar(json, paths[j+rnd]);
-  //     if (val.hasValue()) {
-  //       sum++;
-  //     }
-  //   }
-  // }
-
-  // auto end = std::chrono::high_resolution_clock::now();
-  // auto time_span =
-  // std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-  // std::cout << "It took  " << time_span.count() << " seconds." << std::endl;
-
-  // Folly
-  // start = std::chrono::high_resolution_clock::now();
-  // for (size_t i = 0; i < rounds; i++) {
-  //   for (size_t j = 0; j < paths.size() - rnd; j++) {
-  //     auto val = follyJsonExtractScalar(json, paths[j+rnd]);
-  //     if (val.hasValue()) {
-  //       sum++;
-  //     }
-  //   }
-  // }
-
-  // end = std::chrono::high_resolution_clock::now();
-  // time_span = std::chrono::duration_cast<std::chrono::duration<double>>(end -
-  // start); std::cout << "It took  " << time_span.count() << " seconds." <<
-  // std::endl; std::cout << sum << std::endl;
 }
 
 TEST(JsonExtractorTest, JsonTupleExtractScalar) {

--- a/bolt/functions/sparksql/benchmarks/MapBenchmark.cpp
+++ b/bolt/functions/sparksql/benchmarks/MapBenchmark.cpp
@@ -30,7 +30,6 @@ namespace {
 class MapBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   MapBenchmark() {
-    memory::MemoryManager::deprecatedGetInstance({});
     functions::sparksql::registerFunctions();
 
     const auto Size = 10'000;
@@ -162,7 +161,7 @@ BENCHMARK_MULTI(intFlatKeys, n) {
 
 int main(int argc, char** argv) {
   // todo: use folly::Init init after upgrade folly lib
-  memory::MemoryManager::deprecatedGetInstance({});
+  memory::MemoryManager::initialize({});
   folly::init(&argc, &argv);
   folly::runBenchmarks();
   return 0;

--- a/bolt/serializers/ArrowSerializer.cpp
+++ b/bolt/serializers/ArrowSerializer.cpp
@@ -1174,14 +1174,6 @@ std::unique_ptr<BatchVectorSerializer> ArrowVectorSerde::createBatchSerializer(
       &arrowSerdeOptions.arrowOptions);
 }
 
-void ArrowVectorSerde::deprecatedSerializeEncoded(
-    const RowVectorPtr& vector,
-    StreamArena* streamArena,
-    const Options* options,
-    OutputStream* out) {
-  BOLT_NYI("ArrowVectorSerde::deprecatedSerializeEncoded");
-}
-
 void ArrowVectorSerde::deserialize(
     ByteInputStream* source,
     bolt::memory::MemoryPool* pool,

--- a/bolt/serializers/ArrowSerializer.h
+++ b/bolt/serializers/ArrowSerializer.h
@@ -104,13 +104,6 @@ class ArrowVectorSerde : public VectorSerde {
       memory::MemoryPool* pool,
       const Options* options) override;
 
-  [[deprecated("Use BatchVectorSerializer instead.")]] void
-  deprecatedSerializeEncoded(
-      const RowVectorPtr& vector,
-      StreamArena* streamArena,
-      const Options* options,
-      OutputStream* out);
-
   bool supportsAppendInDeserialize() const override {
     return true;
   }

--- a/bolt/serializers/PrestoSerializer.cpp
+++ b/bolt/serializers/PrestoSerializer.cpp
@@ -3688,20 +3688,6 @@ std::unique_ptr<BatchVectorSerializer> PrestoVectorSerde::createBatchSerializer(
       pool, prestoOptions.useLosslessTimestamp, prestoOptions.compressionKind);
 }
 
-void PrestoVectorSerde::deprecatedSerializeEncoded(
-    const RowVectorPtr& vector,
-    StreamArena* streamArena,
-    const Options* options,
-    OutputStream* out) {
-  auto prestoOptions = toPrestoOptions(options);
-  auto serializer = std::make_unique<PrestoVectorSerializer>(
-      vector,
-      streamArena,
-      prestoOptions.useLosslessTimestamp,
-      prestoOptions.compressionKind);
-  serializer->flushEncoded(vector, out);
-}
-
 void PrestoVectorSerde::deserialize(
     ByteInputStream* source,
     bolt::memory::MemoryPool* pool,

--- a/bolt/serializers/PrestoSerializer.h
+++ b/bolt/serializers/PrestoSerializer.h
@@ -96,26 +96,6 @@ class PrestoVectorSerde : public VectorSerde {
       memory::MemoryPool* pool,
       const Options* options) override;
 
-  /// Serializes a single RowVector with possibly encoded children, preserving
-  /// their encodings. Encodings are preserved recursively for any RowVector
-  /// children, but not for children of other nested vectors such as Array, Map,
-  /// and Dictionary.
-  ///
-  /// PrestoPage does not support serialization of Dictionaries with nulls;
-  /// in case dictionaries contain null they are serialized as flat buffers.
-  ///
-  /// In order to override the encodings of top-level columns in the RowVector,
-  /// you can specify the encodings using PrestoOptions.encodings
-  ///
-  /// DEPRECATED: Use createBatchSerializer and the BatchVectorSerializer's
-  /// serialize function instead.
-  [[deprecated("Use BatchVectorSerializer instead.")]] void
-  deprecatedSerializeEncoded(
-      const RowVectorPtr& vector,
-      StreamArena* streamArena,
-      const Options* options,
-      OutputStream* out);
-
   bool supportsAppendInDeserialize() const override {
     return true;
   }

--- a/bolt/serializers/tests/ArrowSerializerTest.cpp
+++ b/bolt/serializers/tests/ArrowSerializerTest.cpp
@@ -269,25 +269,6 @@ class ArrowSerializerTest
     return stats;
   }
 
-  void serializeEncoded(
-      const RowVectorPtr& rowVector,
-      std::ostream* output,
-      const serializer::arrowserde::ArrowVectorSerde::ArrowSerdeOptions*
-          serdeOptions) {
-    serializer::arrowserde::ArrowOutputStreamListener listener;
-    OStreamOutputStream out(output, &listener);
-    StreamArena arena{pool_.get()};
-    auto paramOptions = getParamSerdeOptions(serdeOptions);
-
-    for (const auto& child : rowVector->children()) {
-      paramOptions.encodings.push_back(child->encoding());
-    }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    serde_->deprecatedSerializeEncoded(rowVector, &arena, &paramOptions, &out);
-#pragma GCC diagnostic pop
-  }
-
   void assertEqualEncoding(
       const RowVectorPtr& expected,
       const RowVectorPtr& actual) {
@@ -337,17 +318,6 @@ class ArrowSerializerTest
     }
 
     assertEqualVectors(expected, result);
-  }
-
-  void testEncodedRoundTrip(
-      const RowVectorPtr& data,
-      const serializer::arrowserde::ArrowVectorSerde::ArrowSerdeOptions*
-          serdeOptions = nullptr) {
-    std::ostringstream out;
-    serializeEncoded(data, &out, serdeOptions);
-    const auto serialized = out.str();
-
-    verifySerializedEncodedData(data, serialized, serdeOptions);
   }
 
   void serializeBatch(
@@ -611,21 +581,14 @@ TEST_P(ArrowSerializerTest, longDecimal) {
 }
 
 // Test that hierarchically encoded columns (rows) have their encodings
-// preserved.
-TEST_P(ArrowSerializerTest, encodings) {
-  GTEST_SKIP() << "Using deprecated function, not yet support";
-  testEncodedRoundTrip(encodingsTestVector());
-}
-
-// Test that hierarchically encoded columns (rows) have their encodings
-// preserved by the PrestoBatchVectorSerializer.
+// preserved by the ArrowBatchVectorSerializer.
 TEST_P(ArrowSerializerTest, encodingsBatchVectorSerializer) {
-  GTEST_SKIP() << "Using deprecated function, not yet support";
+  GTEST_SKIP() << "Not yet supported by ArrowBatchVectorSerializer";
   testBatchVectorSerializerRoundTrip(encodingsTestVector());
 }
 
 TEST_P(ArrowSerializerTest, scatterEncoded) {
-  GTEST_SKIP() << "Using deprecated function, not yet support";
+  GTEST_SKIP() << "Not yet supported by ArrowBatchVectorSerializer";
   // Makes a struct with nulls and constant/dictionary encoded children. The
   // children need to get gaps where the parent struct has a null.
   VectorFuzzer::Options opts;

--- a/bolt/serializers/tests/PrestoSerializerTest.cpp
+++ b/bolt/serializers/tests/PrestoSerializerTest.cpp
@@ -291,25 +291,6 @@ class PrestoSerializerTest
     return stats;
   }
 
-  void serializeEncoded(
-      const RowVectorPtr& rowVector,
-      std::ostream* output,
-      const serializer::presto::PrestoVectorSerde::PrestoOptions*
-          serdeOptions) {
-    bytedance::bolt::serializer::presto::PrestoOutputStreamListener listener;
-    OStreamOutputStream out(output, &listener);
-    StreamArena arena{pool_.get()};
-    auto paramOptions = getParamSerdeOptions(serdeOptions);
-
-    for (const auto& child : rowVector->children()) {
-      paramOptions.encodings.push_back(child->encoding());
-    }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    serde_->deprecatedSerializeEncoded(rowVector, &arena, &paramOptions, &out);
-#pragma GCC diagnostic pop
-  }
-
   void assertEqualEncoding(
       const RowVectorPtr& expected,
       const RowVectorPtr& actual) {
@@ -359,17 +340,6 @@ class PrestoSerializerTest
     }
 
     assertEqualVectors(expected, result);
-  }
-
-  void testEncodedRoundTrip(
-      const RowVectorPtr& data,
-      const serializer::presto::PrestoVectorSerde::PrestoOptions* serdeOptions =
-          nullptr) {
-    std::ostringstream out;
-    serializeEncoded(data, &out, serdeOptions);
-    const auto serialized = out.str();
-
-    verifySerializedEncodedData(data, serialized, serdeOptions);
   }
 
   void serializeBatch(
@@ -630,12 +600,6 @@ TEST_P(PrestoSerializerTest, longDecimal) {
     vector->setNull(i, true);
   }
   testRoundTrip(vector);
-}
-
-// Test that hierarchically encoded columns (rows) have their encodings
-// preserved.
-TEST_P(PrestoSerializerTest, encodings) {
-  testEncodedRoundTrip(encodingsTestVector());
 }
 
 // Test that hierarchically encoded columns (rows) have their encodings

--- a/bolt/vector/arrow/benchmarks/ArrowToBoltArrayBenchmark.cpp
+++ b/bolt/vector/arrow/benchmarks/ArrowToBoltArrayBenchmark.cpp
@@ -38,10 +38,11 @@ void mockSchemaRelease(ArrowSchema*) {}
 void mockArrayRelease(ArrowArray*) {}
 
 const int ITERATION_TIMES = 100000;
+memory::MemoryManager benchmarkMemoryManager;
+auto schemaPool = benchmarkMemoryManager.addLeafPool();
 
 void exportToArrow(const TypePtr& type, ArrowSchema& out) {
-  auto pool = &bytedance::bolt::memory::deprecatedSharedLeafPool();
-  exportToArrow(BaseVector::create(type, 0, pool), out, {});
+  exportToArrow(BaseVector::create(type, 0, schemaPool.get()), out, {});
 }
 
 class ArrowBridgeArrayImportBenchmark {
@@ -91,7 +92,7 @@ class ArrowBridgeArrayImportBenchmark {
   // Boiler plate structures required by vectorMaker.
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::deprecatedAddDefaultLeafMemoryPool()};
+      benchmarkMemoryManager.addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   bytedance::bolt::test::VectorMaker vectorMaker_{execCtx_.pool()};
 

--- a/bolt/vector/arrow/benchmarks/ExportBoltToArrowBenchmark.cpp
+++ b/bolt/vector/arrow/benchmarks/ExportBoltToArrowBenchmark.cpp
@@ -35,9 +35,9 @@ static constexpr int32_t kRowsPerVector = 100'000;
 namespace {
 
 // Boiler plate structures required by vectorMaker.
+memory::MemoryManager memoryManager;
 std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
-std::shared_ptr<memory::MemoryPool> pool_{
-    memory::deprecatedAddDefaultLeafMemoryPool()};
+std::shared_ptr<memory::MemoryPool> pool_{memoryManager.addLeafPool()};
 core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
 bytedance::bolt::test::VectorMaker vectorMaker_{execCtx_.pool()};
 

--- a/bolt/vector/arrow/benchmarks/ImportArrowToBoltBenchmark.cpp
+++ b/bolt/vector/arrow/benchmarks/ImportArrowToBoltBenchmark.cpp
@@ -38,6 +38,8 @@ using namespace bytedance::bolt;
 void mockSchemaRelease(ArrowSchema*) {}
 void mockArrayRelease(ArrowArray*) {}
 
+memory::MemoryManager memoryManager;
+
 class ArrowBridgeArrayImportBenchmark {
  protected:
   // Used by this base test class to import Arrow data and create Bolt Vector.
@@ -84,8 +86,7 @@ class ArrowBridgeArrayImportAsOwnerBenchmark
   }
 };
 
-std::shared_ptr<memory::MemoryPool> pool{
-    memory::deprecatedAddDefaultLeafMemoryPool()};
+std::shared_ptr<memory::MemoryPool> pool{memoryManager.addLeafPool()};
 
 void runImportFromArrowAsViewer(
     uint32_t,

--- a/bolt/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -718,7 +718,7 @@ TEST_F(ArrowBridgeSchemaImportTest, dictionaryTypeTest) {
 }
 
 TEST_F(ArrowBridgeSchemaTest, exportToArrowWithConstantEncoding) {
-  auto* pool = &memory::deprecatedSharedLeafPool();
+  auto* pool = pool_.get();
 
   auto elementType = INTEGER();
   auto arrayType = ARRAY(elementType);


### PR DESCRIPTION
### What problem does this PR solve?
  <!--
  Please explain the context and the problem.
  If this fixes a specific issue, please link it below.
  -->
  Several deprecated APIs remained after production code had moved to supported alternatives. Their remaining in-repo callers were limited to tests, fuzzers, benchmarks, and deprecated wrappers.

  This PR removes the unused implementations and migrates those callers to supported APIs. The `bolt_memory_num_shared_leaf_pools` flag remains defined as a no-op because Gluten still references it.

  Issue Number: N/A

  ### Type of Change
  <!-- Please check the one that applies to this PR -->
  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 🚀 Performance improvement (optimization)
  - [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
  - [x] 🔨 Refactoring (no logic changes)
  - [ ] 🔧 Build/CI or Infrastructure changes
  - [ ] 📝 Documentation only

  ### Description

  This PR removes deprecated APIs that no longer have production callers:

  - Removes deprecated `MemoryManager` singleton and shared leaf pool APIs, along with the unused shared pool storage and initialization logic.
  - Migrates tests, fuzzers, and benchmarks to `MemoryManager::initialize()`, `memoryManager()`, `addRootPool()`, `addLeafPool()`, or explicitly owned memory managers.
  - Keeps `bolt_memory_num_shared_leaf_pools` as a deprecated compatibility flag. The flag is still exported but no longer affects Bolt.
  - Removes the legacy Folly-backed JSON extraction path. The JSON benchmark now uses the registered `json_extract` implementation backed by the supported Sonic/SIMD path.
  - Removes `PrestoVectorSerde::deprecatedSerializeEncoded()` and `ArrowVectorSerde::deprecatedSerializeEncoded()`. Existing batch serializer tests continue to cover the supported API.
  - Leaves Arrow Parquet `TypedColumnReader::ReadBatchSpaced()` unchanged.

  Validation completed:

  - Built `bolt_engine` in Release mode.
  - Ran 2 MemoryManager tests.
  - Ran 3 JSON extractor tests.
  - Ran 6 Presto serializer tests.
  - Ran 12 Arrow serializer tests.
  - Ran pre-commit checks and linters.

  ### Performance Impact
  <!--
  REQUIRED for Performance PRs and Core Engine changes.
  Please verify that your change does not introduce performance regressions.
  -->
  - [x] **No Impact**: This change does not affect the critical path. It removes unused compatibility code and avoids creating unused shared leaf pools during memory manager initialization.
  - [ ] **Positive Impact**: I have run benchmarks.
      <details>
      <summary>Click to view Benchmark Results</summary>

      ```text
      Paste your google-benchmark or TPC-H results here.
      Before: 10.5s
      After:   8.2s  (+20%)
      ```
      </details>
  - [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

  ### Release Note
  <!-- Please write a short summary for the release notes. -->

  Release Note:

  ```text
  Release Note:
  - Removed unused deprecated MemoryManager, JSON extraction, and vector serialization APIs.
  - Kept bolt_memory_num_shared_leaf_pools as a no-op compatibility flag for downstream users.
  ```

  ### Checklist (For Author)
  <!--
  Please double-check the following before submitting.
  -->

  - [x] I have added/updated unit tests (ctest).
  - [x] I have verified the code with local build (Release/Debug).
  - [x] I have run clang-format / linters.
  - [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
  - [ ] No need to test or manual test.

  ### Breaking Changes
  <!--
  Does this PR introduce API or ABI incompatibilities?
  If yes, please describe how users should migrate.
  -->

  - [ ] No
  - [x] Yes (Description: Deprecated public C++ APIs have been removed.)
      <details>
      <summary>Click to view Breaking Changes</summary>

      ```text
      Breaking Changes:
      - Initialize the global memory manager with MemoryManager::initialize() and access it through memoryManager() or MemoryManager::getInstance().
      - Create owned pools with addRootPool() or addLeafPool() instead of the deprecated default and shared pool helpers.
      - Use createBatchSerializer() and BatchVectorSerializer::serialize() instead of deprecatedSerializeEncoded().
      - Use the registered json_extract function or the supported Sonic/SIMD wrappers instead of the legacy Folly JSON extraction APIs.
      - bolt_memory_num_shared_leaf_pools remains available for compatibility but no longer has any effect.
      ```
      </details>