### PR TITLE
perf: optimize all-valid parquet leaf nulls

### DIFF
--- a/bolt/dwio/parquet/arrow/LevelConversion.cpp
+++ b/bolt/dwio/parquet/arrow/LevelConversion.cpp
@@ -40,6 +40,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/logging.h"
+#include "bolt/common/base/SimdUtil.h"
 #include "bolt/dwio/parquet/arrow/Exception.h"
 
 #include "bolt/dwio/parquet/arrow/LevelComparison.h"
@@ -295,6 +296,58 @@ void DefRepLevelsToListInfo(
   }
 }
 
+struct AllValidResult {
+  int64_t valuesRead{0};
+  bool allValid{true};
+};
+
+AllValidResult DefLevelsAreAllValidWithRepeatedParent(
+    const int16_t* def_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info) {
+  AllValidResult result;
+  constexpr int64_t kBatch = xsimd::batch<int16_t>::size;
+  const auto ancestorLevel =
+      xsimd::broadcast<int16_t>(level_info.repeated_ancestor_def_level - 1);
+  const auto validLevel = xsimd::broadcast<int16_t>(level_info.def_level - 1);
+  int64_t i = 0;
+  for (; i + kBatch <= num_def_levels; i += kBatch) {
+    const auto levels = xsimd::load_unaligned(def_levels + i);
+    const auto presentMask = simd::toBitMask(levels > ancestorLevel);
+    if (presentMask == 0) {
+      continue;
+    }
+    result.valuesRead += __builtin_popcount(presentMask);
+    result.allValid &=
+        (simd::toBitMask(levels > validLevel) & presentMask) == presentMask;
+  }
+  for (; i < num_def_levels; ++i) {
+    if (def_levels[i] >= level_info.repeated_ancestor_def_level) {
+      result.allValid &= def_levels[i] >= level_info.def_level;
+      ++result.valuesRead;
+    }
+  }
+  return result;
+}
+
+bool DefLevelsAreAllValidNoRepeatedParent(
+    const int16_t* def_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info) {
+  bool allValid = true;
+  constexpr int64_t kBatch = xsimd::batch<int16_t>::size;
+  const auto validLevel = xsimd::broadcast<int16_t>(level_info.def_level - 1);
+  int64_t i = 0;
+  for (; i + kBatch <= num_def_levels; i += kBatch) {
+    const auto levels = xsimd::load_unaligned(def_levels + i);
+    allValid &= simd::toBitMask(levels > validLevel) == ((1 << kBatch) - 1);
+  }
+  for (; i < num_def_levels; ++i) {
+    allValid &= def_levels[i] >= level_info.def_level;
+  }
+  return allValid;
+}
+
 } // namespace
 
 #if defined(ARROW_HAVE_RUNTIME_BMI2)
@@ -326,6 +379,28 @@ void DefLevelsToBitmap(
     internal::standard::DefLevelsToBitmapSimd</*has_repeated_parent=*/false>(
         def_levels, num_def_levels, level_info, output);
   }
+}
+
+bool DefLevelsAreAllValid(
+    const int16_t* def_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info,
+    int64_t values_read_upper_bound,
+    int64_t* values_read) {
+  AllValidResult result;
+  if (level_info.rep_level > 0) {
+    result = DefLevelsAreAllValidWithRepeatedParent(
+        def_levels, num_def_levels, level_info);
+  } else {
+    result.valuesRead = num_def_levels;
+    result.allValid = DefLevelsAreAllValidNoRepeatedParent(
+        def_levels, num_def_levels, level_info);
+  }
+  if (ARROW_PREDICT_FALSE(result.valuesRead > values_read_upper_bound)) {
+    throw ParquetException("Values read exceeded upper bound");
+  }
+  *values_read = result.valuesRead;
+  return result.allValid;
 }
 
 uint64_t TestOnlyExtractBitsSoftware(uint64_t bitmap, uint64_t select_bitmap) {

--- a/bolt/dwio/parquet/arrow/LevelConversion.h
+++ b/bolt/dwio/parquet/arrow/LevelConversion.h
@@ -191,6 +191,15 @@ void PARQUET_EXPORT DefLevelsToBitmap(
     LevelInfo level_info,
     ValidityBitmapInputOutput* output);
 
+// Computes values_read and whether all produced values are valid using the
+// same semantics as DefLevelsToBitmap, without writing a validity bitmap.
+bool PARQUET_EXPORT DefLevelsAreAllValid(
+    const int16_t* def_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info,
+    int64_t values_read_upper_bound,
+    int64_t* values_read);
+
 // Reconstructs a validity bitmap and list offsets for a list arrays based on
 // def/rep levels. The first element of offsets will not be modified if
 // rep_levels starts with a new list.  The first element of offsets will be used

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
@@ -51,6 +51,13 @@ enum class ListShape {
   kLong,
 };
 
+enum class LeafNullShape {
+  kAllValidFlat,
+  kMiddleNullFlat,
+  kAllValidRepeated,
+  kMiddleNullRepeated,
+};
+
 struct Levels {
   std::vector<int16_t> definitions;
   std::vector<int16_t> repetitions;
@@ -114,6 +121,50 @@ LevelInfo listLevelInfo() {
   info.def_level = 2;
   info.repeated_ancestor_def_level = 0;
   return info;
+}
+
+LevelInfo leafNullLevelInfo(LeafNullShape shape) {
+  LevelInfo info;
+  if (shape == LeafNullShape::kAllValidRepeated ||
+      shape == LeafNullShape::kMiddleNullRepeated) {
+    info.rep_level = 1;
+    info.repeated_ancestor_def_level = 1;
+    info.def_level = 2;
+  } else {
+    info.def_level = 2;
+  }
+  return info;
+}
+
+std::vector<int16_t> makeLeafNullLevels(
+    int32_t numLevels,
+    LeafNullShape shape) {
+  std::vector<int16_t> levels;
+  levels.reserve(numLevels);
+  const auto nullIndex = numLevels / 2;
+  switch (shape) {
+    case LeafNullShape::kAllValidFlat:
+      levels.assign(numLevels, 2);
+      break;
+    case LeafNullShape::kMiddleNullFlat:
+      levels.assign(numLevels, 2);
+      levels[nullIndex] = 1;
+      break;
+    case LeafNullShape::kAllValidRepeated:
+    case LeafNullShape::kMiddleNullRepeated:
+      for (int32_t i = 0; i < numLevels; ++i) {
+        if (i % 11 == 0) {
+          levels.push_back(0);
+        } else if (
+            shape == LeafNullShape::kMiddleNullRepeated && i == nullIndex) {
+          levels.push_back(1);
+        } else {
+          levels.push_back(2);
+        }
+      }
+      break;
+  }
+  return levels;
 }
 
 class LevelConversionBenchmark {
@@ -329,6 +380,82 @@ class FusedLevelConversionBenchmark {
   std::vector<uint8_t> structValidity_;
 };
 
+class LeafNullsBenchmark {
+ public:
+  LeafNullsBenchmark(int32_t numLevels, LeafNullShape shape)
+      : numLevels_(numLevels),
+        levelInfo_(leafNullLevelInfo(shape)),
+        definitions_(makeLeafNullLevels(numLevels, shape)) {
+    bitmap_.resize(numLevels);
+  }
+
+  int64_t materialize() {
+    resetBitmap();
+    auto output = makeOutput(0);
+    DefLevelsToBitmap(
+        definitions_.data(), definitions_.size(), levelInfo_, &output);
+    return output.values_read;
+  }
+
+  int64_t shortcut() {
+    resetBitmap();
+    bool allValidPrefix = true;
+    const int32_t firstSegmentEnd = numLevels_ / 2;
+    appendWithShortcut(0, firstSegmentEnd, allValidPrefix);
+    appendWithShortcut(firstSegmentEnd, numLevels_, allValidPrefix);
+    return valuesWritten_;
+  }
+
+ private:
+  int64_t appendWithShortcut(int32_t begin, int32_t end, bool& allValidPrefix) {
+    int64_t valuesRead = 0;
+    if (allValidPrefix &&
+        DefLevelsAreAllValid(
+            definitions_.data() + begin,
+            end - begin,
+            levelInfo_,
+            end - begin,
+            &valuesRead)) {
+      valuesWritten_ += valuesRead;
+      return valuesRead;
+    }
+
+    const auto startOffset = valuesWritten_;
+    bitmap_.resize((startOffset + end - begin + 7) / 8);
+    if (allValidPrefix) {
+      if (startOffset > 0) {
+        std::fill(bitmap_.begin(), bitmap_.end(), 0xff);
+      }
+      allValidPrefix = false;
+    }
+
+    auto output = makeOutput(startOffset);
+    DefLevelsToBitmap(
+        definitions_.data() + begin, end - begin, levelInfo_, &output);
+    valuesWritten_ += output.values_read;
+    return output.values_read;
+  }
+
+  void resetBitmap() {
+    std::fill(bitmap_.begin(), bitmap_.end(), 0);
+    valuesWritten_ = 0;
+  }
+
+  ValidityBitmapInputOutput makeOutput(int64_t offset) {
+    ValidityBitmapInputOutput output;
+    output.valid_bits = bitmap_.data();
+    output.valid_bits_offset = offset;
+    output.values_read_upper_bound = numLevels_;
+    return output;
+  }
+
+  int32_t numLevels_;
+  LevelInfo levelInfo_;
+  std::vector<int16_t> definitions_;
+  std::vector<uint8_t> bitmap_;
+  int64_t valuesWritten_{0};
+};
+
 LevelConversionBenchmark& benchmark(ListShape shape) {
   static LevelConversionBenchmark singleElement(ListShape::kSingleElement);
   static LevelConversionBenchmark mixed(ListShape::kMixed);
@@ -354,6 +481,17 @@ FusedLevelConversionBenchmark& fusedBenchmark(
   auto& instance = benchmarks[key];
   if (!instance) {
     instance = std::make_unique<FusedLevelConversionBenchmark>(numLists, shape);
+  }
+  return *instance;
+}
+
+LeafNullsBenchmark& leafNullsBenchmark(int32_t numLevels, LeafNullShape shape) {
+  using Key = std::pair<int32_t, LeafNullShape>;
+  static std::map<Key, std::unique_ptr<LeafNullsBenchmark>> benchmarks;
+  const Key key{numLevels, shape};
+  auto& instance = benchmarks[key];
+  if (!instance) {
+    instance = std::make_unique<LeafNullsBenchmark>(numLevels, shape);
   }
   return *instance;
 }
@@ -390,6 +528,20 @@ void runFusedLevelConversion(
         fallback    ? instance.fallback()
             : fused ? instance.fused()
                     : instance.separate());
+  }
+}
+
+void runLeafNulls(
+    uint32_t iters,
+    int32_t numLevels,
+    LeafNullShape shape,
+    bool shortcut) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = leafNullsBenchmark(numLevels, shape);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(
+        shortcut ? instance.shortcut() : instance.materialize());
   }
 }
 
@@ -446,6 +598,28 @@ FUSED_LEVEL_CONVERSION_BENCHMARK(1048576, kMixed, mixed);
 FUSED_LEVEL_CONVERSION_BENCHMARK(1024, kLong, long);
 FUSED_LEVEL_CONVERSION_BENCHMARK(65536, kLong, long);
 FUSED_LEVEL_CONVERSION_BENCHMARK(1048576, kLong, long);
+
+#define LEAF_NULLS_BENCHMARK(size, shape, name)                  \
+  BENCHMARK(leafNullsMaterialize_##name##_##size, iters) {       \
+    runLeafNulls(iters, size, LeafNullShape::shape, false);      \
+  }                                                              \
+  BENCHMARK_RELATIVE(leafNullsShortcut_##name##_##size, iters) { \
+    runLeafNulls(iters, size, LeafNullShape::shape, true);       \
+  }                                                              \
+  BENCHMARK_DRAW_LINE()
+
+LEAF_NULLS_BENCHMARK(4096, kAllValidFlat, allValidFlat);
+LEAF_NULLS_BENCHMARK(65536, kAllValidFlat, allValidFlat);
+LEAF_NULLS_BENCHMARK(1048576, kAllValidFlat, allValidFlat);
+LEAF_NULLS_BENCHMARK(4096, kMiddleNullFlat, middleNullFlat);
+LEAF_NULLS_BENCHMARK(65536, kMiddleNullFlat, middleNullFlat);
+LEAF_NULLS_BENCHMARK(1048576, kMiddleNullFlat, middleNullFlat);
+LEAF_NULLS_BENCHMARK(4096, kAllValidRepeated, allValidRepeated);
+LEAF_NULLS_BENCHMARK(65536, kAllValidRepeated, allValidRepeated);
+LEAF_NULLS_BENCHMARK(1048576, kAllValidRepeated, allValidRepeated);
+LEAF_NULLS_BENCHMARK(4096, kMiddleNullRepeated, middleNullRepeated);
+LEAF_NULLS_BENCHMARK(65536, kMiddleNullRepeated, middleNullRepeated);
+LEAF_NULLS_BENCHMARK(1048576, kMiddleNullRepeated, middleNullRepeated);
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
@@ -873,6 +873,67 @@ TEST(NestedListTest, FusedDirectStructListUpperBound) {
   EXPECT_EQ(lengths[1], -1);
 }
 
+TEST(LevelConversionTest, DefLevelsAreAllValid) {
+  {
+    std::vector<int16_t> def_levels = {3, 3, 3, 3, 3, 3, 3, 3, 3};
+    LevelInfo level_info;
+    level_info.def_level = 3;
+    int64_t values_read = -1;
+    EXPECT_TRUE(DefLevelsAreAllValid(
+        def_levels.data(),
+        def_levels.size(),
+        level_info,
+        def_levels.size(),
+        &values_read));
+    EXPECT_EQ(values_read, def_levels.size());
+  }
+  {
+    std::vector<int16_t> def_levels = {3, 3, 3, 2, 3};
+    LevelInfo level_info;
+    level_info.def_level = 3;
+    int64_t values_read = -1;
+    EXPECT_FALSE(DefLevelsAreAllValid(
+        def_levels.data(),
+        def_levels.size(),
+        level_info,
+        def_levels.size(),
+        &values_read));
+    EXPECT_EQ(values_read, def_levels.size());
+  }
+  {
+    std::vector<int16_t> def_levels = {0, 0, 2, 2, 2, 2, 2, 2, 0, 2};
+    LevelInfo level_info;
+    level_info.rep_level = 1;
+    level_info.repeated_ancestor_def_level = 1;
+    level_info.def_level = 2;
+    int64_t values_read = -1;
+    EXPECT_TRUE(DefLevelsAreAllValid(
+        def_levels.data(), def_levels.size(), level_info, 7, &values_read));
+    EXPECT_EQ(values_read, 7);
+  }
+  {
+    std::vector<int16_t> def_levels = {0, 0, 2, 1, 2, 2, 2, 2};
+    LevelInfo level_info;
+    level_info.rep_level = 1;
+    level_info.repeated_ancestor_def_level = 1;
+    level_info.def_level = 2;
+    int64_t values_read = -1;
+    EXPECT_FALSE(DefLevelsAreAllValid(
+        def_levels.data(), def_levels.size(), level_info, 6, &values_read));
+    EXPECT_EQ(values_read, 6);
+  }
+  {
+    std::vector<int16_t> def_levels = {3, 3, 3};
+    LevelInfo level_info;
+    level_info.def_level = 3;
+    int64_t values_read = -1;
+    EXPECT_THROW(
+        DefLevelsAreAllValid(
+            def_levels.data(), def_levels.size(), level_info, 2, &values_read),
+        ParquetException);
+  }
+}
+
 TEST(TestOnlyExtractBitsSoftware, BasicTest) {
   auto check =
       [](uint64_t bitmap, uint64_t selection, uint64_t expected) -> void {

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -476,18 +476,12 @@ void PageReader::readPageDefLevels() {
   BOLT_CHECK_NOT_NULL(
       wideDefineDecoder_, "parquet read error with maxDefine = {}", maxDefine_);
   wideDefineDecoder_->GetBatch(definitionLevels_.data(), numRepDefsInPage_);
-  leafNulls_.resize(bits::nwords(numRepDefsInPage_));
-  numRowsInPage_ = getLengthsAndNulls(
-      LevelMode::kNulls,
-      leafInfo_,
-      0,
-      numRepDefsInPage_,
-      numRepDefsInPage_,
-      nullptr,
-      leafNulls_.data(),
-      0);
-  leafNullsSize_ = numRowsInPage_;
+  leafNullsSize_ = 0;
+  leafNullsAllValidPrefix_ = true;
   numLeafNullsConsumed_ = 0;
+  erasedLeafNullWords_ = 0;
+  numRowsInPage_ = appendLeafNullsFromLevels(0, numRepDefsInPage_);
+  leafNullsSize_ = numRowsInPage_;
 }
 
 void PageReader::updateRowInfoAfterPageSkipped() {
@@ -1033,16 +1027,8 @@ void PageReader::preloadPageRepDefs(const bool keepRepDefRawData) {
       repeatDecoder_->GetBatch(
           repetitionLevels_.data() + begin, numRepDefsInPage_);
     }
-    leafNulls_.resize(bits::nwords(leafNullsSize_ + numRepDefsInPage_));
-    auto numLeaves = getLengthsAndNulls(
-        LevelMode::kNulls,
-        leafInfo_,
-        begin,
-        begin + numRepDefsInPage_,
-        numRepDefsInPage_,
-        nullptr,
-        leafNulls_.data(),
-        leafNullsSize_);
+    auto numLeaves =
+        appendLeafNullsFromLevels(begin, begin + numRepDefsInPage_);
     leafNullsSize_ += numLeaves;
     numLeavesInPage_.push_back(numLeaves);
   }
@@ -1210,7 +1196,8 @@ void PageReader::decodeRepDefsFromBuffer() {
   int64_t erasedBits = erasedLeafNullWords_ * WordBits;
   BOLT_CHECK_LE(numLeafNullsConsumed_, leafNullsSize_ + erasedBits);
   // clear consumed nulls
-  if (numLeafNullsConsumed_ - erasedBits > WordBits) {
+  if (!leafNullsAllValidPrefix_ &&
+      numLeafNullsConsumed_ - erasedBits > WordBits) {
     auto consumedWords = bits::nwords(numLeafNullsConsumed_ - erasedBits) - 1;
     auto totalNullWords = bits::nwords(leafNullsSize_);
     auto unConsumedNullWords = totalNullWords - consumedWords;
@@ -1291,20 +1278,42 @@ void PageReader::decodeRepDefsFromBuffer() {
     defineDecoder.GetBatch(definitionLevels_.data() + begin, numRepDefsInPage);
     rawData += defineLength;
 
-    leafNulls_.resize(bits::nwords(leafNullsSize_ + numRepDefsInPage));
-    auto numLeaves = getLengthsAndNulls(
-        LevelMode::kNulls,
-        leafInfo_,
-        begin,
-        begin + numRepDefsInPage,
-        numRepDefsInPage,
-        nullptr,
-        leafNulls_.data(),
-        leafNullsSize_);
+    auto numLeaves = appendLeafNullsFromLevels(begin, begin + numRepDefsInPage);
     leafNullsSize_ += numLeaves;
     numLeavesInPage_.push_back(numLeaves);
   }
   preloadedRepDefs_.pop_front();
+}
+
+int32_t PageReader::appendLeafNullsFromLevels(int32_t begin, int32_t end) {
+  int64_t valuesRead = 0;
+  if (leafNullsAllValidPrefix_ &&
+      arrow::DefLevelsAreAllValid(
+          definitionLevels_.data() + begin,
+          end - begin,
+          leafInfo_,
+          end - begin,
+          &valuesRead)) {
+    return static_cast<int32_t>(valuesRead);
+  }
+
+  const auto startOffset = leafNullsSize_;
+  leafNulls_.resize(bits::nwords(startOffset + end - begin));
+  if (leafNullsAllValidPrefix_) {
+    if (startOffset > 0) {
+      bits::fillBits(leafNulls_.data(), 0, startOffset, bits::kNotNull);
+    }
+    leafNullsAllValidPrefix_ = false;
+  }
+  return getLengthsAndNulls(
+      LevelMode::kNulls,
+      leafInfo_,
+      begin,
+      end,
+      end - begin,
+      nullptr,
+      leafNulls_.data(),
+      startOffset);
 }
 
 int32_t PageReader::getLengthsAndNulls(
@@ -1491,6 +1500,11 @@ int32_t PageReader::skipNulls(int32_t numValues) {
   if (!defineDecoder_ && isTopLevel_) {
     return numValues;
   }
+  if (!isTopLevel_ && leafNullsAllValidPrefix_) {
+    BOLT_CHECK_LE(numLeafNullsConsumed_ + numValues, leafNullsSize_);
+    numLeafNullsConsumed_ += numValues;
+    return numValues;
+  }
   BOLT_CHECK(1 == maxDefine_ || !leafNulls_.empty());
   dwio::common::ensureCapacity<bool>(tempNulls_, numValues, &pool_);
   tempNulls_->setSize(0);
@@ -1562,6 +1576,13 @@ PageReader::readNulls(int32_t numValues, BufferPtr& buffer) {
     defineDecoder_->readBits(
         numValues, buffer->asMutable<uint64_t>(), &allOnes);
     return allOnes ? nullptr : buffer->as<uint64_t>();
+  }
+
+  if (leafNullsAllValidPrefix_) {
+    BOLT_CHECK_LE(numLeafNullsConsumed_ + numValues, leafNullsSize_);
+    numLeafNullsConsumed_ += numValues;
+    buffer = nullptr;
+    return nullptr;
   }
 
   const int64_t erasedBits = erasedLeafNullWords_ * 64;

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -323,6 +323,8 @@ class PageReader {
   // 'hasChunkRepDefs_' is false.
   void readPageDefLevels();
 
+  int32_t appendLeafNullsFromLevels(int32_t begin, int32_t end);
+
   // Returns a pointer to contiguous space for the next 'size' bytes
   // from current position. Copies data into 'copy' if the range
   // straddles buffers. Allocates or resizes 'copy' as needed.
@@ -534,6 +536,8 @@ class PageReader {
 
   // Number of valid bits in 'leafNulls_'
   int64_t leafNullsSize_{0};
+
+  bool leafNullsAllValidPrefix_{true};
 
   // Number of leaf nulls read.
   int64_t numLeafNullsConsumed_{0};

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -36,6 +36,7 @@
 #include "bolt/dwio/parquet/reader/ParquetReader.h"
 #include "bolt/dwio/parquet/writer/Writer.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/vector/tests/utils/VectorMaker.h"
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
@@ -49,6 +50,12 @@ const uint32_t kNumRowsPerBatch = 60000;
 const uint32_t kNumBatches = 50;
 const uint32_t kNumRowsPerRowGroup = 10000;
 const double kFilterErrorMargin = 0.2;
+
+enum class AllValidReadShape {
+  kTopLevelBigInt,
+  kList,
+  kMap,
+};
 
 class ParquetReaderBenchmark {
  public:
@@ -278,6 +285,120 @@ class ParquetReaderBenchmark {
   RuntimeStatistics runtimeStats_;
 };
 
+class AllValidReadBenchmark {
+ public:
+  explicit AllValidReadBenchmark(AllValidReadShape shape)
+      : rootPool_(memory::memoryManager()->addRootPool(
+            fmt::format("AllValidReadBenchmark-{}", shapeName(shape)))),
+        leafPool_(rootPool_->addLeafChild(
+            fmt::format("AllValidReadBenchmark-{}", shapeName(shape)))),
+        fileName_(fmt::format("all_valid_{}.parquet", shapeName(shape))),
+        vectorMaker_(leafPool_.get()),
+        rowType_(makeRowType(shape)) {
+    writeFile(makeData(shape));
+  }
+
+  uint64_t read(uint32_t nextSize) {
+    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    auto input = std::make_unique<BufferedInput>(
+        std::make_shared<LocalReadFile>(fileFolder_->path + "/" + fileName_),
+        readerOpts.getMemoryPool());
+    auto reader = std::make_unique<ParquetReader>(std::move(input), readerOpts);
+
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.select(std::make_shared<ColumnSelector>(
+        rowType_, std::vector<std::string>{rowType_->nameOf(0)}));
+    auto scanSpec = std::make_shared<ScanSpec>("");
+    scanSpec->addAllChildFields(*rowType_);
+    rowReaderOpts.setScanSpec(scanSpec);
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+
+    VectorPtr result = BaseVector::create(rowType_, 0, leafPool_.get());
+    uint64_t rows = 0;
+    while (rowReader->next(nextSize, result)) {
+      auto rowVector = result->asUnchecked<RowVector>();
+      auto child = rowVector->childAt(0)->loadedVector();
+      rows += rowVector->size();
+      folly::doNotOptimizeAway(child->retainedSize());
+    }
+    return rows;
+  }
+
+ private:
+  static const char* shapeName(AllValidReadShape shape) {
+    switch (shape) {
+      case AllValidReadShape::kTopLevelBigInt:
+        return "bigint";
+      case AllValidReadShape::kList:
+        return "list";
+      case AllValidReadShape::kMap:
+        return "map";
+    }
+    return "unknown";
+  }
+
+  static RowTypePtr makeRowType(AllValidReadShape shape) {
+    switch (shape) {
+      case AllValidReadShape::kTopLevelBigInt:
+        return ROW({"c0"}, {BIGINT()});
+      case AllValidReadShape::kList:
+        return ROW({"c0"}, {ARRAY(BIGINT())});
+      case AllValidReadShape::kMap:
+        return ROW({"c0"}, {MAP(INTEGER(), BIGINT())});
+    }
+    return ROW({"c0"}, {BIGINT()});
+  }
+
+  RowVectorPtr makeData(AllValidReadShape shape) {
+    switch (shape) {
+      case AllValidReadShape::kTopLevelBigInt:
+        return vectorMaker_.rowVector({vectorMaker_.flatVector<int64_t>(
+            kNumRowsPerBatch, [](vector_size_t row) { return row; })});
+      case AllValidReadShape::kList:
+        return vectorMaker_.rowVector({vectorMaker_.arrayVector<int64_t>(
+            kNumRowsPerBatch,
+            [](vector_size_t /*row*/) { return 4; },
+            [](vector_size_t row, vector_size_t index) {
+              return static_cast<int64_t>(row * 10 + index);
+            })});
+      case AllValidReadShape::kMap:
+        return vectorMaker_.rowVector({vectorMaker_.mapVector<int32_t, int64_t>(
+            kNumRowsPerBatch,
+            [](vector_size_t /*row*/) { return 4; },
+            [](vector_size_t /*row*/, vector_size_t index) {
+              return static_cast<int32_t>(index);
+            },
+            [](vector_size_t row, vector_size_t index) {
+              return static_cast<int64_t>(row * 10 + index);
+            })});
+    }
+    return nullptr;
+  }
+
+  void writeFile(const RowVectorPtr& data) {
+    const auto path = fileFolder_->path + "/" + fileName_;
+    auto localWriteFile = std::make_unique<LocalWriteFile>(path, true, false);
+    auto sink =
+        std::make_unique<WriteFileSink>(std::move(localWriteFile), path);
+    bytedance::bolt::parquet::WriterOptions options;
+    options.enableDictionary = false;
+    options.memoryPool = rootPool_.get();
+    bytedance::bolt::parquet::Writer writer(std::move(sink), options, rowType_);
+    for (uint32_t i = 0; i < kNumBatches; ++i) {
+      writer.write(data);
+    }
+    writer.close();
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> leafPool_;
+  const std::string fileName_;
+  const std::shared_ptr<bytedance::bolt::exec::test::TempDirectoryPath>
+      fileFolder_ = bytedance::bolt::exec::test::TempDirectoryPath::create();
+  test::VectorMaker vectorMaker_;
+  RowTypePtr rowType_;
+};
+
 void run(
     uint32_t,
     const std::string& columnName,
@@ -291,6 +412,31 @@ void run(
   BIGINT()->toString();
   benchmark.readSingleColumn(
       columnName, type, 0, filterRateX100, nullsRateX100, nextSize);
+}
+
+AllValidReadBenchmark& allValidReadBenchmark(AllValidReadShape shape) {
+  static AllValidReadBenchmark topLevelBigInt(
+      AllValidReadShape::kTopLevelBigInt);
+  static AllValidReadBenchmark list(AllValidReadShape::kList);
+  static AllValidReadBenchmark map(AllValidReadShape::kMap);
+  switch (shape) {
+    case AllValidReadShape::kTopLevelBigInt:
+      return topLevelBigInt;
+    case AllValidReadShape::kList:
+      return list;
+    case AllValidReadShape::kMap:
+      return map;
+  }
+  return topLevelBigInt;
+}
+
+void runAllValidRead(uint32_t iters, AllValidReadShape shape) {
+  folly::BenchmarkSuspender suspender;
+  auto& benchmark = allValidReadBenchmark(shape);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(benchmark.read(50000));
+  }
 }
 
 #define PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, _null_) \
@@ -413,6 +559,19 @@ PARQUET_BENCHMARKS(BIGINT(), BigInt);
 PARQUET_BENCHMARKS(DOUBLE(), Double);
 PARQUET_BENCHMARKS_NO_FILTER(MAP(BIGINT(), BIGINT()), Map);
 PARQUET_BENCHMARKS_NO_FILTER(ARRAY(BIGINT()), List);
+
+BENCHMARK(AllValidTopLevelBigInt_next_50k_plain, iters) {
+  runAllValidRead(iters, AllValidReadShape::kTopLevelBigInt);
+}
+
+BENCHMARK(AllValidList_next_50k_plain, iters) {
+  runAllValidRead(iters, AllValidReadShape::kList);
+}
+
+BENCHMARK(AllValidMap_next_50k_plain, iters) {
+  runAllValidRead(iters, AllValidReadShape::kMap);
+}
+BENCHMARK_DRAW_LINE();
 
 // TODO: Add all data types
 


### PR DESCRIPTION
### What problem does this PR solve?

Parquet nested leaf readers can eagerly materialize `leafNulls_` bitmaps even when decoded definition levels produce only valid leaf values. This is unnecessary because Bolt vectors already use a null bitmap pointer of `nullptr` to represent all-valid rows.

This PR avoids writing and compacting all-valid leaf null bitmaps until the first null is observed.

Issue Number: N/A

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds `DefLevelsAreAllValid()`, a no-output helper that uses the same produced-value semantics as `DefLevelsToBitmap()` and reports whether all produced values are valid.

`PageReader` now tracks an all-valid prefix for non-top-level leaf nulls:

- When decoded definition levels remain all-valid, `PageReader` advances the logical leaf null count without materializing `leafNulls_`.
- If a null appears later, it materializes the previous all-valid prefix as not-null bits, then resumes the existing bitmap path.
- `readNulls()` and `skipNulls()` return the existing all-valid representation directly while the prefix remains all-valid.
- Compaction skips bitmap movement while no `leafNulls_` bitmap has been materialized.

The change is scoped to leaf null handling and does not port unrelated rep/def prefix decompression or fused conversion changes.

### Performance Impact
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Level-conversion microbenchmark:
    - leafNullsMaterialize_*: old behavior, always writes a leaf null bitmap.
    - leafNullsShortcut_*: new behavior, keeps an all-valid prefix and materializes only after a null appears.

    allValidFlat:
      4096:    3.66us -> 207.03ns  (~17.7x)
      65536:   59.78us -> 3.97us   (~15.1x)
      1048576: 1.01ms -> 110.24us  (~9.1x)

    allValidRepeated:
      4096:    6.99us -> 358.58ns  (~19.5x)
      65536:   112.07us -> 6.30us  (~17.8x)
      1048576: 1.82ms -> 137.71us  (~13.2x)

    middleNullFlat:
      4096:    3.69us -> 2.01us    (~1.83x)
      65536:   61.81us -> 33.62us  (~1.84x)
      1048576: 1.00ms -> 498.74us  (~2.01x)

    middleNullRepeated:
      4096:    6.99us -> 3.82us    (~1.83x)
      65536:   112.05us -> 61.24us (~1.83x)
      1048576: 1.82ms -> 996.36us  (~1.82x)

    End-to-end Parquet read benchmark, all-valid data, plain encoding, next=50k:
      TopLevel BigInt: oss/main 9.18ms, current 9.32ms  (~-1.5%, no material gain expected)
      List:            oss/main 169.24ms, current 150.52ms (~+12.4%)
      Map:             oss/main 219.43ms, current 182.16ms (~+20.5%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
- Optimized Parquet nested reads by avoiding materialization of all-valid leaf null bitmaps.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation run locally:

```text
cmake --build --preset conan-release --target bolt_dwio_parquet_arrow_test bolt_dwio_parquet_reader_test --parallel 16
cmake --build --preset conan-release --target bolt_dwio_parquet_level_conversion_benchmark bolt_dwio_parquet_reader_benchmark --parallel 16

bolt_dwio_parquet_arrow_test --gtest_filter='LevelConversionTest.DefLevelsAreAllValid:NestedListTest.*'
bolt_dwio_parquet_reader_test --gtest_filter='<complex-type and skip related ParquetReaderTest cases>'
bolt_dwio_parquet_level_conversion_benchmark --bm_regex='leafNulls(Materialize|Shortcut)_'
bolt_dwio_parquet_reader_benchmark --bm_regex='AllValid(TopLevelBigInt|List|Map)_next_50k_plain'
clang-format --dry-run --Werror on touched C++ files
git diff --check
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - N/A
    ```
    </details>
