### PR TITLE
misc: Expose abandoned partial aggregation rows

### DIFF
--- a/bolt/exec/HashAggregation.cpp
+++ b/bolt/exec/HashAggregation.cpp
@@ -498,7 +498,6 @@ void HashAggregation::maybeIncreasePartialAggregationMemoryUsage(
   if (shouldAbandon) {
     groupingSet_->abandonPartialAggregation();
     pool()->release();
-    addRuntimeStat("abandonedPartialAggregation", RuntimeCounter(1));
     abandonedPartialAggregation_ = true;
     LOG(INFO) << __FUNCTION__ << " numInputRows_ = " << numInputRows_
               << ", numOutputRows_ = " << numOutputRows_
@@ -563,6 +562,9 @@ RowVectorPtr HashAggregation::getOutput() {
     }
     prepareOutput(input_->size(), false);
     groupingSet_->toIntermediate(input_, output_);
+    addRuntimeStat(
+        std::string(HashAggregation::kAbandonedPartialAggregationRows),
+        RuntimeCounter(input_->size()));
     numOutputRows_ += input_->size();
     input_ = nullptr;
     return output_;

--- a/bolt/exec/HashAggregation.h
+++ b/bolt/exec/HashAggregation.h
@@ -36,6 +36,10 @@ namespace bytedance::bolt::exec {
 
 class HashAggregation : public Operator {
  public:
+  /// Number of rows emitted after partial aggregation was abandoned.
+  static constexpr std::string_view kAbandonedPartialAggregationRows =
+      "abandonedPartialAggregationRows";
+
   HashAggregation(
       int32_t operatorId,
       DriverCtx* driverCtx,

--- a/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -926,11 +926,9 @@ void AggregationTestBase::testAggregationsImpl(
     makeSource(builder);
 
     core::PlanNodeId partialNodeId;
-    core::PlanNodeId intermediateNodeId;
     builder.partialAggregation(groupingKeys, aggregates)
         .capturePlanNodeId(partialNodeId)
         .intermediateAggregation()
-        .capturePlanNodeId(intermediateNodeId)
         .finalAggregation();
 
     if (!postAggregationProjections.empty()) {
@@ -948,9 +946,8 @@ void AggregationTestBase::testAggregationsImpl(
     auto taskStats = toPlanStats(task->taskStats());
     auto inputVectors = taskStats.at(partialNodeId).inputVectors;
     auto partialStats = taskStats.at(partialNodeId).customStats;
-    auto intermediateStats = taskStats.at(intermediateNodeId).customStats;
     if (inputVectors > 1) {
-      EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
+      EXPECT_LT(0, partialStats.at("abandonedPartialAggregationRows").sum);
     }
   }
 

--- a/bolt/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -164,7 +164,7 @@ TEST_F(CountAggregationTest, mask) {
               "SELECT k, count(c) FILTER (where m) FROM tmp GROUP BY k");
   auto taskStats = toPlanStats(task->taskStats());
   auto partialStats = taskStats.at(partialNodeId).customStats;
-  EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
+  EXPECT_EQ(900, partialStats.at("abandonedPartialAggregationRows").sum);
 }
 
 TEST_F(CountAggregationTest, distinct) {


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Expose abandoned partial aggregation rows

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Upstream Velox added abandonedPartialAggregationRows in https://github.com/facebookincubator/velox/pull/17547 to count rows that bypass partial aggregation after the operator abandons low-benefit aggregation. This keeps flushRowCount scoped to normal partial flush rows while still explaining passthrough output rows.

The local investigation saw FlushableHashAggregate output rows grow when partial aggregation abandoned after high distinct ratios. Those passthrough intermediate rows are counted in operator output rows but not in flushRowCount, so emitting the upstream-compatible runtime stat lets Gluten surface the missing piece. It also quantifies how much of a partial aggregation output-row difference is attributable to the abandon-partial-aggregation path.
<img width="424" height="438" alt="image" src="https://github.com/user-attachments/assets/0d4db13d-1d77-4045-bf6a-cb5371d70b03" />

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
