### PR TITLE
fix(parquet): decode definition levels in bounded windows

### DIFF
--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -51,6 +51,33 @@ namespace bytedance::bolt::parquet {
 using thrift::Encoding;
 using thrift::PageHeader;
 
+int32_t decodeDefinitionLevelsToBitmap(
+    ::arrow::util::RleDecoder& decoder,
+    int32_t numDefinitionLevels,
+    const arrow::LevelInfo& levelInfo,
+    raw_vector<int16_t>& definitionLevels,
+    raw_vector<uint64_t>& leafNulls) {
+  definitionLevels.resize(std::min(numDefinitionLevels, kMaxRepDefDecodeBatch));
+  leafNulls.resize(bits::nwords(numDefinitionLevels));
+  int32_t decodedLevels = 0;
+  int32_t decodedLeaves = 0;
+  while (decodedLevels < numDefinitionLevels) {
+    const auto batchSize =
+        std::min(numDefinitionLevels - decodedLevels, kMaxRepDefDecodeBatch);
+    decoder.GetBatch(definitionLevels.data(), batchSize);
+    arrow::ValidityBitmapInputOutput bits;
+    bits.values_read_upper_bound = batchSize;
+    bits.values_read = 0;
+    bits.null_count = 0;
+    bits.valid_bits = reinterpret_cast<uint8_t*>(leafNulls.data());
+    bits.valid_bits_offset = decodedLeaves;
+    DefLevelsToBitmap(definitionLevels.data(), batchSize, levelInfo, &bits);
+    decodedLevels += batchSize;
+    decodedLeaves += bits.values_read;
+  }
+  return decodedLeaves;
+}
+
 namespace {
 constexpr uint32_t kRepDefPrefixOutputQuantum = 4096;
 
@@ -472,21 +499,15 @@ void PageReader::setPageRowInfo(bool forRepDef) {
 
 void PageReader::readPageDefLevels() {
   BOLT_CHECK(kRowsUnknown == numRowsInPage_ || maxDefine_ > 1);
-  definitionLevels_.resize(numRepDefsInPage_);
   BOLT_CHECK_NOT_NULL(
       wideDefineDecoder_, "parquet read error with maxDefine = {}", maxDefine_);
-  wideDefineDecoder_->GetBatch(definitionLevels_.data(), numRepDefsInPage_);
-  leafNulls_.resize(bits::nwords(numRepDefsInPage_));
-  numRowsInPage_ = getLengthsAndNulls(
-      LevelMode::kNulls,
+  leafNullsSize_ = decodeDefinitionLevelsToBitmap(
+      *wideDefineDecoder_,
+      numRepDefsInPage_,
       leafInfo_,
-      0,
-      numRepDefsInPage_,
-      numRepDefsInPage_,
-      nullptr,
-      leafNulls_.data(),
-      0);
-  leafNullsSize_ = numRowsInPage_;
+      definitionLevels_,
+      leafNulls_);
+  numRowsInPage_ = leafNullsSize_;
   numLeafNullsConsumed_ = 0;
 }
 

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -49,6 +49,14 @@
 namespace bytedance::bolt::parquet {
 constexpr int16_t kNonPageOrdinal = static_cast<int16_t>(-1);
 constexpr uint32_t kDefaultMaxPageHeaderSize = 16 * 1024 * 1024;
+constexpr int32_t kMaxRepDefDecodeBatch = 64 * 1024;
+
+int32_t decodeDefinitionLevelsToBitmap(
+    ::arrow::util::RleDecoder& decoder,
+    int32_t numDefinitionLevels,
+    const arrow::LevelInfo& levelInfo,
+    raw_vector<int16_t>& definitionLevels,
+    raw_vector<uint64_t>& leafNulls);
 
 struct CryptoContext {
   CryptoContext(

--- a/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -137,6 +137,45 @@ ParquetTypeWithIdPtr makeNestedInt64Type() {
 
 class ParquetPageReaderTest : public ParquetTestBase {};
 
+TEST_F(ParquetPageReaderTest, decodeLargeDefinitionLevelsInWindows) {
+  constexpr int32_t kNumLevels = 4 * kMaxRepDefDecodeBatch + 123;
+  constexpr int32_t kMaxDefine = 4;
+  const auto bitWidth = ::arrow::bit_util::NumRequiredBits(kMaxDefine);
+  std::vector<int16_t> expectedLevels(kNumLevels);
+  const auto encodedSize =
+      ::arrow::util::RleEncoder::MaxBufferSize(bitWidth, kNumLevels) +
+      ::arrow::util::RleEncoder::MinBufferSize(bitWidth);
+  std::vector<uint8_t> encodedLevels(encodedSize);
+  ::arrow::util::RleEncoder encoder(
+      encodedLevels.data(), encodedLevels.size(), bitWidth);
+  for (auto i = 0; i < kNumLevels; ++i) {
+    expectedLevels[i] = i % 17 == 0 ? kMaxDefine - 1 : kMaxDefine;
+    ASSERT_TRUE(encoder.Put(expectedLevels[i]));
+  }
+  encoder.Flush();
+
+  ::arrow::util::RleDecoder decoder(
+      encodedLevels.data(), encoder.len(), bitWidth);
+  arrow::LevelInfo levelInfo;
+  levelInfo.def_level = kMaxDefine;
+  levelInfo.rep_level = 1;
+  levelInfo.repeated_ancestor_def_level = 1;
+  raw_vector<int16_t> definitionLevels(leafPool_.get());
+  raw_vector<uint64_t> leafNulls(leafPool_.get());
+
+  EXPECT_EQ(
+      decodeDefinitionLevelsToBitmap(
+          decoder, kNumLevels, levelInfo, definitionLevels, leafNulls),
+      kNumLevels);
+  EXPECT_EQ(definitionLevels.size(), kMaxRepDefDecodeBatch);
+  EXPECT_LT(definitionLevels.capacity(), kNumLevels);
+  for (auto i = 0; i < kNumLevels; ++i) {
+    EXPECT_EQ(
+        bits::isBitSet(leafNulls.data(), i), expectedLevels[i] == kMaxDefine)
+        << "at " << i;
+  }
+}
+
 TEST_F(ParquetPageReaderTest, smallPage) {
   auto readFile =
       std::make_shared<LocalReadFile>(getExampleFilePath("small_page_header"));


### PR DESCRIPTION
### What problem does this PR solve?

Reading a Parquet nested column could abort a query with `MEM_CAP_EXCEEDED`. `PageReader::readPageDefLevels` sized the definition-level scratch (`definitionLevels_`) by the whole page's `num_values` in one shot. A pathological page with 539,824,022 values needs ~1.01 GiB of `int16_t` scratch, but `raw_vector` adds SIMD padding and rounds the capacity up to the next power of two, so it tried to allocate ~2 GiB at once and hit the memory cap.

Issue Number: close #839

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Decode definition levels in bounded windows instead of materializing the whole page at once.

- Add a free function `decodeDefinitionLevelsToBitmap` that decodes definition levels in windows of at most `kMaxRepDefDecodeBatch` (64K) values. Each window is decoded into a small `int16_t` scratch and immediately folded into the leaf-null bitmap via `DefLevelsToBitmap`, advancing `valid_bits_offset` by the number of leaves produced so far.
- `PageReader::readPageDefLevels` now calls this helper: the `definitionLevels_` scratch is capped at the window size (64K) rather than the whole page's `num_values`, so peak scratch memory is bounded regardless of page size. `leafNulls_` is still sized to hold the full page's bitmap (`bits::nwords(numDefinitionLevels)`), which is ~64x smaller than the `int16_t` scratch that previously dominated.
- Add `ParquetPageReaderTest.decodeLargeDefinitionLevelsInWindows`, which encodes `4 * kMaxRepDefDecodeBatch + 123` levels (spanning 5 windows), decodes them through the new helper, and verifies (1) the returned leaf count, (2) that the `int16_t` scratch capacity stays below the total level count, and (3) that the resulting null bitmap matches the expected per-level validity.

Why bounded windows: `raw_vector` rounds allocation size up to a power of two after SIMD padding, so a single large `resize` roughly doubles the request. Capping the scratch at 64K values removes the dependence on page size and eliminates the multi-GiB spike.

### Performance Impact
- [x] **No Impact**: This is a correctness/memory fix on the Parquet rep/def decode path. Definition levels are still decoded once end-to-end; only the scratch buffer is now reused across fixed-size windows instead of being allocated once at page size.

### Release Note

```text
Release Note:
- Fixed a Parquet reader OOM (MEM_CAP_EXCEEDED) when decoding definition levels for pages with a very large number of values, by decoding definition levels in bounded 64K windows.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
