### PR TITLE
fix: export sliced array child rows to Arrow

### DIFF
--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -1252,10 +1252,37 @@ void exportOffsets(
   auto rawOffsets = offsets->asMutable<vector_size_t>();
   if (!rows.changed() && isCompact(vec)) {
     auto copiedSize = vec.size() > out.length ? out.length : vec.size();
+
     memcpy(rawOffsets, vec.rawOffsets(), sizeof(vector_size_t) * copiedSize);
-    rawOffsets[copiedSize] = copiedSize == 0
+
+    const vector_size_t base = (copiedSize == 0) ? 0 : rawOffsets[0];
+    const vector_size_t end = (copiedSize == 0)
         ? 0
         : vec.offsetAt(copiedSize - 1) + vec.sizeAt(copiedSize - 1);
+
+    if (base != 0) {
+      for (vector_size_t i = 0; i < copiedSize; ++i) {
+        rawOffsets[i] -= base;
+      }
+    }
+    rawOffsets[copiedSize] = end - base;
+
+    vector_size_t childTotal = 0;
+    if constexpr (std::is_same_v<Vector, ArrayVector>) {
+      childTotal = vec.elements()->size();
+    } else {
+      static_assert(
+          std::is_same_v<Vector, MapVector>,
+          "exportOffsets expects ArrayVector or MapVector");
+      childTotal = vec.mapKeys()->size();
+    }
+
+    if (base != 0 || end != childTotal) {
+      childRows.clearAll();
+      if (end > base) {
+        childRows.addRange(base, end - base);
+      }
+    }
   } else {
     childRows.clearAll();
     // j: Index of element we are writing.

--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -1239,6 +1239,10 @@ bool isCompact(const Vector& vec) {
   return vec.sizeAt(vec.size() - 1) > 0;
 }
 
+bool hasNulls(const BaseVector& vec, vector_size_t size) {
+  return vec.nulls() && BaseVector::countNulls(vec.nulls(), size) > 0;
+}
+
 template <typename Vector>
 void exportOffsets(
     const Vector& vec,
@@ -1250,7 +1254,7 @@ void exportOffsets(
   auto offsets = AlignedBuffer::allocate<vector_size_t>(
       checkedPlus<size_t>(out.length, 1), pool);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
-  if (!rows.changed() && isCompact(vec)) {
+  if (!rows.changed() && !hasNulls(vec, out.length) && isCompact(vec)) {
     auto copiedSize = vec.size() > out.length ? out.length : vec.size();
 
     memcpy(rawOffsets, vec.rawOffsets(), sizeof(vector_size_t) * copiedSize);
@@ -1287,7 +1291,8 @@ void exportOffsets(
     childRows.clearAll();
     // j: Index of element we are writing.
     // k: Total size so far.
-    vector_size_t j = 0, k = 0;
+    vector_size_t j = 0;
+    vector_size_t k = 0;
     rows.apply([&](vector_size_t i) {
       rawOffsets[j++] = k;
       if (!vec.isNullAt(i)) {
@@ -1313,7 +1318,7 @@ void exportOffsetsIPC(
   auto offsets = AlignedBuffer::allocate<vector_size_t>(
       checkedPlus<size_t>(out.length, 1), pool);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
-  if (!rows.changed() && isCompact(vec)) {
+  if (!rows.changed() && !hasNulls(vec, out.length) && isCompact(vec)) {
     const vector_size_t m = out.length;
     BOLT_DCHECK_EQ(m, vec.size(), "fast path assumes out.length == vec.size()");
 

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -713,6 +713,28 @@ TEST_F(ArrowBridgeArrayExportTest, arraySimple) {
   testArrayVector(data3);
 }
 
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    slicedArrayStringExportsOnlyReferencedElements) {
+  auto elements = vectorMaker_.flatVector<StringView>(
+      {"unused-prefix", "a", "b", "c", "d", "unused-suffix"});
+  auto offsets = makeBuffer<vector_size_t>({0, 1, 3, 4});
+  auto sizes = makeBuffer<vector_size_t>({1, 2, 1, 2});
+  auto vector = std::make_shared<ArrayVector>(
+      pool_.get(), ARRAY(VARCHAR()), nullptr, 4, offsets, sizes, elements);
+  auto sliced = vector->slice(1, 2);
+
+  ArrowArray arrowArray;
+  bolt::exportToArrow(sliced, arrowArray, pool_.get(), options_);
+
+  TArrayContainer<StringView> expected = {{{"a", "b"}}, {{"c"}}};
+  validateListArray(expected, arrowArray);
+
+  arrowArray.release(&arrowArray);
+  EXPECT_EQ(nullptr, arrowArray.release);
+  EXPECT_EQ(nullptr, arrowArray.private_data);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, arrayCrossValidate) {
   auto vec = vectorMaker_.arrayVector<int64_t>({{1, 2, 3}, {4, 5}});
   auto array = toArrow(vec, options_, pool_.get());

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -735,6 +735,30 @@ TEST_F(
   EXPECT_EQ(nullptr, arrowArray.private_data);
 }
 
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    slicedArrayWithNullParentExportsOnlyReferencedElements) {
+  auto elements = vectorMaker_.flatVector<int64_t>({0, 1, 2, 3, 4, 5, 6});
+  auto offsets = makeBuffer<vector_size_t>({0, 1, 3, 5});
+  auto sizes = makeBuffer<vector_size_t>({1, 2, 2, 2});
+  BufferPtr nulls =
+      AlignedBuffer::allocate<bool>(4, pool_.get(), bits::kNotNull);
+  bits::setNull(nulls->asMutable<uint64_t>(), 2, true);
+  auto vector = std::make_shared<ArrayVector>(
+      pool_.get(), ARRAY(BIGINT()), nulls, 4, offsets, sizes, elements, 1);
+  auto sliced = vector->slice(1, 2);
+
+  ArrowArray arrowArray;
+  bolt::exportToArrow(sliced, arrowArray, pool_.get(), options_);
+
+  TArrayContainer<int64_t> expected = {{{1, 2}}, std::nullopt};
+  validateListArray(expected, arrowArray);
+
+  arrowArray.release(&arrowArray);
+  EXPECT_EQ(nullptr, arrowArray.release);
+  EXPECT_EQ(nullptr, arrowArray.private_data);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, arrayCrossValidate) {
   auto vec = vectorMaker_.arrayVector<int64_t>({{1, 2, 3}, {4, 5}});
   auto array = toArrow(vec, options_, pool_.get());
@@ -867,6 +891,46 @@ TEST_F(ArrowBridgeArrayExportTest, mapSimple) {
   ASSERT_EQ(items.length(), 2);
   EXPECT_EQ(items.Value(0), 1);
   EXPECT_EQ(items.Value(1), 1);
+}
+
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    slicedMapWithNullParentExportsOnlyReferencedElements) {
+  auto keys = vectorMaker_.flatVector<int32_t>({0, 10, 11, 20, 21, 30, 31});
+  auto values =
+      vectorMaker_.flatVector<int64_t>({0, 100, 110, 200, 210, 300, 310});
+  auto offsets = makeBuffer<vector_size_t>({0, 1, 3, 5});
+  auto sizes = makeBuffer<vector_size_t>({1, 2, 2, 2});
+  BufferPtr nulls =
+      AlignedBuffer::allocate<bool>(4, pool_.get(), bits::kNotNull);
+  bits::setNull(nulls->asMutable<uint64_t>(), 2, true);
+  auto vector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), BIGINT()),
+      nulls,
+      4,
+      offsets,
+      sizes,
+      keys,
+      values,
+      1);
+  auto sliced = vector->slice(1, 2);
+
+  auto array = toArrow(sliced, options_, pool_.get());
+  ASSERT_OK(array->ValidateFull());
+  EXPECT_EQ(array->null_count(), 1);
+  ASSERT_EQ(*array->type(), *arrow::map(arrow::int32(), arrow::int64()));
+  auto& mapArray = static_cast<const arrow::MapArray&>(*array);
+  validateOffsets(mapArray, {0, 2, 2});
+  auto& exportedKeys = static_cast<const arrow::Int32Array&>(*mapArray.keys());
+  ASSERT_EQ(exportedKeys.length(), 2);
+  EXPECT_EQ(exportedKeys.Value(0), 10);
+  EXPECT_EQ(exportedKeys.Value(1), 11);
+  auto& exportedItems =
+      static_cast<const arrow::Int64Array&>(*mapArray.items());
+  ASSERT_EQ(exportedItems.length(), 2);
+  EXPECT_EQ(exportedItems.Value(0), 100);
+  EXPECT_EQ(exportedItems.Value(1), 110);
 }
 
 TEST_F(ArrowBridgeArrayExportTest, mapNested) {


### PR DESCRIPTION

### What problem does this PR solve?

Fix Arrow export for sliced Array/Map vectors when the compact offsets fast path is used.

  ArrayVector/MapVector::slice keeps the original child vector and only slices parent offsets/sizes. In
  the normal Arrow export path, exportOffsets() previously copied compact parent offsets but left
  childRows as the default full-child selection. As a result, exporting a sliced Array/Map could still
  export the full child vector. For nested VARCHAR/VARBINARY, this could make the exported child string
  buffer exceed Arrow's int32 offset limit even when the top-level batch had already been sliced.

  This change rebases compact offsets to the current slice and restricts childRows to the referenced
  child range [base, end), matching the behavior already used by exportOffsetsIPC().

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fix Arrow export for sliced Array/Map vectors when the compact offsets fast path is used.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
