### PR TITLE
ci: improve merge queue efficiency and runner recovery

### DIFF
--- a/.github/runners/docker-compose.yml
+++ b/.github/runners/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       context: .
       dockerfile: Dockerfile.conanserver
     image: localhost:5000/conan-server:latest
+    restart: unless-stopped
     env_file:
       - variables.env
     ports:
@@ -19,6 +20,7 @@ services:
     command: ["/usr/local/bin/start-conan-server.sh"]
   bolt-registry:
     image: registry:2
+    restart: unless-stopped
     ports:
       - '5000:5000'
     volumes:

--- a/.github/runners/docker-compose.yml
+++ b/.github/runners/docker-compose.yml
@@ -21,6 +21,16 @@ services:
   bolt-registry:
     image: registry:2
     restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          wget -q --spider http://localhost:5000/v2/bolt-ci/manifests/20260114 &&
+          wget -q --spider http://localhost:5000/v2/conan-server/manifests/latest
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
     ports:
       - '5000:5000'
     volumes:
@@ -30,6 +40,9 @@ services:
       service: base-runner
       file: runner-base-compose.yml
     privileged: true
+    depends_on:
+      bolt-registry:
+        condition: service_healthy
     scale: 4
     volumes:
       - ${HOST_DATA_DIR}/runner-data/docker:${DOCKER_DATA_DIR}
@@ -47,7 +60,11 @@ services:
       service: base-runner
       file: runner-base-compose.yml
     privileged: true
-    scale: 5
+    depends_on:
+      bolt-registry:
+        condition: service_healthy
+    # Keep one compatibility runner until workflows created from the old main drain.
+    scale: 1
     volumes:
       - ${HOST_DATA_DIR}/runner-data/docker:/data/docker
       - ${HOST_DATA_DIR}/runner-data/small/workspace:/data/workspace

--- a/.github/runners/runner-base-compose.yml
+++ b/.github/runners/runner-base-compose.yml
@@ -3,9 +3,11 @@ version: '3.8'
 services:
   base-runner:
     build: .
+    restart: unless-stopped
     env_file:
       - variables.env
     extra_hosts:
       - host.docker.internal:host-gateway
     volumes:
+      - /etc/hostname:/etc/host-hostname:ro
       - ${HOST_DATA_DIR}/conan-server-data:/data/conan-server-data:r

--- a/.github/runners/runner/entrypoint.py
+++ b/.github/runners/runner/entrypoint.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 
 HOST_HOSTNAME_PATH = Path("/etc/host-hostname")
+RUNNER_CONFIG_PATH = Path("/actions-runner/.runner")
+RUNNER_CREDENTIALS_PATH = Path("/actions-runner/.credentials")
+RUNNER_RSA_PATH = Path("/actions-runner/.credentials_rsaparams")
 
 
 def normalize_hostname(value, source):
@@ -91,12 +94,26 @@ def create_registration_token(token, org_name, repo_name):
     return response.json()["token"]
 
 
+def runner_is_configured(
+    config_path=RUNNER_CONFIG_PATH,
+    credentials_path=RUNNER_CREDENTIALS_PATH,
+    rsa_path=RUNNER_RSA_PATH,
+):
+    configuration_files = (config_path, credentials_path, rsa_path)
+    configured_files = [path for path in configuration_files if path.is_file()]
+    if configured_files and len(configured_files) != len(configuration_files):
+        raise RuntimeError(
+            "Runner configuration is incomplete; recreate the container to register "
+            "it again"
+        )
+    return len(configured_files) == len(configuration_files)
+
+
 def main():
     # ensure all variables are set, error message should include unset variables
     unset_vars = [
         var
         for var in [
-            "GITHUB_RUNNER_TOKEN",
             "ORGANIZATION_NAME",
             "REPOSITORY_NAME",
             "RUNNER_LABELS",
@@ -110,7 +127,6 @@ def main():
     runner_hostname = runner_instance_hostname()
     host_hostname = resolve_host_hostname()
 
-    gh_auth_token = os.environ["GITHUB_RUNNER_TOKEN"]
     runner_name = f"{host_hostname}-{runner_hostname}"
     org_name = os.environ["ORGANIZATION_NAME"]
     repo_name = os.environ["REPOSITORY_NAME"]
@@ -126,25 +142,34 @@ def main():
     ensure_docker_storage(docker_data_dir, runner_hostname)
     subprocess.run(["service", "docker", "start"], check=True)
 
-    # create a registration token for the runner
-    registration_token = create_registration_token(gh_auth_token, org_name, repo_name)
-    print(f"Configuring the runner with name {runner_name}")
-    subprocess.run(
-        [
-            "/actions-runner/config.sh",
-            "--url",
-            f"https://github.com/{org_name}/{repo_name}",
-            "--token",
-            registration_token,
-            "--name",
-            runner_name,
-            "--replace",
-            "--labels",
-            runner_labels,
-            "--unattended",
-        ],
-        check=True,
-    )
+    if runner_is_configured():
+        print(f"Runner {runner_name} is already configured; reusing its credentials")
+    else:
+        gh_auth_token = os.environ.get("GITHUB_RUNNER_TOKEN")
+        if not gh_auth_token:
+            raise ValueError("GITHUB_RUNNER_TOKEN must be set for initial registration")
+        registration_token = create_registration_token(
+            gh_auth_token,
+            org_name,
+            repo_name,
+        )
+        print(f"Configuring the runner with name {runner_name}")
+        subprocess.run(
+            [
+                "/actions-runner/config.sh",
+                "--url",
+                f"https://github.com/{org_name}/{repo_name}",
+                "--token",
+                registration_token,
+                "--name",
+                runner_name,
+                "--replace",
+                "--labels",
+                runner_labels,
+                "--unattended",
+            ],
+            check=True,
+        )
 
     print("Starting the runner...")
     os.execv("/bin/bash", ["/bin/bash", "/actions-runner/run.sh"])

--- a/.github/runners/runner/entrypoint.py
+++ b/.github/runners/runner/entrypoint.py
@@ -1,17 +1,92 @@
 #!/usr/bin/env python3
 import os
+import socket
 import subprocess
-import requests
+from pathlib import Path
+
+
+HOST_HOSTNAME_PATH = Path("/etc/host-hostname")
+
+
+def normalize_hostname(value, source):
+    hostname = value.strip().split(".", 1)[0]
+    if not hostname or hostname == "unknown-host":
+        raise ValueError(f"{source} does not contain a usable hostname")
+    allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+    if any(character not in allowed for character in hostname):
+        raise ValueError(f"{source} contains an invalid hostname: {hostname!r}")
+    return hostname
+
+
+def resolve_host_hostname(explicit=None, hostname_path=HOST_HOSTNAME_PATH):
+    explicit = os.environ.get("RUNNER_HOSTNAME", "") if explicit is None else explicit
+    if explicit.strip() and explicit.strip() != "unknown-host":
+        return normalize_hostname(explicit, "RUNNER_HOSTNAME")
+
+    try:
+        persisted = hostname_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ValueError(
+            f"Set RUNNER_HOSTNAME or mount the host /etc/hostname at {hostname_path}"
+        ) from error
+    return normalize_hostname(persisted, str(hostname_path))
+
+
+def runner_instance_hostname():
+    container_hostname = socket.gethostname()
+    try:
+        container_ip = socket.gethostbyname(container_hostname)
+        result = subprocess.run(
+            ["dig", "-x", container_ip, "+short"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        reverse_dns_name = result.stdout.strip()
+    except (OSError, socket.gaierror, subprocess.CalledProcessError):
+        reverse_dns_name = ""
+    return normalize_hostname(
+        reverse_dns_name or container_hostname,
+        "container hostname",
+    )
+
+
+def ensure_docker_storage(
+    docker_data_dir,
+    runner_hostname,
+    docker_root=Path("/var/lib/docker"),
+):
+    storage = Path(docker_data_dir) / runner_hostname
+    storage.mkdir(parents=True, exist_ok=True)
+
+    if docker_root.is_symlink():
+        if docker_root.resolve() != storage.resolve():
+            raise RuntimeError(
+                f"{docker_root} points to {docker_root.resolve()}, not {storage}"
+            )
+        return storage
+
+    if docker_root.exists():
+        if not docker_root.is_dir() or any(docker_root.iterdir()):
+            raise RuntimeError(
+                f"Refusing to replace non-empty Docker data path {docker_root}"
+            )
+        docker_root.rmdir()
+
+    docker_root.symlink_to(storage, target_is_directory=True)
+    return storage
 
 
 def create_registration_token(token, org_name, repo_name):
+    import requests
+
     url = f"https://api.github.com/repos/{org_name}/{repo_name}/actions/runners/registration-token"
     headers = {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    response = requests.post(url, headers=headers)
+    response = requests.post(url, headers=headers, timeout=30)
     response.raise_for_status()
     return response.json()["token"]
 
@@ -32,13 +107,11 @@ def main():
     if unset_vars:
         raise ValueError(f"Variables {', '.join(unset_vars)} must be set")
 
-    # do a reverse DNS lookup to get the hostname:
-    runner_hostname = subprocess.check_output(
-        "dig -x $(hostname -i) +short | cut -d'.' -f1", shell=True
-    ).strip()
+    runner_hostname = runner_instance_hostname()
+    host_hostname = resolve_host_hostname()
 
     gh_auth_token = os.environ["GITHUB_RUNNER_TOKEN"]
-    runner_name = f"{os.environ['RUNNER_HOSTNAME']}-{runner_hostname}"
+    runner_name = f"{host_hostname}-{runner_hostname}"
     org_name = os.environ["ORGANIZATION_NAME"]
     repo_name = os.environ["REPOSITORY_NAME"]
     runner_labels = os.environ["RUNNER_LABELS"]
@@ -50,15 +123,28 @@ def main():
     # starting docker - each runner replica needs a unique /var/lib/docker directory
     # compose isn't capable of editing mounts after startup, so we need to create
     # the directory and symlink it to /var/lib/docker
-    os.system(f"mkdir -p {docker_data_dir}/{runner_hostname}")
-    os.system(f"ln -s {docker_data_dir}/{runner_hostname} /var/lib/docker")
-    os.system("service docker start")
+    ensure_docker_storage(docker_data_dir, runner_hostname)
+    subprocess.run(["service", "docker", "start"], check=True)
 
     # create a registration token for the runner
     registration_token = create_registration_token(gh_auth_token, org_name, repo_name)
     print(f"Configuring the runner with name {runner_name}")
-    config_command = f"/actions-runner/config.sh --url https://github.com/{org_name}/{repo_name} --token {registration_token} --name {runner_name} --replace --labels {runner_labels} --unattended"
-    os.system(config_command)
+    subprocess.run(
+        [
+            "/actions-runner/config.sh",
+            "--url",
+            f"https://github.com/{org_name}/{repo_name}",
+            "--token",
+            registration_token,
+            "--name",
+            runner_name,
+            "--replace",
+            "--labels",
+            runner_labels,
+            "--unattended",
+        ],
+        check=True,
+    )
 
     print("Starting the runner...")
     os.execv("/bin/bash", ["/bin/bash", "/actions-runner/run.sh"])

--- a/.github/runners/setup-runners.sh
+++ b/.github/runners/setup-runners.sh
@@ -6,9 +6,22 @@ cd "$SCRIPT_DIR"
 
 # shellcheck disable=SC2086
 docker compose build ${BUILD_ARGS}
-docker compose up -d
-# wait a few seconds for the registry to start up
-sleep 5
+docker compose up -d bolt-registry
+
+for attempt in $(seq 1 45); do
+  if docker compose exec -T bolt-registry \
+    wget -q --spider http://localhost:5000/v2/; then
+    break
+  fi
+  if [ "$attempt" -eq 45 ]; then
+    echo "Registry API did not become ready" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
 docker compose push ci-image
 docker compose push conan_server
+docker compose up -d --wait --wait-timeout 90 bolt-registry
+docker compose up -d conan_server runner-medium runner-small
 exec docker compose ps

--- a/.github/runners/variables.env
+++ b/.github/runners/variables.env
@@ -1,7 +1,8 @@
 # Setup variables
 ORGANIZATION_NAME=bytedance
 REPOSITORY_NAME=bolt
-RUNNER_HOSTNAME=${HOSTNAME:-unknown-host}
+# Leave empty to use the host's persistent /etc/hostname.
+RUNNER_HOSTNAME=
 DOCKER_DATA_DIR=${DOCKER_DATA_DIR}
 CONAN_ADMIN_USERNAME=
 CONAN_ADMIN_PASSWORD=

--- a/.github/scripts/merge_queue_ci.py
+++ b/.github/scripts/merge_queue_ci.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Helpers for merge-queue CI reuse and stale-run reconciliation."""
+"""Helpers for merge-queue CI reuse, gating, and stale-run cleanup."""
 
 import argparse
 import datetime as dt
@@ -9,7 +9,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -17,10 +16,21 @@ from pathlib import Path
 
 
 API_VERSION = "2022-11-28"
-ARTIFACT_PREFIX = "bolt-ci-result-v1"
+RESULT_ARTIFACT_PREFIX = "bolt-ci-result-v2"
+SOURCE_ARTIFACT_PREFIX = "bolt-ci-source-v1"
+GATE_CHECK_NAME = "merge-queue-gate"
+GATE_WORKFLOW_PATH = ".github/workflows/merge-queue-gate.yml"
+REQUIRED_WORKFLOWS = ("build-test.yml", "pre-commit-checks.yml")
 REUSABLE_EVENTS = {"pull_request", "merge_group"}
-ACTIVE_RUN_STATUSES = ("queued", "in_progress")
+ACTIVE_RUN_STATUSES = (
+    "queued",
+    "in_progress",
+    "waiting",
+    "pending",
+    "requested",
+)
 SHA_RE = re.compile(r"^[0-9a-f]{40,64}$")
+CONFIG_HASH_RE = re.compile(r"^[0-9a-f]{20}$")
 
 
 class GitHubApiError(RuntimeError):
@@ -59,7 +69,8 @@ class GitHubApi:
             body = error.read().decode("utf-8", errors="replace")
             raise GitHubApiError(
                 error.code,
-                f"GitHub API {method} {path} failed with HTTP {error.code}: {body[:500]}",
+                f"GitHub API {method} {path} failed with HTTP {error.code}: "
+                f"{body[:500]}",
             ) from error
         except urllib.error.URLError as error:
             raise GitHubApiError(
@@ -72,6 +83,11 @@ class GitHubApi:
 
 def parse_github_time(value):
     return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def github_time(value=None):
+    value = value or dt.datetime.now(dt.timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
 
 
 def utc_now():
@@ -88,9 +104,15 @@ def validate_repository(repository):
     return repository
 
 
-def validate_sha(value):
-    if not SHA_RE.fullmatch(value):
-        raise ValueError(f"Invalid Git SHA: {value!r}")
+def validate_sha(value, field="Git SHA"):
+    if not SHA_RE.fullmatch(value or ""):
+        raise ValueError(f"Invalid {field}: {value!r}")
+    return value
+
+
+def validate_config_hash(value):
+    if not CONFIG_HASH_RE.fullmatch(value or ""):
+        raise ValueError(f"Invalid CI configuration hash: {value!r}")
     return value
 
 
@@ -102,6 +124,16 @@ def append_github_output(path, values):
             output.write(f"{key}={value}\n")
 
 
+def write_json(path, payload):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def git_tree_sha():
     result = subprocess.run(
         ["git", "rev-parse", "HEAD^{tree}"],
@@ -109,23 +141,50 @@ def git_tree_sha():
         capture_output=True,
         text=True,
     )
-    return validate_sha(result.stdout.strip())
+    return validate_sha(result.stdout.strip(), "tree SHA")
 
 
-def make_fingerprint(tree_sha, salt):
-    tree_sha = validate_sha(tree_sha)
-    config_hash = hashlib.sha256(
-        f"{ARTIFACT_PREFIX}\0{salt}".encode("utf-8")
+def config_hash(salt):
+    return hashlib.sha256(
+        f"{RESULT_ARTIFACT_PREFIX}\0{salt}".encode("utf-8")
     ).hexdigest()[:20]
+
+
+def make_fingerprint(tree_sha, base_sha, salt):
+    tree_sha = validate_sha(tree_sha, "tree SHA")
+    base_sha = validate_sha(base_sha, "base SHA")
+    config = config_hash(salt)
     return {
         "tree_sha": tree_sha,
-        "config_hash": config_hash,
-        "artifact_name": f"{ARTIFACT_PREFIX}-{tree_sha}-{config_hash}",
+        "base_sha": base_sha,
+        "config_hash": config,
+        "artifact_name": (f"{RESULT_ARTIFACT_PREFIX}-{tree_sha}-{base_sha}-{config}"),
     }
 
 
 def normalize_workflow_path(value):
     return (value or "").split("@", 1)[0]
+
+
+def workflow_filename(value):
+    return normalize_workflow_path(value).rsplit("/", 1)[-1]
+
+
+def workflow_key(value):
+    filename = workflow_filename(value)
+    if filename == "build-test.yml":
+        return "build-test"
+    if filename == "pre-commit-checks.yml":
+        return "pre-commit"
+    raise ValueError(f"Unsupported CI workflow: {value!r}")
+
+
+def source_artifact_name(workflow, run_id, run_attempt, merge_sha, config):
+    return (
+        f"{SOURCE_ARTIFACT_PREFIX}-{workflow_key(workflow)}-{run_id}-"
+        f"{run_attempt}-{validate_sha(merge_sha, 'merge SHA')}-"
+        f"{validate_config_hash(config)}"
+    )
 
 
 def list_named_artifacts(api, repository, artifact_name):
@@ -135,6 +194,20 @@ def list_named_artifacts(api, repository, artifact_name):
         response = api.request(
             f"/repos/{repository}/actions/artifacts"
             f"?name={encoded_name}&per_page=100&page={page}"
+        )
+        batch = response.get("artifacts", [])
+        artifacts.extend(batch)
+        if len(batch) < 100:
+            break
+    return artifacts
+
+
+def list_run_artifacts(api, repository, run_id):
+    artifacts = []
+    for page in range(1, 101):
+        response = api.request(
+            f"/repos/{repository}/actions/runs/{run_id}/artifacts"
+            f"?per_page=100&page={page}"
         )
         batch = response.get("artifacts", [])
         artifacts.extend(batch)
@@ -162,7 +235,7 @@ def find_reusable_result(
     )
 
     for artifact in artifacts:
-        if artifact.get("expired"):
+        if artifact.get("expired") or artifact.get("name") != artifact_name:
             continue
         created_at = parse_github_time(artifact["created_at"])
         if created_at < cutoff:
@@ -175,7 +248,7 @@ def find_reusable_result(
         run = api.request(f"/repos/{repository}/actions/runs/{run_id}")
         if run.get("status") != "completed" or run.get("conclusion") != "success":
             continue
-        if run.get("event") not in REUSABLE_EVENTS:
+        if run.get("event") != "workflow_run":
             continue
         if normalize_workflow_path(run.get("path")) != normalize_workflow_path(
             workflow_path
@@ -217,9 +290,9 @@ def list_workflow_runs(api, repository, workflow, head_sha, event):
     return response.get("workflow_runs", [])
 
 
-def select_event_run(runs, gate_created_at, window_seconds):
-    lower_bound = gate_created_at - dt.timedelta(seconds=window_seconds)
-    upper_bound = gate_created_at + dt.timedelta(seconds=window_seconds)
+def select_event_run(runs, source_created_at, window_seconds):
+    lower_bound = source_created_at - dt.timedelta(seconds=window_seconds)
+    upper_bound = source_created_at + dt.timedelta(seconds=window_seconds)
     candidates = [
         run
         for run in runs
@@ -237,61 +310,272 @@ def select_event_run(runs, gate_created_at, window_seconds):
     )
 
 
-def wait_for_workflows(
+def correlated_ci_runs(
     api,
     repository,
-    workflows,
+    source_run,
+    workflows=REQUIRED_WORKFLOWS,
+    window_seconds=900,
+):
+    head_sha = validate_sha(source_run.get("head_sha"), "head SHA")
+    event = source_run.get("event")
+    if event not in REUSABLE_EVENTS:
+        raise ValueError(f"Unsupported source event: {event!r}")
+    source_created_at = parse_github_time(source_run["created_at"])
+    correlated = {}
+    for workflow in workflows:
+        runs = list_workflow_runs(api, repository, workflow, head_sha, event)
+        correlated[workflow] = select_event_run(
+            runs,
+            source_created_at,
+            window_seconds,
+        )
+    return correlated
+
+
+def check_state(runs):
+    present = [run for run in runs.values() if run]
+    if any(
+        run.get("status") == "completed" and run.get("conclusion") != "success"
+        for run in present
+    ):
+        return "completed", "failure"
+    if len(present) == len(runs) and all(
+        run.get("status") == "completed" and run.get("conclusion") == "success"
+        for run in present
+    ):
+        return "completed", "success"
+    return "in_progress", None
+
+
+def check_summary(runs, validation_error=None):
+    lines = []
+    for workflow, run in runs.items():
+        if not run:
+            lines.append(f"- `{workflow}`: missing")
+            continue
+        state = run.get("conclusion") or run.get("status") or "unknown"
+        url = run.get("html_url", "")
+        lines.append(f"- [`{workflow}`]({url}): {state}")
+    if validation_error:
+        lines.extend(("", f"CI evidence rejected: `{validation_error}`"))
+    return "\n".join(lines)
+
+
+def upsert_gate_check(
+    api,
+    repository,
     head_sha,
     event,
-    gate_run_id,
-    timeout_seconds,
-    poll_seconds,
-    run_window_seconds,
-    sleep=time.sleep,
+    runs,
+    status,
+    conclusion,
+    validation_error=None,
+):
+    external_id = f"bolt-merge-queue-gate:{event}:{head_sha}"
+    query = urllib.parse.urlencode({"check_name": GATE_CHECK_NAME, "per_page": 100})
+    response = api.request(f"/repos/{repository}/commits/{head_sha}/check-runs?{query}")
+    existing = next(
+        (
+            check
+            for check in response.get("check_runs", [])
+            if check.get("external_id") == external_id
+        ),
+        None,
+    )
+    details_url = next(
+        (
+            run.get("html_url", "")
+            for run in runs.values()
+            if run and run.get("html_url")
+        ),
+        "",
+    )
+    payload = {
+        "name": GATE_CHECK_NAME,
+        "status": status,
+        "external_id": external_id,
+        "details_url": details_url,
+        "output": {
+            "title": (
+                "CI evidence rejected"
+                if validation_error
+                else "Required CI passed"
+                if conclusion == "success"
+                else "Required CI failed"
+                if conclusion == "failure"
+                else "Waiting for required CI"
+            ),
+            "summary": check_summary(runs, validation_error),
+        },
+    }
+    if status == "completed":
+        payload["conclusion"] = conclusion
+        payload["completed_at"] = github_time()
+
+    if existing:
+        return api.request(
+            f"/repos/{repository}/check-runs/{existing['id']}",
+            method="PATCH",
+            payload=payload,
+        )
+
+    payload["head_sha"] = head_sha
+    if status == "in_progress":
+        payload["started_at"] = github_time()
+    return api.request(
+        f"/repos/{repository}/check-runs",
+        method="POST",
+        payload=payload,
+    )
+
+
+def find_source_evidence(api, repository, run, expected_config):
+    workflow = workflow_filename(run.get("path"))
+    prefix = (
+        f"{SOURCE_ARTIFACT_PREFIX}-{workflow_key(workflow)}-{run['id']}-"
+        f"{run.get('run_attempt', 1)}-"
+    )
+    matches = [
+        artifact
+        for artifact in list_run_artifacts(api, repository, run["id"])
+        if not artifact.get("expired") and artifact.get("name", "").startswith(prefix)
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Expected one source evidence artifact for run {run['id']}, "
+            f"found {len(matches)}"
+        )
+    suffix = matches[0]["name"][len(prefix) :]
+    try:
+        merge_sha, evidence_config = suffix.split("-", 1)
+    except ValueError as error:
+        raise RuntimeError(
+            f"Malformed source evidence artifact: {matches[0]['name']}"
+        ) from error
+    validate_sha(merge_sha, "merge SHA")
+    if evidence_config != expected_config:
+        raise RuntimeError(
+            f"CI configuration mismatch for run {run['id']}: "
+            f"{evidence_config} != {expected_config}"
+        )
+    validate_config_hash(evidence_config)
+    return {
+        "artifact_id": matches[0]["id"],
+        "merge_sha": merge_sha,
+        "config_hash": evidence_config,
+    }
+
+
+def reusable_pr_result(api, repository, runs, salt):
+    expected_config = config_hash(salt)
+    evidences = {
+        workflow: find_source_evidence(api, repository, run, expected_config)
+        for workflow, run in runs.items()
+    }
+    merge_shas = {evidence["merge_sha"] for evidence in evidences.values()}
+    if len(merge_shas) != 1:
+        raise RuntimeError(f"CI workflows tested different merge commits: {merge_shas}")
+    merge_sha = merge_shas.pop()
+    commit = api.request(f"/repos/{repository}/git/commits/{merge_sha}")
+    parents = [parent["sha"] for parent in commit.get("parents", [])]
+    head_shas = {run.get("head_sha") for run in runs.values()}
+    if len(head_shas) != 1:
+        raise RuntimeError(f"CI workflows have different head SHAs: {head_shas}")
+    head_sha = validate_sha(head_shas.pop(), "head SHA")
+    if len(parents) != 2 or parents[1] != head_sha:
+        raise RuntimeError(
+            f"Merge commit {merge_sha} does not have expected PR head {head_sha}"
+        )
+    base_sha = validate_sha(parents[0], "base SHA")
+    tree_sha = validate_sha((commit.get("tree") or {}).get("sha"), "tree SHA")
+    result = make_fingerprint(tree_sha, base_sha, salt)
+    result.update(
+        {
+            "event": "pull_request",
+            "head_sha": head_sha,
+            "merge_sha": merge_sha,
+            "source_runs": {workflow: run["id"] for workflow, run in runs.items()},
+            "created_at": github_time(),
+        }
+    )
+    return result
+
+
+def reconcile_gate(
+    api,
+    repository,
+    source_run_id,
+    salt,
+    output,
+    github_output=None,
 ):
     repository = validate_repository(repository)
-    validate_sha(head_sha)
-    gate_run = api.request(f"/repos/{repository}/actions/runs/{gate_run_id}")
-    gate_created_at = parse_github_time(gate_run["created_at"])
-    deadline = time.monotonic() + timeout_seconds
-    last_state = None
+    source_run = api.request(f"/repos/{repository}/actions/runs/{source_run_id}")
+    if workflow_filename(source_run.get("path")) not in REQUIRED_WORKFLOWS:
+        raise ValueError(f"Run {source_run_id} is not from a required CI workflow")
+    runs = correlated_ci_runs(api, repository, source_run)
+    status, conclusion = check_state(runs)
+    head_sha = validate_sha(source_run.get("head_sha"), "head SHA")
+    event = source_run.get("event")
+    result = None
+    validation_error = None
+    if conclusion == "success" and event == "pull_request":
+        try:
+            result = reusable_pr_result(api, repository, runs, salt)
+        except GitHubApiError:
+            raise
+        except (KeyError, RuntimeError, TypeError, ValueError) as error:
+            status = "completed"
+            conclusion = "failure"
+            validation_error = str(error)
 
-    while True:
-        states = {}
-        for workflow in workflows:
-            runs = list_workflow_runs(api, repository, workflow, head_sha, event)
-            selected = select_event_run(runs, gate_created_at, run_window_seconds)
-            if selected is None:
-                states[workflow] = ("missing", None)
-            else:
-                states[workflow] = (
-                    selected.get("status", "unknown"),
-                    selected.get("conclusion"),
-                )
+    check = upsert_gate_check(
+        api,
+        repository,
+        head_sha,
+        event,
+        runs,
+        status,
+        conclusion,
+        validation_error,
+    )
 
-        if states != last_state:
-            print(json.dumps({"workflow_states": states}, sort_keys=True))
-            last_state = states
+    values = {
+        "status": status,
+        "conclusion": conclusion or "",
+        "reusable": "false",
+        "artifact_name": "",
+        "check_url": check.get("html_url", ""),
+    }
+    if result:
+        path = write_json(output, result)
+        values["reusable"] = "true"
+        values["artifact_name"] = result["artifact_name"]
+        values["result_path"] = str(path)
 
-        failures = {
-            workflow: conclusion
-            for workflow, (status, conclusion) in states.items()
-            if status == "completed" and conclusion != "success"
-        }
-        if failures:
-            raise RuntimeError(f"Required CI workflow failed: {failures}")
-
-        if all(
-            status == "completed" and conclusion == "success"
-            for status, conclusion in states.values()
-        ):
-            return states
-
-        if time.monotonic() >= deadline:
-            raise TimeoutError(
-                f"Timed out waiting for CI workflows after {timeout_seconds}s: {states}"
-            )
-        sleep(poll_seconds)
+    append_github_output(github_output, values)
+    print(
+        json.dumps(
+            {
+                "gate": values,
+                "workflow_states": {
+                    workflow: (
+                        None
+                        if run is None
+                        else {
+                            "id": run["id"],
+                            "status": run.get("status"),
+                            "conclusion": run.get("conclusion"),
+                        }
+                    )
+                    for workflow, run in runs.items()
+                },
+            },
+            sort_keys=True,
+        )
+    )
+    return values
 
 
 def list_live_merge_queue_shas(api, repository, base_branch):
@@ -411,7 +695,7 @@ def write_step_summary(path, summary):
 
 
 def command_fingerprint(args):
-    result = make_fingerprint(git_tree_sha(), args.salt)
+    result = make_fingerprint(git_tree_sha(), args.base_sha, args.salt)
     append_github_output(args.github_output, result)
     print(json.dumps(result, sort_keys=True))
     return 0
@@ -429,16 +713,24 @@ def command_find_reuse(args):
         return 0
 
     try:
+        fingerprint = make_fingerprint(args.tree_sha, args.base_sha, args.salt)
         api = GitHubApi(args.token)
         result = find_reusable_result(
             api,
             validate_repository(args.repository),
-            args.artifact_name,
+            fingerprint["artifact_name"],
             args.workflow_path,
             args.max_age_hours,
             current_run_id=args.current_run_id,
         )
-    except (GitHubApiError, KeyError, OSError, TypeError, ValueError) as error:
+    except (
+        GitHubApiError,
+        KeyError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
         print(
             f"::warning::CI reuse lookup failed; running full CI instead: {error}",
             file=sys.stderr,
@@ -455,39 +747,45 @@ def command_find_reuse(args):
     return 0
 
 
-def command_wait(args):
-    api = GitHubApi(args.token)
-    states = wait_for_workflows(
-        api,
-        validate_repository(args.repository),
+def command_record_source(args):
+    payload = {
+        "schema_version": 1,
+        "workflow": workflow_filename(args.workflow),
+        "event": args.event,
+        "source_run_id": args.run_id,
+        "source_run_attempt": args.run_attempt,
+        "merge_sha": validate_sha(args.merge_sha, "merge SHA"),
+        "tree_sha": validate_sha(args.tree_sha, "tree SHA"),
+        "base_sha": validate_sha(args.base_sha, "base SHA"),
+        "config_hash": validate_config_hash(args.config_hash),
+        "created_at": github_time(),
+    }
+    artifact_name = source_artifact_name(
         args.workflow,
-        validate_sha(args.head_sha),
-        args.event,
-        args.gate_run_id,
-        args.timeout_seconds,
-        args.poll_seconds,
-        args.run_window_seconds,
+        args.run_id,
+        args.run_attempt,
+        args.merge_sha,
+        args.config_hash,
     )
-    print(json.dumps({"completed": states}, sort_keys=True))
+    path = write_json(args.output, payload)
+    append_github_output(
+        args.github_output,
+        {"artifact_name": artifact_name, "result_path": str(path)},
+    )
+    print(json.dumps({"artifact_name": artifact_name, **payload}, sort_keys=True))
     return 0
 
 
-def command_record(args):
-    payload = {
-        "artifact_name": args.artifact_name,
-        "tree_sha": validate_sha(args.tree_sha),
-        "config_hash": args.config_hash,
-        "run_id": args.run_id,
-        "run_url": args.run_url,
-        "created_at": utc_now().isoformat(),
-    }
-    path = Path(args.output)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+def command_reconcile_gate(args):
+    api = GitHubApi(args.token)
+    reconcile_gate(
+        api,
+        validate_repository(args.repository),
+        args.source_run_id,
+        args.salt,
+        args.output,
+        github_output=args.github_output,
     )
-    print(path)
     return 0
 
 
@@ -511,6 +809,7 @@ def build_parser():
 
     fingerprint = subparsers.add_parser("fingerprint")
     fingerprint.add_argument("--salt", required=True)
+    fingerprint.add_argument("--base-sha", required=True)
     fingerprint.add_argument("--github-output")
     fingerprint.set_defaults(func=command_fingerprint)
 
@@ -518,35 +817,36 @@ def build_parser():
     reuse.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
     reuse.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
     reuse.add_argument("--event", required=True)
-    reuse.add_argument("--artifact-name", required=True)
-    reuse.add_argument(
-        "--workflow-path", default=".github/workflows/merge-queue-gate.yml"
-    )
+    reuse.add_argument("--tree-sha", required=True)
+    reuse.add_argument("--base-sha", required=True)
+    reuse.add_argument("--salt", required=True)
+    reuse.add_argument("--workflow-path", default=GATE_WORKFLOW_PATH)
     reuse.add_argument("--max-age-hours", type=int, default=24)
     reuse.add_argument("--current-run-id", default=os.environ.get("GITHUB_RUN_ID"))
     reuse.add_argument("--github-output")
     reuse.set_defaults(func=command_find_reuse)
 
-    wait = subparsers.add_parser("wait-for-workflows")
-    wait.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
-    wait.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
-    wait.add_argument("--workflow", action="append", required=True)
-    wait.add_argument("--head-sha", required=True)
-    wait.add_argument("--event", required=True)
-    wait.add_argument("--gate-run-id", default=os.environ.get("GITHUB_RUN_ID"))
-    wait.add_argument("--timeout-seconds", type=int, default=5100)
-    wait.add_argument("--poll-seconds", type=int, default=15)
-    wait.add_argument("--run-window-seconds", type=int, default=900)
-    wait.set_defaults(func=command_wait)
+    source = subparsers.add_parser("record-source")
+    source.add_argument("--workflow", required=True)
+    source.add_argument("--event", required=True, choices=sorted(REUSABLE_EVENTS))
+    source.add_argument("--run-id", required=True)
+    source.add_argument("--run-attempt", required=True, type=int)
+    source.add_argument("--merge-sha", required=True)
+    source.add_argument("--tree-sha", required=True)
+    source.add_argument("--base-sha", required=True)
+    source.add_argument("--config-hash", required=True)
+    source.add_argument("--output", required=True)
+    source.add_argument("--github-output")
+    source.set_defaults(func=command_record_source)
 
-    record = subparsers.add_parser("record")
-    record.add_argument("--artifact-name", required=True)
-    record.add_argument("--tree-sha", required=True)
-    record.add_argument("--config-hash", required=True)
-    record.add_argument("--run-id", required=True)
-    record.add_argument("--run-url", required=True)
-    record.add_argument("--output", required=True)
-    record.set_defaults(func=command_record)
+    gate = subparsers.add_parser("reconcile-gate")
+    gate.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    gate.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    gate.add_argument("--source-run-id", required=True)
+    gate.add_argument("--salt", required=True)
+    gate.add_argument("--output", required=True)
+    gate.add_argument("--github-output")
+    gate.set_defaults(func=command_reconcile_gate)
 
     cleanup = subparsers.add_parser("cleanup")
     cleanup.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
@@ -566,7 +866,14 @@ def main():
     args = build_parser().parse_args()
     try:
         return args.func(args)
-    except (GitHubApiError, RuntimeError, TimeoutError, ValueError) as error:
+    except (
+        GitHubApiError,
+        KeyError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
         print(f"::error::{error}", file=sys.stderr)
         return 1
 

--- a/.github/scripts/merge_queue_ci.py
+++ b/.github/scripts/merge_queue_ci.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Helpers for merge-queue CI reuse and stale-run reconciliation."""
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+API_VERSION = "2022-11-28"
+ARTIFACT_PREFIX = "bolt-ci-result-v1"
+REUSABLE_EVENTS = {"pull_request", "merge_group"}
+ACTIVE_RUN_STATUSES = ("queued", "in_progress")
+SHA_RE = re.compile(r"^[0-9a-f]{40,64}$")
+
+
+class GitHubApiError(RuntimeError):
+    def __init__(self, status, message):
+        super().__init__(message)
+        self.status = status
+
+
+class GitHubApi:
+    def __init__(self, token, base_url=None):
+        if not token:
+            raise ValueError("A GitHub token is required")
+        self.token = token
+        self.base_url = (
+            base_url or os.environ.get("GITHUB_API_URL") or "https://api.github.com"
+        ).rstrip("/")
+
+    def request(self, path, method="GET", payload=None):
+        url = path if path.startswith("http") else f"{self.base_url}{path}"
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": API_VERSION,
+                "User-Agent": "bolt-merge-queue-ci",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            raise GitHubApiError(
+                error.code,
+                f"GitHub API {method} {path} failed with HTTP {error.code}: {body[:500]}",
+            ) from error
+        except urllib.error.URLError as error:
+            raise GitHubApiError(
+                None,
+                f"GitHub API {method} {path} failed: {error.reason}",
+            ) from error
+
+        return json.loads(body) if body else None
+
+
+def parse_github_time(value):
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def utc_now():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def validate_repository(repository):
+    if (
+        not repository
+        or repository.count("/") != 1
+        or any(not part for part in repository.split("/"))
+    ):
+        raise ValueError(f"Invalid GitHub repository: {repository!r}")
+    return repository
+
+
+def validate_sha(value):
+    if not SHA_RE.fullmatch(value):
+        raise ValueError(f"Invalid Git SHA: {value!r}")
+    return value
+
+
+def append_github_output(path, values):
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def git_tree_sha():
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD^{tree}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return validate_sha(result.stdout.strip())
+
+
+def make_fingerprint(tree_sha, salt):
+    tree_sha = validate_sha(tree_sha)
+    config_hash = hashlib.sha256(
+        f"{ARTIFACT_PREFIX}\0{salt}".encode("utf-8")
+    ).hexdigest()[:20]
+    return {
+        "tree_sha": tree_sha,
+        "config_hash": config_hash,
+        "artifact_name": f"{ARTIFACT_PREFIX}-{tree_sha}-{config_hash}",
+    }
+
+
+def normalize_workflow_path(value):
+    return (value or "").split("@", 1)[0]
+
+
+def list_named_artifacts(api, repository, artifact_name):
+    artifacts = []
+    encoded_name = urllib.parse.quote(artifact_name, safe="")
+    for page in range(1, 101):
+        response = api.request(
+            f"/repos/{repository}/actions/artifacts"
+            f"?name={encoded_name}&per_page=100&page={page}"
+        )
+        batch = response.get("artifacts", [])
+        artifacts.extend(batch)
+        if len(batch) < 100:
+            break
+    return artifacts
+
+
+def find_reusable_result(
+    api,
+    repository,
+    artifact_name,
+    workflow_path,
+    max_age_hours,
+    current_run_id=None,
+    now=None,
+):
+    repository = validate_repository(repository)
+    now = now or utc_now()
+    cutoff = now - dt.timedelta(hours=max_age_hours)
+    artifacts = sorted(
+        list_named_artifacts(api, repository, artifact_name),
+        key=lambda item: item.get("created_at", ""),
+        reverse=True,
+    )
+
+    for artifact in artifacts:
+        if artifact.get("expired"):
+            continue
+        created_at = parse_github_time(artifact["created_at"])
+        if created_at < cutoff:
+            continue
+        source = artifact.get("workflow_run") or {}
+        run_id = source.get("id")
+        if not run_id or str(run_id) == str(current_run_id):
+            continue
+
+        run = api.request(f"/repos/{repository}/actions/runs/{run_id}")
+        if run.get("status") != "completed" or run.get("conclusion") != "success":
+            continue
+        if run.get("event") not in REUSABLE_EVENTS:
+            continue
+        if normalize_workflow_path(run.get("path")) != normalize_workflow_path(
+            workflow_path
+        ):
+            continue
+        run_repository = (run.get("repository") or {}).get("full_name", "")
+        if run_repository.lower() != repository.lower():
+            continue
+
+        return {
+            "hit": True,
+            "artifact_id": artifact["id"],
+            "source_run_id": run_id,
+            "source_run_url": run.get("html_url", ""),
+            "created_at": artifact["created_at"],
+        }
+
+    return {
+        "hit": False,
+        "artifact_id": "",
+        "source_run_id": "",
+        "source_run_url": "",
+        "created_at": "",
+    }
+
+
+def list_workflow_runs(api, repository, workflow, head_sha, event):
+    workflow = urllib.parse.quote(workflow, safe="")
+    query = urllib.parse.urlencode(
+        {
+            "head_sha": head_sha,
+            "event": event,
+            "per_page": 100,
+        }
+    )
+    response = api.request(
+        f"/repos/{repository}/actions/workflows/{workflow}/runs?{query}"
+    )
+    return response.get("workflow_runs", [])
+
+
+def select_event_run(runs, gate_created_at, window_seconds):
+    lower_bound = gate_created_at - dt.timedelta(seconds=window_seconds)
+    upper_bound = gate_created_at + dt.timedelta(seconds=window_seconds)
+    candidates = [
+        run
+        for run in runs
+        if lower_bound <= parse_github_time(run["created_at"]) <= upper_bound
+    ]
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda run: (
+            parse_github_time(run["created_at"]),
+            run.get("run_attempt", 1),
+            run["id"],
+        ),
+    )
+
+
+def wait_for_workflows(
+    api,
+    repository,
+    workflows,
+    head_sha,
+    event,
+    gate_run_id,
+    timeout_seconds,
+    poll_seconds,
+    run_window_seconds,
+    sleep=time.sleep,
+):
+    repository = validate_repository(repository)
+    validate_sha(head_sha)
+    gate_run = api.request(f"/repos/{repository}/actions/runs/{gate_run_id}")
+    gate_created_at = parse_github_time(gate_run["created_at"])
+    deadline = time.monotonic() + timeout_seconds
+    last_state = None
+
+    while True:
+        states = {}
+        for workflow in workflows:
+            runs = list_workflow_runs(api, repository, workflow, head_sha, event)
+            selected = select_event_run(runs, gate_created_at, run_window_seconds)
+            if selected is None:
+                states[workflow] = ("missing", None)
+            else:
+                states[workflow] = (
+                    selected.get("status", "unknown"),
+                    selected.get("conclusion"),
+                )
+
+        if states != last_state:
+            print(json.dumps({"workflow_states": states}, sort_keys=True))
+            last_state = states
+
+        failures = {
+            workflow: conclusion
+            for workflow, (status, conclusion) in states.items()
+            if status == "completed" and conclusion != "success"
+        }
+        if failures:
+            raise RuntimeError(f"Required CI workflow failed: {failures}")
+
+        if all(
+            status == "completed" and conclusion == "success"
+            for status, conclusion in states.values()
+        ):
+            return states
+
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Timed out waiting for CI workflows after {timeout_seconds}s: {states}"
+            )
+        sleep(poll_seconds)
+
+
+def list_live_merge_queue_shas(api, repository, base_branch):
+    ref_prefix = f"refs/heads/gh-readonly-queue/{base_branch}/"
+    encoded = urllib.parse.quote(
+        f"heads/gh-readonly-queue/{base_branch}/",
+        safe="/",
+    )
+    refs = api.request(f"/repos/{repository}/git/matching-refs/{encoded}")
+    if not isinstance(refs, list):
+        raise RuntimeError("GitHub matching-refs response was not a list")
+    return {
+        ref["object"]["sha"]
+        for ref in refs
+        if ref.get("ref", "").startswith(ref_prefix)
+        and (ref.get("object") or {}).get("type") == "commit"
+    }
+
+
+def list_active_merge_group_runs(api, repository):
+    runs_by_id = {}
+    for status in ACTIVE_RUN_STATUSES:
+        for page in range(1, 101):
+            response = api.request(
+                f"/repos/{repository}/actions/runs"
+                f"?event=merge_group&status={status}&per_page=100&page={page}"
+            )
+            batch = response.get("workflow_runs", [])
+            for run in batch:
+                runs_by_id[run["id"]] = run
+            if len(batch) < 100:
+                break
+    return list(runs_by_id.values())
+
+
+def find_stale_runs(runs, live_shas, base_branch, grace_seconds, now=None):
+    now = now or utc_now()
+    branch_prefix = f"gh-readonly-queue/{base_branch}/"
+    stale = []
+    for run in runs:
+        if run.get("event") != "merge_group":
+            continue
+        if run.get("status") not in ACTIVE_RUN_STATUSES:
+            continue
+        if not run.get("head_branch", "").startswith(branch_prefix):
+            continue
+        if run.get("head_sha") in live_shas:
+            continue
+        age = (now - parse_github_time(run["created_at"])).total_seconds()
+        if age < grace_seconds:
+            continue
+        stale.append(run)
+    return sorted(stale, key=lambda run: run["created_at"])
+
+
+def reconcile_stale_runs(
+    api,
+    repository,
+    base_branch,
+    grace_seconds,
+    mode,
+    now=None,
+):
+    live_shas = list_live_merge_queue_shas(api, repository, base_branch)
+    active_runs = list_active_merge_group_runs(api, repository)
+    stale_runs = find_stale_runs(
+        active_runs,
+        live_shas,
+        base_branch,
+        grace_seconds,
+        now=now,
+    )
+    cancelled = []
+    raced = []
+
+    for run in stale_runs:
+        print(
+            f"{'CANCEL' if mode == 'cancel' else 'STALE'} "
+            f"run={run['id']} sha={run['head_sha']} "
+            f"workflow={run.get('name', '')} url={run.get('html_url', '')}"
+        )
+        if mode != "cancel":
+            continue
+        try:
+            api.request(
+                f"/repos/{repository}/actions/runs/{run['id']}/cancel",
+                method="POST",
+            )
+            cancelled.append(run["id"])
+        except GitHubApiError as error:
+            if error.status == 409:
+                raced.append(run["id"])
+                print(
+                    f"::notice::Run {run['id']} finished before cancellation",
+                    file=sys.stderr,
+                )
+                continue
+            raise
+
+    return {
+        "mode": mode,
+        "live_queue_shas": len(live_shas),
+        "active_merge_group_runs": len(active_runs),
+        "stale_runs": [run["id"] for run in stale_runs],
+        "cancelled_runs": cancelled,
+        "already_finished_runs": raced,
+    }
+
+
+def write_step_summary(path, summary):
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as output:
+        output.write("## Merge Queue cleanup\n\n")
+        for key, value in summary.items():
+            output.write(f"- **{key.replace('_', ' ')}:** {value}\n")
+
+
+def command_fingerprint(args):
+    result = make_fingerprint(git_tree_sha(), args.salt)
+    append_github_output(args.github_output, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+def command_find_reuse(args):
+    miss = {
+        "hit": "false",
+        "source_run_id": "",
+        "source_run_url": "",
+    }
+    if args.event != "merge_group":
+        append_github_output(args.github_output, miss)
+        print(json.dumps(miss, sort_keys=True))
+        return 0
+
+    try:
+        api = GitHubApi(args.token)
+        result = find_reusable_result(
+            api,
+            validate_repository(args.repository),
+            args.artifact_name,
+            args.workflow_path,
+            args.max_age_hours,
+            current_run_id=args.current_run_id,
+        )
+    except (GitHubApiError, KeyError, OSError, TypeError, ValueError) as error:
+        print(
+            f"::warning::CI reuse lookup failed; running full CI instead: {error}",
+            file=sys.stderr,
+        )
+        result = miss
+
+    output = {
+        "hit": str(result["hit"]).lower(),
+        "source_run_id": result.get("source_run_id", ""),
+        "source_run_url": result.get("source_run_url", ""),
+    }
+    append_github_output(args.github_output, output)
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+def command_wait(args):
+    api = GitHubApi(args.token)
+    states = wait_for_workflows(
+        api,
+        validate_repository(args.repository),
+        args.workflow,
+        validate_sha(args.head_sha),
+        args.event,
+        args.gate_run_id,
+        args.timeout_seconds,
+        args.poll_seconds,
+        args.run_window_seconds,
+    )
+    print(json.dumps({"completed": states}, sort_keys=True))
+    return 0
+
+
+def command_record(args):
+    payload = {
+        "artifact_name": args.artifact_name,
+        "tree_sha": validate_sha(args.tree_sha),
+        "config_hash": args.config_hash,
+        "run_id": args.run_id,
+        "run_url": args.run_url,
+        "created_at": utc_now().isoformat(),
+    }
+    path = Path(args.output)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(path)
+    return 0
+
+
+def command_cleanup(args):
+    api = GitHubApi(args.token)
+    summary = reconcile_stale_runs(
+        api,
+        validate_repository(args.repository),
+        args.base_branch,
+        args.grace_seconds,
+        args.mode,
+    )
+    write_step_summary(args.step_summary, summary)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fingerprint = subparsers.add_parser("fingerprint")
+    fingerprint.add_argument("--salt", required=True)
+    fingerprint.add_argument("--github-output")
+    fingerprint.set_defaults(func=command_fingerprint)
+
+    reuse = subparsers.add_parser("find-reuse")
+    reuse.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    reuse.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    reuse.add_argument("--event", required=True)
+    reuse.add_argument("--artifact-name", required=True)
+    reuse.add_argument(
+        "--workflow-path", default=".github/workflows/merge-queue-gate.yml"
+    )
+    reuse.add_argument("--max-age-hours", type=int, default=24)
+    reuse.add_argument("--current-run-id", default=os.environ.get("GITHUB_RUN_ID"))
+    reuse.add_argument("--github-output")
+    reuse.set_defaults(func=command_find_reuse)
+
+    wait = subparsers.add_parser("wait-for-workflows")
+    wait.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    wait.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    wait.add_argument("--workflow", action="append", required=True)
+    wait.add_argument("--head-sha", required=True)
+    wait.add_argument("--event", required=True)
+    wait.add_argument("--gate-run-id", default=os.environ.get("GITHUB_RUN_ID"))
+    wait.add_argument("--timeout-seconds", type=int, default=5100)
+    wait.add_argument("--poll-seconds", type=int, default=15)
+    wait.add_argument("--run-window-seconds", type=int, default=900)
+    wait.set_defaults(func=command_wait)
+
+    record = subparsers.add_parser("record")
+    record.add_argument("--artifact-name", required=True)
+    record.add_argument("--tree-sha", required=True)
+    record.add_argument("--config-hash", required=True)
+    record.add_argument("--run-id", required=True)
+    record.add_argument("--run-url", required=True)
+    record.add_argument("--output", required=True)
+    record.set_defaults(func=command_record)
+
+    cleanup = subparsers.add_parser("cleanup")
+    cleanup.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    cleanup.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    cleanup.add_argument("--base-branch", default="main")
+    cleanup.add_argument("--grace-seconds", type=int, default=600)
+    cleanup.add_argument("--mode", choices=("report", "cancel"), default="report")
+    cleanup.add_argument(
+        "--step-summary", default=os.environ.get("GITHUB_STEP_SUMMARY")
+    )
+    cleanup.set_defaults(func=command_cleanup)
+
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    try:
+        return args.func(args)
+    except (GitHubApiError, RuntimeError, TimeoutError, ValueError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,15 +27,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: read
+  contents: read
+
 env:
   CCACHE_DIR: /data/ccache-data
   CCACHE_MAX_SIZE: '100G'
   CI_NUM_THREADS: "16"
   IN_CI: '1'
+  # Bump this when external CI images/tooling change without a tree change.
+  CI_REUSE_SALT: >-
+    bolt-ci:20260114|conan-server:latest|build-test-v1
 
 jobs:
+  reuse-check:
+    runs-on: ubuntu-latest
+    outputs:
+      hit: ${{ steps.reuse.outputs.hit }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Compute CI fingerprint
+        id: fingerprint
+        run: |
+          python3 .github/scripts/merge_queue_ci.py fingerprint \
+            --salt "${CI_REUSE_SALT}" \
+            --github-output "${GITHUB_OUTPUT}"
+      - name: Find reusable CI result
+        id: reuse
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/merge_queue_ci.py find-reuse \
+            --event "${{ github.event_name }}" \
+            --artifact-name "${{ steps.fingerprint.outputs.artifact_name }}" \
+            --github-output "${GITHUB_OUTPUT}"
+
   changes:
-    runs-on:  [ self-hosted, small ]
+    runs-on: ubuntu-latest
     outputs:
       source_code: ${{ steps.filter.outputs.source_code }}
     steps:
@@ -55,8 +85,10 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/**'
   build-test:
-    needs: changes
-    if: ${{ needs.changes.outputs.source_code == 'true' }}
+    needs: [reuse-check, changes]
+    if: >-
+      ${{ needs.reuse-check.outputs.hit != 'true' &&
+          needs.changes.outputs.source_code == 'true' }}
     runs-on: [ self-hosted, medium ]
     container:
       image: bolt-registry:5000/bolt-ci:20260114
@@ -87,8 +119,10 @@ jobs:
         make unittest_${{ matrix.build_type }}
 
   build-only:
-      needs: changes
-      if: ${{ needs.changes.outputs.source_code == 'true' }}
+      needs: [reuse-check, changes]
+      if: >-
+        ${{ needs.reuse-check.outputs.hit != 'true' &&
+            needs.changes.outputs.source_code == 'true' }}
       runs-on: [ self-hosted, medium ]
       container:
         image: bolt-registry:5000/bolt-ci:20260114

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,7 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 env:
   CCACHE_DIR: /data/ccache-data
@@ -38,13 +39,20 @@ env:
   IN_CI: '1'
   # Bump this when external CI images/tooling change without a tree change.
   CI_REUSE_SALT: >-
-    bolt-ci:20260114|conan-server:latest|build-test-v1
+    bolt-ci:20260114|conan-server:latest|build-test-v2
+  CI_BASE_SHA: >-
+    ${{ github.event_name == 'pull_request' &&
+        github.event.pull_request.base.sha ||
+        github.event.merge_group.base_sha }}
 
 jobs:
   reuse-check:
     runs-on: ubuntu-latest
     outputs:
       hit: ${{ steps.reuse.outputs.hit }}
+      tree_sha: ${{ steps.fingerprint.outputs.tree_sha }}
+      base_sha: ${{ steps.fingerprint.outputs.base_sha }}
+      config_hash: ${{ steps.fingerprint.outputs.config_hash }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -53,6 +61,7 @@ jobs:
         run: |
           python3 .github/scripts/merge_queue_ci.py fingerprint \
             --salt "${CI_REUSE_SALT}" \
+            --base-sha "${CI_BASE_SHA}" \
             --github-output "${GITHUB_OUTPUT}"
       - name: Find reusable CI result
         id: reuse
@@ -61,7 +70,9 @@ jobs:
         run: |
           python3 .github/scripts/merge_queue_ci.py find-reuse \
             --event "${{ github.event_name }}" \
-            --artifact-name "${{ steps.fingerprint.outputs.artifact_name }}" \
+            --tree-sha "${{ steps.fingerprint.outputs.tree_sha }}" \
+            --base-sha "${{ steps.fingerprint.outputs.base_sha }}" \
+            --salt "${CI_REUSE_SALT}" \
             --github-output "${GITHUB_OUTPUT}"
 
   changes:
@@ -148,3 +159,39 @@ jobs:
         run: |
           echo 'tools.cmake.cmaketoolchain:extra_variables={"CMAKE_CXX_FLAGS_DEBUG": ""}' >> $(conan profile path default)
           make ${{ matrix.build_target }}
+
+  source-result:
+    needs: [reuse-check, changes, build-test, build-only]
+    if: >-
+      ${{ always() &&
+          needs.reuse-check.result == 'success' &&
+          needs.changes.result == 'success' &&
+          (needs.build-test.result == 'success' ||
+           needs.build-test.result == 'skipped') &&
+          (needs.build-only.result == 'success' ||
+           needs.build-only.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Record tested source
+        id: source
+        run: |
+          python3 .github/scripts/merge_queue_ci.py record-source \
+            --workflow build-test.yml \
+            --event "${{ github.event_name }}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --merge-sha "${GITHUB_SHA}" \
+            --tree-sha "${{ needs.reuse-check.outputs.tree_sha }}" \
+            --base-sha "${{ needs.reuse-check.outputs.base_sha }}" \
+            --config-hash "${{ needs.reuse-check.outputs.config_hash }}" \
+            --output ci-source/result.json \
+            --github-output "${GITHUB_OUTPUT}"
+      - name: Upload tested source
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.source.outputs.artifact_name }}
+          path: ci-source/result.json
+          if-no-files-found: error
+          retention-days: 2

--- a/.github/workflows/merge-queue-cleanup.yml
+++ b/.github/workflows/merge-queue-cleanup.yml
@@ -46,7 +46,11 @@ jobs:
       - name: Reconcile stale merge-group runs
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          CLEANUP_MODE: ${{ github.event_name == 'schedule' && 'cancel' || inputs.mode }}
+          # Scheduled cleanup is report-only until the repository variable is
+          # explicitly changed to "cancel" after observing dry-run results.
+          CLEANUP_MODE: >-
+            ${{ github.event_name == 'schedule' &&
+                (vars.MERGE_QUEUE_CLEANUP_MODE || 'report') || inputs.mode }}
         run: |
           python3 .github/scripts/merge_queue_ci.py cleanup \
             --base-branch main \

--- a/.github/workflows/merge-queue-cleanup.yml
+++ b/.github/workflows/merge-queue-cleanup.yml
@@ -1,0 +1,54 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Merge Queue Cleanup
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Report stale runs or cancel them
+        required: true
+        type: choice
+        default: report
+        options:
+          - report
+          - cancel
+
+concurrency:
+  group: merge-queue-cleanup
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Reconcile stale merge-group runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CLEANUP_MODE: ${{ github.event_name == 'schedule' && 'cancel' || inputs.mode }}
+        run: |
+          python3 .github/scripts/merge_queue_ci.py cleanup \
+            --base-branch main \
+            --grace-seconds 600 \
+            --mode "${CLEANUP_MODE}"

--- a/.github/workflows/merge-queue-gate.yml
+++ b/.github/workflows/merge-queue-gate.yml
@@ -1,0 +1,104 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Merge Queue Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  # Keep this in sync with the two CI workflows.
+  CI_REUSE_SALT: >-
+    bolt-ci:20260114|conan-server:latest|build-test-v1
+
+jobs:
+  reuse_check:
+    name: Find reusable CI result
+    runs-on: ubuntu-latest
+    outputs:
+      hit: ${{ steps.reuse.outputs.hit }}
+      source_run_url: ${{ steps.reuse.outputs.source_run_url }}
+      artifact_name: ${{ steps.fingerprint.outputs.artifact_name }}
+      tree_sha: ${{ steps.fingerprint.outputs.tree_sha }}
+      config_hash: ${{ steps.fingerprint.outputs.config_hash }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Compute CI fingerprint
+        id: fingerprint
+        run: |
+          python3 .github/scripts/merge_queue_ci.py fingerprint \
+            --salt "${CI_REUSE_SALT}" \
+            --github-output "${GITHUB_OUTPUT}"
+      - name: Find reusable CI result
+        id: reuse
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/merge_queue_ci.py find-reuse \
+            --event "${{ github.event_name }}" \
+            --artifact-name "${{ steps.fingerprint.outputs.artifact_name }}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+  merge_queue_gate:
+    name: merge-queue-gate
+    needs: reuse_check
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Reuse passed CI result
+        if: ${{ needs.reuse_check.outputs.hit == 'true' }}
+        run: |
+          echo "Reusing CI result from ${{ needs.reuse_check.outputs.source_run_url }}"
+      - name: Checkout code
+        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
+        uses: actions/checkout@v6
+      - name: Wait for current tree CI
+        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/merge_queue_ci.py wait-for-workflows \
+            --workflow build-test.yml \
+            --workflow pre-commit-checks.yml \
+            --head-sha "${GITHUB_SHA}" \
+            --event "${{ github.event_name }}"
+      - name: Write result metadata
+        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
+        run: |
+          python3 .github/scripts/merge_queue_ci.py record \
+            --artifact-name "${{ needs.reuse_check.outputs.artifact_name }}" \
+            --tree-sha "${{ needs.reuse_check.outputs.tree_sha }}" \
+            --config-hash "${{ needs.reuse_check.outputs.config_hash }}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output ci-result/result.json
+      - name: Upload passed CI result
+        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.reuse_check.outputs.artifact_name }}
+          path: ci-result/result.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/merge-queue-gate.yml
+++ b/.github/workflows/merge-queue-gate.yml
@@ -15,90 +15,48 @@
 name: Merge Queue Gate
 
 on:
-  pull_request:
-    branches: [ main ]
-  merge_group:
+  workflow_run:
+    workflows: [Build and Test, pre-commit checks]
+    types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: merge-queue-gate-${{ github.event.workflow_run.event }}-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 permissions:
   actions: read
+  checks: write
   contents: read
 
 env:
-  # Keep this in sync with the two CI workflows.
+  # Keep this in sync with the two source CI workflows.
   CI_REUSE_SALT: >-
-    bolt-ci:20260114|conan-server:latest|build-test-v1
+    bolt-ci:20260114|conan-server:latest|build-test-v2
 
 jobs:
-  reuse_check:
-    name: Find reusable CI result
+  reconcile:
     runs-on: ubuntu-latest
-    outputs:
-      hit: ${{ steps.reuse.outputs.hit }}
-      source_run_url: ${{ steps.reuse.outputs.source_run_url }}
-      artifact_name: ${{ steps.fingerprint.outputs.artifact_name }}
-      tree_sha: ${{ steps.fingerprint.outputs.tree_sha }}
-      config_hash: ${{ steps.fingerprint.outputs.config_hash }}
+    timeout-minutes: 10
     steps:
-      - name: Checkout code
+      # workflow_run executes this workflow from the default branch. Never
+      # checkout or execute code from the triggering pull request here.
+      - name: Checkout trusted gate code
         uses: actions/checkout@v6
-      - name: Compute CI fingerprint
-        id: fingerprint
+      - name: Reconcile required CI
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          python3 .github/scripts/merge_queue_ci.py fingerprint \
+          python3 .github/scripts/merge_queue_ci.py reconcile-gate \
+            --source-run-id "${{ github.event.workflow_run.id }}" \
             --salt "${CI_REUSE_SALT}" \
+            --output ci-result/result.json \
             --github-output "${GITHUB_OUTPUT}"
-      - name: Find reusable CI result
-        id: reuse
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python3 .github/scripts/merge_queue_ci.py find-reuse \
-            --event "${{ github.event_name }}" \
-            --artifact-name "${{ steps.fingerprint.outputs.artifact_name }}" \
-            --github-output "${GITHUB_OUTPUT}"
-
-  merge_queue_gate:
-    name: merge-queue-gate
-    needs: reuse_check
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    steps:
-      - name: Reuse passed CI result
-        if: ${{ needs.reuse_check.outputs.hit == 'true' }}
-        run: |
-          echo "Reusing CI result from ${{ needs.reuse_check.outputs.source_run_url }}"
-      - name: Checkout code
-        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
-        uses: actions/checkout@v6
-      - name: Wait for current tree CI
-        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python3 .github/scripts/merge_queue_ci.py wait-for-workflows \
-            --workflow build-test.yml \
-            --workflow pre-commit-checks.yml \
-            --head-sha "${GITHUB_SHA}" \
-            --event "${{ github.event_name }}"
-      - name: Write result metadata
-        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
-        run: |
-          python3 .github/scripts/merge_queue_ci.py record \
-            --artifact-name "${{ needs.reuse_check.outputs.artifact_name }}" \
-            --tree-sha "${{ needs.reuse_check.outputs.tree_sha }}" \
-            --config-hash "${{ needs.reuse_check.outputs.config_hash }}" \
-            --run-id "${GITHUB_RUN_ID}" \
-            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --output ci-result/result.json
-      - name: Upload passed CI result
-        if: ${{ needs.reuse_check.outputs.hit != 'true' }}
+      - name: Upload trusted reusable result
+        if: ${{ steps.gate.outputs.reusable == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.reuse_check.outputs.artifact_name }}
-          path: ci-result/result.json
+          name: ${{ steps.gate.outputs.artifact_name }}
+          path: ${{ steps.gate.outputs.result_path }}
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -23,6 +23,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: read
+  contents: read
+
 env:
   PRE_COMMIT_HOME: /data/pre-commit-cache
   CCACHE_DIR: /data/ccache-data
@@ -32,9 +36,37 @@ env:
   GOMAXPROCS: 8
   GOMODCACHE: /data/pre-commit-cache/gomodcache
   GOCACHE: /data/pre-commit-cache/gocache
+  # Bump this when external CI images/tooling change without a tree change.
+  CI_REUSE_SALT: >-
+    bolt-ci:20260114|conan-server:latest|build-test-v1
 
 jobs:
+  reuse-check:
+    runs-on: ubuntu-latest
+    outputs:
+      hit: ${{ steps.reuse.outputs.hit }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Compute CI fingerprint
+        id: fingerprint
+        run: |
+          python3 .github/scripts/merge_queue_ci.py fingerprint \
+            --salt "${CI_REUSE_SALT}" \
+            --github-output "${GITHUB_OUTPUT}"
+      - name: Find reusable CI result
+        id: reuse
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/merge_queue_ci.py find-reuse \
+            --event "${{ github.event_name }}" \
+            --artifact-name "${{ steps.fingerprint.outputs.artifact_name }}" \
+            --github-output "${GITHUB_OUTPUT}"
+
   lint:
+    needs: reuse-check
+    if: ${{ needs.reuse-check.outputs.hit != 'true' }}
     runs-on: ['self-hosted', 'medium']
     container:
       image: bolt-registry:5000/bolt-ci:20260114

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -26,6 +26,7 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 env:
   PRE_COMMIT_HOME: /data/pre-commit-cache
@@ -38,13 +39,20 @@ env:
   GOCACHE: /data/pre-commit-cache/gocache
   # Bump this when external CI images/tooling change without a tree change.
   CI_REUSE_SALT: >-
-    bolt-ci:20260114|conan-server:latest|build-test-v1
+    bolt-ci:20260114|conan-server:latest|build-test-v2
+  CI_BASE_SHA: >-
+    ${{ github.event_name == 'pull_request' &&
+        github.event.pull_request.base.sha ||
+        github.event.merge_group.base_sha }}
 
 jobs:
   reuse-check:
     runs-on: ubuntu-latest
     outputs:
       hit: ${{ steps.reuse.outputs.hit }}
+      tree_sha: ${{ steps.fingerprint.outputs.tree_sha }}
+      base_sha: ${{ steps.fingerprint.outputs.base_sha }}
+      config_hash: ${{ steps.fingerprint.outputs.config_hash }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -53,6 +61,7 @@ jobs:
         run: |
           python3 .github/scripts/merge_queue_ci.py fingerprint \
             --salt "${CI_REUSE_SALT}" \
+            --base-sha "${CI_BASE_SHA}" \
             --github-output "${GITHUB_OUTPUT}"
       - name: Find reusable CI result
         id: reuse
@@ -61,7 +70,9 @@ jobs:
         run: |
           python3 .github/scripts/merge_queue_ci.py find-reuse \
             --event "${{ github.event_name }}" \
-            --artifact-name "${{ steps.fingerprint.outputs.artifact_name }}" \
+            --tree-sha "${{ steps.fingerprint.outputs.tree_sha }}" \
+            --base-sha "${{ steps.fingerprint.outputs.base_sha }}" \
+            --salt "${CI_REUSE_SALT}" \
             --github-output "${GITHUB_OUTPUT}"
 
   lint:
@@ -95,3 +106,36 @@ jobs:
       - name: Run pre-commit hooks
         run: |
           pre-commit run --all-files
+
+  source-result:
+    needs: [reuse-check, lint]
+    if: >-
+      ${{ always() &&
+          needs.reuse-check.result == 'success' &&
+          (needs.lint.result == 'success' ||
+           needs.lint.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Record tested source
+        id: source
+        run: |
+          python3 .github/scripts/merge_queue_ci.py record-source \
+            --workflow pre-commit-checks.yml \
+            --event "${{ github.event_name }}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --merge-sha "${GITHUB_SHA}" \
+            --tree-sha "${{ needs.reuse-check.outputs.tree_sha }}" \
+            --base-sha "${{ needs.reuse-check.outputs.base_sha }}" \
+            --config-hash "${{ needs.reuse-check.outputs.config_hash }}" \
+            --output ci-source/result.json \
+            --github-output "${GITHUB_OUTPUT}"
+      - name: Upload tested source
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.source.outputs.artifact_name }}
+          path: ci-source/result.json
+          if-no-files-found: error
+          retention-days: 2


### PR DESCRIPTION
### What problem does this PR solve?

The self-hosted GitHub Actions runners were not recovering reliably after host or container restarts. Runner hostname detection was also inconsistent, and runners could start before the local Docker registry was ready, causing CI containers such as the pre-commit environment to fail to start.

The merge queue also repeated expensive CI workflows when the Git tree had already passed CI, while workflows belonging to deleted merge groups could remain queued or in progress and continue occupying runner capacity.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR improves self-hosted runner reliability and merge queue efficiency.

#### Self-hosted runner recovery

- Configure runners, the local registry, and the Conan server with `restart: unless-stopped`.
- Add a health check for the local Docker registry.
- Start runner containers only after the registry is healthy.
- Persist the host hostname by mounting `/etc/hostname` into runner containers.
- Use the explicit `RUNNER_HOSTNAME` when configured, otherwise fall back to the persistent host hostname.
- Validate runner hostnames before registration.
- Persist Docker data separately for each runner replica.
- Make Docker storage initialization idempotent and refuse to overwrite an existing non-empty Docker data directory.
- Use argument-based subprocess execution for runner configuration and Docker startup.
- Add a timeout to GitHub runner registration-token requests.

#### Merge queue handling

- Add a unified `merge-queue-gate` check for pull requests and merge groups.
- Generate a CI fingerprint from the Git tree SHA and the CI environment salt.
- Reuse a previously successful CI result when the resulting Git tree and CI configuration are unchanged.
- Fall back to running the complete CI workflow if result lookup fails or no reusable result exists.
- Wait for both build/test and pre-commit workflows before recording a reusable result.
- Add scheduled cleanup for queued or in-progress workflows whose merge-group refs no longer exist.
- Apply a grace period before stale workflows are cancelled to avoid cancelling newly created or racing runs.
- Move lightweight change detection and reuse checks to GitHub-hosted runners so self-hosted capacity remains available for actual builds.

The runner changes were also validated with an Ubuntu canary deployment using four medium and five small runner replicas.

### Performance Impact

- [x] **No Impact**: This change does not affect the runtime or critical execution path of Bolt.
- [ ] **Positive Impact**: I have run benchmarks.
  <details>
  <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
  </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Improved self-hosted GitHub Actions runner recovery and registry readiness handling.
- Reused successful CI results for unchanged merge results and cleaned up workflows from deleted merge groups.
```


### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
