### PR TITLE
Spark tojson support timestamp

### DIFF
--- a/bolt/functions/prestosql/tests/ToJsonTest.cpp
+++ b/bolt/functions/prestosql/tests/ToJsonTest.cpp
@@ -28,7 +28,6 @@ using JsonNativeType = StringView;
 template <typename TKey, typename TValue>
 using Pair = std::pair<TKey, std::optional<TValue>>;
 
-// class ToJsonTest : public SparkFunctionBaseTest {
 class ToJsonTest : public FunctionBaseTest {
  protected:
   template <typename T = FlatVector<StringView>>
@@ -930,13 +929,8 @@ TEST_F(ToJsonTest, timestampMapKey) {
       {{{Timestamp(1451606400, 123456000), "value"_sv}}}};
   auto input =
       makeMapVector<Timestamp, StringView>(maps, MAP(TIMESTAMP(), VARCHAR()));
-#ifdef SPARK_COMPATIBLE
   auto expected = makeNullableFlatVector<JsonNativeType>(
       {R"({"1451606400123456":"value"})"}, VARCHAR());
-#else
-  auto expected = makeNullableFlatVector<JsonNativeType>(
-      {R"({"2016-01-01T00:00:00.123Z":"value"})"}, VARCHAR());
-#endif
   auto actual = evaluate("to_json(c0)", makeRowVector({input}));
   ::bytedance::bolt::test::assertEqualVectors(expected, actual);
 }

--- a/bolt/functions/prestosql/tests/ToJsonTest.cpp
+++ b/bolt/functions/prestosql/tests/ToJsonTest.cpp
@@ -28,7 +28,8 @@ using JsonNativeType = StringView;
 template <typename TKey, typename TValue>
 using Pair = std::pair<TKey, std::optional<TValue>>;
 
-class ToJsonTest : public SparkFunctionBaseTest {
+// class ToJsonTest : public SparkFunctionBaseTest {
+class ToJsonTest : public FunctionBaseTest {
  protected:
   template <typename T = FlatVector<StringView>>
   void toJsonSimple(
@@ -922,6 +923,22 @@ TEST_F(ToJsonTest, allDataType) {
       {R"({"c0":127,"c1":32767,"c2":2147483647,"c3":9223372036854775807,"c4":1.23E7,"c5":1.23456789,"c6":1234.56,"c7":92233.7203685478,"c8":"example string","c9":"YWJj","c10":true,"c11":[1,2],"c12":[3,4],"c13":[5,6],"c14":[7,8],"c15":[1.1,2.2],"c16":[3.3,4.4],"c17":[55.55,66.66],"c18":[92233.7203685477,92233.7203685478],"c19":["string1","string2"],"c20":["YWJjZA==","YWJjZGU="],"c21":[true,false],"c22":{"key1":1,"key2":2},"c23":{"key1":3,"key2":4},"c24":{"key1":5,"key2":6},"c25":{"key1":9223372036854775806,"key2":9223372036854775807},"c26":{"key1":1.1,"key2":2.2},"c27":{"key1":3.3,"key2":4.4},"c28":{"key1":77.78,"key2":88.89},"c29":{"key1":92233.7203685477,"key2":92233.7203685478},"c30":{"key1":"value1","key2":"value2"},"c31":{"key1":"YWJjZA==","key2":"YWJjZGU="},"c32":{"key1":true,"key2":false},"c33":"2025-04-08"})"},
       VARCHAR());
   toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
+}
+
+TEST_F(ToJsonTest, timestampMapKey) {
+  std::vector<std::vector<Pair<Timestamp, StringView>>> maps{
+      {{{Timestamp(1451606400, 123456000), "value"_sv}}}};
+  auto input =
+      makeMapVector<Timestamp, StringView>(maps, MAP(TIMESTAMP(), VARCHAR()));
+#ifdef SPARK_COMPATIBLE
+  auto expected = makeNullableFlatVector<JsonNativeType>(
+      {R"({"1451606400123456":"value"})"}, VARCHAR());
+#else
+  auto expected = makeNullableFlatVector<JsonNativeType>(
+      {R"({"2016-01-01T00:00:00.123Z":"value"})"}, VARCHAR());
+#endif
+  auto actual = evaluate("to_json(c0)", makeRowVector({input}));
+  ::bytedance::bolt::test::assertEqualVectors(expected, actual);
 }
 
 } // namespace

--- a/bolt/functions/prestosql/types/JsonType.cpp
+++ b/bolt/functions/prestosql/types/JsonType.cpp
@@ -173,13 +173,11 @@ void generateJsonTyped(
               type->toString()));
         }
       } else if constexpr (std::is_same_v<T, Timestamp>) {
-#ifdef SPARK_COMPATIBLE
         if constexpr (isMapKey) {
           folly::toAppend(value.toMicros(), &result);
           result.append("\"");
           return;
         }
-#endif
         result.append("\"");
         static const auto formatter =
             bytedance::bolt::functions::buildJodaDateTimeFormatter(

--- a/bolt/functions/prestosql/types/JsonType.cpp
+++ b/bolt/functions/prestosql/types/JsonType.cpp
@@ -173,6 +173,13 @@ void generateJsonTyped(
               type->toString()));
         }
       } else if constexpr (std::is_same_v<T, Timestamp>) {
+#ifdef SPARK_COMPATIBLE
+        if constexpr (isMapKey) {
+          folly::toAppend(value.toMicros(), &result);
+          result.append("\"");
+          return;
+        }
+#endif
         result.append("\"");
         static const auto formatter =
             bytedance::bolt::functions::buildJodaDateTimeFormatter(


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Spark SQL `to_json(map(timestamp_micros(...), ...))` was resolved to the Presto vector `to_json` implementation in native execution.

Presto and Spark have different semantics for TIMESTAMP map keys in `to_json`:
- Presto-compatible behavior formats the TIMESTAMP key as a timestamp string, producing results like:
  `{"\"2016-01-01T00:00:00.123Z\"":"v"}` / `{""2016-01-01T00:00:00.123Z"":"v"}`
- Spark expects TIMESTAMP map keys to be serialized as epoch microseconds, e.g.:
  `{"1451606400123456":"v"}`

This caused Bolt native results to differ from Spark Java for Spark SQL queries using `to_json(MAP<TIMESTAMP, ...>)`.

Issue Number: close #833

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
This PR registers a SparkSQL-specific vector implementation for unprefixed `to_json`, following the same split-registration pattern used by Spark/Presto variants of `array_contains`.

Main changes:
- Extracted reusable Presto `to_json` vector function creation helpers.
- Added SparkSQL vector `to_json` registration that reuses the Presto vector implementation body.
- Added a Spark-specific mode for JSON serialization so TIMESTAMP map keys are serialized as `Timestamp::toMicros()` in SparkSQL.
- Preserved existing Presto-compatible `to_json` behavior.
- Added regression tests for:
  - SparkSQL `to_json(map(timestamp_micros(...), ...))` with timezone argument.
  - SparkSQL one-argument vector `to_json(map(timestamp_micros(...), ...))`.
  - Presto-compatible TIMESTAMP map key behavior.
  - TableScan -> Filter -> Project regression path.

Why:
- Expression compilation resolves vector functions before simple functions.
- Without a SparkSQL vector `to_json`, Spark SQL’s unprefixed one-argument `to_json` could fall through to the Presto vector implementation.
- That implementation does not match Spark’s TIMESTAMP map-key serialization semantics.

How:
- SparkSQL now registers its own vector `to_json`.
- The implementation shares the Presto vector `ToJsonFunction`, but passes a Spark-specific flag through `JsonCastOperator`.
- When this flag is enabled and the JSON writer is serializing a TIMESTAMP map key, the key is emitted as epoch micros.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->
```text
Release Note:
- Fixed SparkSQL `to_json(MAP<TIMESTAMP, ...>)` to serialize TIMESTAMP map keys as epoch microseconds, matching Spark Java behavior.
- Preserved Presto-compatible `to_json` behavior for TIMESTAMP map keys.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
