### PR TITLE
fix: support Spark legacy week-year calendar patterns

### DIFF
--- a/bolt/functions/lib/DateTimeFormatter.cpp
+++ b/bolt/functions/lib/DateTimeFormatter.cpp
@@ -66,6 +66,8 @@ struct Date {
   int32_t week = 1;
   int32_t dayOfWeek = 1;
   bool weekDateFormat = false;
+  bool hasWeekYear = false;
+  bool hasDayOfWeek = false;
 
   int32_t dayOfYear = 1;
   bool dayOfYearFormat = false;
@@ -762,6 +764,7 @@ ErrorCode parseFromPattern(
     }
     cur += size;
     date.weekDateFormat = true;
+    date.hasDayOfWeek = type == DateTimeFormatterType::LEGACY_SPARK;
     date.dayOfYearFormat = false;
     if (!date.hasYear) {
       date.hasYear = true;
@@ -928,6 +931,12 @@ ErrorCode parseFromPattern(
       case DateTimeFormatSpecifier::YEAR:
       case DateTimeFormatSpecifier::YEAR_OF_ERA:
         date.centuryFormat = false;
+        if (type == DateTimeFormatterType::LEGACY_SPARK && date.hasWeekYear) {
+          date.weekDateFormat = false;
+        }
+        if (type == DateTimeFormatterType::LEGACY_SPARK) {
+          date.hasWeekYear = false;
+        }
         date.isYearOfEra =
             (curPattern.specifier == DateTimeFormatSpecifier::YEAR_OF_ERA);
         // Enforce Joda's year range if year was specified as "year of era".
@@ -1051,6 +1060,7 @@ ErrorCode parseFromPattern(
         }
         date.year = number;
         date.weekDateFormat = true;
+        date.hasWeekYear = type == DateTimeFormatterType::LEGACY_SPARK;
         date.dayOfYearFormat = false;
         date.centuryFormat = false;
         date.hasYear = true;
@@ -1094,6 +1104,7 @@ ErrorCode parseFromPattern(
           return ErrorCode::DAY_OUT_OF_RANGE;
         }
         date.dayOfWeek = number;
+        date.hasDayOfWeek = type == DateTimeFormatterType::LEGACY_SPARK;
         date.weekDateFormat = true;
         date.dayOfYearFormat = false;
         if (!date.hasYear) {
@@ -1795,6 +1806,15 @@ DateTimeResult DateTimeFormatter::parse(
     }
   }
 
+  if (isLegacy && type_ == DateTimeFormatterType::LEGACY_SPARK &&
+      date.hasWeekYear) {
+    date.weekDateFormat = true;
+    date.dayOfYearFormat = false;
+    if (!date.hasDayOfWeek) {
+      date.dayOfWeek = 7;
+    }
+  }
+
   auto isJulianSpecialYear = [](int32_t year) {
     return (year >= util::kMinYear) && (year < util::kJulianEndYear) &&
         (year % 100 == 0) && (year % 400 != 0);
@@ -2332,7 +2352,6 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
     BOLT_USER_FAIL("Invalid pattern specification");
   }
 
-  bool hasWeekBasedYear = false, hasMonth = false;
   DateTimeFormatterBuilder builder(format.size());
   const char* cur = format.data();
   const char* end = cur + format.size();
@@ -2376,7 +2395,6 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
           builder.appendCenturyOfEra(count);
           break;
         case 'Y':
-          hasWeekBasedYear = true;
           builder.appendWeekYear(count);
           break;
         case 'w':
@@ -2395,7 +2413,6 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
           builder.appendDayOfYear(count);
           break;
         case 'M':
-          hasMonth = true;
           if (count <= 2) {
             builder.appendMonthOfYear(count);
           } else {
@@ -2463,9 +2480,6 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
     }
   }
 
-  BOLT_USER_CHECK(
-      !(hasWeekBasedYear && hasMonth),
-      "Cannot have both week-based year[YYYY] and month[MM] in the pattern for legacy formatter");
   return builder.setType(DateTimeFormatterType::LEGACY_SPARK).build();
 }
 

--- a/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -124,7 +124,52 @@ class DateTimeFormatterTest : public testing::Test {
     result.resize(resultSize);
     return result;
   }
+
+#ifdef SPARK_COMPATIBLE
+  std::string formatLegacySparkDateTime(
+      const std::string& format,
+      const Timestamp& timestamp) const {
+    auto formatter = buildLegacySparkDateTimeFormatter(format);
+    const auto maxSize = formatter->maxResultSize(nullptr);
+    std::string result(maxSize, '\0');
+    const auto resultSize = formatter->format(
+        timestamp, nullptr, maxSize, result.data(), false, TimePolicy::LEGACY);
+    result.resize(resultSize);
+    return result;
+  }
+
+  Timestamp timestampFromDate(int32_t year, int32_t month, int32_t day) const {
+    return util::fromDatetime(
+        util::daysSinceEpochFromDate(year, month, day), 0);
+  }
+#endif
 };
+
+#ifdef SPARK_COMPATIBLE
+TEST_F(DateTimeFormatterTest, legacySparkWeekYearWithCalendarFields) {
+  EXPECT_EQ(
+      "2019-12-30",
+      formatLegacySparkDateTime("YYYY-MM-dd", timestampFromDate(2018, 12, 30)));
+
+  auto formatter = buildLegacySparkDateTimeFormatter("YYYY-MM-dd");
+  EXPECT_EQ(
+      timestampFromDate(1969, 12, 28),
+      formatter->parse("1970-01-01", TimePolicy::LEGACY).value().timestamp);
+
+  EXPECT_EQ(
+      timestampFromDate(2001, 6, 15),
+      buildLegacySparkDateTimeFormatter("YYYY-yyyy-MM-dd")
+          ->parse("1970-2001-06-15", TimePolicy::LEGACY)
+          .value()
+          .timestamp);
+  EXPECT_EQ(
+      timestampFromDate(1969, 12, 28),
+      buildLegacySparkDateTimeFormatter("yyyy-YYYY-MM-dd")
+          ->parse("2001-1970-06-15", TimePolicy::LEGACY)
+          .value()
+          .timestamp);
+}
+#endif
 
 TEST_F(DateTimeFormatterTest, fixedLengthTokenBuilder) {
   DateTimeFormatterBuilder builder(100);

--- a/bolt/functions/prestosql/tests/PrestoSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/prestosql/tests/PrestoSqlDateTimeFunctionsTest.cpp
@@ -286,14 +286,18 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, parseDatetimeSignatures) {
   ASSERT_EQ(
       1, signatures.count("(varchar,varchar) -> timestamp with time zone"));
 }
-TEST_F(PrestoSqlDateTimeFunctionsTest, FromUnixtimeYYYYThrowError) {
+TEST_F(PrestoSqlDateTimeFunctionsTest, fromUnixtimeWeekYearWithMonth) {
   const auto fromUnixTime = [&](const std::optional<std::string>& unixTime,
                                 const std::optional<std::string>& timeFormat) {
     return evaluateOnce<std::string>(
         "from_unixtime(try_cast(c0 as bigint), c1)", unixTime, timeFormat);
   };
 
+#ifdef SPARK_COMPATIBLE
+  EXPECT_EQ("2021-12-28", fromUnixTime("1609167953", "YYYY-MM-dd").value());
+#else
   EXPECT_THROW(fromUnixTime("1609167953", "YYYY-MM-dd"), BoltUserError);
+#endif
 
   const auto fromUnixTimeWithTimezone = [&](const std::optional<std::string>&
                                                 unixTime,
@@ -308,9 +312,16 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, FromUnixtimeYYYYThrowError) {
         timezone);
   };
 
+#ifdef SPARK_COMPATIBLE
+  EXPECT_EQ(
+      "2021-12-28",
+      fromUnixTimeWithTimezone("1609167953", "YYYY-MM-dd", "Asia/Shanghai")
+          .value());
+#else
   EXPECT_THROW(
       fromUnixTimeWithTimezone("1609167953", "YYYY-MM-dd", "Asia/Shanghai"),
       BoltUserError);
+#endif
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, civilDateTimeMillisecondRange) {
@@ -368,7 +379,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesPrestoParity) {
   }
 }
 
-TEST_F(PrestoSqlDateTimeFunctionsTest, DateFormatYYYYThrowError) {
+TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormatWeekYearWithMonth) {
   using util::fromTimestampString;
 
   const auto dateFormat = [&](std::optional<Timestamp> timestamp,
@@ -380,9 +391,15 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, DateFormatYYYYThrowError) {
              makeNullableFlatVector<std::string>({format})}));
     return resultVector->as<SimpleVector<StringView>>()->valueAt(0);
   };
+#ifdef SPARK_COMPATIBLE
+  EXPECT_EQ(
+      "2019-12-30",
+      dateFormat(fromTimestampString("2018-12-30", nullptr), "YYYY-MM-dd"));
+#else
   EXPECT_THROW(
       dateFormat(fromTimestampString("1970-01-01", nullptr), "YYYY-MM-dd"),
       BoltUserError);
+#endif
 }
 TEST_F(PrestoSqlDateTimeFunctionsTest, dayOfXxxSignatures) {
   for (const auto& name :

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -2255,14 +2255,15 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkTimezone) {
       fromUnixTime(253402300801, "America/Los_Angeles"), "9999-12-31 16:00:01");
 }
 
-TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeYYYYThrowError) {
+TEST_F(SparkSqlDateTimeFunctionsTest, fromUnixtimeWeekYearWithMonth) {
+  setTimeParserPolicy("legacy");
   const auto fromUnixTime = [&](const std::optional<std::string>& unixTime,
                                 const std::optional<std::string>& timeFormat) {
     return evaluateOnce<std::string>(
         "from_unixtime(try_cast(c0 as bigint), c1)", unixTime, timeFormat);
   };
 
-  EXPECT_THROW(fromUnixTime("1609167953", "YYYY-MM-dd"), BoltUserError);
+  EXPECT_EQ("2021-12-28", fromUnixTime("1609167953", "YYYY-MM-dd").value());
 
   const auto fromUnixTimeWithTimezone = [&](const std::optional<std::string>&
                                                 unixTime,
@@ -2277,9 +2278,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeYYYYThrowError) {
         timezone);
   };
 
-  EXPECT_THROW(
-      fromUnixTimeWithTimezone("1609167953", "YYYY-MM-dd", "Asia/Shanghai"),
-      BoltUserError);
+  EXPECT_EQ(
+      "2021-12-28",
+      fromUnixTimeWithTimezone("1609167953", "YYYY-MM-dd", "Asia/Shanghai")
+          .value());
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, dateFormat) {
@@ -2297,9 +2299,19 @@ TEST_F(SparkSqlDateTimeFunctionsTest, dateFormat) {
         resultVector->as<SimpleVector<StringView>>()->valueAt(0);
     return resultStringView.getString();
   };
-  EXPECT_THROW(
-      dateFormat(fromTimestampString("1970-01-01", nullptr), "YYYY-MM-dd"),
-      BoltUserError);
+  setTimeParserPolicy("legacy");
+  EXPECT_EQ(
+      "2019-12-30",
+      dateFormat(fromTimestampString("2018-12-30", nullptr), "YYYY-MM-dd"));
+  EXPECT_EQ(
+      "2019-12-30",
+      evaluate(
+          "date_format(c0, 'YYYY-MM-dd')",
+          makeRowVector({makeFlatVector<Timestamp>(
+              {fromTimestampString("2018-12-30", nullptr)})}))
+          ->as<SimpleVector<StringView>>()
+          ->valueAt(0)
+          .str());
   EXPECT_EQ(
       "20180314 01:02:03.123",
       dateFormat(
@@ -2340,8 +2352,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, weekBased) {
   };
 
   setTimeParserPolicy("legacy");
-  // YYYY should not used with MM
-  EXPECT_THROW(dateFormat("1970-01-01", "YYYY-MM-dd"), BoltUserError);
+  EXPECT_EQ("2018-12-29", dateFormat("2018-12-29", "YYYY-MM-dd"));
+  EXPECT_EQ("2019-12-30", dateFormat("2018-12-30", "YYYY-MM-dd"));
+  EXPECT_EQ("2019-12-31", dateFormat("2018-12-31", "YYYY-MM-dd"));
+  EXPECT_EQ("2019-01-01", dateFormat("2019-01-01", "YYYY-MM-dd"));
 
   // YYYY-ww-uu
   EXPECT_EQ("2024-52-06", dateFormat("2024-12-28", "YYYY-ww-uu"));
@@ -2393,8 +2407,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, weekBased) {
         ->toString(options);
   };
 
-  // YYYY should not used with MM
-  EXPECT_THROW(getTimestamp("1970-01-01", "YYYY-MM-dd"), BoltUserError);
+  EXPECT_EQ("1969-12-28", getTimestamp("1970-01-01", "YYYY-MM-dd"));
+  EXPECT_EQ("2020-12-27", getTimestamp("2021-12-31", "YYYY-MM-dd"));
+  EXPECT_EQ("2001-06-15", getTimestamp("1970-2001-06-15", "YYYY-yyyy-MM-dd"));
+  EXPECT_EQ("1969-12-28", getTimestamp("2001-1970-06-15", "yyyy-YYYY-MM-dd"));
 
   // YYYY-ww-uu
   EXPECT_EQ("2024-12-28", getTimestamp("2024-52-06", "YYYY-ww-uu"));


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Support Spark legacy week-year calendar patterns

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Spark LEGACY accepts mixed week-year and calendar fields such as YYYY-MM-dd, but Bolt rejected the pattern while constructing the formatter with:

  BoltUserError: Cannot have both week-based year[YYYY] and month[MM] in the pattern for legacy formatter

This fails constant expressions during function initialization, including date_format(timestamp, 'YYYY-MM-dd'), before any row is evaluated.

Spark 3.2 delegates LEGACY timestamp parsing and formatting to java.text.SimpleDateFormat. LegacySimpleTimestampFormatter constructs SimpleDateFormat directly, sets its time zone and leniency, and uses it for both parse and format:

  https://github.com/apache/spark/blob/e428fe902bb1f12cea973de7fe4b885ae69fd6ca/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala#L294-L322

Under this behavior, YYYY-MM-dd is valid. For example, formatting 2018-12-30 produces 2019-12-30 because YYYY is the Sunday-based week-year while MM-dd remain calendar fields. Parsing 1970-01-01 with the same LEGACY pattern resolves to 1969-12-28, the first day of week-year 1970.

Remove the invalid construction-time restriction. For LEGACY_SPARK parsing, retain whether the active year came from a week-year token and whether a day-of-week was supplied so calendar month/day tokens do not incorrectly discard week-date precedence. Preserve pattern order: a later ordinary year overrides an earlier week-year, while a later week-year overrides an ordinary year.

Add formatter-level and Spark SQL regression coverage for constant and dynamic date_format patterns, from_unixtime, get_timestamp, year-boundary cases, mixed year token order, and the existing YYYY-ww-uu behavior. Keep non-Spark Presto behavior unchanged.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
