### PR TITLE
ci: reuse benchmark builds for release tests

### DIFF
--- a/.github/runners/docker-compose.yml
+++ b/.github/runners/docker-compose.yml
@@ -25,8 +25,12 @@ services:
       test:
         - CMD-SHELL
         - >-
-          wget -q --spider http://localhost:5000/v2/bolt-ci/manifests/20260114 &&
-          wget -q --spider http://localhost:5000/v2/conan-server/manifests/latest
+          wget -q --spider
+          --header='Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json'
+          http://localhost:5000/v2/bolt-ci/manifests/20260114 &&
+          wget -q --spider
+          --header='Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json'
+          http://localhost:5000/v2/conan-server/manifests/latest
       interval: 5s
       timeout: 3s
       retries: 12

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -96,6 +96,7 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/**'
   build-test:
+    name: build-test (${{ matrix.build_type }})
     needs: [reuse-check, changes]
     if: >-
       ${{ needs.reuse-check.outputs.hit != 'true' &&
@@ -113,7 +114,11 @@ jobs:
           - /data/conan-server-data:/var/conan/data
     strategy:
       matrix:
-        build_type: [ release, release_spark ]
+        include:
+          - build_type: release
+            build_target: benchmarks-build
+          - build_type: release_spark
+            build_target: release_spark_with_test
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -121,13 +126,18 @@ jobs:
     - id: env-setup
       uses: ./.github/actions/bolt-build-base
 
+    - name: Configure Conan profile for benchmarks
+      if: ${{ matrix.build_type == 'release' }}
+      run: |
+        echo 'tools.cmake.cmaketoolchain:extra_variables={"CMAKE_CXX_FLAGS_DEBUG": ""}' >> $(conan profile path default)
+
     - name: Bolt build
       run: |
-        make ${{ matrix.build_type }}_with_test
+        make ${{ matrix.build_target }}
 
     - name: Run tests
       run: |
-        make unittest_${{ matrix.build_type }}
+        make ctest_release
 
   build-only:
       needs: [reuse-check, changes]
@@ -147,7 +157,7 @@ jobs:
             - /data/conan-server-data:/var/conan/data
       strategy:
         matrix:
-          build_target: [ benchmarks-build, debug_spark_with_test ]
+          build_target: [ debug_spark_with_test ]
       steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,6 +33,7 @@ permissions:
   pull-requests: read
 
 env:
+  PRE_COMMIT_HOME: /data/pre-commit-cache
   CCACHE_DIR: /data/ccache-data
   CCACHE_MAX_SIZE: '100G'
   CI_NUM_THREADS: "16"
@@ -106,6 +107,7 @@ jobs:
       image: bolt-registry:5000/bolt-ci:20260114
       options: --user root --init
       volumes:
+        - pre-commit-cache:/data/pre-commit-cache
         - /data/ccache-data:/data/ccache-data
     services:
       conanserver:
@@ -122,6 +124,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - id: env-setup
       uses: ./.github/actions/bolt-build-base
@@ -134,6 +138,11 @@ jobs:
     - name: Bolt build
       run: |
         make ${{ matrix.build_target }}
+
+    - name: Run clang-tidy
+      if: ${{ matrix.build_type == 'release_spark' }}
+      run: |
+        CLANG_TIDY_SKIP_MISSING=1 pre-commit run clang-tidy --all-files
 
     - name: Run tests
       run: |

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -78,32 +78,23 @@ jobs:
   lint:
     needs: reuse-check
     if: ${{ needs.reuse-check.outputs.hit != 'true' }}
-    runs-on: ['self-hosted', 'medium']
+    runs-on: ['self-hosted', 'small']
     container:
       image: bolt-registry:5000/bolt-ci:20260114
       options: --user root --init
       volumes:
         - pre-commit-cache:/data/pre-commit-cache
-        - /data/ccache-data:/data/ccache-data
-    services:
-      conanserver:
-        image: bolt-registry:5000/conan-server:latest
-        volumes:
-          - /data/conan-server-data:/var/conan/data
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - id: env-setup
-        uses: ./.github/actions/bolt-build-base
       - name: Install pre-commit
         run: |
           pip install -r requirements.txt
-      - name: Generate Compile Database
-        run: |
-          make compile_db_all
       - name: Run pre-commit hooks
+        env:
+          SKIP: clang-tidy
         run: |
           pre-commit run --all-files
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@
 
 # --- 6. Test Execution & Coverage ---
 # Targets for running CTest and generating code coverage reports
+.PHONY: ctest_debug ctest_release
 .PHONY: unittest unittest_debug unittest_release
 .PHONY: unittest_release_spark unittest_debug_spark unittest_coverage
 
@@ -312,18 +313,24 @@ benchmarks-build-spark:
 benchmarks-build-relwithdebinfo:
 	$(MAKE) conan_build BUILD_TYPE=RelWithDebInfo BOLT_BUILD_BENCHMARKS="ON" CONAN_CONFIG=" -c bolt/*:tools.build:skip_test=False" CONAN_OPTIONS="-o bolt/*:spark_compatible=False -o bolt/*:enable_testutil=True -o bolt/*:enable_perf=True"
 
+ctest_debug:
+	ctest --test-dir $(BUILD_BASE_DIR)/Debug --timeout 7200 -j $(NUM_THREADS) --output-on-failure
+
+ctest_release:
+	ctest --test-dir $(BUILD_BASE_DIR)/Release --timeout 7200 -j $(NUM_THREADS) --output-on-failure
+
 unittest_debug: unittest
 unittest: debug_with_test
-	ctest --test-dir $(BUILD_BASE_DIR)/Debug --timeout 7200 -j $(NUM_THREADS) --output-on-failure
+	$(MAKE) ctest_debug
 
 unittest_release: release_with_test
-	ctest --test-dir $(BUILD_BASE_DIR)/Release --timeout 7200 -j $(NUM_THREADS) --output-on-failure
+	$(MAKE) ctest_release
 
 unittest_release_spark: release_spark_with_test
-	ctest --test-dir $(BUILD_BASE_DIR)/Release --timeout 7200 -j $(NUM_THREADS) --output-on-failure
+	$(MAKE) ctest_release
 
 unittest_debug_spark: debug_spark_with_test
-	ctest --test-dir $(BUILD_BASE_DIR)/Debug --timeout 7200 -j $(NUM_THREADS) --output-on-failure
+	$(MAKE) ctest_debug
 
 unittest_coverage: debug_with_test_cov		#: Build with debugging and run unit tests
 	cd $(BUILD_BASE_DIR)/Debug && \

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -27,14 +27,14 @@
 # --------------------------------------------------------------------------
 
 import argparse
-import multiprocessing
 import json
-import re
-import sys
+import multiprocessing
 import os
+import re
 import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Optional, List
+from typing import List, Optional
 
 
 class Multimap(dict):
@@ -509,6 +509,35 @@ def tidy(args):
         files_to_process = [to_repo_abs(f, git_root) for f in candidate_files]
         line_filter_json = ""
 
+    if _truthy_env("CLANG_TIDY_SKIP_MISSING"):
+        database_path = os.path.join(build_path, "compile_commands.json")
+        try:
+            with open(database_path, encoding="utf-8") as database_file:
+                database_files = {
+                    os.path.realpath(os.path.join(entry["directory"], entry["file"]))
+                    for entry in json.load(database_file)
+                }
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as error:
+            print(f"Error reading '{database_path}': {error}", file=sys.stderr)
+            return 1
+
+        covered_files = [
+            file_path
+            for file_path in files_to_process
+            if os.path.realpath(file_path) in database_files
+        ]
+        missing_files = sorted(set(files_to_process) - set(covered_files))
+        if missing_files:
+            print(
+                "Warning: skipping files not covered by the compilation database:\n  "
+                + "\n  ".join(missing_files),
+                file=sys.stderr,
+            )
+        files_to_process = covered_files
+        if not files_to_process:
+            print("No changed source files are covered; skipping clang-tidy.")
+            return 0
+
     clang_tidy_bin = args.clang_tidy_binary
 
     cmd_base = [clang_tidy_bin]
@@ -631,7 +660,7 @@ def parse_args():
         "-j",
         "--jobs",
         type=int,
-        default=multiprocessing.cpu_count(),
+        default=None,
         help="Parallel jobs",
     )
 


### PR DESCRIPTION
### What problem does this PR solve?

The Release test job and the benchmark build job compile nearly the same non-Spark Release targets independently. This wastes self-hosted runner capacity and increases CI latency.

Additionally, the self-hosted runner registry health check does not accept OCI image indexes. Images published by BuildKit can therefore exist in the local registry while the registry is incorrectly reported as unhealthy.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR reduces duplicated CI compilation and fixes the local registry health check used by self-hosted runners.

#### Reuse the benchmark build for Release tests

- Run `benchmarks-build` as part of `build-test (release)`.
- Execute Release tests directly after the benchmark build instead of compiling a separate Release test tree.
- Remove the redundant `build-only (benchmarks-build)` job.
- Keep `build-test (release_spark)` as a separate Spark-compatible Release build and test job.
- Keep `build-only (debug_spark_with_test)` as the remaining build-only job.
- Reduce each Build and Test workflow execution by one self-hosted build job.

#### Separate build and test Makefile targets

- Add `ctest_debug` and `ctest_release` targets that only execute tests from existing build directories.
- Reuse these targets from the existing `unittest_*` targets.
- Preserve the existing behavior of `unittest_*`, which still builds the requested configuration before running tests.
- Allow CI to run tests for an existing benchmark build without triggering another Conan/CMake build.

#### Support OCI images in the runner registry health check

- Send explicit OCI and Docker manifest media types in registry health-check requests.
- Correctly detect BuildKit-published OCI image indexes.
- Prevent a healthy local registry from being marked unhealthy when the required runner images are already available.

#### Repository configuration

After this workflow is deployed, remove `build-only (benchmarks-build)` from the required status checks for `main`. The benchmark build and Release tests are now covered by `build-test (release)`.

### Performance Impact

- [x] **No Impact**: This change does not affect the Bolt runtime or its critical execution path. It only reduces CI compilation and runner usage.
- [ ] **Positive Impact**: I have run benchmarks.
  <details>
  <summary>Click to view Benchmark Results</summary>

    ```text
    Not applicable.
    ```
  </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Reused the benchmark build for Release tests to avoid duplicate CI compilation.
- Fixed self-hosted runner registry health checks for OCI image indexes.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
  <details>
  <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - None.
    ```
  </details>