### PR TITLE
[WIP] Optimize performance of jit row vector compare 

### DIFF
--- a/bolt/exec/HashTable.h
+++ b/bolt/exec/HashTable.h
@@ -84,19 +84,33 @@ struct HashLookup {
     hits.resize(size);
     newGroups.clear();
     if (jitRowEqVectors) {
-      decodedVectors.clear();
-      for (auto& hasher : hashers) {
-        decodedVectors.emplace_back((char*)(&hasher->decodedVector()));
+      rowEqVectorRuntimes.resize(hashers.size());
+      decodedVectorRuntimePtrs.resize(hashers.size());
+      for (auto key = 0; key < hashers.size(); ++key) {
+        auto& hasher = hashers[key];
+        auto& decoded = hasher->decodedVector();
+        rowEqVectorRuntimes[key] = {
+            decoded.dataAsVoid(),
+            decoded.indices(),
+            decoded.nulls(),
+            &decoded,
+            decoded.constantIndex(),
+            decoded.isIdentityMapping(),
+            decoded.isConstantMapping(),
+            decoded.nullsUseTopLevelIndex()};
+        decodedVectorRuntimePtrs[key] =
+            reinterpret_cast<char*>(&rowEqVectorRuntimes[key]);
       }
     }
   }
 
   char** getDecodedVectors() {
-    BOLT_CHECK(!decodedVectors.empty());
-    return decodedVectors.data();
+    BOLT_CHECK(!decodedVectorRuntimePtrs.empty());
+    return decodedVectorRuntimePtrs.data();
   }
 
-  std::vector<char*> decodedVectors;
+  std::vector<RowEqVectorRuntime> rowEqVectorRuntimes;
+  std::vector<char*> decodedVectorRuntimePtrs;
 
   /// One entry per group-by or join key.
   const std::vector<std::unique_ptr<VectorHasher>>& hashers;

--- a/bolt/exec/RowContainer.h
+++ b/bolt/exec/RowContainer.h
@@ -34,6 +34,7 @@
 #include "bolt/common/memory/HashStringAllocator.h"
 #include "bolt/core/PlanNode.h"
 #include "bolt/exec/ContainerRowSerde.h"
+#include "bolt/exec/RowEqVectorRuntime.h"
 #include "bolt/functions/InlineFlatten.h"
 #include "bolt/jit/RowContainer/RowContainerCodeGenerator.h"
 #include "bolt/vector/DecodedVector.h"

--- a/bolt/exec/RowEqVectorRuntime.h
+++ b/bolt/exec/RowEqVectorRuntime.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "bolt/vector/TypeAliases.h"
+
+namespace bytedance::bolt {
+
+class DecodedVector;
+
+namespace exec {
+
+struct RowEqVectorRuntime {
+  const void* values;
+  const vector_size_t* indices;
+  const uint64_t* nulls;
+  const DecodedVector* decodedVector;
+  vector_size_t constantIndex;
+  bool isIdentityMapping;
+  bool isConstantMapping;
+  bool nullsUseTopLevelIndex;
+};
+
+} // namespace exec
+} // namespace bytedance::bolt

--- a/bolt/exec/benchmarks/CMakeLists.txt
+++ b/bolt/exec/benchmarks/CMakeLists.txt
@@ -124,6 +124,14 @@ target_link_libraries(
     GTest::gtest_main
 )
 
+add_executable(bolt_row_row_compare_benchmark RowRowCompareBenchmark.cpp)
+target_link_libraries(
+  bolt_row_row_compare_benchmark PRIVATE
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
+    GTest::gtest_main
+)
+
 add_executable(hash_vectors_bench HashVectorsBenchmark.cpp)
 target_link_libraries(
   hash_vectors_bench PRIVATE

--- a/bolt/exec/benchmarks/RowEqVectorsBenchmark.cpp
+++ b/bolt/exec/benchmarks/RowEqVectorsBenchmark.cpp
@@ -266,9 +266,20 @@ class rowEqvectorsBenchmark : public OperatorTestBase {
     int32_t equalNum = 0;
     int32_t vectorSize = decodedVectors[0]->size();
     int32_t keysNum = decodedVectors.size();
-    std::vector<char*> vectors;
-    for (auto& decoded : decodedVectors) {
-      vectors.emplace_back((char*)(decoded.get()));
+    std::vector<exec::RowEqVectorRuntime> vectorRuntimes(decodedVectors.size());
+    std::vector<char*> vectors(decodedVectors.size());
+    for (auto key = 0; key < decodedVectors.size(); ++key) {
+      auto& decoded = *decodedVectors[key];
+      vectorRuntimes[key] = {
+          decoded.dataAsVoid(),
+          decoded.indices(),
+          decoded.nulls(),
+          &decoded,
+          decoded.constantIndex(),
+          decoded.isIdentityMapping(),
+          decoded.isConstantMapping(),
+          decoded.nullsUseTopLevelIndex()};
+      vectors[key] = reinterpret_cast<char*>(&vectorRuntimes[key]);
     }
 
     for (auto& row : rows) {
@@ -376,7 +387,9 @@ class rowEqvectorsBenchmark : public OperatorTestBase {
       auto [jitMod, funcName] =
           rowContainer_->codegenRowEqVectors(types_, hasNulls_);
       jitModule_ = std::move(jitMod);
-      eqFunc_ = (exec::RowEqVectors)jitModule_->getFuncPtr(funcName);
+      if (jitModule_ != nullptr) {
+        eqFunc_ = (exec::RowEqVectors)jitModule_->getFuncPtr(funcName);
+      }
     }
 #endif
 

--- a/bolt/exec/benchmarks/RowEqVectorsBenchmark.cpp
+++ b/bolt/exec/benchmarks/RowEqVectorsBenchmark.cpp
@@ -229,6 +229,13 @@ class rowEqvectorsBenchmark : public OperatorTestBase {
   }
 
   ~rowEqvectorsBenchmark() override {
+    rows_.clear();
+    decodedVectors_.clear();
+    inputVector_.reset();
+    rowContainer_.reset();
+#ifdef ENABLE_BOLT_JIT
+    jitModule_.reset();
+#endif
     OperatorTestBase::TearDown();
   }
 
@@ -421,8 +428,10 @@ class rowEqvectorsBenchmark : public OperatorTestBase {
 std::unique_ptr<rowEqvectorsBenchmark> benchmark;
 
 void doRun(uint32_t it, const std::string& keys, const bool useJit) {
-  benchmark->setUseJit(useJit);
-  benchmark->prepare(keys);
+  BENCHMARK_SUSPEND {
+    benchmark->setUseJit(useJit);
+    benchmark->prepare(keys);
+  }
   for (int i = 0; i < FLAGS_iterations; i++) {
     benchmark->run();
   }
@@ -430,6 +439,26 @@ void doRun(uint32_t it, const std::string& keys, const bool useJit) {
 
 BENCHMARK_NAMED_PARAM(doRun, rowEQvecBenchmark_noJIT, FLAGS_keys, false);
 BENCHMARK_RELATIVE_NAMED_PARAM(doRun, rowEQvecBenchmark_JIT, FLAGS_keys, true);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(doRun, rowEQvecBenchmark_noJIT_i64_i32, "i64:i32", false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    doRun,
+    rowEQvecBenchmark_JIT_i64_i32,
+    "i64:i32",
+    true);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    doRun,
+    rowEQvecBenchmark_noJIT_i64_i32_str_inline,
+    "i64:i32:str_inline",
+    false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    doRun,
+    rowEQvecBenchmark_JIT_i64_i32_str_inline,
+    "i64:i32:str_inline",
+    true);
 BENCHMARK_DRAW_LINE();
 
 // bool_dict

--- a/bolt/exec/benchmarks/RowEqVectorsBenchmark.cpp
+++ b/bolt/exec/benchmarks/RowEqVectorsBenchmark.cpp
@@ -474,6 +474,18 @@ BENCHMARK_RELATIVE_NAMED_PARAM(
     true);
 BENCHMARK_DRAW_LINE();
 
+BENCHMARK_NAMED_PARAM(
+    doRun,
+    rowEQvecBenchmark_noJIT_str_str_dict,
+    "str:str_dict",
+    false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    doRun,
+    rowEQvecBenchmark_JIT_str_str_dict,
+    "str:str_dict",
+    true);
+BENCHMARK_DRAW_LINE();
+
 // bool_dict
 BENCHMARK_NAMED_PARAM(
     doRun,

--- a/bolt/exec/benchmarks/RowRowCompareBenchmark.cpp
+++ b/bolt/exec/benchmarks/RowRowCompareBenchmark.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "bolt/exec/RowContainer.h"
+#include "bolt/exec/tests/utils/OperatorTestBase.h"
+#include "bolt/jit/RowContainer/RowContainerCodeGenerator.h"
+
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::exec;
+using namespace bytedance::bolt::exec::test;
+
+DEFINE_int32(row_count, 4096, "Number of rows to compare");
+
+namespace {
+
+enum class KeyPattern {
+  kHighCardinality,
+  kStringFallback,
+};
+
+class RowRowCompareBenchmark : public OperatorTestBase {
+ public:
+  RowRowCompareBenchmark(jit::CmpType cmpType, KeyPattern keyPattern)
+      : cmpType_(cmpType), keyPattern_(keyPattern) {
+    OperatorTestBase::SetUp();
+    prepare();
+  }
+
+  ~RowRowCompareBenchmark() override {
+    rows_.clear();
+    decodedVectors_.clear();
+    rowVector_.reset();
+    rowContainer_.reset();
+#ifdef ENABLE_BOLT_JIT
+    jitModule_.reset();
+#endif
+    OperatorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  int64_t runNoJit() {
+    int64_t result = 0;
+    const auto size = rows_.size();
+    for (auto i = 0; i < size; ++i) {
+      const auto* left = rows_[i];
+      const auto* right = rows_[(i * 131 + 17) & (size - 1)];
+      const auto cmp = rowContainer_->compareRows(left, right, compareFlags_);
+      result += cmpType_ == jit::CmpType::SORT_LESS ? (cmp < 0) : cmp;
+    }
+    return result;
+  }
+
+  int64_t runJit() {
+    int64_t result = 0;
+    const auto size = rows_.size();
+    for (auto i = 0; i < size; ++i) {
+      const auto* left = rows_[i];
+      const auto* right = rows_[(i * 131 + 17) & (size - 1)];
+      result += rowRowCompare_(left, right);
+    }
+    return result;
+  }
+
+ private:
+  void prepare() {
+    const auto rowCount = nextPowerOfTwo(std::max(FLAGS_row_count, 2));
+    auto int64Vector = makeFlatVector<int64_t>(rowCount, [&](auto row) {
+      return keyPattern_ == KeyPattern::kHighCardinality ? row * 17 : row % 16;
+    });
+    auto int32Vector = makeFlatVector<int32_t>(rowCount, [&](auto row) {
+      return keyPattern_ == KeyPattern::kHighCardinality ? row * 31 : row % 16;
+    });
+    auto stringVector = makeFlatVector<std::string>(
+        rowCount, [](auto row) { return fmt::format("k{:010}", row); });
+
+    rowVector_ = makeRowVector(
+        {"i64", "i32", "s"}, {int64Vector, int32Vector, stringVector});
+    types_ = {BIGINT(), INTEGER(), VARCHAR()};
+    compareFlags_ = std::vector<CompareFlags>(types_.size(), CompareFlags());
+    rowContainer_ = std::make_shared<RowContainer>(types_, pool());
+    decodedVectors_.reserve(types_.size());
+    for (auto& child : rowVector_->children()) {
+      decodedVectors_.emplace_back(std::make_shared<DecodedVector>(*child));
+    }
+
+    rows_.resize(rowCount);
+    for (auto row = 0; row < rowCount; ++row) {
+      rows_[row] = rowContainer_->newRow();
+      for (auto key = 0; key < decodedVectors_.size(); ++key) {
+        rowContainer_->store(*decodedVectors_[key], row, rows_[row], key);
+      }
+    }
+
+#ifdef ENABLE_BOLT_JIT
+    auto [jitModule, funcName] =
+        rowContainer_->codegenCompare(types_, compareFlags_, cmpType_, false);
+    jitModule_ = std::move(jitModule);
+    rowRowCompare_ =
+        reinterpret_cast<RowRowCompare>(jitModule_->getFuncPtr(funcName));
+    BOLT_CHECK_NOT_NULL(rowRowCompare_);
+#else
+    BOLT_FAIL("Row-row compare benchmark requires ENABLE_BOLT_JIT");
+#endif
+  }
+
+  static int32_t nextPowerOfTwo(int32_t value) {
+    int32_t result = 1;
+    while (result < value) {
+      result <<= 1;
+    }
+    return result;
+  }
+
+  jit::CmpType cmpType_;
+  KeyPattern keyPattern_;
+  std::shared_ptr<RowContainer> rowContainer_;
+  RowVectorPtr rowVector_;
+  std::vector<TypePtr> types_;
+  std::vector<CompareFlags> compareFlags_;
+  std::vector<std::shared_ptr<DecodedVector>> decodedVectors_;
+  std::vector<char*> rows_;
+  RowRowCompare rowRowCompare_{nullptr};
+#ifdef ENABLE_BOLT_JIT
+  bytedance::bolt::jit::CompiledModuleSP jitModule_;
+#endif
+};
+
+void runSortLessHighCardinality(uint32_t /*iters*/, bool useJit) {
+  std::unique_ptr<RowRowCompareBenchmark> benchmark;
+  BENCHMARK_SUSPEND {
+    benchmark = std::make_unique<RowRowCompareBenchmark>(
+        jit::CmpType::SORT_LESS, KeyPattern::kHighCardinality);
+  }
+  auto result = useJit ? benchmark->runJit() : benchmark->runNoJit();
+  folly::doNotOptimizeAway(result);
+}
+
+void runSortLessStringFallback(uint32_t /*iters*/, bool useJit) {
+  std::unique_ptr<RowRowCompareBenchmark> benchmark;
+  BENCHMARK_SUSPEND {
+    benchmark = std::make_unique<RowRowCompareBenchmark>(
+        jit::CmpType::SORT_LESS, KeyPattern::kStringFallback);
+  }
+  auto result = useJit ? benchmark->runJit() : benchmark->runNoJit();
+  folly::doNotOptimizeAway(result);
+}
+
+void runCmpSpillHighCardinality(uint32_t /*iters*/, bool useJit) {
+  std::unique_ptr<RowRowCompareBenchmark> benchmark;
+  BENCHMARK_SUSPEND {
+    benchmark = std::make_unique<RowRowCompareBenchmark>(
+        jit::CmpType::CMP_SPILL, KeyPattern::kHighCardinality);
+  }
+  auto result = useJit ? benchmark->runJit() : benchmark->runNoJit();
+  folly::doNotOptimizeAway(result);
+}
+
+void runCmpSpillStringFallback(uint32_t /*iters*/, bool useJit) {
+  std::unique_ptr<RowRowCompareBenchmark> benchmark;
+  BENCHMARK_SUSPEND {
+    benchmark = std::make_unique<RowRowCompareBenchmark>(
+        jit::CmpType::CMP_SPILL, KeyPattern::kStringFallback);
+  }
+  auto result = useJit ? benchmark->runJit() : benchmark->runNoJit();
+  folly::doNotOptimizeAway(result);
+}
+
+BENCHMARK_NAMED_PARAM(
+    runSortLessHighCardinality,
+    rowRowSortLessHighCardinality_noJIT,
+    false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    runSortLessHighCardinality,
+    rowRowSortLessHighCardinality_JIT,
+    true);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    runSortLessStringFallback,
+    rowRowSortLessStringFallback_noJIT,
+    false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    runSortLessStringFallback,
+    rowRowSortLessStringFallback_JIT,
+    true);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    runCmpSpillHighCardinality,
+    rowRowCmpSpillHighCardinality_noJIT,
+    false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    runCmpSpillHighCardinality,
+    rowRowCmpSpillHighCardinality_JIT,
+    true);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    runCmpSpillStringFallback,
+    rowRowCmpSpillStringFallback_noJIT,
+    false);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    runCmpSpillStringFallback,
+    rowRowCmpSpillStringFallback_JIT,
+    true);
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  RowRowCompareBenchmark::SetUpTestCase();
+  folly::runBenchmarks();
+  RowRowCompareBenchmark::TearDownTestCase();
+  return 0;
+}

--- a/bolt/exec/benchmarks/SortWindowBenchmark.cpp
+++ b/bolt/exec/benchmarks/SortWindowBenchmark.cpp
@@ -35,13 +35,16 @@ DEFINE_bool(enable_log, false, "enable log");
 DEFINE_int32(window_injection_type, 1, "Type of injections for window");
 DEFINE_bool(input_fuzz, true, "input fuzz");
 DEFINE_int32(warmup_rounds, 0, "nums of warmup rounds");
+DEFINE_int32(jit_level, -1, "jit.level config for the benchmark task");
+DEFINE_int32(num_vectors, 2000, "Number of input vectors");
+DEFINE_int32(rows_per_vector, 1000, "Rows per input vector");
 // DEFINE_bool(merge_sort_window, false, "enable merge sort window");
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::connector::hive;
 using namespace bytedance::bolt::exec::test;
 
-int32_t kNumVectors = 2000;
-int32_t kRowsPerVector = 1000;
+int32_t kNumVectors = FLAGS_num_vectors;
+int32_t kRowsPerVector = FLAGS_rows_per_vector;
 int32_t kNumWarmupRounds = FLAGS_warmup_rounds;
 
 namespace {
@@ -355,13 +358,14 @@ class SortWindowBenchmark : public HiveConnectorTestBase {
       const core::PlanFragment& plan) {
     auto queryCtx = core::QueryCtx::create(executor_.get());
     std::unordered_map<std::string, std::string> configs;
+    configs[core::QueryConfig::kJitLevel] = std::to_string(FLAGS_jit_level);
     if (param.enableWindowSpill) {
       configs[core::QueryConfig::kSpillEnabled] = "true";
       configs[core::QueryConfig::kWindowSpillEnabled] = "true";
       configs[core::QueryConfig::kRowBasedSpillMode] = "compression";
-      configs[core::QueryConfig::kJitLevel] = "-1";
-      // configs[core::QueryConfig::kPreferredOutputBatchBytes] = "256";
-      // configs[core::QueryConfig::kMaxOutputBatchRows] = "3";
+      configs[core::QueryConfig::kPreferredOutputBatchBytes] = "1024";
+      configs[core::QueryConfig::kPreferredOutputBatchRows] = "1024";
+      configs[core::QueryConfig::kMaxOutputBatchRows] = "1024";
       configs[core::QueryConfig::kTestingSpillPct] = "100";
     }
     queryCtx->testingOverrideConfigUnsafe(std::move(configs));
@@ -384,6 +388,9 @@ class SortWindowBenchmark : public HiveConnectorTestBase {
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  kNumVectors = FLAGS_num_vectors;
+  kRowsPerVector = FLAGS_rows_per_vector;
+  kNumWarmupRounds = FLAGS_warmup_rounds;
   SortWindowBenchmark::SetUpTestCase();
   std::unique_ptr<SortWindowBenchmark> benchmark;
   std::vector<SortWindowBenchmarkParam> params;

--- a/bolt/jit/RowContainer/RowEqVectorsCodeGenerator.cpp
+++ b/bolt/jit/RowContainer/RowEqVectorsCodeGenerator.cpp
@@ -36,6 +36,221 @@ std::string RowEqVectorsCodeGenerator::GetCmpFuncName() {
   return fn;
 }
 
+llvm::Value* RowEqVectorsCodeGenerator::loadMappedIndex(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime,
+    llvm::Value* row) {
+  auto* func = builder.GetInsertBlock()->getParent();
+  auto* i32Ty = builder.getInt32Ty();
+  auto* i8Ty = builder.getInt8Ty();
+  auto* i32PtrTy = i32Ty->getPointerTo();
+
+  auto* isIdentity =
+      getValueByPtr(builder, runtime, i8Ty, kRuntimeIsIdentityMappingOffset);
+
+  auto* identityBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "mapped_index_identity", func);
+  auto* nonIdentityBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "mapped_index_non_identity", func);
+  auto* doneBlk =
+      llvm::BasicBlock::Create(builder.getContext(), "mapped_index_done", func);
+  builder.CreateCondBr(
+      builder.CreateICmpNE(isIdentity, builder.getInt8(0)),
+      identityBlk,
+      nonIdentityBlk);
+
+  builder.SetInsertPoint(identityBlk);
+  builder.CreateBr(doneBlk);
+  identityBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(nonIdentityBlk);
+  auto* isConstant =
+      getValueByPtr(builder, runtime, i8Ty, kRuntimeIsConstantMappingOffset);
+  auto* constantBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "mapped_index_constant", func);
+  auto* dictionaryBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "mapped_index_dictionary", func);
+  builder.CreateCondBr(
+      builder.CreateICmpNE(isConstant, builder.getInt8(0)),
+      constantBlk,
+      dictionaryBlk);
+
+  builder.SetInsertPoint(constantBlk);
+  auto* constantIndex =
+      getValueByPtr(builder, runtime, i32Ty, kRuntimeConstantIndexOffset);
+  builder.CreateBr(doneBlk);
+  constantBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(dictionaryBlk);
+  auto* indicesAddr =
+      getValueByPtr(builder, runtime, i32PtrTy, kRuntimeIndicesOffset);
+  auto* indexAddr = builder.CreateGEP(i32Ty, indicesAddr, row);
+  auto* indexedIndex = builder.CreateLoad(i32Ty, indexAddr);
+  builder.CreateBr(doneBlk);
+  dictionaryBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(doneBlk);
+  auto* phi = builder.CreatePHI(i32Ty, 3);
+  phi->addIncoming(row, identityBlk);
+  phi->addIncoming(constantIndex, constantBlk);
+  phi->addIncoming(indexedIndex, dictionaryBlk);
+  return phi;
+}
+
+llvm::Value* RowEqVectorsCodeGenerator::loadRightValue(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime,
+    llvm::Value* row,
+    llvm::Type* dataTy) {
+  auto* valuesAddr = getValueByPtr(
+      builder, runtime, dataTy->getPointerTo(), kRuntimeValuesOffset);
+  auto* index = loadMappedIndex(builder, runtime, row);
+  if (dataTy->isIntegerTy(128)) {
+    auto* i8Values = builder.CreatePointerCast(
+        valuesAddr, builder.getInt8Ty()->getPointerTo());
+    auto* valueAddr = builder.CreateGEP(
+        builder.getInt8Ty(),
+        i8Values,
+        builder.CreateMul(index, builder.getInt32(sizeof(int128_t))));
+    auto* lower64 = builder.CreateLoad(
+        builder.getInt64Ty(),
+        builder.CreatePointerCast(
+            valueAddr, builder.getInt64Ty()->getPointerTo()));
+    auto* upperAddr = builder.CreateConstInBoundsGEP1_64(
+        builder.getInt8Ty(), valueAddr, sizeof(int64_t));
+    auto* upper64 = builder.CreateLoad(
+        builder.getInt64Ty(),
+        builder.CreatePointerCast(
+            upperAddr, builder.getInt64Ty()->getPointerTo()));
+    auto* lower128 = builder.CreateZExt(lower64, builder.getInt128Ty());
+    auto* upper128 = builder.CreateZExt(upper64, builder.getInt128Ty());
+    return builder.CreateOr(builder.CreateShl(upper128, 64), lower128);
+  }
+  return builder.CreateLoad(
+      dataTy, builder.CreateGEP(dataTy, valuesAddr, index));
+}
+
+llvm::Value* RowEqVectorsCodeGenerator::loadRightBool(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime,
+    llvm::Value* row) {
+  auto* i64Ty = builder.getInt64Ty();
+  auto* valuesAddr = getValueByPtr(
+      builder, runtime, i64Ty->getPointerTo(), kRuntimeValuesOffset);
+  auto* index = loadMappedIndex(builder, runtime, row);
+  auto* wordIndex = builder.CreateLShr(index, builder.getInt32(6));
+  auto* bitIndex = builder.CreateAnd(index, builder.getInt32(63));
+  auto* word = builder.CreateLoad(
+      i64Ty, builder.CreateGEP(i64Ty, valuesAddr, wordIndex));
+  auto* bit = builder.CreateAnd(
+      builder.CreateLShr(word, builder.CreateZExt(bitIndex, i64Ty)),
+      builder.getInt64(1));
+  return castToI8(builder, builder.CreateICmpNE(bit, builder.getInt64(0)));
+}
+
+llvm::Value* RowEqVectorsCodeGenerator::loadRightStringViewAddr(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime,
+    llvm::Value* row) {
+  return loadRightValueAddr(builder, runtime, row, sizeof(StringView));
+}
+
+llvm::Value* RowEqVectorsCodeGenerator::loadRightValueAddr(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime,
+    llvm::Value* row,
+    int32_t valueSize) {
+  auto* valueTy = builder.getInt8Ty();
+  auto* valuesAddr = getValueByPtr(
+      builder, runtime, valueTy->getPointerTo(), kRuntimeValuesOffset);
+  auto* index = loadMappedIndex(builder, runtime, row);
+  return builder.CreateGEP(
+      valueTy,
+      valuesAddr,
+      builder.CreateMul(index, builder.getInt32(valueSize)));
+}
+
+llvm::Value* RowEqVectorsCodeGenerator::loadRightNull(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime,
+    llvm::Value* row) {
+  auto* func = builder.GetInsertBlock()->getParent();
+  auto* i8Ty = builder.getInt8Ty();
+  auto* i64Ty = builder.getInt64Ty();
+  auto* nullsAddr = getValueByPtr(
+      builder, runtime, i64Ty->getPointerTo(), kRuntimeNullsOffset);
+  auto* noNullBlk =
+      llvm::BasicBlock::Create(builder.getContext(), "decoded_no_nulls", func);
+  auto* hasNullBlk =
+      llvm::BasicBlock::Create(builder.getContext(), "decoded_has_nulls", func);
+  auto* doneBlk =
+      llvm::BasicBlock::Create(builder.getContext(), "decoded_null_done", func);
+  builder.CreateCondBr(
+      builder.CreateICmpEQ(
+          nullsAddr, llvm::ConstantPointerNull::get(i64Ty->getPointerTo())),
+      noNullBlk,
+      hasNullBlk);
+
+  builder.SetInsertPoint(noNullBlk);
+  builder.CreateBr(doneBlk);
+  noNullBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(hasNullBlk);
+  auto* nullsUseTopLevelIndex = getValueByPtr(
+      builder, runtime, i8Ty, kRuntimeNullsUseTopLevelIndexOffset);
+  auto* topLevelNullIndexBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "decoded_null_top_level_index", func);
+  auto* mappedNullIndexBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "decoded_null_mapped_index", func);
+  auto* nullIndexDoneBlk = llvm::BasicBlock::Create(
+      builder.getContext(), "decoded_null_index_done", func);
+  builder.CreateCondBr(
+      builder.CreateICmpNE(nullsUseTopLevelIndex, builder.getInt8(0)),
+      topLevelNullIndexBlk,
+      mappedNullIndexBlk);
+
+  builder.SetInsertPoint(topLevelNullIndexBlk);
+  builder.CreateBr(nullIndexDoneBlk);
+  topLevelNullIndexBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(mappedNullIndexBlk);
+  auto* mappedNullIndex = loadMappedIndex(builder, runtime, row);
+  builder.CreateBr(nullIndexDoneBlk);
+  mappedNullIndexBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(nullIndexDoneBlk);
+  auto* nullIndex = builder.CreatePHI(builder.getInt32Ty(), 2);
+  nullIndex->addIncoming(row, topLevelNullIndexBlk);
+  nullIndex->addIncoming(mappedNullIndex, mappedNullIndexBlk);
+  auto* wordIndex = builder.CreateLShr(nullIndex, builder.getInt32(6));
+  auto* bitIndex = builder.CreateAnd(nullIndex, builder.getInt32(63));
+  auto* word =
+      builder.CreateLoad(i64Ty, builder.CreateGEP(i64Ty, nullsAddr, wordIndex));
+  auto* bit = builder.CreateAnd(
+      builder.CreateLShr(word, builder.CreateZExt(bitIndex, i64Ty)),
+      builder.getInt64(1));
+  auto* isNull =
+      castToI8(builder, builder.CreateICmpEQ(bit, builder.getInt64(0)));
+  builder.CreateBr(doneBlk);
+  hasNullBlk = builder.GetInsertBlock();
+
+  builder.SetInsertPoint(doneBlk);
+  auto* phi = builder.CreatePHI(i8Ty, 2);
+  phi->addIncoming(builder.getInt8(0), noNullBlk);
+  phi->addIncoming(isNull, hasNullBlk);
+  return phi;
+}
+
+llvm::Value* RowEqVectorsCodeGenerator::loadDecodedVector(
+    llvm::IRBuilder<>& builder,
+    llvm::Value* runtime) {
+  return getValueByPtr(
+      builder,
+      runtime,
+      builder.getInt8Ty()->getPointerTo(),
+      kRuntimeDecodedVectorOffset);
+}
+
 llvm::BasicBlock* RowEqVectorsCodeGenerator::genNullBitCmpIR(
     const llvm::SmallVector<llvm::Value*>& values,
     const size_t idx,
@@ -75,9 +290,8 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genNullBitCmpIR(
       builder.CreateICmpNE(
           builder.CreateAnd(leftValUnmask, constMask), builder.getInt8(0)));
 
-  // get right value from call
-  auto rightVal =
-      createCall(builder, GetDecodedIsNull, {values[2 + idx], values[1]});
+  auto rightVal = loadRightNull(builder, values[2 + idx], values[1]);
+  currBlk = builder.GetInsertBlock();
 
   auto nilNe = builder.CreateICmpNE(leftVal, rightVal);
   auto nilNeBlk = llvm::BasicBlock::Create(
@@ -148,26 +362,19 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genIntegerCmpIR(
 
   auto rowTy = builder.getInt8Ty();
   llvm::Type* dataTy = nullptr;
-  std::string rightValCall = GetDecodedValueI32;
   if (kind == bytedance::bolt::TypeKind::BOOLEAN) {
     // Just follow Clang. Clang chose i8 over i1 for a boolean field
     dataTy = builder.getInt8Ty();
-    rightValCall = GetDecodedValueBool;
   } else if (kind == bytedance::bolt::TypeKind::TINYINT) {
     dataTy = builder.getInt8Ty();
-    rightValCall = GetDecodedValueI8;
   } else if (kind == bytedance::bolt::TypeKind::SMALLINT) {
     dataTy = builder.getInt16Ty();
-    rightValCall = GetDecodedValueI16;
   } else if (kind == bytedance::bolt::TypeKind::INTEGER) {
     dataTy = builder.getInt32Ty();
-    rightValCall = GetDecodedValueI32;
   } else if (kind == bytedance::bolt::TypeKind::BIGINT) {
     dataTy = builder.getInt64Ty();
-    rightValCall = GetDecodedValueI64;
   } else if (kind == bytedance::bolt::TypeKind::HUGEINT) {
     dataTy = builder.getInt128Ty();
-    rightValCall = GetDecodedValueI128;
   } else {
     BOLT_UNREACHABLE();
   }
@@ -189,9 +396,10 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genIntegerCmpIR(
   } else {
     leftVal = getValueByPtr(builder, values[0], dataTy, keyOffsets[idx]);
   }
-  // right value from createCall
-  auto rightVal =
-      createCall(builder, rightValCall, {values[2 + idx], values[1]});
+  auto rightVal = kind == bytedance::bolt::TypeKind::BOOLEAN
+      ? loadRightBool(builder, values[2 + idx], values[1])
+      : loadRightValue(builder, values[2 + idx], values[1], dataTy);
+  currBlk = builder.GetInsertBlock();
 
   auto keyEq = builder.CreateICmpEQ(leftVal, rightVal);
 
@@ -237,13 +445,21 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genTimestampCmpIR(
   // Generate value comparison IR
   builder.SetInsertPoint(currBlk);
 
-  auto keyEq = createCall(
+  auto* int64Ty = builder.getInt64Ty();
+  auto leftAddr = builder.CreateConstInBoundsGEP1_64(
+      builder.getInt8Ty(), values[0], keyOffsets[idx]);
+  auto rightAddr = loadRightValueAddr(
+      builder, values[2 + idx], values[1], sizeof(Timestamp));
+  currBlk = builder.GetInsertBlock();
+  auto leftSeconds = getValueByPtr(builder, leftAddr, int64Ty, 0);
+  auto rightSeconds = getValueByPtr(builder, rightAddr, int64Ty, 0);
+  auto leftNanos = getValueByPtr(builder, leftAddr, int64Ty, sizeof(int64_t));
+  auto rightNanos = getValueByPtr(builder, rightAddr, int64Ty, sizeof(int64_t));
+  auto keyEq = castToI8(
       builder,
-      CmpRowVecTimestamp,
-      {values[2 + idx],
-       values[1],
-       builder.CreateConstInBoundsGEP1_64(
-           builder.getInt8Ty(), values[0], keyOffsets[idx])});
+      builder.CreateAnd(
+          builder.CreateICmpEQ(leftSeconds, rightSeconds),
+          builder.CreateICmpEQ(leftNanos, rightNanos)));
 
   // If it the last key, generate the fast logic
   if (idx == keysTypes.size() - 1) {
@@ -279,10 +495,6 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genFloatPointCmpIR(
   bool isDouble = kind == bytedance::bolt::TypeKind::DOUBLE;
 
   auto dataTy = isDouble ? builder.getDoubleTy() : builder.getFloatTy();
-  std::string rightValCall =
-      isDouble ? GetDecodedValueDouble : GetDecodedValueFloat;
-  llvm::PointerType* dataPtrTy = dataTy->getPointerTo();
-
   // Block for next key.
   auto nextBlk =
       llvm::BasicBlock::Create(llvm_context, getLabel(idx + 1), func, phiBlk);
@@ -294,9 +506,9 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genFloatPointCmpIR(
   builder.SetInsertPoint(currBlk);
 
   auto leftValRaw = getValueByPtr(builder, values[0], dataTy, keyOffsets[idx]);
-  // right value from createCall
   auto rightValRaw =
-      createCall(builder, rightValCall, {values[2 + idx], values[1]});
+      loadRightValue(builder, values[2 + idx], values[1], dataTy);
+  currBlk = builder.GetInsertBlock();
 
   auto constFloat0 = isDouble ? llvm::ConstantFP::get(dataTy, (double)0.0)
                               : llvm::ConstantFP::get(dataTy, (float)0.0);
@@ -451,9 +663,8 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genStringViewCmpIR(
   auto leftAddr = builder.CreateConstInBoundsGEP1_64(
       builder.getInt8Ty(), values[0], keyOffsets[idx]);
 
-  // get right value from createCall
-  auto rightAddr = createCall(
-      builder, GetDecodedValueStringView, {values[2 + idx], values[1]});
+  auto rightAddr = loadRightStringViewAddr(builder, values[2 + idx], values[1]);
+  currBlk = builder.GetInsertBlock();
   // Check Prefix + length (8 chars)
   {
     auto int64Ty = builder.getInt64Ty();
@@ -577,7 +788,7 @@ llvm::BasicBlock* RowEqVectorsCodeGenerator::genComplexCmpIR(
       ComplexTypeRowEqVectors,
       {values[0],
        builder.getInt32(keyOffsets[idx]),
-       values[2 + idx],
+       loadDecodedVector(builder, values[2 + idx]),
        values[1]});
 
   if (idx == keysTypes.size() - 1) {
@@ -722,7 +933,7 @@ bool RowEqVectorsCodeGenerator::GenCmpIR() {
     }
     builder.CreateRet(cmpPhi);
   }
-  auto err = llvm::verifyFunction(*func);
+  auto err = llvm::verifyFunction(*func, &llvm::errs());
   return err;
 }
 

--- a/bolt/jit/RowContainer/RowEqVectorsCodeGenerator.h
+++ b/bolt/jit/RowContainer/RowEqVectorsCodeGenerator.h
@@ -18,6 +18,9 @@
 
 #ifdef ENABLE_BOLT_JIT
 
+#include <cstddef>
+
+#include "bolt/exec/RowEqVectorRuntime.h"
 #include "bolt/jit/RowContainer/RowContainerCodeGenerator.h"
 
 namespace bytedance::bolt::jit {
@@ -84,6 +87,60 @@ class RowEqVectorsCodeGenerator : public RowContainerCodeGenerator {
       PhiNodeInputs& phiInputs,
       llvm::BasicBlock* currBlk,
       llvm::BasicBlock* phiBlk) override;
+
+ private:
+  static constexpr int32_t kRuntimeValuesOffset =
+      offsetof(exec::RowEqVectorRuntime, values);
+  static constexpr int32_t kRuntimeIndicesOffset =
+      offsetof(exec::RowEqVectorRuntime, indices);
+  static constexpr int32_t kRuntimeNullsOffset =
+      offsetof(exec::RowEqVectorRuntime, nulls);
+  static constexpr int32_t kRuntimeDecodedVectorOffset =
+      offsetof(exec::RowEqVectorRuntime, decodedVector);
+  static constexpr int32_t kRuntimeConstantIndexOffset =
+      offsetof(exec::RowEqVectorRuntime, constantIndex);
+  static constexpr int32_t kRuntimeIsIdentityMappingOffset =
+      offsetof(exec::RowEqVectorRuntime, isIdentityMapping);
+  static constexpr int32_t kRuntimeIsConstantMappingOffset =
+      offsetof(exec::RowEqVectorRuntime, isConstantMapping);
+  static constexpr int32_t kRuntimeNullsUseTopLevelIndexOffset =
+      offsetof(exec::RowEqVectorRuntime, nullsUseTopLevelIndex);
+
+  llvm::Value* loadMappedIndex(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime,
+      llvm::Value* row);
+
+  llvm::Value* loadRightValue(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime,
+      llvm::Value* row,
+      llvm::Type* dataTy);
+
+  llvm::Value* loadRightBool(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime,
+      llvm::Value* row);
+
+  llvm::Value* loadRightStringViewAddr(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime,
+      llvm::Value* row);
+
+  llvm::Value* loadRightValueAddr(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime,
+      llvm::Value* row,
+      int32_t valueSize);
+
+  llvm::Value* loadRightNull(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime,
+      llvm::Value* row);
+
+  llvm::Value* loadDecodedVector(
+      llvm::IRBuilder<>& builder,
+      llvm::Value* runtime);
 };
 
 } // namespace bytedance::bolt::jit

--- a/bolt/jit/tests/RowEqVectorsIRTest.cpp
+++ b/bolt/jit/tests/RowEqVectorsIRTest.cpp
@@ -267,9 +267,20 @@ class RowEqvectorsTest : public OperatorTestBase {
     int32_t equalNum = 0;
     int32_t vectorSize = decodedVectors[0]->size();
     int32_t keysNum = decodedVectors.size();
-    std::vector<char*> vectors;
-    for (auto& decoded : decodedVectors) {
-      vectors.emplace_back((char*)(decoded.get()));
+    std::vector<exec::RowEqVectorRuntime> vectorRuntimes(decodedVectors.size());
+    std::vector<char*> vectors(decodedVectors.size());
+    for (auto key = 0; key < decodedVectors.size(); ++key) {
+      auto& decoded = *decodedVectors[key];
+      vectorRuntimes[key] = {
+          decoded.dataAsVoid(),
+          decoded.indices(),
+          decoded.nulls(),
+          &decoded,
+          decoded.constantIndex(),
+          decoded.isIdentityMapping(),
+          decoded.isConstantMapping(),
+          decoded.nullsUseTopLevelIndex()};
+      vectors[key] = reinterpret_cast<char*>(&vectorRuntimes[key]);
     }
 
     for (auto& row : rows) {
@@ -347,6 +358,7 @@ class RowEqvectorsTest : public OperatorTestBase {
     auto rows = store(*rowContainer, decodedVectors, decodedVectors[0]->size());
     auto [jitMod, funcName] =
         rowContainer->codegenRowEqVectors(types, nullable);
+    BOLT_CHECK(jitMod != nullptr);
     auto eqFunc = (exec::RowEqVectors)jitMod->getFuncPtr(funcName);
     if (nullable) {
       RowEqualVectors<true>(rowContainer.get(), rows, decodedVectors, eqFunc);
@@ -383,7 +395,9 @@ class RowEqvectorsTest : public OperatorTestBase {
       auto [jitMod, funcName] =
           rowContainer_->codegenRowEqVectors(types_, hasNulls_);
       jitModule_ = std::move(jitMod);
-      eqFunc_ = (exec::RowEqVectors)jitModule_->getFuncPtr(funcName);
+      if (jitModule_ != nullptr) {
+        eqFunc_ = (exec::RowEqVectors)jitModule_->getFuncPtr(funcName);
+      }
     }
 
     rows_ = store(*rowContainer_, decodedVectors_, inputVector_->size());

--- a/bolt/vector/DecodedVector.h
+++ b/bolt/vector/DecodedVector.h
@@ -151,6 +151,10 @@ class DecodedVector {
     return reinterpret_cast<const T*>(data_);
   }
 
+  const void* dataAsVoid() const {
+    return data_;
+  }
+
   /// Returns the raw nulls buffer for the base vector combined with nulls found
   /// in dictionary wrappings. May return nullptr if there are no nulls. Use
   /// top-level row numbers to access individual null flags, e.g.
@@ -241,6 +245,14 @@ class DecodedVector {
   /// Returns true if the decoded vector was constant.
   bool isConstantMapping() const {
     return isConstantMapping_;
+  }
+
+  bool nullsUseTopLevelIndex() const {
+    return isIdentityMapping_ || hasExtraNulls_;
+  }
+
+  vector_size_t constantIndex() const {
+    return constantIndex_;
   }
 
   /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### What problem does this PR solve?

HashAggregation grouping-key equality and HashJoin build/probe-key equality both use the row=vector comparison path:

```cpp
rowEqVectorsFunc_(group, row, lookup.getDecodedVectors())
```

Before this PR, the generated row=vector JIT still called `DecodedVector` helper functions on the hot comparison path, for example `jit_GetDecodedIsNull()` and `jit_GetDecodedValue*()`. These helper calls add noticeable overhead when probing hash tables with multiple grouping/join keys.

This PR optimizes that shared row=vector JIT path by passing decoded-vector runtime descriptors into JIT and letting generated IR directly handle mapped index, null-bit, and scalar value loads.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds `RowEqVectorRuntime`, a compact runtime descriptor prepared once per `HashLookup::reset()` for each key:

- `values`: base vector raw values
- `indices`: top-level row to base row mapping
- `nulls`: decoded null bitmap
- `decodedVector`: original `DecodedVector*` for complex-type fallback
- `constantIndex`, `isIdentityMapping`, `isConstantMapping`, `nullsUseTopLevelIndex`

The row=vector JIT ABI still uses the existing third argument shape (`char*[]`), but each element now points to a `RowEqVectorRuntime` instead of a raw `DecodedVector*`.

Generated IR now directly handles:

- identity / constant / dictionary mapped-index calculation
- Bolt null bitmap polarity (`bit=1` means not-null, `bit=0` means null)
- bool bit-packed loads
- integer / floating-point / HugeInt / Timestamp / StringView raw value loads

Complex array/map/row keys still fall back to the existing `jit_ComplexTypeRowEqVectors` helper via the stored `decodedVector`, so this PR does not attempt to reimplement `ContainerRowSerde` in IR.

This optimization applies to the row=vector equality path shared by:

- HashAggregation grouping-key equality
- HashJoin build/probe-key equality

It does not directly apply to OrderBy, Window, or spill row-row comparators because those use `RowContainer::codegenCompare()` over two row-container rows, not `RowEqVectors`.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.

<details>
<summary>Click to view Benchmark Results</summary>

Benchmark target:

```bash
cmake --build --preset conan-release --target rowEqVectors_benchmark --parallel 16
```

Benchmark command:

```bash
_build/Release/bolt/exec/benchmarks/rowEqVectors_benchmark --bm_regex='.*i64_i32.*' --bm_min_iters=5 --iterations=3
_build/Release/bolt/exec/benchmarks/rowEqVectors_benchmark --bm_regex='.*str_str_dict.*' --bm_min_iters=5 --iterations=3
```

The `jit-old` numbers are from the benchmark-only baseline before this descriptor optimization. `jit-new` numbers are after this PR.

| case | not-jit | jit-old | jit-new | improvement |
|---|---:|---:|---:|---:|
| `i64:i32` | 1.01s | 294.46ms | 157.94ms | 46.4% |
| `i64:i32:str_inline` | 1.02s | 293.87ms | 157.42ms | 46.4% |
| `str:str_dict` | 1.19s | 369.59ms | 293.19ms | 20.7% |

The `str:str_dict` case covers multiple non-inline string keys (`stringLength=100`), including a flat string key and a dictionary string key.

</details>

### Validation

Correctness:

```bash
cmake --build --preset conan-release --target bolt_row_vec_cmp_test --parallel 16
_build/Release/bolt/jit/tests/bolt_row_vec_cmp_test
```

Result:

```text
[  PASSED  ] 11 tests.
```

Build and benchmark:

```bash
cmake --build --preset conan-release --target rowEqVectors_benchmark --parallel 16
```

### Release Note

```text
Release Note:
- Optimized row=vector JIT key equality used by HashAggregation and HashJoin by passing decoded-vector runtime descriptors into generated IR.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)