### PR TITLE
fix(shuffle): expose peak bytes allocated

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -228,6 +228,14 @@ class BoltShuffleWriter : public ShuffleWriter {
 
   const uint64_t cachedPayloadSize() const override;
 
+  int64_t peakBytesAllocated() const {
+    auto peakBytes = boltPool_->peakBytes();
+    if (dynamic_cast<BoltArrowMemoryPool*>(pool_) == nullptr) {
+      peakBytes += pool_->max_memory();
+    }
+    return peakBytes;
+  }
+
   arrow::Status evictPartitionBuffers(uint32_t partitionId, bool reuseBuffers);
 
   int64_t rawPartitionBytes() const;
@@ -596,6 +604,7 @@ class BoltShuffleWriter : public ShuffleWriter {
         metrics_.rawPartitionLengths.begin(),
         metrics_.rawPartitionLengths.end(),
         0LL);
+    metrics_.peakBytes = peakBytesAllocated();
   }
 
   void logShuffleCheckStats(const char* writerType) const;

--- a/bolt/shuffle/sparksql/Options.h
+++ b/bolt/shuffle/sparksql/Options.h
@@ -206,6 +206,7 @@ struct ShuffleWriterMetrics {
   // total time for shuffle write, including split, evict, write, compress
   int64_t shuffleWriteTime{0};
   int64_t dataSize{0};
+  int64_t peakBytes{0};
   std::vector<int64_t> partitionLengths{};
   std::vector<int64_t> rawPartitionLengths{}; // Uncompressed size.
 };


### PR DESCRIPTION
 ### What problem does this PR solve?

 Bolt shuffle does not expose its peak allocated bytes independently, preventing Gluten from reporting the peak bytes allocated shuffle metric correctly.

 Issue Number: N/A

 ### Type of Change

 - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
 - [ ] ✨ New feature (non-breaking change which adds functionality)
 - [ ] 🚀 Performance improvement (optimization)
 - [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] 🔨 Refactoring (no logic changes)
 - [ ] 🔧 Build/CI or Infrastructure changes
 - [ ] 📝 Documentation only

 ### Description

 - Adds peakBytes to ShuffleWriterMetrics.
 - Captures the peak allocated bytes when finalizing shuffle writer metrics.
 - Uses the Bolt memory pool peak for shuffle offload.
 - Includes the existing Arrow memory pool peak for non-offload writers without adding separate Arrow peak tracking.
 - Avoids double counting when BoltArrowMemoryPool delegates allocations to the Bolt memory pool.
 - Keeps maxPartitionBufferSize semantics unchanged.

 Corresponding Gluten change: 99b883a370.

 ### Performance Impact

 - [x] No Impact: Peak memory is collected only when finalizing the shuffle writer and does not affect the per-row processing path.
 - [ ] Positive Impact: I have run benchmarks.
 - [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

 ### Release Note

 Release Note:

 ```text
   Release Note:
   - Exposed peak allocated bytes in Bolt shuffle writer metrics for Gluten integration.
 ```

 ### Checklist (For Author)

 - [ ] I have added/updated unit tests (ctest).
 - [x] I have verified the code with local build (Release).
 - [x] I have run clang-format / linters.
 - [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
 - [ ] No need to test or manual test.

 Additional validation:

 - Bolt Release native build passed.
 - Gluten Bolt native integration build passed.
 - The targeted Gluten shuffle peakBytes > 0 test passed.

 ### Breaking Changes

 - [x] No
 - [ ] Yes (Description: ...)
