### PR TITLE
feat(shuffle): add row-based threshold option

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -761,8 +761,10 @@ BoltColumnarBatchDeserializerFactory::createDeserializer(
   auto partitioning = toPartitioning(partitioningShortName_);
   bool isRowBased = supportAdaptiveShuffleWriter(partitioning) &&
       ((shuffleWriterType_ == ShuffleWriterType::Adaptive &&
-        numPartitions_ >= rowBasePartitionThreshold &&
-        schema_->num_fields() >= rowBaseColumnNumThreshold) ||
+        ((numPartitions_ >= rowBasePartitionThreshold &&
+          schema_->num_fields() >= rowBaseColumnNumThreshold) ||
+         static_cast<int64_t>(numPartitions_) * schema_->num_fields() >
+             rowBasedShuffleThreshold_)) ||
        (shuffleWriterType_ == ShuffleWriterType::RowBased));
   if (!zstdCodec_) {
     zstdCodec_ = std::make_shared<AdaptiveParallelZstdCodec>(
@@ -880,6 +882,7 @@ BoltShuffleReader::BoltShuffleReader(
   factory_->setpartitioningShortName(options.partitionShortName);
   factory_->setShuffleBufferSize(options.shuffleBufferSize);
   factory_->setRowFormat(options.rowFormat);
+  factory_->setRowBasedShuffleThreshold(options.rowBasedShuffleThreshold);
 }
 
 } // namespace bytedance::bolt::shuffle::sparksql

--- a/bolt/shuffle/sparksql/BoltShuffleReader.h
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.h
@@ -321,6 +321,10 @@ class BoltColumnarBatchDeserializerFactory {
     rowFormat_ = rowFormat;
   }
 
+  void setRowBasedShuffleThreshold(int64_t threshold) {
+    rowBasedShuffleThreshold_ = threshold;
+  }
+
  private:
   std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<Codec> codec_;
@@ -333,6 +337,7 @@ class BoltColumnarBatchDeserializerFactory {
   std::string partitioningShortName_;
   bytedance::bolt::row::RowFormat rowFormat_{
       bytedance::bolt::row::RowFormat::DENSE};
+  int64_t rowBasedShuffleThreshold_{kDefaultRowBasedShuffleThreshold};
   arrow::MemoryPool* memoryPool_;
   bytedance::bolt::memory::MemoryPool* boltPool_;
 

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -303,8 +303,10 @@ ShuffleWriterType decideBoltShuffleWriterType(
   ShuffleWriterType type = ShuffleWriterType::V1;
   if (supportAdaptive) {
     // for large partition number with multiple columns
-    if (numPartitions >= rowBasePartitionThreshold &&
-        numColumnsExludePid >= rowBaseColumnNumThreshold) {
+    if ((numPartitions >= rowBasePartitionThreshold &&
+         numColumnsExludePid >= rowBaseColumnNumThreshold) ||
+        static_cast<int64_t>(numPartitions) * numColumnsExludePid >
+            options.rowBasedShuffleThreshold) {
       type = ShuffleWriterType::RowBased;
       LOG(INFO) << __FUNCTION__ << ": forceShuffleWriterType = "
                 << options.forceShuffleWriterType

--- a/bolt/shuffle/sparksql/Options.h
+++ b/bolt/shuffle/sparksql/Options.h
@@ -66,7 +66,8 @@ static constexpr int32_t kDefaultAccumulateBatchMaxColumns =
     0; // default is close
 static constexpr int32_t kDefaultShuffleCheckMaxColumns =
     std::numeric_limits<int32_t>::max();
-
+static constexpr int64_t kDefaultRowBasedShuffleThreshold =
+    std::numeric_limits<int64_t>::max();
 static constexpr int32_t rowBasePartitionThreshold = 8000;
 static constexpr int32_t rowBaseColumnNumThreshold = 5;
 
@@ -113,6 +114,8 @@ struct ShuffleReaderOptions {
 
   // On-wire row format for the row-based shuffle. Must match the writer side.
   row::RowFormat rowFormat = row::RowFormat::COMPACT;
+
+  int64_t rowBasedShuffleThreshold = kDefaultRowBasedShuffleThreshold;
 
   // Enable checksum in codec for shuffle data corruption detection
   bool checksumEnabled = true;
@@ -180,6 +183,7 @@ struct ShuffleWriterOptions {
   double shuffleCheckRatio = 0;
   int32_t shuffleCheckMaxColumns = kDefaultShuffleCheckMaxColumns;
   row::RowFormat rowFormat = row::RowFormat::COMPACT;
+  int64_t rowBasedShuffleThreshold = kDefaultRowBasedShuffleThreshold;
   PartitionWriterOptions partitionWriterOptions{};
 };
 

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
@@ -81,8 +81,10 @@ SparkShuffleReader::SparkShuffleReader(
   auto partitioning = toPartitioning(partitioningShortName_);
   isRowBased_ = supportAdaptiveShuffleWriter(partitioning) &&
       ((shuffleWriterType_ == ShuffleWriterType::Adaptive &&
-        numPartitions_ >= rowBasePartitionThreshold &&
-        outputType_->size() >= rowBaseColumnNumThreshold) ||
+        ((numPartitions_ >= rowBasePartitionThreshold &&
+          outputType_->size() >= rowBaseColumnNumThreshold) ||
+         static_cast<int64_t>(numPartitions_) * outputType_->size() >
+             shuffleReaderOptions_.rowBasedShuffleThreshold)) ||
        (shuffleWriterType_ == ShuffleWriterType::RowBased));
   reuseBufferedInputStream_ = shuffleReaderOptions_.reuseBufferedInputStream;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Adaptive shuffle currently selects the row-based implementation only when both fixed thresholds are met: at least 8,000 partitions and at least 5 columns. This cannot represent workloads whose combined partition-column scale is large while either dimension remains below its fixed threshold.

This PR adds an opt-in product threshold so row-based shuffle can also be selected when `numPartitions * numColumns` exceeds a configurable value, while preserving the existing default behavior.

Issue Number: #853 

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Add `rowBasedShuffleThreshold` to both `ShuffleWriterOptions` and `ShuffleReaderOptions`.
- Preserve the existing adaptive selection rule:
  `numPartitions >= 8000 && numColumns >= 5`.
- Add an alternative rule that selects row-based shuffle when
  `numPartitions * numColumns > rowBasedShuffleThreshold`.
- Use `int64_t` for the product calculation to avoid 32-bit overflow.
- Apply the same selection logic to the writer, `SparkShuffleReader`, and `BoltColumnarBatchDeserializerFactory`.
- Propagate the reader option into the deserializer factory so the reader and writer make consistent wire-format decisions.
- Default the new threshold to `std::numeric_limits<int64_t>::max()`, disabling the new rule unless explicitly configured.

The writer and reader must be configured with the same threshold to ensure they agree on the shuffle wire format.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

The default configuration preserves the existing shuffle selection behavior. The additional multiplication and comparison occur during writer or reader initialization rather than per row. Configuring the new threshold intentionally changes which shuffle implementation is selected.

### Release Note

```text
Release Note:
- Added a configurable partition-column product threshold for adaptive row-based shuffle selection while preserving existing defaults.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)