### PR TITLE
fix: release scan resources after final split

### DIFF
--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -326,6 +326,11 @@ class DataSource {
     return kUnknownRowSize;
   }
 
+  // Releases memory retained by the final completed split after no-more-splits
+  // has been received. This is narrower than close(): it must not wait for
+  // unrelated asynchronous preload work or otherwise terminate the data source.
+  virtual void releaseFinalSplitResources() {}
+
   virtual void close() {}
 };
 

--- a/bolt/connectors/hive/HiveDataSource.h
+++ b/bolt/connectors/hive/HiveDataSource.h
@@ -110,12 +110,23 @@ class HiveDataSource : public DataSource {
       const bool isPartOfPaimonSplit);
 
   void close() override {
+    releaseSplitReader();
+  }
+
+  void releaseFinalSplitResources() override {
+    releaseSplitReader();
+  }
+
+ protected:
+  void releaseSplitReader() {
+    // Destroy the whole SplitReader. SplitReader::resetSplit() keeps
+    // baseRowReader_ alive for adaptation, but final-split cleanup needs to
+    // release the RowReader -> ReaderBase -> BufferedInput/PageReader chain.
     if (splitReader_) {
       splitReader_.reset();
     }
   }
 
- protected:
   // Creates a split reader, which reads the split given as param
   virtual std::unique_ptr<SplitReader> createSplitReader(
       const std::shared_ptr<HiveConnectorSplit>& split,

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -735,6 +735,37 @@ TEST_F(ParquetTableScanTest, countStar) {
   assertQuery(plan, {split}, "SELECT 20");
 }
 
+TEST_F(ParquetTableScanTest, scanAggregationWithFilePreload) {
+  const vector_size_t kSize = 256 * 1024;
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kSize, [](auto row) { return row; }),
+  });
+  auto file = TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->setConnectorSessionOverridesUnsafe(
+      kHiveConnectorId,
+      {{connector::hive::HiveConfig::kFilePreloadThreshold, "32MB"}});
+
+  auto plan = PlanBuilder(pool())
+                  .tableScan(asRowType(data->type()))
+                  .singleAggregation({}, {"sum(c0)"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = AssertQueryBuilder(plan)
+                    .split(makeSplit(file->getPath()))
+                    .queryCtx(queryCtx)
+                    .copyResults(pool(), task);
+
+  const auto expectedSum = static_cast<int64_t>(kSize - 1) * kSize / 2;
+  assertEqualResults(
+      {makeRowVector({makeFlatVector<int64_t>({expectedSum})})}, {result});
+  ASSERT_TRUE(task->isFinished());
+  EXPECT_GT(getRuntimeStat(task, "storageReadBytes"), 0);
+}
+
 TEST_F(ParquetTableScanTest, decimalSubfieldFilter) {
   // decimal.parquet holds two columns (a: DECIMAL(5, 2), b: DECIMAL(20, 5)) and
   // 20 rows (10 rows per group). Data is in plain uncompressed format:

--- a/bolt/exec/TableScan.cpp
+++ b/bolt/exec/TableScan.cpp
@@ -107,26 +107,64 @@ folly::dynamic TableScan::toJson() const {
   return ret;
 }
 
+void TableScan::mergeDataSourceRuntimeStats(bool logIoPattern) {
+  BOLT_CHECK_NOT_NULL(dataSource_);
+  curStatus_ = "updating dataSource runtime stats";
+  auto connectorStats = dataSource_->runtimeStats();
+  auto lockedStats = stats_.wlock();
+  if (logIoPattern && connectorStats.contains("rawBytesRead<4k")) {
+    LOG(INFO) << "IO pattern: "
+              << "totalBytesRead: "
+              << succinctBytes(connectorStats.at("rawBytesRead").value)
+              << ", totalScanTime: "
+              << succinctNanos(connectorStats.at("totalScanTime").value)
+              << ", totalMergeTime: "
+              << succinctNanos(connectorStats.at("totalMergeTime").value)
+              << ", readBytes < 4K: [scantime: "
+              << succinctNanos(connectorStats.at("totalTimeRead<4k").value)
+              << ", readCnt: " << connectorStats.at("cntRead<4k").value
+              << ", readBytes: "
+              << succinctBytes(connectorStats.at("rawBytesRead<4k").value)
+              << "]"
+              << ", 4k <= readBytes < 32K: [scantime: "
+              << succinctNanos(connectorStats.at("totalTimeRead<32k").value)
+              << ", readCnt: " << connectorStats.at("cntRead<32k").value
+              << ", readBytes: "
+              << succinctBytes(connectorStats.at("rawBytesRead<32k").value)
+              << "]"
+              << ", 32k <= readBytes < 128K: [scantime: "
+              << succinctNanos(connectorStats.at("totalTimeRead<128k").value)
+              << ", readCnt: " << connectorStats.at("cntRead<128k").value
+              << ", readBytes: "
+              << succinctBytes(connectorStats.at("rawBytesRead<128k").value)
+              << "]"
+              << ", readBytes >= 128K: [scantime: "
+              << succinctNanos(connectorStats.at("totalTimeRead>=128k").value)
+              << ", readCnt: " << connectorStats.at("cntRead>=128k").value
+              << ", readBytes: "
+              << succinctBytes(connectorStats.at("rawBytesRead>=128k").value)
+              << "]";
+  }
+  for (const auto& [name, counter] : connectorStats) {
+    if (name == "ioWaitWallNanos") {
+      ioWaitNanos_ += counter.value - lastIoWaitNanos_;
+      lastIoWaitNanos_ = counter.value;
+    }
+    if (UNLIKELY(!lockedStats->runtimeStats.contains(name))) {
+      lockedStats->runtimeStats.insert(
+          std::make_pair(name, RuntimeMetric(counter.unit)));
+    } else {
+      BOLT_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, counter.unit);
+    }
+    lockedStats->runtimeStats.at(name).addValue(counter.value);
+  }
+}
+
 OperatorStats TableScan::stats(bool clear) {
   if (!noMoreSplits_) {
     VLOG(1) << "get stats when there exist more splits!" << std::endl;
     if (dataSource_) {
-      curStatus_ = "getOutput: noMoreSplits_=1, updating stats_";
-      auto connectorStats = dataSource_->runtimeStats();
-      auto lockedStats = stats_.wlock();
-      for (const auto& [name, counter] : connectorStats) {
-        if (name == "ioWaitWallNanos") {
-          ioWaitNanos_ += counter.value - lastIoWaitNanos_;
-          lastIoWaitNanos_ = counter.value;
-        }
-        if (UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
-          lockedStats->runtimeStats.insert(
-              std::make_pair(name, RuntimeMetric(counter.unit)));
-        } else {
-          BOLT_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, counter.unit);
-        }
-        lockedStats->runtimeStats.at(name).addValue(counter.value);
-      }
+      mergeDataSourceRuntimeStats(false);
     }
   }
   return Operator::stats(clear);
@@ -201,59 +239,12 @@ RowVectorPtr TableScan::getOutput() {
         noMoreSplits_ = true;
         pendingDynamicFilters_.clear();
         if (dataSource_) {
-          curStatus_ = "getOutput: noMoreSplits_=1, updating stats_";
-          auto connectorStats = dataSource_->runtimeStats();
-          auto lockedStats = stats_.wlock();
-          if (connectorStats.count("rawBytesRead<4k") > 0) {
-            LOG(INFO)
-                << "IO pattern: "
-                << "totalBytesRead: "
-                << succinctBytes(connectorStats.at("rawBytesRead").value)
-                << ", totalScanTime: "
-                << succinctNanos(connectorStats.at("totalScanTime").value)
-                << ", totalMergeTime: "
-                << succinctNanos(connectorStats.at("totalMergeTime").value)
-                << ", readBytes < 4K: [scantime: "
-                << succinctNanos(connectorStats.at("totalTimeRead<4k").value)
-                << ", readCnt: " << connectorStats.at("cntRead<4k").value
-                << ", readBytes: "
-                << succinctBytes(connectorStats.at("rawBytesRead<4k").value)
-                << "]"
-                << ", 4k <= readBytes < 32K: [scantime: "
-                << succinctNanos(connectorStats.at("totalTimeRead<32k").value)
-                << ", readCnt: " << connectorStats.at("cntRead<32k").value
-                << ", readBytes: "
-                << succinctBytes(connectorStats.at("rawBytesRead<32k").value)
-                << "]"
-                << ", 32k <= readBytes < 128K: [scantime: "
-                << succinctNanos(connectorStats.at("totalTimeRead<128k").value)
-                << ", readCnt: " << connectorStats.at("cntRead<128k").value
-                << ", readBytes: "
-                << succinctBytes(connectorStats.at("rawBytesRead<128k").value)
-                << "]"
-                << ", readBytes >= 128K: [scantime: "
-                << succinctNanos(connectorStats.at("totalTimeRead>=128k").value)
-                << ", readCnt: " << connectorStats.at("cntRead>=128k").value
-                << ", readBytes: "
-                << succinctBytes(connectorStats.at("rawBytesRead>=128k").value)
-                << "]";
-          }
-          for (const auto& [name, counter] : connectorStats) {
-            if (name == "ioWaitWallNanos") {
-              ioWaitNanos_ += counter.value - lastIoWaitNanos_;
-              lastIoWaitNanos_ = counter.value;
-            }
-            if (UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
-              lockedStats->runtimeStats.insert(
-                  std::make_pair(name, RuntimeMetric(counter.unit)));
-            } else {
-              BOLT_CHECK_EQ(
-                  lockedStats->runtimeStats.at(name).unit, counter.unit);
-            }
-            lockedStats->runtimeStats.at(name).addValue(counter.value);
-          }
-          lockedStats->addRuntimeStat(
-              "dynamicConcurrency", RuntimeCounter(this->getConcurrency()));
+          mergeDataSourceRuntimeStats(true);
+          stats_.wlock()->addRuntimeStat(
+              "dynamicConcurrency", RuntimeCounter(getConcurrency()));
+          // The final split has already finished. Release scan reader/input
+          // buffers before downstream operators enter final output processing.
+          dataSource_->releaseFinalSplitResources();
         }
         return nullptr;
       }

--- a/bolt/exec/TableScan.h
+++ b/bolt/exec/TableScan.h
@@ -104,6 +104,8 @@ class TableScan : public SourceOperator {
 
   void estimateBytesPerRow(const std::optional<RowVectorPtr>& dataOptional);
 
+  void mergeDataSourceRuntimeStats(bool logIoPattern);
+
   // Process-wide IO wait time.
   static std::atomic<uint64_t> ioWaitNanos_;
 

--- a/bolt/exec/tests/AsyncConnectorTest.cpp
+++ b/bolt/exec/tests/AsyncConnectorTest.cpp
@@ -43,6 +43,13 @@ namespace {
 
 const std::string kTestConnectorId = "test";
 
+struct TestDataSourceStats {
+  int releaseFinalSplitResourcesCalls{0};
+  int closeCalls{0};
+};
+
+TestDataSourceStats testDataSourceStats;
+
 class TestTableHandle : public connector::ConnectorTableHandle {
  public:
   TestTableHandle() : connector::ConnectorTableHandle(kTestConnectorId) {}
@@ -89,7 +96,8 @@ class TestSplit : public connector::ConnectorSplit {
 
 class TestDataSource : public connector::DataSource {
  public:
-  explicit TestDataSource(memory::MemoryPool* pool) : pool_{pool} {}
+  TestDataSource(memory::MemoryPool* pool, TestDataSourceStats* stats)
+      : pool_{pool}, stats_{stats} {}
 
   void addSplit(std::shared_ptr<connector::ConnectorSplit> split) override {
     auto testSplit = std::dynamic_pointer_cast<TestSplit>(split);
@@ -142,15 +150,29 @@ class TestDataSource : public connector::DataSource {
     return {};
   }
 
+  void releaseFinalSplitResources() override {
+    ++stats_->releaseFinalSplitResourcesCalls;
+  }
+
+  void close() override {
+    ++stats_->closeCalls;
+    BOLT_CHECK_GT(
+        stats_->releaseFinalSplitResourcesCalls,
+        0,
+        "close must not run before no-more-splits resource release");
+  }
+
  private:
   memory::MemoryPool* pool_;
+  TestDataSourceStats* const stats_;
   bool needSplit_{true};
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 };
 
 class TestConnector : public connector::Connector {
  public:
-  TestConnector(const std::string& id) : connector::Connector(id) {}
+  TestConnector(const std::string& id, TestDataSourceStats* stats)
+      : connector::Connector(id), stats_{stats} {}
 
   std::unique_ptr<connector::DataSource> createDataSource(
       const RowTypePtr& /* outputType */,
@@ -160,7 +182,8 @@ class TestConnector : public connector::Connector {
           std::shared_ptr<connector::ColumnHandle>>& /* columnHandles */,
       std::shared_ptr<ConnectorQueryCtx> connectorQueryCtx,
       const core::QueryConfig& /* queryConfig */) override {
-    return std::make_unique<TestDataSource>(connectorQueryCtx->memoryPool());
+    return std::make_unique<TestDataSource>(
+        connectorQueryCtx->memoryPool(), stats_);
   }
 
   std::unique_ptr<connector::DataSink> createDataSink(
@@ -172,6 +195,9 @@ class TestConnector : public connector::Connector {
       const core::QueryConfig& /*queryConfig*/) override final {
     BOLT_NYI();
   }
+
+ private:
+  TestDataSourceStats* const stats_;
 };
 
 class TestConnectorFactory : public connector::ConnectorFactory {
@@ -184,7 +210,7 @@ class TestConnectorFactory : public connector::ConnectorFactory {
       const std::string& id,
       std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* /* executor */) override {
-    return std::make_shared<TestConnector>(id);
+    return std::make_shared<TestConnector>(id, &testDataSourceStats);
   }
 
   std::shared_ptr<Connector> newConnector(
@@ -204,6 +230,7 @@ class AsyncConnectorTest : public OperatorTestBase {
  public:
   void SetUp() override {
     OperatorTestBase::SetUp();
+    testDataSourceStats = {};
     connector::registerConnectorFactory(
         std::make_shared<TestConnectorFactory>());
     auto testConnector =
@@ -218,7 +245,13 @@ class AsyncConnectorTest : public OperatorTestBase {
 
   void TearDown() override {
     connector::unregisterConnector(kTestConnectorId);
+    connector::unregisterConnectorFactory(
+        TestConnectorFactory::kTestConnectorName);
     OperatorTestBase::TearDown();
+  }
+
+  TestDataSourceStats& stats() {
+    return testDataSourceStats;
   }
 };
 
@@ -250,6 +283,22 @@ TEST_F(AsyncConnectorTest, basic) {
     const auto& scanStats = stats.at(scanId);
     ASSERT_GT(scanStats.blockedWallNanos, 0);
   }
+}
+
+TEST_F(AsyncConnectorTest, releaseFinalSplitResourcesBeforeClose) {
+  auto tableHandle = std::make_shared<TestTableHandle>();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(ROW({"a"}, {BIGINT()}))
+                  .tableHandle(tableHandle)
+                  .endTableScan()
+                  .singleAggregation({}, {"min(a)"})
+                  .planNode();
+
+  assertQuery(plan, {std::make_shared<TestSplit>(0)}, "SELECT 0");
+
+  EXPECT_EQ(stats().releaseFinalSplitResourcesCalls, 1);
+  EXPECT_EQ(stats().closeCalls, 1);
 }
 
 } // namespace bytedance::bolt::exec::test


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Release scan resources after final split.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

TableScan kept the final split reader alive until the whole driver closed. In scan + aggregation pipelines, this left Parquet reader/input buffers retained while the aggregation entered final output processing, so the task-level peak could include both scan-retained memory and the aggregation output spike.

Merge DataSource runtime stats before releasing resources, then close the DataSource as soon as TableScan observes no-more-splits. For Hive/Parquet this resets the split reader and releases the base row reader, ReaderBase, BufferedInput, and PageReader chain without closing the SourceOperator early. The final TableScan::close path remains idempotent.

Add a Parquet scan + aggregation coverage case with file preload enabled to verify results and scan stats remain valid after the early release path.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
