### PR TITLE
[fix] Add specific errors for ignorable corrupt files

### DIFF
--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -71,11 +71,6 @@ namespace {
   return algo;
 }
 
-// Schema-mismatch checks for ReaderBase::convertType.
-constexpr const char* kTypeMappingErrorFmtStr =
-    "ParquetReader::convertType() cannot convert column. "
-    "Column: [{}], From Kind: {}, To Kind: {}";
-
 std::string parquetSourceTypeName(const thrift::SchemaElement& schemaElement) {
   if (schemaElement.__isset.converted_type) {
     return fmt::format(
@@ -1080,7 +1075,8 @@ TypePtr ReaderBase::convertType(
             isCompatibleFunc(requestedType->asArray().elementType());
         if (!(strictMatch || unannotatedArrayMatch)) {
           BOLT_SCHEMA_MISMATCH_ERROR(fmt::format(
-              kTypeMappingErrorFmtStr,
+              "{} Column: [{}], From Kind: {}, To Kind: {}",
+              kParquetTypeMappingErrorPrefix,
               schemaElement.name,
               parquetSourceTypeName(schemaElement),
               mapTypeKindToName(requestedType->kind())));

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -73,7 +73,8 @@ namespace {
 
 // Schema-mismatch checks for ReaderBase::convertType.
 constexpr const char* kTypeMappingErrorFmtStr =
-    "Schema mismatch, Column: [{}], From Kind: {}, To Kind: {}";
+    "ParquetReader::convertType() cannot convert column. "
+    "Column: [{}], From Kind: {}, To Kind: {}";
 
 std::string parquetSourceTypeName(const thrift::SchemaElement& schemaElement) {
   if (schemaElement.__isset.converted_type) {

--- a/bolt/dwio/parquet/reader/ParquetReader.h
+++ b/bolt/dwio/parquet/reader/ParquetReader.h
@@ -48,6 +48,9 @@ class BufferedInput;
 } // namespace bytedance::bolt::dwio::common
 namespace bytedance::bolt::parquet {
 
+inline constexpr const char* kParquetTypeMappingErrorPrefix =
+    "ParquetReader::convertType() cannot convert column.";
+
 enum class ParquetMetricsType { HEADER, FILE_METADATA, FILE, BLOCK, TEST };
 
 class StructColumnReader;

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -673,7 +673,9 @@ TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
             {SMALLINT(), INTEGER(), INTEGER(), uint64Type});
     dwio::common::ReaderOptions readerOptions{leafPool_.get()};
     readerOptions.setFileSchema(rowType);
-    BOLT_ASSERT_THROW(createReader(sample, readerOptions), "Schema mismatch");
+    BOLT_ASSERT_THROW(
+        createReader(sample, readerOptions),
+        "ParquetReader::convertType() cannot convert column.");
   }
 }
 #endif

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -674,8 +674,7 @@ TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
     dwio::common::ReaderOptions readerOptions{leafPool_.get()};
     readerOptions.setFileSchema(rowType);
     BOLT_ASSERT_THROW(
-        createReader(sample, readerOptions),
-        "ParquetReader::convertType() cannot convert column.");
+        createReader(sample, readerOptions), kParquetTypeMappingErrorPrefix);
   }
 }
 #endif

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1635,7 +1635,7 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     // Override when a case is rejected by a later layer with a
     // different message (e.g. ParquetColumnReader::matchType in
     // non-Spark builds).
-    const char* errMsg = "ParquetReader::convertType() cannot convert column.";
+    const char* errMsg = kParquetTypeMappingErrorPrefix;
   };
 
   // clang-format off

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1631,12 +1631,11 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     bool shouldThrow;
     // Substring to match against the thrown error. Defaults to the
     // BoltUserError raised by ReaderBase::convertType via
-    // BOLT_SCHEMA_MISMATCH_ERROR (same error code as DWRF/ORC, same
-    // "Schema mismatch, ..., From Kind: X, To Kind: Y" layout).
+    // BOLT_SCHEMA_MISMATCH_ERROR with a Parquet-specific stable prefix.
     // Override when a case is rejected by a later layer with a
     // different message (e.g. ParquetColumnReader::matchType in
     // non-Spark builds).
-    const char* errMsg = "Schema mismatch";
+    const char* errMsg = "ParquetReader::convertType() cannot convert column.";
   };
 
   // clang-format off

--- a/bolt/type/filter/FilterBase.h
+++ b/bolt/type/filter/FilterBase.h
@@ -39,6 +39,9 @@
 
 namespace bytedance::bolt::common {
 
+inline constexpr const char* kBigintRangeTestBytesRangeErrorPrefix =
+    "BigintRange::testBytesRange() is not supported.";
+
 enum class FilterKind {
   kAlwaysFalse,
   kAlwaysTrue,
@@ -915,8 +918,7 @@ class BigintRange final : public Filter {
       std::optional<std::string_view> /*max*/,
       bool /*hasNull*/) const final {
     BOLT_UNSUPPORTED(
-        "BigintRange::testBytesRange() is not supported. Filter: {}",
-        toString());
+        "{} Filter: {}", kBigintRangeTestBytesRangeErrorPrefix, toString());
   }
 
   int64_t lower() const {

--- a/bolt/type/filter/FilterBase.h
+++ b/bolt/type/filter/FilterBase.h
@@ -910,6 +910,15 @@ class BigintRange final : public Filter {
     return !(min > upper_ || max < lower_);
   }
 
+  bool testBytesRange(
+      std::optional<std::string_view> /*min*/,
+      std::optional<std::string_view> /*max*/,
+      bool /*hasNull*/) const final {
+    BOLT_UNSUPPORTED(
+        "BigintRange::testBytesRange() is not supported. Filter: {}",
+        toString());
+  }
+
   int64_t lower() const {
     return lower_;
   }

--- a/bolt/type/tests/FilterTest.cpp
+++ b/bolt/type/tests/FilterTest.cpp
@@ -240,7 +240,8 @@ TEST(FilterTest, bigintRangeUnsupportedBytesRange) {
       const std::string message = e.what();
       EXPECT_NE(
           message.find(
-              "BigintRange::testBytesRange() is not supported. Filter: "),
+              std::string(common::kBigintRangeTestBytesRangeErrorPrefix) +
+              " Filter: "),
           std::string::npos);
       EXPECT_NE(message.find(filter->toString()), std::string::npos);
     }

--- a/bolt/type/tests/FilterTest.cpp
+++ b/bolt/type/tests/FilterTest.cpp
@@ -226,6 +226,27 @@ TEST(FilterTest, bigIntRange) {
   }
 }
 
+TEST(FilterTest, bigintRangeUnsupportedBytesRange) {
+  std::vector<std::unique_ptr<Filter>> filters;
+  filters.emplace_back(std::make_unique<BigintRange>(
+      1, std::numeric_limits<int64_t>::max(), false));
+  filters.emplace_back(std::make_unique<BigintRange>(-10, 10, true));
+
+  for (const auto& filter : filters) {
+    try {
+      filter->testBytesRange("a", "z", false);
+      FAIL() << "Expected testBytesRange() to throw";
+    } catch (const BoltException& e) {
+      const std::string message = e.what();
+      EXPECT_NE(
+          message.find(
+              "BigintRange::testBytesRange() is not supported. Filter: "),
+          std::string::npos);
+      EXPECT_NE(message.find(filter->toString()), std::string::npos);
+    }
+  }
+}
+
 TEST(FilterTest, negatedBigintRange) {
   auto filter = notEqual(1, false);
   EXPECT_FALSE(filter->testNull());


### PR DESCRIPTION
### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description
Java supports ignoring these cases when the `ignoreCorruptFile` flag is enabled, so Bolt needs to align with this behavior. Based on the current implementation of `ignoreCorruptFile` in Bolt, the error messages need to be made more precise.

- add a BigintRange-specific unsupported error for byte-range checks
- add a stable Parquet type-conversion error prefix
- update regression tests for both error paths


Test by following tests:
- `bolt_type_test`
- `bolt_dwio_parquet_reader_test`
- `bolt_dwio_parquet_table_scan_test`

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>