### PR TITLE
perf: skip clearing Parquet repdef lengths buffers

### DIFF
--- a/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionBenchmark.cpp
@@ -34,6 +34,7 @@
 #include <folly/init/Init.h>
 
 #include <algorithm>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <random>
@@ -315,7 +316,25 @@ class FusedLevelConversionBenchmark {
     return listOutput.values_read + structOutput.values_read;
   }
 
-  int64_t fused() {
+  int64_t directLengths(bool clearLengths) {
+    if (clearLengths) {
+      std::memset(lengths_.data(), 0, lengths_.size() * sizeof(lengths_[0]));
+    }
+    auto listOutput = makeOutput(listValidity_);
+    DefRepLevelsToListLengths(
+        levels_.definitions.data(),
+        levels_.repetitions.data(),
+        levels_.definitions.size(),
+        fusedListLevelInfo(),
+        &listOutput,
+        lengths_.data());
+    return listOutput.values_read;
+  }
+
+  int64_t fused(bool clearLengths = false) {
+    if (clearLengths) {
+      std::memset(lengths_.data(), 0, lengths_.size() * sizeof(lengths_[0]));
+    }
     auto listOutput = makeOutput(listValidity_);
     auto structOutput = makeOutput(structValidity_);
     const auto converted = DefRepLevelsToListLengthsAndStructBitmap(
@@ -545,6 +564,22 @@ void runLeafNulls(
   }
 }
 
+void runLengthsBufferClear(
+    uint32_t iters,
+    int32_t numLists,
+    FusedListShape shape,
+    bool fused,
+    bool clearLengths) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = fusedBenchmark(numLists, shape);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(
+        fused ? instance.fused(clearLengths)
+              : instance.directLengths(clearLengths));
+  }
+}
+
 } // namespace
 
 BENCHMARK(offsetsThenLengths_single, iters) {
@@ -620,6 +655,28 @@ LEAF_NULLS_BENCHMARK(1048576, kAllValidRepeated, allValidRepeated);
 LEAF_NULLS_BENCHMARK(4096, kMiddleNullRepeated, middleNullRepeated);
 LEAF_NULLS_BENCHMARK(65536, kMiddleNullRepeated, middleNullRepeated);
 LEAF_NULLS_BENCHMARK(1048576, kMiddleNullRepeated, middleNullRepeated);
+
+#define LENGTHS_BUFFER_CLEAR_BENCHMARK(size, shape, name)                    \
+  BENCHMARK(lengthsWithClear_##name##_##size, iters) {                       \
+    runLengthsBufferClear(iters, size, FusedListShape::shape, false, true);  \
+  }                                                                          \
+  BENCHMARK_RELATIVE(lengthsWithoutClear_##name##_##size, iters) {           \
+    runLengthsBufferClear(iters, size, FusedListShape::shape, false, false); \
+  }                                                                          \
+  BENCHMARK(fusedLengthsWithClear_##name##_##size, iters) {                  \
+    runLengthsBufferClear(iters, size, FusedListShape::shape, true, true);   \
+  }                                                                          \
+  BENCHMARK_RELATIVE(fusedLengthsWithoutClear_##name##_##size, iters) {      \
+    runLengthsBufferClear(iters, size, FusedListShape::shape, true, false);  \
+  }                                                                          \
+  BENCHMARK_DRAW_LINE()
+
+LENGTHS_BUFFER_CLEAR_BENCHMARK(4096, kSingleElement, single);
+LENGTHS_BUFFER_CLEAR_BENCHMARK(65536, kSingleElement, single);
+LENGTHS_BUFFER_CLEAR_BENCHMARK(4096, kMixed, mixed);
+LENGTHS_BUFFER_CLEAR_BENCHMARK(65536, kMixed, mixed);
+LENGTHS_BUFFER_CLEAR_BENCHMARK(4096, kLong, long);
+LENGTHS_BUFFER_CLEAR_BENCHMARK(65536, kLong, long);
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -352,7 +352,6 @@ void MapColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
   BufferPtr lengths = std::move(lengths_.lengths());
   dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs + 1, &memoryPool_);
-  memset(lengths->asMutable<uint64_t>(), 0, lengths->size());
   dwio::common::ensureCapacity<uint64_t>(
       nullsInReadRange_, bits::nwords(numRepDefs), &memoryPool_);
   auto numLists = pageReader.getLengthsAndNulls(
@@ -483,7 +482,6 @@ void ListColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
   BufferPtr lengths = std::move(lengths_.lengths());
   dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs + 1, &memoryPool_);
-  memset(lengths->asMutable<uint64_t>(), 0, lengths->size());
   dwio::common::ensureCapacity<uint64_t>(
       nullsInReadRange_, bits::nwords(numRepDefs), &memoryPool_);
   auto numLists = pageReader.getLengthsAndNulls(

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2910,6 +2910,70 @@ TEST_F(ParquetReaderTest, fusedLevelConversionTopLevelFilter) {
   EXPECT_EQ(totalRows, 2'000);
 }
 
+TEST_F(ParquetReaderTest, repDefLengthsExposeOnlyConvertedValues) {
+  constexpr int32_t kPoison = 0x5a5a5a5a;
+  const std::vector<int16_t> definitions = {0, 1, 2, 3, 4, 4, 2, 0};
+  const std::vector<int16_t> repetitions = {0, 0, 0, 0, 0, 1, 0, 0};
+  const std::vector<int32_t> expectedLengths = {0, 0, 0, 1, 2, 0, 0};
+
+  bytedance::bolt::parquet::arrow::LevelInfo listInfo;
+  listInfo.rep_level = 1;
+  listInfo.def_level = 3;
+  bytedance::bolt::parquet::arrow::LevelInfo structInfo;
+  structInfo.rep_level = 0;
+  structInfo.def_level = 1;
+
+  for (const bool fused : {false, true}) {
+    auto lengths = AlignedBuffer::allocate<int32_t>(
+        definitions.size() + 1, leafPool_.get());
+    std::fill_n(lengths->asMutable<int32_t>(), definitions.size() + 1, kPoison);
+
+    bytedance::bolt::parquet::arrow::ValidityBitmapInputOutput listOutput;
+    listOutput.values_read_upper_bound = definitions.size();
+    if (fused) {
+      bytedance::bolt::parquet::arrow::ValidityBitmapInputOutput structOutput;
+      structOutput.values_read_upper_bound = definitions.size();
+      ASSERT_TRUE(bytedance::bolt::parquet::arrow::
+                      DefRepLevelsToListLengthsAndStructBitmap(
+                          definitions.data(),
+                          repetitions.data(),
+                          definitions.size(),
+                          listInfo,
+                          structInfo,
+                          &listOutput,
+                          lengths->asMutable<int32_t>(),
+                          &structOutput));
+    } else {
+      bytedance::bolt::parquet::arrow::DefRepLevelsToListLengths(
+          definitions.data(),
+          repetitions.data(),
+          definitions.size(),
+          listInfo,
+          &listOutput,
+          lengths->asMutable<int32_t>());
+    }
+
+    ASSERT_EQ(listOutput.values_read, expectedLengths.size());
+    EXPECT_EQ(
+        std::vector<int32_t>(
+            lengths->as<int32_t>(),
+            lengths->as<int32_t>() + listOutput.values_read),
+        expectedLengths);
+    for (auto i = listOutput.values_read;
+         i < static_cast<int64_t>(definitions.size() + 1);
+         ++i) {
+      EXPECT_EQ(lengths->as<int32_t>()[i], kPoison);
+    }
+
+    lengths->setSize(listOutput.values_read * sizeof(int32_t));
+    RepeatedLengths repeatedLengths;
+    repeatedLengths.setLengths(std::move(lengths));
+    std::vector<int32_t> consumed(definitions.size() + 1, kPoison);
+    repeatedLengths.readLengths(consumed.data(), consumed.size());
+    EXPECT_EQ(consumed, std::vector<int32_t>({0, 0, 0, 1, 2, 0, 0, 0, 0}));
+  }
+}
+
 TEST_F(ParquetReaderTest, readVariantParquet) {
   const std::string sample(getVariantFixturePath("variant_sample.parquet"));
 


### PR DESCRIPTION
## Summary

- Remove the full-buffer `memset` before List/Map rep/def length conversion.
- Keep the existing `setSize(values_read * sizeof(int32_t))` boundary, since direct and fused conversion write every length in `[0, values_read)`.
- Add a poisoned-tail regression test covering direct and fused conversion. It verifies the unwritten tail is not modified and cannot be observed after the buffer is resized.
- Add clear-vs-no-clear microbenchmarks using the same stable-state visible buffer size as the reader.

## Performance

Release build, 64K lists, multiple runs:

| Shape | Direct | Fused |
| --- | ---: | ---: |
| Single element | 3.8%-4.5% faster | 2.5%-3.0% faster |
| Mixed | 0.3%-0.7% faster | 0.3%-0.5% faster |
| Long | 0.2%-0.5% faster | 0.3%-0.4% faster |

## Validation

- `ParquetReaderTest.repDefLengthsExposeOnlyConvertedValues`
- Full `bolt_dwio_parquet_reader_test`
- Direct/fused list-length conversion tests, including randomized fixed-seed and upper-bound cases
- `clang-format-14 --dry-run --Werror`
- `git diff --check`