### PR TITLE
fix: release hash aggregation rows during output

### DIFF
--- a/bolt/common/base/AggregationStats.h
+++ b/bolt/common/base/AggregationStats.h
@@ -26,6 +26,7 @@ struct AggregationStats {
   uint64_t aggExtractGroupsTimeNs{0};
   uint64_t aggOutputUniqueRows{0};
   uint64_t aggOutputTimeNs{0};
+  uint64_t aggOutputReleasedBytes{0};
   uint64_t aggProbeBypassTimeNs{0};
   uint64_t aggProbeBypassCount{0};
 };

--- a/bolt/common/memory/AllocationPool.cpp
+++ b/bolt/common/memory/AllocationPool.cpp
@@ -36,6 +36,9 @@ namespace bytedance::bolt::memory {
 
 folly::Range<char*> AllocationPool::rangeAt(int32_t index) const {
   if (index < allocations_.size()) {
+    if (allocationStates_[index].released) {
+      return folly::Range<char*>(static_cast<char*>(nullptr), size_t{0});
+    }
     auto run = allocations_[index].runAt(0);
     return folly::Range<char*>(
         run.data<char>(),
@@ -43,6 +46,9 @@ folly::Range<char*> AllocationPool::rangeAt(int32_t index) const {
   }
   const auto largeIndex = index - allocations_.size();
   if (largeIndex < largeAllocations_.size()) {
+    if (largeAllocationStates_[largeIndex].released) {
+      return folly::Range<char*>(static_cast<char*>(nullptr), size_t{0});
+    }
     auto range = largeAllocations_[largeIndex].hugePageRange().value();
     if (range.data() == startOfRun_) {
       return folly::Range<char*>(range.data(), currentOffset_);
@@ -55,10 +61,14 @@ folly::Range<char*> AllocationPool::rangeAt(int32_t index) const {
 void AllocationPool::clear() {
   allocations_.clear();
   largeAllocations_.clear();
+  allocationStates_.clear();
+  largeAllocationStates_.clear();
   startOfRun_ = nullptr;
   bytesInRun_ = 0;
   currentOffset_ = 0;
   usedBytes_ = 0;
+  currentRunIsLarge_ = false;
+  largeRunsStarted_ = false;
 }
 
 char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
@@ -69,6 +79,7 @@ char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
     if (currentOffset_ > endOfReservedRun()) {
       growLastAllocation();
     }
+    recordAllocation();
     return result;
   }
   BOLT_CHECK_EQ(
@@ -92,7 +103,44 @@ char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
   if (currentOffset_ > endOfReservedRun()) {
     growLastAllocation();
   }
+  recordAllocation();
   return result;
+}
+
+AllocationPool::ReleasedRangeStats AllocationPool::releaseRangesBefore(
+    int32_t rangeIndex) {
+  rangeIndex = std::min(rangeIndex, numRanges());
+  ReleasedRangeStats stats;
+  const auto numSmallRanges = static_cast<int32_t>(allocations_.size());
+  for (auto i = 0; i < std::min(rangeIndex, numSmallRanges); ++i) {
+    if (allocationStates_[i].released) {
+      continue;
+    }
+    stats.bytes += allocations_[i].byteSize();
+    stats.allocations += allocationStates_[i].allocations;
+    pool_->freeNonContiguous(allocations_[i]);
+    allocationStates_[i].released = true;
+  }
+
+  const auto largeEnd = std::max<int32_t>(0, rangeIndex - numSmallRanges);
+  const auto numLargeRanges = static_cast<int32_t>(largeAllocations_.size());
+  for (auto i = 0; i < std::min(largeEnd, numLargeRanges); ++i) {
+    if (largeAllocationStates_[i].released) {
+      continue;
+    }
+    stats.bytes += largeAllocations_[i].size();
+    stats.allocations += largeAllocationStates_[i].allocations;
+    pool_->freeContiguous(largeAllocations_[i]);
+    largeAllocationStates_[i].released = true;
+  }
+  usedBytes_ -= stats.bytes;
+  if (rangeIndex == numRanges()) {
+    startOfRun_ = nullptr;
+    bytesInRun_ = 0;
+    currentOffset_ = 0;
+    currentRunIsLarge_ = false;
+  }
+  return stats;
 }
 
 void AllocationPool::growLastAllocation() {
@@ -104,7 +152,7 @@ void AllocationPool::growLastAllocation() {
 }
 
 void AllocationPool::newRunImpl(MachinePageCount numPages) {
-  if (usedBytes_ >= hugePageThreshold_ ||
+  if (largeRunsStarted_ || usedBytes_ >= hugePageThreshold_ ||
       numPages > pool_->sizeClasses().back()) {
     // At least 16 huge pages, no more than kMaxMmapBytes. The next is
     // double the previous. Because the previous is a hair under the
@@ -138,7 +186,10 @@ void AllocationPool::newRunImpl(MachinePageCount numPages) {
     startOfRun_ = range.data();
     bytesInRun_ = range.size();
     largeAllocations_.emplace_back(std::move(largeAlloc));
+    largeAllocationStates_.emplace_back();
     currentOffset_ = 0;
+    currentRunIsLarge_ = true;
+    largeRunsStarted_ = true;
     usedBytes_ += AllocationTraits::pageBytes(pagesToAlloc);
     return;
   }
@@ -150,12 +201,22 @@ void AllocationPool::newRunImpl(MachinePageCount numPages) {
   startOfRun_ = allocation.runAt(0).data<char>();
   bytesInRun_ = allocation.runAt(0).numBytes();
   currentOffset_ = 0;
+  currentRunIsLarge_ = false;
   allocations_.push_back(std::move(allocation));
+  allocationStates_.emplace_back();
   usedBytes_ += bytesInRun_;
 }
 
 void AllocationPool::newRun(int64_t preferredSize) {
   newRunImpl(AllocationTraits::numPages(preferredSize));
+}
+
+void AllocationPool::recordAllocation() {
+  if (currentRunIsLarge_) {
+    ++largeAllocationStates_.back().allocations;
+  } else {
+    ++allocationStates_.back().allocations;
+  }
 }
 
 } // namespace bytedance::bolt::memory

--- a/bolt/common/memory/AllocationPool.h
+++ b/bolt/common/memory/AllocationPool.h
@@ -43,6 +43,11 @@ class AllocationPool {
  public:
   static constexpr int32_t kMinPages = 16;
 
+  struct ReleasedRangeStats {
+    uint64_t bytes{0};
+    uint64_t allocations{0};
+  };
+
   explicit AllocationPool(memory::MemoryPool* pool) : pool_(pool) {}
 
   ~AllocationPool() {
@@ -69,6 +74,10 @@ class AllocationPool {
   /// distance from start to first byte after last allocation.
   folly::Range<char*> rangeAt(int32_t index) const;
 
+  /// Releases all complete ranges before 'rangeIndex'. Range indexes stay
+  /// stable: released ranges remain addressable as empty ranges.
+  ReleasedRangeStats releaseRangesBefore(int32_t rangeIndex);
+
   int64_t currentOffset() const {
     return currentOffset_;
   }
@@ -79,7 +88,7 @@ class AllocationPool {
 
   /// Returns the number of bytes allocatable without growing 'this'.
   int64_t freeBytes() const {
-    if (largeAllocations_.empty()) {
+    if (!currentRunIsLarge_) {
       return freeAddressableBytes();
     }
     return largeAllocations_.back().size() - currentOffset_;
@@ -132,7 +141,7 @@ class AllocationPool {
   // to 'bytesInRun_' ut they are not marked used by the
   // pool/allocator. So use growContiguous() to update this.
   int64_t endOfReservedRun() {
-    if (largeAllocations_.empty()) {
+    if (!currentRunIsLarge_) {
       return bytesInRun_;
     }
     return largeAllocations_.back().size();
@@ -151,9 +160,18 @@ class AllocationPool {
 
   void newRunImpl(memory::MachinePageCount numPages);
 
+  void recordAllocation();
+
+  struct RangeState {
+    uint64_t allocations{0};
+    bool released{false};
+  };
+
   memory::MemoryPool* pool_;
   std::vector<memory::Allocation> allocations_;
   std::vector<memory::ContiguousAllocation> largeAllocations_;
+  std::vector<RangeState> allocationStates_;
+  std::vector<RangeState> largeAllocationStates_;
 
   // Points to the start of the run from which allocations are being nade.
   char* startOfRun_{nullptr};
@@ -168,6 +186,8 @@ class AllocationPool {
   // Total space returned to users. Size of allocations can be larger specially
   // if mmapped in advance of use.
   int64_t usedBytes_{0};
+  bool currentRunIsLarge_{false};
+  bool largeRunsStarted_{false};
 
   // Start using large mmaps with huge pages after 'usedBytes_' exceeds this.
   int64_t hugePageThreshold_{kDefaultHugePageThreshold};

--- a/bolt/common/memory/tests/AllocationPoolTest.cpp
+++ b/bolt/common/memory/tests/AllocationPoolTest.cpp
@@ -121,3 +121,30 @@ TEST_F(AllocationPoolTest, hugePages) {
   // Should be empty after destruction.
   EXPECT_EQ(0, pool_->currentBytes());
 }
+
+TEST_F(AllocationPoolTest, releaseRangesBefore) {
+  auto allocationPool = std::make_unique<memory::AllocationPool>(pool_.get());
+  allocationPool->setHugePageThreshold(1 << 20);
+
+  allocationPool->allocateFixed(64 << 10);
+  allocationPool->allocateFixed(1);
+  ASSERT_EQ(2, allocationPool->numRanges());
+
+  const auto bytesBeforeRelease = pool_->currentBytes();
+  auto released = allocationPool->releaseRangesBefore(1);
+  EXPECT_EQ(1, released.allocations);
+  EXPECT_GT(released.bytes, 0);
+  EXPECT_LT(pool_->currentBytes(), bytesBeforeRelease);
+
+  released = allocationPool->releaseRangesBefore(1);
+  EXPECT_EQ(0, released.allocations);
+  EXPECT_EQ(0, released.bytes);
+
+  released = allocationPool->releaseRangesBefore(allocationPool->numRanges());
+  EXPECT_EQ(1, released.allocations);
+  EXPECT_GT(released.bytes, 0);
+  EXPECT_EQ(0, pool_->currentBytes());
+
+  allocationPool->clear();
+  EXPECT_EQ(0, pool_->currentBytes());
+}

--- a/bolt/exec/GroupingSet.cpp
+++ b/bolt/exec/GroupingSet.cpp
@@ -808,6 +808,14 @@ bool GroupingSet::getOutput(
 #elif defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
+  if (noMoreInput_ && !outputTableReleased_) {
+    const auto releasedBytes = table_ ? table_->releaseTable() : 0;
+    if (releasedBytes > 0) {
+      stats_.aggOutputReleasedBytes += releasedBytes;
+      pool_.release();
+    }
+    outputTableReleased_ = true;
+  }
   const int32_t numGroups = table_
       ? table_->rows()->listRows(
             &iterator, maxOutputRows, maxOutputBytes, groups)
@@ -822,6 +830,16 @@ bool GroupingSet::getOutput(
     extractGroupsInRowFormat(folly::Range<char**>(groups, numGroups), result);
   } else {
     extractGroups(folly::Range<char**>(groups, numGroups), result);
+    if (noMoreInput_ && sortedAggregations_ == nullptr) {
+      auto* rows = table_->rows();
+      const auto releasedBytes = rows->releaseOutputRangesBefore(iterator);
+      if (releasedBytes > 0) {
+        stats_.aggOutputReleasedBytes += releasedBytes;
+        // Free the reservation that only made sense while these output rows
+        // were still retained by the aggregation.
+        pool_.release();
+      }
+    }
   }
   return true;
 }

--- a/bolt/exec/GroupingSet.h
+++ b/bolt/exec/GroupingSet.h
@@ -486,6 +486,7 @@ class GroupingSet {
   const bool isAdaptive_;
 
   bool noMoreInput_{false};
+  bool outputTableReleased_{false};
 
   // In case of partial streaming aggregation, the input vector passed to
   // addInput(). A set of rows that belong to the last group of pre-grouped

--- a/bolt/exec/HashTable.cpp
+++ b/bolt/exec/HashTable.cpp
@@ -877,6 +877,22 @@ void HashTable<ignoreNullKeys>::clear() {
 }
 
 template <bool ignoreNullKeys>
+uint64_t HashTable<ignoreNullKeys>::releaseTable() {
+  if (table_ == nullptr) {
+    return 0;
+  }
+  const auto releasedBytes = tableAllocation_.size();
+  rows_->pool()->freeContiguous(tableAllocation_);
+  table_ = nullptr;
+  capacity_ = 0;
+  sizeMask_ = 0;
+  bucketOffsetMask_ = 0;
+  numBuckets_ = 0;
+  numTombstones_ = 0;
+  return releasedBytes;
+}
+
+template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::checkSize(
     int32_t numNew,
     bool initNormalizedKeys) {

--- a/bolt/exec/HashTable.h
+++ b/bolt/exec/HashTable.h
@@ -321,6 +321,10 @@ class BaseHashTable {
   /// be used for flushing a partial group by, for example.
   virtual void clear() = 0;
 
+  /// Releases the hash lookup table while keeping payload rows intact. This is
+  /// used by final aggregation output after all input has been processed.
+  virtual uint64_t releaseTable() = 0;
+
   /// Returns the capacity of the internal hash table which is number of rows
   /// it can stores in a group by or hash join build.
   virtual uint64_t capacity() const = 0;
@@ -656,6 +660,8 @@ class HashTable : public BaseHashTable {
       char** rows) override;
 
   void clear() override;
+
+  uint64_t releaseTable() override;
 
   void directAddRows(
       HashLookup& lookup,

--- a/bolt/exec/Operator.cpp
+++ b/bolt/exec/Operator.cpp
@@ -809,6 +809,13 @@ void Operator::recordGroupingSetStats(const common::AggregationStats& stats) {
         RuntimeCounter{
             (int64_t)stats.aggOutputTimeNs, RuntimeCounter::Unit::kNanos});
   }
+  if (stats.aggOutputReleasedBytes) {
+    lockedStats->addRuntimeStat(
+        "aggOutputReleasedBytes",
+        RuntimeCounter{
+            (int64_t)stats.aggOutputReleasedBytes,
+            RuntimeCounter::Unit::kBytes});
+  }
   if (stats.aggProbeTimeNs) {
     lockedStats->addRuntimeStat(
         "aggProbeTimeNs",

--- a/bolt/exec/RowContainer.cpp
+++ b/bolt/exec/RowContainer.cpp
@@ -445,6 +445,19 @@ int32_t RowContainer::findRows(folly::Range<char**> rows, char** result) {
   return numRows;
 }
 
+uint64_t RowContainer::releaseOutputRangesBefore(
+    const RowContainerIterator& iterator) {
+  if (!supportsOutputRangeRelease()) {
+    return 0;
+  }
+  const auto released = rows_.releaseRangesBefore(iterator.allocationIndex);
+  BOLT_CHECK_LE(released.allocations, numRows_);
+  numRows_ -= released.allocations;
+  numRowsWithNormalizedKey_ -=
+      std::min<int64_t>(numRowsWithNormalizedKey_, released.allocations);
+  return released.bytes;
+}
+
 void RowContainer::eraseRowsSkippingKeys(folly::Range<char**> rows) {
   for (auto i = 0; i < types_.size(); ++i) {
     if (i < keyTypes_.size()) {

--- a/bolt/exec/RowContainer.h
+++ b/bolt/exec/RowContainer.h
@@ -583,6 +583,10 @@ class RowContainer {
         (iter->normalizedKeysLeft > 0 ? originalNormalizedKeySize_ : 0);
     for (auto i = iter->allocationIndex; i < numAllocations; ++i) {
       auto range = rows_.rangeAt(i);
+      if (range.empty()) {
+        iter->rowOffset = 0;
+        continue;
+      }
       auto* data =
           range.data() + memory::alignmentPadding(range.data(), alignment_);
       auto limit = range.size() -
@@ -754,6 +758,14 @@ class RowContainer {
   uint64_t allocatedBytes() const {
     return rows_.allocatedBytes() + stringAllocator_->retainedSize();
   }
+
+  bool supportsOutputRangeRelease() const {
+    return rowSizeOffset_ == 0 && !usesExternalMemory_ &&
+        !hasVariableAccumulator_ && numFreeRows_ == 0 && !checkFree_ &&
+        !useListRowIndex_;
+  }
+
+  uint64_t releaseOutputRangesBefore(const RowContainerIterator& iterator);
 
   uint64_t usedBytes() const {
     return rows_.allocatedBytes() - rows_.freeBytes() +

--- a/bolt/exec/tests/AggregationTest.cpp
+++ b/bolt/exec/tests/AggregationTest.cpp
@@ -1523,6 +1523,66 @@ TEST_P(AggregationTest, partialAggregationMaybeReservationReleaseCheck) {
   EXPECT_GT(kMaxPartialMemoryUsage, task->pool()->currentBytes());
 }
 
+TEST_P(AggregationTest, releasesOutputRangesBeforeDownstreamSort) {
+  if (GetParam().useGPU) {
+    GTEST_SKIP() << "GPU Aggregation does not support statistics yet\n";
+  }
+
+  constexpr vector_size_t kNumRows = 200000;
+  constexpr int32_t kNumKeys = 8;
+  constexpr int32_t kNumValues = 24;
+  constexpr int32_t kNumColumns = kNumKeys + kNumValues;
+  std::vector<VectorPtr> columns;
+  columns.reserve(kNumColumns);
+  for (auto column = 0; column < kNumKeys; ++column) {
+    columns.push_back(makeFlatVector<int64_t>(
+        kNumRows, [column](auto row) { return row * kNumKeys + column; }));
+  }
+  for (auto column = 0; column < kNumValues; ++column) {
+    columns.push_back(makeFlatVector<int64_t>(
+        kNumRows, [column](auto row) { return row + column; }));
+  }
+  auto data = makeRowVector(std::move(columns));
+
+  std::vector<std::string> groupingKeys;
+  groupingKeys.reserve(kNumKeys);
+  for (auto column = 0; column < kNumKeys; ++column) {
+    groupingKeys.push_back(fmt::format("c{}", column));
+  }
+  std::vector<std::string> aggregates;
+  aggregates.reserve(kNumValues);
+  for (auto column = 0; column < kNumValues; ++column) {
+    aggregates.push_back(fmt::format("sum(c{})", kNumKeys + column));
+  }
+
+  core::PlanNodeId aggregationId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation(groupingKeys, aggregates)
+                  .capturePlanNodeId(aggregationId)
+                  .orderBy({"c0"}, false)
+                  .planNode();
+
+  std::vector<VectorPtr> expectedColumns;
+  expectedColumns.reserve(kNumColumns);
+  for (auto column = 0; column < kNumKeys; ++column) {
+    expectedColumns.push_back(makeFlatVector<int64_t>(
+        kNumRows, [column](auto row) { return row * kNumKeys + column; }));
+  }
+  for (auto column = 0; column < kNumValues; ++column) {
+    expectedColumns.push_back(makeFlatVector<int64_t>(
+        kNumRows, [column](auto row) { return row + column; }));
+  }
+  auto expected = makeRowVector(std::move(expectedColumns));
+
+  auto task = AssertQueryBuilder(plan)
+                  .config(QueryConfig::kPreferredOutputBatchRows, "1024")
+                  .assertResults({expected});
+  const auto stats = toPlanStats(task->taskStats());
+  const auto& aggStats = stats.at(aggregationId).customStats;
+  ASSERT_GT(aggStats.at("aggOutputReleasedBytes").sum, 0);
+}
+
 TEST_P(AggregationTest, spillWithMemoryLimit) {
   if (GetParam().useGPU) {
     GTEST_SKIP() << "GPU Aggregation does not support spilling\n";

--- a/bolt/exec/tests/RowContainerTest.cpp
+++ b/bolt/exec/tests/RowContainerTest.cpp
@@ -1079,6 +1079,48 @@ TEST_F(RowContainerTest, erase) {
   data->checkConsistency();
 }
 
+TEST_F(RowContainerTest, releaseOutputRangesBefore) {
+  auto data = makeRowContainer({BIGINT()}, {BIGINT()});
+  ASSERT_TRUE(data->supportsOutputRangeRelease());
+
+  constexpr int32_t kNumRows = 4096;
+  std::vector<char*> rows;
+  rows.reserve(kNumRows);
+  for (auto i = 0; i < kNumRows; ++i) {
+    auto* row = data->newRow();
+    RowContainer::valueAt<int64_t>(row, data->columnAt(0).offset()) = i;
+    RowContainer::valueAt<int64_t>(row, data->columnAt(1).offset()) = i * 10;
+    rows.push_back(row);
+  }
+  ASSERT_GT(data->numRows(), 0);
+
+  RowContainerIterator iter;
+  std::vector<char*> output(kNumRows);
+  ASSERT_GT(data->listRows(&iter, kNumRows / 2, output.data()), 0);
+  auto releasedBytes = data->releaseOutputRangesBefore(iter);
+  EXPECT_GT(releasedBytes, 0);
+  EXPECT_LT(data->numRows(), kNumRows);
+
+  auto remainingRows = data->numRows();
+  iter.reset();
+  ASSERT_EQ(remainingRows, data->listRows(&iter, remainingRows, output.data()));
+  for (auto i = 0; i < remainingRows; ++i) {
+    EXPECT_EQ(
+        RowContainer::valueAt<int64_t>(output[i], data->columnAt(1).offset()),
+        RowContainer::valueAt<int64_t>(output[i], data->columnAt(0).offset()) *
+            10);
+  }
+
+  releasedBytes = data->releaseOutputRangesBefore(iter);
+  EXPECT_GT(releasedBytes, 0);
+  ASSERT_EQ(0, data->listRows(&iter, 1, output.data()));
+  releasedBytes = data->releaseOutputRangesBefore(iter);
+  EXPECT_GT(releasedBytes, 0);
+  EXPECT_EQ(0, data->numRows());
+  data->clear();
+  EXPECT_EQ(0, data->numRows());
+}
+
 TEST_P(RowContainerTest, initialNulls) {
   std::vector<TypePtr> keys{INTEGER()};
   std::vector<TypePtr> dependent{INTEGER()};


### PR DESCRIPTION


### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Release hash aggregation rows during output.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Hash aggregation keeps its RowContainer storage and hash lookup table until the whole output phase finishes. In pipelines such as hash aggregation followed by sort or another blocking operator, rows and lookup table entries that have already served final output no longer need to stay in the aggregation operator. Keeping these structures retained can make the task-level peak include both already-output aggregation memory and downstream memory growth.

Add range-level accounting to AllocationPool so complete allocation ranges can be released while keeping range indexes stable for existing RowContainer iterators. RowContainer now exposes a narrow output-stage release path that only applies to fixed-width rows with no external-memory accumulators, no variable-width state, no free-list entries, and no list-row index. This deliberately avoids eraseRows(), free-list maintenance, and aggregate destruction.

For the non-spilled final output path, GroupingSet releases the hash table pointer array before listing output rows and releases RowContainer ranges after extractGroups() has copied the current batch into the output vector. If memory is released, the operator also releases no-longer-needed reservation so downstream blocking operators do not inherit stale aggregation reservation.

Add coverage for AllocationPool range release, RowContainer sequential output release, and a hash aggregation followed by sort that verifies released output bytes are reported while preserving query results.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
