### PR TITLE
feat(sparksql): support bitmap_bucket_number

### DIFF
--- a/bolt/functions/sparksql/Bitmap.h
+++ b/bolt/functions/sparksql/Bitmap.h
@@ -22,6 +22,21 @@
 
 namespace bytedance::bolt::functions::sparksql {
 
+/// Spark-compatible bitmap_bucket_number(BIGINT) -> BIGINT.
+/// Matches Spark 3.5 BitmapExpressionUtils.bitmapBucketNumber.
+template <typename T>
+struct BitmapBucketNumberFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(int64_t& result, int64_t value) {
+    if (value > 0) {
+      result = 1 + (value - 1) / kBitmapNumBits;
+      return;
+    }
+    result = value / kBitmapNumBits;
+  }
+};
+
 /// Spark-compatible bitmap_count(BINARY) -> BIGINT.
 /// Matches Spark 3.5 BitmapExpressionUtils.bitmapCount.
 template <typename T>

--- a/bolt/functions/sparksql/registration/RegisterBitmap.cpp
+++ b/bolt/functions/sparksql/registration/RegisterBitmap.cpp
@@ -20,6 +20,8 @@
 namespace bytedance::bolt::functions::sparksql {
 
 void registerBitmapFunctions(const std::string& prefix) {
+  registerFunction<BitmapBucketNumberFunction, int64_t, int64_t>(
+      {prefix + "bitmap_bucket_number"});
   registerFunction<BitmapCountFunction, int64_t, Varbinary>(
       {prefix + "bitmap_count"});
 }

--- a/bolt/functions/sparksql/tests/BitmapBucketNumberTest.cpp
+++ b/bolt/functions/sparksql/tests/BitmapBucketNumberTest.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace bytedance::bolt::functions::sparksql::test {
+namespace {
+
+class BitmapBucketNumberTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<int64_t> bucketNumber(std::optional<int64_t> value) {
+    return evaluateOnce<int64_t>("bitmap_bucket_number(c0)", value);
+  }
+
+  std::optional<int64_t> bucketNumberFromInt(std::optional<int32_t> value) {
+    return evaluateOnce<int64_t>(
+        "bitmap_bucket_number(cast(c0 as bigint))", value);
+  }
+};
+
+TEST_F(BitmapBucketNumberTest, positiveInputs) {
+  EXPECT_EQ(bucketNumber(1), 1);
+  EXPECT_EQ(bucketNumber(2), 1);
+  EXPECT_EQ(bucketNumber(32768), 1);
+  EXPECT_EQ(bucketNumber(32769), 2);
+  EXPECT_EQ(bucketNumber(65536), 2);
+  EXPECT_EQ(bucketNumber(65537), 3);
+  EXPECT_EQ(bucketNumber(3232423), 99);
+  EXPECT_EQ(
+      bucketNumber(std::numeric_limits<int64_t>::max()), 281474976710656L);
+}
+
+TEST_F(BitmapBucketNumberTest, nonPositiveInputs) {
+  EXPECT_EQ(bucketNumber(0), 0);
+  EXPECT_EQ(bucketNumber(-1), 0);
+  EXPECT_EQ(bucketNumber(-32767), 0);
+  EXPECT_EQ(bucketNumber(-32768), -1);
+  EXPECT_EQ(bucketNumber(-32769), -1);
+  EXPECT_EQ(bucketNumber(-65535), -1);
+  EXPECT_EQ(bucketNumber(-65536), -2);
+  EXPECT_EQ(bucketNumber(-3843485), -117);
+  EXPECT_EQ(
+      bucketNumber(std::numeric_limits<int64_t>::min()), -281474976710656L);
+  EXPECT_EQ(
+      bucketNumber(std::numeric_limits<int64_t>::min() + 1), -281474976710655L);
+}
+
+TEST_F(BitmapBucketNumberTest, nullAndCastInputs) {
+  EXPECT_EQ(bucketNumber(std::nullopt), std::nullopt);
+  EXPECT_EQ(bucketNumberFromInt(65537), 3);
+  EXPECT_EQ(bucketNumberFromInt(-65536), -2);
+  EXPECT_EQ(bucketNumberFromInt(std::nullopt), std::nullopt);
+}
+
+} // namespace
+} // namespace bytedance::bolt::functions::sparksql::test

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   ArraysZipTest.cpp
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
+  BitmapBucketNumberTest.cpp
   BitmapCountTest.cpp
   BitwiseTest.cpp
   CharVarcharTest.cpp


### PR DESCRIPTION
### What problem does this PR solve?

Spark 3.5 exposes `bitmap_bucket_number(BIGINT)`, but Bolt had no native Spark SQL implementation, causing Gluten plans using this expression to fall back.

Issue Number: close #759

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Implement Spark 3.5-compatible bucket calculation for positive, zero, and negative `BIGINT` values with a 32,768-bit bucket size.
- Register `bitmap_bucket_number(BIGINT) -> BIGINT` with the Spark SQL function registry.
- Preserve the scalar UDF framework's default null propagation and cover explicit casts to `BIGINT`.
- Add boundary coverage around multiple buckets plus `INT64_MIN` and `INT64_MAX`.
- Use Bolt's existing same-name Substrait identity fallback: `SubstraitParser::mapToBoltFunction` keeps an unmapped function name unchanged, so no Bolt-side alias entry is needed for `bitmap_bucket_number`.

### Performance Impact

- [x] **No Impact**: Existing query paths are unchanged; the new calculation runs only when the new function is invoked.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Added Spark-compatible `bitmap_bucket_number(BIGINT)` support.
```

### Validation

- `clang-format --dry-run --Werror` on all changed C++ files: passed.
- `SKIP=clang-tidy pre-commit run --files ...`: all applicable hooks passed.
- `cmake --build --preset conan-release --target bolt_functions_spark --parallel 12`: passed on AppleClang 17.
- Built `BitmapBucketNumberTest.cpp.o` from the real `bolt_functions_spark_test` target: passed.
- ASan/UBSan formula cross-check over exact boundaries and 1,000,000 random 64-bit values: passed.

The complete local SparkSQL test executable is blocked on macOS by the current upstream `bolt/common/process/CrashReport.cpp` unconditionally including Linux-only `<link.h>`; the failure occurs before linking and is unrelated to this change. Linux CI will provide the full test execution.

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)