### PR TITLE
fix(sparksql): validate json_object_keys input

### DIFF
--- a/bolt/functions/sparksql/JsonObjectKeys.h
+++ b/bolt/functions/sparksql/JsonObjectKeys.h
@@ -52,8 +52,11 @@ struct JsonObjectKeysFunction {
       return false;
     }
 
-    // The result is NULL if the given string is not a JSON object string.
-    if (jsonDoc.type() != simdjson::ondemand::json_type::object) {
+    // On-Demand parsing is lazy. Check the result before reading the type to
+    // avoid surfacing parser errors for invalid JSON.
+    auto jsonType = jsonDoc.type();
+    if (jsonType.error() != simdjson::SUCCESS ||
+        jsonType.value_unsafe() != simdjson::ondemand::json_type::object) {
       return false;
     }
 
@@ -64,9 +67,20 @@ struct JsonObjectKeysFunction {
     }
 
     for (auto field : jsonObject) {
-      out.add_item().copy_from(std::string_view(field.unescaped_key(false)));
+      if (field.error() != simdjson::SUCCESS) {
+        return false;
+      }
+
+      auto key = field.unescaped_key(false);
+      if (key.error() != simdjson::SUCCESS) {
+        return false;
+      }
+      out.add_item().copy_from(std::string_view(key.value_unsafe()));
     }
-    return true;
+
+    // Iteration validates the object structure, while at_end() rejects valid
+    // objects followed by trailing non-whitespace content.
+    return jsonDoc.at_end();
   }
 };
 

--- a/bolt/functions/sparksql/tests/JsonObjectKeysTest.cpp
+++ b/bolt/functions/sparksql/tests/JsonObjectKeysTest.cpp
@@ -51,10 +51,29 @@ TEST_F(JsonObjectKeysTest, basic) {
   expected = makeArrayVectorFromJson<std::string>({"[]"});
   assertEqualVectors(jsonObjectKeys(R"({})"), expected);
 
+  expected = makeArrayVectorFromJson<std::string>({"[\"f1\",\"f2\"]"});
+  assertEqualVectors(
+      jsonObjectKeys(R"({"f1":"abc","f2":{"f3":"a", "f4":"b"}})"), expected);
+
+  expected = makeArrayVectorFromJson<std::string>({"[\"key\"]"});
+  assertEqualVectors(jsonObjectKeys(R"({"key": "value"})"), expected);
+  assertEqualVectors(jsonObjectKeys(R"({"\u006bey": 1})"), expected);
+
   expected = makeNullableArrayVector<std::string>({std::nullopt});
   assertEqualVectors(jsonObjectKeys(R"(1)"), expected);
   assertEqualVectors(jsonObjectKeys(R"("hello")"), expected);
   assertEqualVectors(jsonObjectKeys(R"("")"), expected);
+  assertEqualVectors(jsonObjectKeys(R"([])"), expected);
+  assertEqualVectors(jsonObjectKeys(R"(invalid json)"), expected);
+  assertEqualVectors(
+      jsonObjectKeys(R"({"key": 45, "random_string"})"), expected);
+  assertEqualVectors(
+      jsonObjectKeys(R"({[1, 2, {"Key": "Invalid JSON"}]})"), expected);
+  assertEqualVectors(jsonObjectKeys(R"({"key: 45})"), expected);
+  assertEqualVectors(
+      jsonObjectKeys(R"({"pie": true, "cherry": [1, 2, 3 })"), expected);
+  assertEqualVectors(jsonObjectKeys(R"({"key": 1} trailing })"), expected);
+  assertEqualVectors(jsonObjectKeys(R"({"\x": 1})"), expected);
 }
 
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #742

`json_object_keys` used simdjson's On-Demand API without checking lazy parse errors while reading the root type, iterating fields, or unescaping keys. Malformed JSON could therefore raise a parser exception instead of returning `NULL`, and trailing content could be accepted.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Check the lazy root-type parse result before accessing it.
- Return `NULL` for malformed object fields and invalid escaped keys.
- Reject valid objects followed by trailing non-whitespace content.
- Cover the issue examples, nested objects, non-object inputs, malformed structures, invalid literals, escaped keys, and trailing content.

### Performance Impact

- [x] **No Impact**: The change adds lightweight error checks to parser operations already performed by this function.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixed SparkSQL json_object_keys to return NULL for malformed JSON instead of surfacing parser errors or accepting trailing content.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
