### PR TITLE
 perf(shuffle): avoid per-buffer RTTI (dynamic_pointer_cast) in InMemoryPayload::merge on the shuffle read path

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -409,7 +409,8 @@ std::unique_ptr<InMemoryPayload> BoltColumnarBatchDeserializer::drainSaved() {
         std::move(savedPayload),
         memoryPool_,
         INT64_MAX,
-        INT64_MIN);
+        INT64_MIN,
+        /*sourceBuffersResizable=*/true);
     BOLT_CHECK(result.ok(), "Failed to merge payloads");
     payload = std::move(result.ValueUnsafe());
   }

--- a/bolt/shuffle/sparksql/Payload.cpp
+++ b/bolt/shuffle/sparksql/Payload.cpp
@@ -730,9 +730,18 @@ arrow::Result<std::unique_ptr<InMemoryPayload>> InMemoryPayload::merge(
     std::unique_ptr<InMemoryPayload> append,
     arrow::MemoryPool* pool,
     int64_t rowvectorModeCompressionMinColumns,
-    int64_t rowvectorModeCompressionMaxBufferSize) {
+    int64_t rowvectorModeCompressionMaxBufferSize,
+    bool sourceBuffersResizable) {
   auto mergedRows = source->numRows() + append->numRows();
   auto isValidityBuffer = source->isValidityBuffer();
+
+  auto asResizable =
+      [sourceBuffersResizable](const std::shared_ptr<arrow::Buffer>& buffer) {
+        if (sourceBuffersResizable) {
+          return std::static_pointer_cast<arrow::ResizableBuffer>(buffer);
+        }
+        return std::dynamic_pointer_cast<arrow::ResizableBuffer>(buffer);
+      };
 
   auto numBuffers = append->numBuffers();
   ARROW_RETURN_IF(
@@ -768,8 +777,7 @@ arrow::Result<std::unique_ptr<InMemoryPayload>> InMemoryPayload::merge(
         // Because sourceBuffer can be resized, need to save buffer size in
         // advance.
         auto sourceBufferSize = sourceBuffer->size();
-        auto resizable =
-            std::dynamic_pointer_cast<arrow::ResizableBuffer>(sourceBuffer);
+        auto resizable = asResizable(sourceBuffer);
         auto mergedBytes = arrow::bit_util::BytesForBits(mergedRows);
         if (resizable) {
           // If source is resizable, resize and reuse source.
@@ -807,8 +815,7 @@ arrow::Result<std::unique_ptr<InMemoryPayload>> InMemoryPayload::merge(
         // advance.
         auto sourceBufferSize = sourceBuffer->size();
         auto mergedSize = sourceBufferSize + appendBuffer->size();
-        auto resizable =
-            std::dynamic_pointer_cast<arrow::ResizableBuffer>(sourceBuffer);
+        auto resizable = asResizable(sourceBuffer);
         if (resizable) {
           // If source is resizable, resize and reuse source.
           RETURN_NOT_OK(resizable->Resize(mergedSize + simd::kPadding));

--- a/bolt/shuffle/sparksql/Payload.h
+++ b/bolt/shuffle/sparksql/Payload.h
@@ -196,7 +196,8 @@ class InMemoryPayload final : public Payload {
       std::unique_ptr<InMemoryPayload> append,
       arrow::MemoryPool* pool,
       int64_t rowvectorModeCompressionMinColumns,
-      int64_t rowvectorModeCompressionMaxBufferSize);
+      int64_t rowvectorModeCompressionMaxBufferSize,
+      bool sourceBuffersResizable = false);
 
   arrow::Status serialize(arrow::io::OutputStream* outputStream) override;
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #864 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Give InMemoryPayload::merge an opt-in flag that lets the caller assert the source buffers are resizable, allowing the cheaper static_pointer_cast:

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>
