### PR TITLE
fix: support clang16 libc++ hugeint build

### DIFF
--- a/bolt/common/base/Portability.h
+++ b/bolt/common/base/Portability.h
@@ -50,6 +50,10 @@ namespace bytedance::bolt {
 #define INLINE_LAMBDA
 #endif
 
+#if defined(__clang__) && defined(__GLIBCXX__) && (__clang_major__ <= 16)
+#define BOLT_CLANG_LIBSTDCXX_INT128_COMPAT 1
+#endif
+
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
 #define TSAN_BUILD 1

--- a/bolt/common/encode/Coding.h
+++ b/bolt/common/encode/Coding.h
@@ -39,7 +39,9 @@
 #include <folly/GroupVarint.h>
 #include <folly/Likely.h>
 #include <algorithm>
+#include <type_traits>
 #include <utility>
+#include "bolt/common/base/Portability.h"
 #include "bolt/common/encode/UInt128.h"
 #include "bolt/common/strings/ByteStream.h"
 namespace bytedance {
@@ -275,6 +277,18 @@ class Varint {
   }
 };
 
+template <typename U>
+struct ZigZagSignedType {
+  using type = typename std::make_signed<U>::type;
+};
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+struct ZigZagSignedType<__uint128_t> {
+  using type = __int128_t;
+};
+#endif
+
 // Zig-zag encoding that maps signed integers with a small absolute value
 // to unsigned integers with a small (positive) value.
 // if x >= 0, ZigZag::encode(x) == 2*x
@@ -290,7 +304,7 @@ class ZigZag {
   static __uint128_t encodeInt128(__int128_t val) {
     return (static_cast<__uint128_t>(val) << 1) ^ (val >> 127);
   }
-  template <typename U, typename T = typename std::make_signed<U>::type>
+  template <typename U, typename T = typename ZigZagSignedType<U>::type>
   static T decode(U val) {
     return static_cast<T>((val >> 1) ^ -(val & 1));
   }

--- a/bolt/duckdb/DuckDbCompat.h
+++ b/bolt/duckdb/DuckDbCompat.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace duckdb {
+class QueryNode;
+class SelectStatement;
+struct CommonTableExpressionInfo;
+} // namespace duckdb
+
+namespace std {
+// DuckDB parser headers contain unique_ptr cycles that clang16/libstdc++13
+// instantiates before the pointee types are complete.
+template <>
+struct default_delete<duckdb::QueryNode> {
+  constexpr default_delete() noexcept = default;
+  void operator()(duckdb::QueryNode* ptr) const;
+};
+
+template <>
+struct default_delete<duckdb::SelectStatement> {
+  constexpr default_delete() noexcept = default;
+  void operator()(duckdb::SelectStatement* ptr) const;
+};
+
+template <>
+struct default_delete<duckdb::CommonTableExpressionInfo> {
+  constexpr default_delete() noexcept = default;
+  void operator()(duckdb::CommonTableExpressionInfo* ptr) const;
+};
+} // namespace std
+
+#include <duckdb.hpp> // @manual
+
+namespace std {
+inline void default_delete<duckdb::QueryNode>::operator()(
+    duckdb::QueryNode* ptr) const {
+  delete ptr;
+}
+
+inline void default_delete<duckdb::SelectStatement>::operator()(
+    duckdb::SelectStatement* ptr) const {
+  delete ptr;
+}
+
+inline void default_delete<duckdb::CommonTableExpressionInfo>::operator()(
+    duckdb::CommonTableExpressionInfo* ptr) const {
+  delete ptr;
+}
+} // namespace std

--- a/bolt/duckdb/conversion/DuckConversion.h
+++ b/bolt/duckdb/conversion/DuckConversion.h
@@ -32,7 +32,14 @@
 
 #include "bolt/type/Type.h"
 
-#include <duckdb.hpp> // @manual
+#include <duckdb/common/types.hpp> // @manual
+#include <duckdb/common/types/date.hpp> // @manual
+#include <duckdb/common/types/hugeint.hpp> // @manual
+#include <duckdb/common/types/timestamp.hpp> // @manual
+#include <duckdb/common/types/value.hpp> // @manual
+#include <duckdb/common/types/vector.hpp> // @manual
+#include <duckdb/common/types/vector_buffer.hpp> // @manual
+#include <duckdb/common/vector_operations/vector_operations.hpp> // @manual
 namespace bytedance::bolt {
 class variant;
 }

--- a/bolt/duckdb/conversion/DuckParser.cpp
+++ b/bolt/duckdb/conversion/DuckParser.cpp
@@ -35,7 +35,7 @@
 #include "bolt/parse/Expressions.h"
 #include "bolt/type/Variant.h"
 
-#include <duckdb.hpp> // @manual
+#include "bolt/duckdb/DuckDbCompat.h"
 #include <duckdb/parser/expression/between_expression.hpp> // @manual
 #include <duckdb/parser/expression/case_expression.hpp> // @manual
 #include <duckdb/parser/expression/cast_expression.hpp> // @manual

--- a/bolt/duckdb/conversion/DuckWrapper.cpp
+++ b/bolt/duckdb/conversion/DuckWrapper.cpp
@@ -29,7 +29,7 @@
  */
 
 #include "bolt/duckdb/conversion/DuckWrapper.h"
-#include <duckdb.hpp>
+#include "bolt/duckdb/DuckDbCompat.h"
 #include "bolt/common/base/BitUtil.h"
 #include "bolt/duckdb/conversion/DuckConversion.h"
 #include "bolt/vector/FlatVector.h"

--- a/bolt/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/bolt/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -28,7 +28,7 @@
  * --------------------------------------------------------------------------
  */
 
-#include <duckdb.hpp>
+#include "bolt/duckdb/DuckDbCompat.h"
 
 #include "bolt/duckdb/conversion/DuckWrapper.h"
 #include "bolt/vector/tests/utils/VectorMaker.h"

--- a/bolt/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/bolt/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -43,7 +43,7 @@
 #include <folly/Random.h>
 #include <folly/init/Init.h>
 
-#include <duckdb.hpp> // @manual
+#include "bolt/duckdb/DuckDbCompat.h"
 
 using namespace folly;
 using namespace bytedance::bolt;

--- a/bolt/dwio/common/tests/utils/FilterGenerator.h
+++ b/bolt/dwio/common/tests/utils/FilterGenerator.h
@@ -33,11 +33,13 @@
 #include <folly/Random.h>
 #include <memory>
 
+#include "bolt/common/base/Portability.h"
 #include "bolt/common/memory/Memory.h"
 #include "bolt/dwio/common/Mutation.h"
 #include "bolt/dwio/common/ScanSpec.h"
 #include "bolt/dwio/common/exception/Exception.h"
 #include "bolt/type/Filter.h"
+#include "bolt/type/HugeInt.h"
 #include "bolt/type/Subfield.h"
 #include "bolt/vector/ComplexVector.h"
 #include "bolt/vector/SimpleVector.h"
@@ -122,6 +124,23 @@ class AbstractColumnStats {
   std::unordered_map<size_t, int> uniques_;
   static uint32_t counter_;
 };
+
+template <typename T>
+size_t columnStatsHash(const T& value) {
+  return folly::hasher<T>()(value);
+}
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+inline size_t columnStatsHash<int128_t>(const int128_t& value) {
+  return HugeInt::hash(value);
+}
+
+template <>
+inline size_t columnStatsHash<uint128_t>(const uint128_t& value) {
+  return HugeInt::hash(value);
+}
+#endif
 
 template <typename T>
 class ColumnStats : public AbstractColumnStats {
@@ -243,7 +262,7 @@ class ColumnStats : public AbstractColumnStats {
       return;
     }
     T value = vector->valueAt(index);
-    size_t hash = folly::hasher<T>()(value) & kUniquesMask;
+    size_t hash = columnStatsHash<T>(value) & kUniquesMask;
     if (uniques_.find(hash) != uniques_.end()) {
       uniques_[hash]++;
       return;
@@ -259,7 +278,7 @@ class ColumnStats : public AbstractColumnStats {
 
     for (; index < values_.size(); index++) {
       auto value = values_[index];
-      size_t hash = folly::hasher<T>()(value) & kUniquesMask;
+      size_t hash = columnStatsHash<T>(value) & kUniquesMask;
       sampleCount += uniques_[hash];
       if (sampleCount >= (pct / 100) * (numSamples_ - numNulls_)) {
         break;

--- a/bolt/dwio/parquet/reader/RleBpDataDecoder.h
+++ b/bolt/dwio/parquet/reader/RleBpDataDecoder.h
@@ -32,11 +32,24 @@
 
 #include "bolt/common/base/GTestMacros.h"
 #include "bolt/common/base/Nulls.h"
+#include "bolt/common/base/Portability.h"
 #include "bolt/dwio/common/BitPackDecoder.h"
 #include "bolt/dwio/common/DecoderUtil.h"
 #include "bolt/dwio/common/TypeUtil.h"
 #include "bolt/dwio/parquet/reader/RleBpDecoder.h"
 namespace bytedance::bolt::parquet {
+
+template <typename T>
+struct RleBpSignedIndexType {
+  using type = std::make_signed_t<T>;
+};
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+struct RleBpSignedIndexType<__uint128_t> {
+  using type = __int128_t;
+};
+#endif
 
 // This class will be used for dictionary Ids or other data that is RLE/BP
 // encoded.
@@ -181,8 +194,8 @@ class RleBpDataDecoder : public bytedance::bolt::parquet::RleBpDecoder {
         (rows[rowIndex + numRows - 1] + 1 - currentRow) * bitWidth_;
 
     using TValues = typename std::remove_reference<decltype(values[0])>::type;
-    using TIndex = typename std::make_signed_t<
-        typename dwio::common::make_index<TValues>::type>;
+    using TIndex = typename RleBpSignedIndexType<
+        typename dwio::common::make_index<TValues>::type>::type;
     bytedance::bolt::dwio::common::unpack(
         reinterpret_cast<const uint64_t*>(super::bufferStart_),
         bitOffset_,

--- a/bolt/exec/ContainerRowSerde.cpp
+++ b/bolt/exec/ContainerRowSerde.cpp
@@ -1084,6 +1084,15 @@ uint64_t hashOne(ByteInputStream& stream, const Type* /*type*/) {
   return folly::hasher<T>()(stream.read<T>());
 }
 
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+uint64_t hashOne<TypeKind::HUGEINT>(
+    ByteInputStream& stream,
+    const Type* /*type*/) {
+  return HugeInt::hash(stream.read<int128_t>());
+}
+#endif
+
 template <>
 uint64_t hashOne<TypeKind::VARCHAR>(
     ByteInputStream& stream,

--- a/bolt/exec/RowContainer.cpp
+++ b/bolt/exec/RowContainer.cpp
@@ -1002,15 +1002,19 @@ void RowContainer::hashTyped(
                       : BaseVector::kNullHash;
     } else {
       uint64_t hash;
-      if (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+      if constexpr (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
         hash =
             folly::hasher<StringView>()(HashStringAllocator::contiguousString(
                 valueAt<StringView>(row, offset), storage));
-      } else if (
+      } else if constexpr (
           Kind == TypeKind::ROW || Kind == TypeKind::ARRAY ||
           Kind == TypeKind::MAP) {
         auto in = prepareRead(row, offset);
         hash = ContainerRowSerde::hash(*in, type);
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+      } else if constexpr (Kind == TypeKind::HUGEINT) {
+        hash = HugeInt::hash(valueAt<T>(row, offset));
+#endif
       } else {
         hash = folly::hasher<T>()(valueAt<T>(row, offset));
       }

--- a/bolt/exec/SetAccumulator.h
+++ b/bolt/exec/SetAccumulator.h
@@ -41,11 +41,34 @@ namespace bytedance::bolt::aggregate::prestosql {
 
 namespace detail {
 
+template <typename T>
+struct SetAccumulatorHash : std::hash<T> {};
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+struct SetAccumulatorHash<int128_t> {
+  size_t operator()(int128_t value) const noexcept {
+    return HugeInt::hash(value);
+  }
+};
+
+template <>
+struct SetAccumulatorHash<__uint128_t> {
+  size_t operator()(__uint128_t value) const noexcept {
+    return HugeInt::hash(value);
+  }
+};
+#endif
+
 /// Maintains a set of unique values. Non-null values are stored in F14FastSet.
 /// A separate flag tracks presence of the null value.
 template <
     typename T,
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+    typename Hash = SetAccumulatorHash<T>,
+#else
     typename Hash = std::hash<T>,
+#endif
     typename EqualTo = std::equal_to<T>>
 struct SetAccumulator {
   std::optional<vector_size_t> nullIndex;

--- a/bolt/exec/VectorHasher.cpp
+++ b/bolt/exec/VectorHasher.cpp
@@ -78,7 +78,15 @@ inline uint64_t hashOne(DecodedVector& decoded, vector_size_t index) {
 
   // Inlined for scalars.
   using T = typename KindToFlatVector<Kind>::HashRowType;
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+  if constexpr (Kind == TypeKind::HUGEINT) {
+    return HugeInt::hash(decoded.valueAt<T>(index));
+  } else {
+    return folly::hasher<T>()(decoded.valueAt<T>(index));
+  }
+#else
   return folly::hasher<T>()(decoded.valueAt<T>(index));
+#endif
 }
 
 template <TypeKind Kind>

--- a/bolt/exec/tests/utils/QueryAssertions.h
+++ b/bolt/exec/tests/utils/QueryAssertions.h
@@ -37,7 +37,7 @@
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/vector/ComplexVector.h"
 
-#include <duckdb.hpp> // @manual
+#include "bolt/duckdb/DuckDbCompat.h"
 namespace bytedance::bolt::exec::test {
 
 using MaterializedRow = std::vector<bolt::variant>;

--- a/bolt/exec/tests/utils/RowBasedSerde.cpp
+++ b/bolt/exec/tests/utils/RowBasedSerde.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "bolt/exec/tests/utils/RowBasedSerde.h"
+#include "bolt/common/base/Portability.h"
 #include "bolt/exec/VariantSerdeDetail.h"
+#include "bolt/type/HugeInt.h"
 #include "bolt/vector/ComplexVector.h"
 #include "bolt/vector/FlatVector.h"
 #include "bolt/vector/VariantVector.h"
@@ -767,6 +769,15 @@ uint64_t hashOne(ByteInputStream& stream, const Type* /*type*/) {
   using T = typename TypeTraits<Kind>::NativeType;
   return folly::hasher<T>()(stream.read<T>());
 }
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+uint64_t hashOne<TypeKind::HUGEINT>(
+    ByteInputStream& stream,
+    const Type* /*type*/) {
+  return HugeInt::hash(stream.read<int128_t>());
+}
+#endif
 
 template <>
 uint64_t hashOne<TypeKind::VARCHAR>(

--- a/bolt/functions/prestosql/Arithmetic.h
+++ b/bolt/functions/prestosql/Arithmetic.h
@@ -43,6 +43,7 @@
 
 #include "bolt/common/base/Doubles.h"
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/Portability.h"
 #include "bolt/functions/Macros.h"
 #include "bolt/functions/prestosql/ArithmeticImpl.h"
 #include "folly/CPortability.h"
@@ -577,8 +578,16 @@ struct ToBaseFunction {
       B runningValue = value < 0 ? -1 * value : value;
       B remainder;
       char* resultPtr;
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+      int128_t resultSize =
+          (int128_t)std::floor(
+              std::log(static_cast<long double>(runningValue)) /
+              std::log(static_cast<long double>(radix))) +
+          1;
+#else
       int128_t resultSize =
           (int128_t)std::floor(std::log(runningValue) / std::log(radix)) + 1;
+#endif
       if (value < 0) {
         resultSize += 1;
         result.resize(resultSize);

--- a/bolt/functions/prestosql/aggregates/ApproxPercentileAggregate.h
+++ b/bolt/functions/prestosql/aggregates/ApproxPercentileAggregate.h
@@ -548,10 +548,9 @@ class ApproxPercentileAggregate : public exec::Aggregate {
       vector_size_t len) {
     if (!percentiles_) {
       BOLT_USER_CHECK_GT(len, 0, "Percentile cannot be empty");
-      percentiles_ = {
-          .values = std::vector<double>(len),
-          .isArray = isArray,
-      };
+      percentiles_.emplace();
+      percentiles_->values.resize(len);
+      percentiles_->isArray = isArray;
       for (vector_size_t i = 0; i < len; ++i) {
         BOLT_USER_CHECK(!percentiles.isNullAt(i), "Percentile cannot be null");
         auto value = percentiles.valueAt<double>(offset + i);

--- a/bolt/functions/prestosql/aggregates/HiveUDAFPercentileAggregate.cpp
+++ b/bolt/functions/prestosql/aggregates/HiveUDAFPercentileAggregate.cpp
@@ -496,9 +496,8 @@ class HiveUDAFPercentileAggregate : public exec::Aggregate {
       const std::vector<bool>& isNull) {
     if (!percentiles_) {
       BOLT_USER_CHECK_GT(len, 0, "Percentile cannot be empty");
-      percentiles_ = {
-          .values = std::vector<double>(len),
-      };
+      percentiles_.emplace();
+      percentiles_->values.resize(len);
       for (vector_size_t i = 0; i < len; ++i) {
         BOLT_USER_CHECK(!isNull[i], "Percentile cannot be null");
         BOLT_USER_CHECK_GE(data[i], 0, "Percentile must be between 0 and 1");

--- a/bolt/functions/prestosql/json/SIMDJsonWrapper.h
+++ b/bolt/functions/prestosql/json/SIMDJsonWrapper.h
@@ -30,8 +30,35 @@
 
 #pragma once
 
+// clang16 cannot parse parts of libstdc++13's C++23 <ranges>. simdjson only
+// uses this macro to enable optional std::ranges view adapters.
+#include "bolt/common/base/Portability.h"
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+#ifndef SIMDJSON_DISABLE_RANGES
+#define SIMDJSON_DISABLE_RANGES
+#define BOLT_SIMDJSON_UNDEFINE_DISABLE_RANGES
+#endif
+
+#if defined(__cpp_lib_ranges)
+#define BOLT_SIMDJSON_RESTORE_CPP_LIB_RANGES
+#pragma push_macro("__cpp_lib_ranges")
+#undef __cpp_lib_ranges
+#endif
+#endif
+
 #if __has_include("simdjson/singleheader/simdjson.h")
 #include "simdjson/singleheader/simdjson.h"
 #else
 #include "simdjson.h"
+#endif
+
+#if defined(BOLT_SIMDJSON_RESTORE_CPP_LIB_RANGES)
+#pragma pop_macro("__cpp_lib_ranges")
+#undef BOLT_SIMDJSON_RESTORE_CPP_LIB_RANGES
+#endif
+
+#if defined(BOLT_SIMDJSON_UNDEFINE_DISABLE_RANGES)
+#undef SIMDJSON_DISABLE_RANGES
+#undef BOLT_SIMDJSON_UNDEFINE_DISABLE_RANGES
 #endif

--- a/bolt/functions/sparksql/aggregates/ModeAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/ModeAggregate.cpp
@@ -42,10 +42,26 @@ namespace bytedance::bolt::functions::aggregate::sparksql {
 
 namespace {
 
+template <typename T>
+struct ModeAggregateHash : std::hash<T> {};
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+struct ModeAggregateHash<int128_t> {
+  size_t operator()(int128_t value) const noexcept {
+    return HugeInt::hash(value);
+  }
+};
+#endif
+
 // Mode aggregate function for scalar types.
 template <
     typename T,
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+    typename Hash = ModeAggregateHash<T>,
+#else
     typename Hash = std::hash<T>,
+#endif
     typename EqualTo = std::equal_to<T>>
 class ModeAggregate {
  public:

--- a/bolt/functions/sparksql/aggregates/PercentileAggregate.h
+++ b/bolt/functions/sparksql/aggregates/PercentileAggregate.h
@@ -53,24 +53,26 @@ struct custom_equal_to {
 
 template <typename T>
 struct custom_hash {
- private:
-  std::hash<T> hasher_;
-
- public:
   size_t operator()(const T& val) const {
     if constexpr (std::is_same_v<T, float>) {
       const static float Nan = std::nan("");
       if (FOLLY_UNLIKELY(std::isnan(val))) {
-        return hasher_(Nan);
+        return std::hash<T>{}(Nan);
       }
-    }
-    if constexpr (std::is_same_v<T, double>) {
+      return std::hash<T>{}(val);
+    } else if constexpr (std::is_same_v<T, double>) {
       const static double Nan = std::nan("");
       if (FOLLY_UNLIKELY(std::isnan(val))) {
-        return hasher_(Nan);
+        return std::hash<T>{}(Nan);
       }
+      return std::hash<T>{}(val);
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+    } else if constexpr (std::is_same_v<T, int128_t>) {
+      return HugeInt::hash(val);
+#endif
+    } else {
+      return std::hash<T>{}(val);
     }
-    return hasher_(val);
   }
 };
 
@@ -785,10 +787,9 @@ class PercentileAggregate : public exec::Aggregate {
       const std::vector<bool>& isNull) {
     if (!percentiles_) {
       BOLT_USER_CHECK_GT(len, 0, "Percentile cannot be empty");
-      percentiles_ = {
-          .values = std::vector<double>(len),
-          .isArray = isArray,
-      };
+      percentiles_.emplace();
+      percentiles_->values.resize(len);
+      percentiles_->isArray = isArray;
       for (vector_size_t i = 0; i < len; ++i) {
         BOLT_USER_CHECK(!isNull[i], "Percentile cannot be null");
         BOLT_USER_CHECK_GE(data[i], 0, "Percentile must be between 0 and 1");

--- a/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.cpp
+++ b/bolt/functions/sparksql/aggregates/PercentileApproxAggregate.cpp
@@ -89,10 +89,9 @@ void PercentileApproxAggregateBase::checkSetPercentile(
     const std::vector<bool>& isNull) {
   if (!percentiles_) {
     BOLT_USER_CHECK_GT(len, 0, "Percentile cannot be empty");
-    percentiles_ = {
-        .values = std::vector<double>(len),
-        .isArray = isArray,
-    };
+    percentiles_.emplace();
+    percentiles_->values.resize(len);
+    percentiles_->isArray = isArray;
     for (vector_size_t i = 0; i < len; ++i) {
       BOLT_USER_CHECK(!isNull[i], "Percentage value must not be null");
       BOLT_USER_CHECK(

--- a/bolt/parse/DuckLogicalOperator.h
+++ b/bolt/parse/DuckLogicalOperator.h
@@ -30,10 +30,9 @@
 
 #pragma once
 
-// This file contains the definitions of the logical plan nodes extracted from
-// the duckdb-internal.hpp file. It is not possible to include
-// duckdb-internal.hpp directly because it contains an incompatible / outdated
-// copy of fmt/format.h.
+// This file keeps DuckDB logical operator includes in one place. Do not include
+// duckdb-internal.hpp here because it can bring an incompatible / outdated copy
+// of fmt/format.h.
 
 /*
 Copyright 2018-2022 Stichting DuckDB Foundation
@@ -56,162 +55,10 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <duckdb.hpp> // @manual
-#include <duckdb/common/insertion_order_preserving_map.hpp> // @manual
-
-namespace duckdb {
-
-//! LogicalDummyScan represents a dummy scan returning a single row
-class LogicalDummyScan : public LogicalOperator {
- public:
-  explicit LogicalDummyScan(idx_t table_index)
-      : LogicalOperator(LogicalOperatorType::LOGICAL_DUMMY_SCAN),
-        table_index(table_index) {}
-
-  idx_t table_index;
-
- public:
-  vector<ColumnBinding> GetColumnBindings() override {
-    return {ColumnBinding(table_index, 0)};
-  }
-
-  idx_t EstimateCardinality(ClientContext& context) override {
-    return 1;
-  }
-
- protected:
-  void ResolveTypes() override {
-    if (types.size() == 0) {
-      types.emplace_back(LogicalType::INTEGER);
-    }
-  }
-};
-
-//! LogicalGet represents a scan operation from a data source
-class LogicalGet : public LogicalOperator {
- public:
-  LogicalGet(
-      idx_t table_index,
-      TableFunction function,
-      unique_ptr<FunctionData> bind_data,
-      vector<LogicalType> returned_types,
-      vector<string> returned_names);
-
-  //! The table index in the current bind context
-  idx_t table_index;
-  //! The function that is called
-  TableFunction function;
-  //! The bind data of the function
-  unique_ptr<FunctionData> bind_data;
-  //! The types of ALL columns that can be returned by the table function
-  vector<LogicalType> returned_types;
-  //! The names of ALL columns that can be returned by the table function
-  vector<string> names;
-  //! Columns that are used outside the scan
-  vector<idx_t> projection_ids;
-  //! Filters pushed down for table scan
-  TableFilterSet table_filters;
-  //! The set of input parameters for the table function
-  vector<Value> parameters;
-  string GetName() const override;
-  InsertionOrderPreservingMap<string> ParamsToString() const override;
-  //! Returns the underlying table that is being scanned, or nullptr if there is
-  //! none
-  optional_ptr<TableCatalogEntry> GetTable() const;
-
- public:
-  const vector<column_t>& GetColumnIds() const;
-  vector<ColumnBinding> GetColumnBindings() override;
-
-  idx_t EstimateCardinality(ClientContext& context) override;
-
- protected:
-  void ResolveTypes() override;
-
- private:
-  LogicalGet();
-};
-
-//! LogicalFilter represents a filter operation (e.g. WHERE or HAVING clause)
-class LogicalFilter : public LogicalOperator {
- public:
-  explicit LogicalFilter(unique_ptr<Expression> expression);
-  LogicalFilter();
-
-  vector<idx_t> projection_map;
-  vector<ColumnBinding> GetColumnBindings() override;
-
-  bool SplitPredicates() {
-    return SplitPredicates(expressions);
-  }
-  //! Splits up the predicates of the LogicalFilter into a set of predicates
-  //! separated by AND Returns whether or not any splits were made
-  static bool SplitPredicates(vector<unique_ptr<Expression>>& expressions);
-
- protected:
-  void ResolveTypes() override;
-};
-
-//! LogicalProjection represents the projection list in a SELECT clause
-class LogicalProjection : public LogicalOperator {
- public:
-  LogicalProjection(
-      idx_t table_index,
-      vector<unique_ptr<Expression>> select_list);
-
-  idx_t table_index;
-
- public:
-  vector<ColumnBinding> GetColumnBindings() override;
-
- protected:
-  void ResolveTypes() override;
-};
-
-using GroupingSet = set<idx_t>;
-
-//! LogicalAggregate represents an aggregate operation with (optional) GROUP BY
-//! operator.
-class LogicalAggregate : public LogicalOperator {
- public:
-  LogicalAggregate(
-      idx_t group_index,
-      idx_t aggregate_index,
-      vector<unique_ptr<Expression>> select_list);
-
-  //! The table index for the groups of the LogicalAggregate
-  idx_t group_index;
-  //! The table index for the aggregates of the LogicalAggregate
-  idx_t aggregate_index;
-  //! The table index for the GROUPING function calls of the LogicalAggregate
-  idx_t groupings_index;
-  //! The set of groups (optional).
-  vector<unique_ptr<Expression>> groups;
-  //! The set of grouping sets (optional).
-  vector<GroupingSet> grouping_sets;
-  //! The list of grouping function calls (optional)
-  vector<vector<idx_t>> grouping_functions;
-  //! Group statistics (optional)
-  vector<unique_ptr<BaseStatistics>> group_stats;
-
- public:
-  InsertionOrderPreservingMap<string> ParamsToString() const override;
-
-  vector<ColumnBinding> GetColumnBindings() override;
-
- protected:
-  void ResolveTypes() override;
-};
-
-//! LogicalCrossProduct represents a cross product between two relations
-class LogicalCrossProduct : public LogicalOperator {
- public:
-  LogicalCrossProduct();
-
- public:
-  vector<ColumnBinding> GetColumnBindings() override;
-
- protected:
-  void ResolveTypes() override;
-};
-} // namespace duckdb
+#include <duckdb/planner/operator/logical_aggregate.hpp> // @manual
+#include <duckdb/planner/operator/logical_cross_product.hpp> // @manual
+#include <duckdb/planner/operator/logical_dummy_scan.hpp> // @manual
+#include <duckdb/planner/operator/logical_filter.hpp> // @manual
+#include <duckdb/planner/operator/logical_get.hpp> // @manual
+#include <duckdb/planner/operator/logical_projection.hpp> // @manual
+#include <duckdb/planner/operator/logical_unnest.hpp> // @manual

--- a/bolt/parse/QueryPlanner.cpp
+++ b/bolt/parse/QueryPlanner.cpp
@@ -29,19 +29,25 @@
  */
 
 #include "bolt/parse/QueryPlanner.h"
+
+#include "bolt/duckdb/DuckDbCompat.h"
 #include "bolt/duckdb/conversion/DuckConversion.h"
 #include "bolt/parse/DuckLogicalOperator.h"
 #include "bolt/vector/VariantToVector.h"
 
-#include <duckdb.hpp> // @manual
 #include <duckdb/function/aggregate_function.hpp> // @manual
+#include <duckdb/parser/statement/select_statement.hpp> // @manual
 #include <duckdb/main/connection.hpp> // @manual
+#include <duckdb/main/database.hpp> // @manual
 #include <duckdb/planner/expression/bound_aggregate_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_cast_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_comparison_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_constant_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_function_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_reference_expression.hpp> // @manual
+
+#include <type_traits>
+
 namespace bytedance::bolt::core {
 
 namespace {
@@ -86,6 +92,22 @@ struct QueryContext {
     return columnNameGenerator.next(prefix);
   }
 };
+
+template <typename T>
+const auto& getColumnIdsImpl(T& logicalGet)
+  requires requires(T& value) { value.GetColumnIds(); }
+{
+  return logicalGet.GetColumnIds();
+}
+
+template <typename T>
+const auto& getColumnIdsImpl(T& logicalGet) {
+  return logicalGet.column_ids;
+}
+
+const auto& getColumnIds(::duckdb::LogicalGet& logicalGet) {
+  return getColumnIdsImpl(logicalGet);
+}
 
 std::string mapScalarFunctionName(const std::string& name) {
   static const std::unordered_map<std::string, std::string> kMapping = {
@@ -206,7 +228,7 @@ PlanNodePtr toBoltPlan(
   BOLT_CHECK_EQ(logicalGet.function.name, "seq_scan");
   BOLT_CHECK_EQ(0, sources.size());
 
-  const auto& columnIds = logicalGet.GetColumnIds();
+  const auto& columnIds = getColumnIds(logicalGet);
   std::vector<std::string> names(columnIds.size());
   std::vector<TypePtr> types(columnIds.size());
 
@@ -540,15 +562,45 @@ static void customScalarFunction(
   BOLT_UNREACHABLE();
 }
 
-::duckdb::idx_t customAggregateState(
+::duckdb::idx_t customAggregateState() {
+  BOLT_UNREACHABLE();
+}
+
+::duckdb::idx_t customAggregateStateWithFunction(
     const ::duckdb::AggregateFunction& /*function*/) {
   BOLT_UNREACHABLE();
 }
 
-void customAggregateInitialize(
+template <typename AggregateSize>
+AggregateSize customAggregateStateFunction() {
+  if constexpr (std::is_same_v<
+                    AggregateSize,
+                    ::duckdb::idx_t (*)()>) {
+    return &customAggregateState;
+  } else {
+    return &customAggregateStateWithFunction;
+  }
+}
+
+void customAggregateInitialize(::duckdb::data_ptr_t /* state */) {
+  BOLT_UNREACHABLE();
+}
+
+void customAggregateInitializeWithFunction(
     const ::duckdb::AggregateFunction& /*function*/,
     ::duckdb::data_ptr_t /* state */) {
   BOLT_UNREACHABLE();
+}
+
+template <typename AggregateInitialize>
+AggregateInitialize customAggregateInitializeFunction() {
+  if constexpr (std::is_same_v<
+                    AggregateInitialize,
+                    void (*)(::duckdb::data_ptr_t)>) {
+    return &customAggregateInitialize;
+  } else {
+    return &customAggregateInitializeWithFunction;
+  }
 }
 
 static void customAggregateUpdate(
@@ -579,6 +631,20 @@ static void customAggregateFinalize(
 
 } // namespace
 
+struct DuckDbQueryPlanner::Impl {
+  explicit Impl(memory::MemoryPool* pool) : conn{db}, pool{pool} {}
+
+  ::duckdb::DuckDB db;
+  ::duckdb::Connection conn;
+  memory::MemoryPool* pool;
+  std::unordered_map<std::string, std::vector<RowVectorPtr>> tables;
+};
+
+DuckDbQueryPlanner::DuckDbQueryPlanner(memory::MemoryPool* pool)
+    : impl_{std::make_unique<Impl>(pool)} {}
+
+DuckDbQueryPlanner::~DuckDbQueryPlanner() = default;
+
 PlanNodePtr parseQuery(
     const std::string& sql,
     memory::MemoryPool* pool,
@@ -597,15 +663,15 @@ void DuckDbQueryPlanner::registerTable(
     const std::string& name,
     const std::vector<RowVectorPtr>& data) {
   BOLT_CHECK_EQ(
-      0, tables_.count(name), "Table is already registered: {}", name);
+      0, impl_->tables.count(name), "Table is already registered: {}", name);
 
   auto createTableSql =
       duckdb::makeCreateTableSql(name, *asRowType(data[0]->type()));
-  auto res = conn_.Query(createTableSql);
+  auto res = impl_->conn.Query(createTableSql);
   BOLT_CHECK(
       !res->HasError(), "Failed to create DuckDB table: {}", res->GetError());
 
-  tables_.insert({name, data});
+  impl_->tables.insert({name, data});
 }
 
 void DuckDbQueryPlanner::registerScalarFunction(
@@ -617,7 +683,7 @@ void DuckDbQueryPlanner::registerScalarFunction(
     argDuckTypes.push_back(duckdb::fromBoltType(type));
   }
 
-  conn_.CreateVectorizedFunction(
+  impl_->conn.CreateVectorizedFunction(
       name,
       argDuckTypes,
       duckdb::fromBoltType(returnType),
@@ -633,12 +699,12 @@ void DuckDbQueryPlanner::registerAggregateFunction(
     argDuckTypes.push_back(duckdb::fromBoltType(type));
   }
 
-  conn_.CreateAggregateFunction(
+  impl_->conn.CreateAggregateFunction(
       name,
       argDuckTypes,
       duckdb::fromBoltType(returnType),
-      customAggregateState,
-      customAggregateInitialize,
+      customAggregateStateFunction<::duckdb::aggregate_size_t>(),
+      customAggregateInitializeFunction<::duckdb::aggregate_initialize_t>(),
       customAggregateUpdate,
       customAggregateCombine,
       customAggregateFinalize);
@@ -647,12 +713,12 @@ void DuckDbQueryPlanner::registerAggregateFunction(
 PlanNodePtr DuckDbQueryPlanner::plan(const std::string& sql) {
   // Disable the optimizer. Otherwise, the filter over table scan gets pushdown
   // as a callback that is impossible to recover.
-  conn_.Query("PRAGMA disable_optimizer");
+  impl_->conn.Query("PRAGMA disable_optimizer");
 
-  auto plan = conn_.ExtractPlan(sql);
+  auto plan = impl_->conn.ExtractPlan(sql);
 
-  QueryContext queryContext{tables_};
-  return toBoltPlan(*plan, pool_, queryContext);
+  QueryContext queryContext{impl_->tables};
+  return toBoltPlan(*plan, impl_->pool, queryContext);
 }
 
 } // namespace bytedance::bolt::core

--- a/bolt/parse/QueryPlanner.h
+++ b/bolt/parse/QueryPlanner.h
@@ -33,12 +33,17 @@
 #include "bolt/core/PlanNode.h"
 #include "bolt/parse/PlanNodeIdGenerator.h"
 
-#include <duckdb.hpp> // @manual
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 namespace bytedance::bolt::core {
 
 class DuckDbQueryPlanner {
  public:
-  DuckDbQueryPlanner(memory::MemoryPool* pool) : pool_{pool} {}
+  explicit DuckDbQueryPlanner(memory::MemoryPool* pool);
+  ~DuckDbQueryPlanner();
 
   void registerTable(
       const std::string& name,
@@ -60,10 +65,8 @@ class DuckDbQueryPlanner {
   PlanNodePtr plan(const std::string& sql);
 
  private:
-  ::duckdb::DuckDB db_;
-  ::duckdb::Connection conn_{db_};
-  memory::MemoryPool* pool_;
-  std::unordered_map<std::string, std::vector<RowVectorPtr>> tables_;
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 PlanNodePtr parseQuery(

--- a/bolt/type/DecimalUtil.h
+++ b/bolt/type/DecimalUtil.h
@@ -37,6 +37,7 @@
 #include "bolt/common/base/CountBits.h"
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/common/base/Nulls.h"
+#include "bolt/common/base/Portability.h"
 #include "bolt/common/base/Status.h"
 #include "bolt/type/Type.h"
 namespace bytedance::bolt {
@@ -135,6 +136,66 @@ class DecimalUtil {
 
   enum class DecimalStringFormat { kPlain, kSpark };
 
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+  inline static std::to_chars_result toChars(
+      char* first,
+      char* last,
+      uint128_t value) {
+    char buffer[LongDecimalType::kMaxPrecision + 1];
+    char* position = std::end(buffer);
+    do {
+      *--position = static_cast<char>('0' + value % 10);
+      value /= 10;
+    } while (value != 0);
+
+    const auto size = std::end(buffer) - position;
+    if (last - first < size) {
+      return {last, std::errc::value_too_large};
+    }
+    std::memcpy(first, position, size);
+    return {first + size, std::errc()};
+  }
+
+  inline static std::to_chars_result toChars(
+      char* first,
+      char* last,
+      int128_t value) {
+    if (value < 0) {
+      if (first == last) {
+        return {last, std::errc::value_too_large};
+      }
+      *first++ = '-';
+      return toChars(first, last, static_cast<uint128_t>(-value));
+    }
+    return toChars(first, last, static_cast<uint128_t>(value));
+  }
+
+  template <typename T>
+  inline static std::to_chars_result toChars(char* first, char* last, T value) {
+    return std::to_chars(first, last, value);
+  }
+
+  template <typename T>
+  struct UnsignedDecimalType {
+    using type = typename std::make_unsigned<T>::type;
+  };
+
+  template <>
+  struct UnsignedDecimalType<int128_t> {
+    using type = uint128_t;
+  };
+#else
+  template <typename T>
+  inline static std::to_chars_result toChars(char* first, char* last, T value) {
+    return std::to_chars(first, last, value);
+  }
+
+  template <typename T>
+  struct UnsignedDecimalType {
+    using type = typename std::make_unsigned<T>::type;
+  };
+#endif
+
   template <typename T>
   inline static size_t convertToPlainString(
       T unscaledValue,
@@ -156,7 +217,7 @@ class DecimalUtil {
         *writePosition++ = '-';
         unscaledValue = -unscaledValue;
       }
-      auto [position, errorCode] = std::to_chars(
+      auto [position, errorCode] = toChars(
           writePosition,
           endPosition,
           unscaledValue / (T)DecimalUtil::kPowersOfTen[scale]);
@@ -176,7 +237,7 @@ class DecimalUtil {
         std::memset(writePosition, '0', numLeadingZeros);
         writePosition += numLeadingZeros;
         // Append remaining fraction digits.
-        auto result = std::to_chars(writePosition, endPosition, fraction);
+        auto result = toChars(writePosition, endPosition, fraction);
         BOLT_DCHECK_EQ(
             result.ec,
             std::errc(),
@@ -195,7 +256,7 @@ class DecimalUtil {
       int32_t maxVarcharSize,
       char* const startPosition) {
     if (scale == 0) {
-      auto [endPosition, errorCode] = std::to_chars(
+      auto [endPosition, errorCode] = toChars(
           startPosition, startPosition + maxVarcharSize, unscaledValue);
       BOLT_DCHECK_EQ(
           errorCode,
@@ -237,7 +298,7 @@ class DecimalUtil {
       }
       // [!sci could have made 0]
       *writePosition++ = 'E';
-      auto [position, errorCode] = std::to_chars(
+      auto [position, errorCode] = toChars(
           writePosition, startPosition + maxVarcharSize, adjusted);
       BOLT_DCHECK_EQ(
           errorCode,
@@ -478,7 +539,7 @@ class DecimalUtil {
         return static_cast<TOutput>(0);
       }
       auto shifted = value >> shift;
-      using unsigned_type = typename std::make_unsigned<TOutput>::type;
+      using unsigned_type = typename UnsignedDecimalType<TOutput>::type;
       auto threshold = static_cast<unsigned_type>(1) << (shift - 1);
       auto rest = value & ((((unsigned_type)1) << shift) - 1);
       if (rest >= threshold) {

--- a/bolt/type/HugeInt.h
+++ b/bolt/type/HugeInt.h
@@ -33,7 +33,12 @@
 #include <string>
 #include "bolt/common/base/BitUtil.h"
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/Portability.h"
 #include "bolt/type/StringView.h"
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+#include <folly/hash/Hash.h>
+#endif
 
 #pragma once
 namespace bytedance::bolt {
@@ -81,6 +86,20 @@ class HugeInt {
   static constexpr FOLLY_ALWAYS_INLINE uint64_t upper(int128_t value) {
     return static_cast<uint64_t>(value >> 64);
   }
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+  static FOLLY_ALWAYS_INLINE size_t hash(int128_t value) {
+    auto unsignedValue = static_cast<uint128_t>(value);
+    return folly::hash::hash_128_to_64(
+        static_cast<uint64_t>(unsignedValue >> 64),
+        static_cast<uint64_t>(unsignedValue));
+  }
+
+  static FOLLY_ALWAYS_INLINE size_t hash(uint128_t value) {
+    return folly::hash::hash_128_to_64(
+        static_cast<uint64_t>(value >> 64), static_cast<uint64_t>(value));
+  }
+#endif
 
   static FOLLY_ALWAYS_INLINE int128_t deserialize(const char* serializedData) {
     int128_t value;

--- a/bolt/type/Type.h
+++ b/bolt/type/Type.h
@@ -35,6 +35,7 @@
 #include <folly/Format.h>
 #include <folly/Range.h>
 #include <folly/String.h>
+#include <folly/container/HeterogeneousAccess.h>
 #include <folly/json.h>
 #include <cstdint>
 #include <cstring>
@@ -56,6 +57,29 @@
 #include "bolt/type/Tree.h"
 #include "bolt/type/VariantValue.h"
 #include "folly/CPortability.h"
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+namespace folly {
+template <>
+struct HeterogeneousAccessHash<__int128_t, void> {
+  using folly_is_avalanching = std::true_type;
+
+  size_t operator()(__int128_t value) const noexcept {
+    return bytedance::bolt::HugeInt::hash(value);
+  }
+};
+
+template <>
+struct HeterogeneousAccessHash<__uint128_t, void> {
+  using folly_is_avalanching = std::true_type;
+
+  size_t operator()(__uint128_t value) const noexcept {
+    return bytedance::bolt::HugeInt::hash(value);
+  }
+};
+} // namespace folly
+#endif
+
 namespace bytedance::bolt {
 
 using int128_t = __int128_t;

--- a/bolt/type/Variant.cpp
+++ b/bolt/type/Variant.cpp
@@ -568,7 +568,7 @@ folly::dynamic variant::serialize() const {
       break;
     }
     case TypeKind::HUGEINT: {
-      objValue = value<TypeKind::HUGEINT>();
+      objValue = std::to_string(value<TypeKind::HUGEINT>());
       break;
     }
     case TypeKind::BOOLEAN: {
@@ -681,7 +681,8 @@ variant variant::create(const folly::dynamic& variantobj) {
     case TypeKind::BIGINT:
       return variant::create<TypeKind::BIGINT>(obj.asInt());
     case TypeKind::HUGEINT:
-      return variant::create<TypeKind::HUGEINT>(obj.asInt());
+      return variant::create<TypeKind::HUGEINT>(
+          obj.isString() ? HugeInt::parse(obj.asString()) : obj.asInt());
     case TypeKind::BOOLEAN: {
       return variant(obj.asBool());
     }
@@ -779,7 +780,11 @@ uint64_t variant::hash() const {
     case TypeKind::BIGINT:
       return folly::Hash{}(value<TypeKind::BIGINT>());
     case TypeKind::HUGEINT:
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+      return HugeInt::hash(value<TypeKind::HUGEINT>());
+#else
       return folly::Hash{}(value<TypeKind::HUGEINT>());
+#endif
     case TypeKind::INTEGER:
       return folly::Hash{}(value<TypeKind::INTEGER>());
     case TypeKind::SMALLINT:

--- a/bolt/vector/FlatVector-inl.h
+++ b/bolt/vector/FlatVector-inl.h
@@ -102,9 +102,8 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
   auto hashData = hashBuffer->asMutable<uint64_t>();
 
   if (rawValues_ != nullptr) { // non all-null case
-    folly::hasher<T> hasher;
     for (size_t i = 0; i < BaseVector::length_; ++i) {
-      hashData[i] = hasher(valueAtFast(i));
+      hashData[i] = vectorHashValue(valueAtFast(i));
     }
   }
 

--- a/bolt/vector/SimpleVector.h
+++ b/bolt/vector/SimpleVector.h
@@ -53,6 +53,20 @@ class EvalCtx;
 }
 
 template <typename T>
+inline uint64_t vectorHashValue(const T& value) {
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+  if constexpr (std::is_same_v<T, int128_t> ||
+                std::is_same_v<T, __uint128_t>) {
+    return HugeInt::hash(value);
+  } else {
+    return folly::hasher<T>{}(value);
+  }
+#else
+  return folly::hasher<T>{}(value);
+#endif
+}
+
+template <typename T>
 struct SimpleVectorStats {
   std::optional<T> min;
   std::optional<T> max;
@@ -184,7 +198,7 @@ class SimpleVector : public BaseVector {
    */
   uint64_t hashValueAt(vector_size_t index) const override {
     return isNullAt(index) ? BaseVector::kNullHash
-                           : folly::hasher<T>{}(valueAt(index));
+                           : vectorHashValue(valueAt(index));
   }
 
   std::optional<bool> isSorted() const {

--- a/bolt/vector/tests/utils/VectorMakerStats.h
+++ b/bolt/vector/tests/utils/VectorMakerStats.h
@@ -75,6 +75,25 @@ struct EvalTypeHelper<uint128_t> {
 template <typename T>
 using EvalType = typename EvalTypeHelper<T>::Type;
 
+template <typename T>
+struct VectorMakerStatsHash : std::hash<T> {};
+
+#if defined(BOLT_CLANG_LIBSTDCXX_INT128_COMPAT)
+template <>
+struct VectorMakerStatsHash<int128_t> {
+  size_t operator()(int128_t value) const noexcept {
+    return HugeInt::hash(value);
+  }
+};
+
+template <>
+struct VectorMakerStatsHash<uint128_t> {
+  size_t operator()(uint128_t value) const noexcept {
+    return HugeInt::hash(value);
+  }
+};
+#endif
+
 // Struct that caries metadata about a vector of nullable elements.
 template <typename T>
 class VectorMakerStats {
@@ -97,7 +116,7 @@ class VectorMakerStats {
   bool isSorted{false};
 
  private:
-  std::unordered_set<T> distinctSet_;
+  std::unordered_set<T, VectorMakerStatsHash<T>> distinctSet_;
 };
 
 // Generates VectorMakerStats for a given vector of nullable elements.

--- a/conanfile.py
+++ b/conanfile.py
@@ -159,6 +159,8 @@ class BoltConan(ConanFile):
             if scm_branch != "main":
                 cmd = f"-b {scm_branch} origin/{scm_branch}"
                 git.checkout(cmd)
+                git.run(f"fetch origin {scm_branch}")
+                git.checkout("FETCH_HEAD")
 
     def io_uring_supported(self):
         if not self.options.io_uring_supported:
@@ -180,6 +182,30 @@ class BoltConan(ConanFile):
                 return has_minimum_kernel
         self.output.info("OS is not Linux. io_uring is not supported.")
         return False
+
+    @staticmethod
+    def _append_cache_flags(cache_variables, key, flags):
+        if isinstance(flags, str):
+            flags = [flags]
+        current = str(cache_variables.get(key, "")).strip()
+        additions = [str(flag).strip() for flag in flags if str(flag).strip()]
+        if additions:
+            cache_variables[key] = " ".join(
+                [value for value in [current, *additions] if value]
+            )
+
+    def _toolchain_cxx_flags(self):
+        flags = []
+        if (
+            str(self.settings.compiler) == "clang"
+            and str(self.settings.compiler.get_safe("libcxx")) == "libc++"
+        ):
+            flags.append("-stdlib=libc++")
+        flags.extend(self.conf.get("tools.build:cxxflags", default=[]))
+        return flags
+
+    def _toolchain_c_flags(self):
+        return self.conf.get("tools.build:cflags", default=[])
 
     def requirements(self):
         protobuf_version = os.getenv("PROTOBUF_VERSION", "3.21.4")
@@ -435,13 +461,29 @@ class BoltConan(ConanFile):
             flags = (
                 f"{self.BOLT_GLOBAL_FLAGS} -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 "
             )
-            tc.cache_variables["CMAKE_CXX_FLAGS"] = flags
-            tc.cache_variables["CMAKE_C_FLAGS"] = flags
+            self._append_cache_flags(
+                tc.cache_variables,
+                "CMAKE_CXX_FLAGS",
+                [*self._toolchain_cxx_flags(), flags],
+            )
+            self._append_cache_flags(
+                tc.cache_variables,
+                "CMAKE_C_FLAGS",
+                [*self._toolchain_c_flags(), flags],
+            )
 
         if str(self.settings.arch) in ["armv8", "arm", "armv9"]:
             flags = self._get_arm_cpu_flags()
-            tc.cache_variables["CMAKE_CXX_FLAGS"] = flags
-            tc.cache_variables["CMAKE_C_FLAGS"] = flags
+            self._append_cache_flags(
+                tc.cache_variables,
+                "CMAKE_CXX_FLAGS",
+                [*self._toolchain_cxx_flags(), flags],
+            )
+            self._append_cache_flags(
+                tc.cache_variables,
+                "CMAKE_C_FLAGS",
+                [*self._toolchain_c_flags(), flags],
+            )
         if (
             self.options.enable_torch is not None
             and self.options.enable_torch.value is not None
@@ -713,6 +755,11 @@ class BoltConan(ConanFile):
                 "gtest::gtest",
                 "duckdb::duckdb",
             ]
+        else:
+            self.cpp_info.components["bolt_testutils"].set_property(
+                "cmake_target_name", "bolt::bolt_testutils"
+            )
+            self.cpp_info.components["bolt_testutils"].requires = ["bolt_engine"]
 
     def _get_arm_cpu_flags(self) -> str:
         """


### PR DESCRIPTION
Port the clang16/libc++ compatibility fixes from the internal Bolt branch into the open-source SSOT. This preserves libc++ toolchain flags, adds DuckDB parser compatibility, and hardens HUGEINT hashing, serialization, and percentile state initialization paths.

Validation: conan export . --name=bolt --version=fix-clang16-libcxx-int128-oss --user=bytedance --channel=testing

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
