### PR TITLE
test: Remove Arrow testing dependency and cap executor threads

### DIFF
--- a/bolt/common/base/tests/ArrowTestUtils.h
+++ b/bolt/common/base/tests/ArrowTestUtils.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/util/string_builder.h"
+
+namespace bytedance::bolt::test::detail {
+
+inline ::arrow::Status arrowStatus(const ::arrow::Status& status) {
+  return status;
+}
+
+template <typename T>
+::arrow::Status arrowStatus(const ::arrow::Result<T>& result) {
+  return result.status();
+}
+
+} // namespace bytedance::bolt::test::detail
+
+// Keep these names aligned with the Arrow-derived tests while using only
+// Arrow's public runtime APIs.
+#define ASSERT_OK(expression)                                          \
+  for (const auto _boltArrowStatus =                                   \
+           ::bytedance::bolt::test::detail::arrowStatus((expression)); \
+       !_boltArrowStatus.ok();)                                        \
+  FAIL() << "'" #expression "' failed with " << _boltArrowStatus.ToString()
+
+#define BOLT_ARROW_EXPECT_OK(expression)                                    \
+  do {                                                                      \
+    auto&& _boltArrowResult = (expression);                                 \
+    const auto _boltArrowStatus =                                           \
+        ::bytedance::bolt::test::detail::arrowStatus(_boltArrowResult);     \
+    EXPECT_TRUE(_boltArrowStatus.ok())                                      \
+        << "'" #expression "' failed with " << _boltArrowStatus.ToString(); \
+  } while (false)
+
+#define BOLT_ARROW_CONCAT_IMPL(x, y) x##y
+#define BOLT_ARROW_CONCAT(x, y) BOLT_ARROW_CONCAT_IMPL(x, y)
+
+#define BOLT_ARROW_ASSIGN_OR_HANDLE_ERROR_IMPL( \
+    handleError, statusName, lhs, expression)   \
+  auto&& statusName = (expression);             \
+  handleError(statusName.status());             \
+  lhs = std::move(statusName).ValueOrDie()
+
+#define ASSERT_OK_AND_ASSIGN(lhs, expression)           \
+  BOLT_ARROW_ASSIGN_OR_HANDLE_ERROR_IMPL(               \
+      ASSERT_OK,                                        \
+      BOLT_ARROW_CONCAT(_boltArrowResult, __COUNTER__), \
+      lhs,                                              \
+      expression)
+
+#define EXPECT_OK_AND_ASSIGN(lhs, expression)           \
+  BOLT_ARROW_ASSIGN_OR_HANDLE_ERROR_IMPL(               \
+      BOLT_ARROW_EXPECT_OK,                             \
+      BOLT_ARROW_CONCAT(_boltArrowResult, __COUNTER__), \
+      lhs,                                              \
+      expression)
+
+#define ARROW_SCOPED_TRACE(...) \
+  SCOPED_TRACE(::arrow::util::StringBuilder(__VA_ARGS__))

--- a/bolt/dwio/parquet/arrow/tests/BloomFilterTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/BloomFilterTest.cpp
@@ -43,9 +43,8 @@
 #include "arrow/buffer.h"
 #include "arrow/io/file.h"
 #include "arrow/status.h"
-#include "arrow/testing/gtest_util.h"
-#include "arrow/testing/random.h"
 
+#include "bolt/common/base/tests/ArrowTestUtils.h"
 #include "bolt/dwio/parquet/arrow/Exception.h"
 #include "bolt/dwio/parquet/arrow/Platform.h"
 #include "bolt/dwio/parquet/arrow/Types.h"
@@ -482,7 +481,7 @@ TYPED_TEST(TestBatchBloomFilter, Basic) {
     batch_insert_filter.WriteTo(sink.get());
     ASSERT_OK_AND_ASSIGN(batch_insert_buffer, sink->Finish());
   }
-  AssertBufferEqual(*buffer, *batch_insert_buffer);
+  ASSERT_TRUE(buffer->Equals(*batch_insert_buffer));
 }
 
 } // namespace test

--- a/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
@@ -43,10 +43,10 @@
 #include "arrow/array/builder_binary.h"
 #include "arrow/buffer.h"
 #include "arrow/io/buffered.h"
-#include "arrow/testing/gtest_util.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_builders.h"
 
+#include "bolt/common/base/tests/ArrowTestUtils.h"
 #include "bolt/dwio/parquet/arrow/ColumnWriter.h"
 #include "bolt/dwio/parquet/arrow/Encoding.h"
 #include "bolt/dwio/parquet/arrow/EncodingInternal.h"

--- a/bolt/dwio/parquet/arrow/tests/FileDeserializeTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/FileDeserializeTest.cpp
@@ -51,9 +51,11 @@
 
 #include "arrow/io/memory.h"
 #include "arrow/status.h"
-#include "arrow/testing/gtest_util.h"
 #include "arrow/util/compression.h"
 #include "arrow/util/crc32.h"
+
+#include "bolt/common/base/tests/ArrowTestUtils.h"
+
 namespace bytedance::bolt::parquet::arrow {
 
 using ::arrow::io::BufferReader;

--- a/bolt/dwio/parquet/arrow/tests/FileSerializeTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/FileSerializeTest.cpp
@@ -37,7 +37,6 @@
 #include <gtest/gtest.h>
 
 #include "arrow/api.h"
-#include "arrow/testing/gtest_compat.h"
 
 #include "bolt/dwio/parquet/arrow/ColumnWriter.h"
 #include "bolt/dwio/parquet/arrow/FileWriter.h"

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
@@ -42,7 +42,6 @@
 #include <string>
 #include <vector>
 
-#include "arrow/testing/gtest_compat.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap.h"
 #include "arrow/util/ubsan.h"

--- a/bolt/dwio/parquet/arrow/tests/StatisticsTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/StatisticsTest.cpp
@@ -42,15 +42,15 @@
 #include <vector>
 
 #include "arrow/array.h"
+#include "arrow/array/builder_binary.h"
 #include "arrow/buffer.h"
 #include "arrow/memory_pool.h"
-#include "arrow/testing/builder.h"
-#include "arrow/testing/gtest_util.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/ubsan.h"
 
+#include "bolt/common/base/tests/ArrowTestUtils.h"
 #include "bolt/dwio/parquet/arrow/ColumnWriter.h"
 #include "bolt/dwio/parquet/arrow/FileWriter.h"
 #include "bolt/dwio/parquet/arrow/Platform.h"
@@ -1248,11 +1248,20 @@ template <typename ArrowType>
 void TestByteArrayStatisticsFromArrow() {
   using TypeTraits = ::arrow::TypeTraits<ArrowType>;
   using ArrayType = typename TypeTraits::ArrayType;
+  using BuilderType = typename TypeTraits::BuilderType;
 
-  auto values = ArrayFromJSON(
-      TypeTraits::type_singleton(),
-      "[\"c123\", \"b123\", \"a123\", null, "
-      "null, \"f123\", \"g123\", \"h123\", \"i123\", \"ü123\"]");
+  BuilderType builder;
+  ASSERT_OK(builder.Append("c123"));
+  ASSERT_OK(builder.Append("b123"));
+  ASSERT_OK(builder.Append("a123"));
+  ASSERT_OK(builder.AppendNull());
+  ASSERT_OK(builder.AppendNull());
+  ASSERT_OK(builder.Append("f123"));
+  ASSERT_OK(builder.Append("g123"));
+  ASSERT_OK(builder.Append("h123"));
+  ASSERT_OK(builder.Append("i123"));
+  ASSERT_OK(builder.Append("ü123"));
+  ASSERT_OK_AND_ASSIGN(auto values, builder.Finish());
 
   const auto& typed_values = static_cast<const ArrayType&>(*values);
 
@@ -1426,7 +1435,11 @@ void CheckExtrema() {
   std::vector<bool> is_valid = {
       true, false, false, false, false, true, true, true};
   std::shared_ptr<Buffer> valid_bitmap;
-  ::arrow::BitmapFromVector(is_valid, &valid_bitmap);
+  ASSERT_OK_AND_ASSIGN(
+      valid_bitmap, ::arrow::AllocateEmptyBitmap(is_valid.size()));
+  for (size_t i = 0; i < is_valid.size(); ++i) {
+    bit_util::SetBitTo(valid_bitmap->mutable_data(), i, is_valid[i]);
+  }
   {
     ARROW_SCOPED_TRACE(
         "spaced unsigned statistics: umin = ",

--- a/bolt/dwio/parquet/arrow/tests/TestUtil.h
+++ b/bolt/dwio/parquet/arrow/tests/TestUtil.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <memory>
 #include <random>
@@ -43,7 +44,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/io/memory.h"
-#include "arrow/testing/util.h"
+#include "arrow/util/pcg_random.h"
 
 #include "bolt/dwio/parquet/arrow/ColumnPage.h"
 #include "bolt/dwio/parquet/arrow/ColumnWriter.h"
@@ -744,9 +745,21 @@ void inline InitValues<bool>(
     std::vector<uint8_t>& buffer) {
   values = {};
   if (seed == 0) {
-    seed = static_cast<uint32_t>(::arrow::random_seed());
+    seed = static_cast<uint32_t>(
+        std::chrono::high_resolution_clock::now().time_since_epoch().count());
   }
-  ::arrow::random_is_valid(num_values, 0.5, &values, static_cast<int>(seed));
+  ::arrow::random::pcg32_fast generator(seed);
+  // Preserve Arrow's former random_is_valid sequence without its test helper.
+  constexpr double kGeneratorRange =
+      static_cast<double>(::arrow::random::pcg32_fast::max()) + 1;
+  values.resize(num_values);
+  std::generate(values.begin(), values.end(), [&]() {
+    const double randomValue =
+        (static_cast<double>(generator()) +
+         static_cast<double>(generator()) * kGeneratorRange) /
+        (kGeneratorRange * kGeneratorRange);
+    return randomValue > 0.5;
+  });
 }
 
 template <>

--- a/bolt/exec/tests/utils/AssertQueryBuilder.h
+++ b/bolt/exec/tests/utils/AssertQueryBuilder.h
@@ -182,7 +182,7 @@ class AssertQueryBuilder {
 
   static std::unique_ptr<folly::Executor> newExecutor() {
     return std::make_unique<folly::CPUThreadPoolExecutor>(
-        std::thread::hardware_concurrency());
+        testExecutorConcurrency());
   }
 
   // Used by the created task as the default driver executor.

--- a/bolt/exec/tests/utils/Cursor.cpp
+++ b/bolt/exec/tests/utils/Cursor.cpp
@@ -31,8 +31,21 @@
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/common/file/FileSystems.h"
 
+#include <folly/system/HardwareConcurrency.h>
+
+#include <algorithm>
 #include <filesystem>
+
 namespace bytedance::bolt::exec::test {
+
+namespace {
+constexpr unsigned kMaxTestExecutorThreads = 4;
+}
+
+unsigned testExecutorConcurrency() {
+  return std::min(
+      kMaxTestExecutorThreads, std::max(1u, folly::hardware_concurrency()));
+}
 
 bool waitForTaskDriversToFinish(exec::Task* task, uint64_t maxWaitMicros) {
   BOLT_USER_CHECK(!task->isRunning());
@@ -231,7 +244,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
       : TaskCursorBase(
             params,
             std::make_shared<folly::CPUThreadPoolExecutor>(
-                std::thread::hardware_concurrency())),
+                testExecutorConcurrency())),
         maxDrivers_{params.maxDrivers},
         numConcurrentSplitGroups_{params.numConcurrentSplitGroups},
         numSplitGroups_{params.numSplitGroups} {

--- a/bolt/exec/tests/utils/Cursor.h
+++ b/bolt/exec/tests/utils/Cursor.h
@@ -38,6 +38,10 @@
 
 namespace bytedance::bolt::exec::test {
 
+/// Returns the maximum number of threads for test executors, capped to avoid
+/// scaling every parallel test process to all CPUs visible on the host.
+unsigned testExecutorConcurrency();
+
 /// Wait up to maxWaitMicros for all the task drivers to finish. The function
 /// returns true if all the drivers have finished, otherwise false.
 ///

--- a/bolt/vector/arrow/benchmarks/CMakeLists.txt
+++ b/bolt/vector/arrow/benchmarks/CMakeLists.txt
@@ -45,5 +45,4 @@ target_link_libraries(
   import_arrow_bolt_bridge_benchmark PRIVATE
   bolt_arrow_bridge
   ${BOLT_BENCHMARK_DEPS}
-  arrow::libarrow_testing # TODO: remove this dependency
 )

--- a/bolt/vector/arrow/benchmarks/ImportArrowToBoltBenchmark.cpp
+++ b/bolt/vector/arrow/benchmarks/ImportArrowToBoltBenchmark.cpp
@@ -17,14 +17,15 @@
 #include <fmt/format.h>
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
+#include <algorithm>
+#include <random>
 #include <string>
 
 #include <arrow/api.h>
 #include <arrow/array.h>
 #include <arrow/c/bridge.h>
-#include <arrow/testing/gtest_util.h>
-#include <arrow/testing/random.h>
 
+#include "bolt/common/base/tests/ArrowTestUtils.h"
 #include "bolt/core/QueryCtx.h"
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/exec/tests/utils/OperatorTestBase.h"
@@ -112,58 +113,64 @@ ArrowArray stringViewArray_halfNull;
 ArrowSchema stringSchema;
 ArrowSchema stringViewSchema;
 
+template <typename Builder>
 void createStringArray(
-    arrow::random::RandomArrayGenerator& gen,
+    std::mt19937& generator,
     ArrowSchema& schema,
     ArrowArray& data,
     size_t minStringLength,
     size_t maxStringLength,
-    double null_prob) {
-  std::shared_ptr<arrow::Array> random_strings =
-      gen.String(kRowsPerVector, minStringLength, maxStringLength, null_prob);
-  ASSERT_OK(arrow::ExportType(*random_strings->type(), &schema));
-  ASSERT_OK(arrow::ExportArray(*random_strings, &data));
-}
+    double nullProbability) {
+  Builder builder;
+  std::uniform_int_distribution<size_t> lengthDistribution(
+      minStringLength, maxStringLength);
+  std::uniform_int_distribution<int> characterDistribution('a', 'z');
+  std::bernoulli_distribution nullDistribution(nullProbability);
 
-void createStringViewArray(
-    arrow::random::RandomArrayGenerator& gen,
-    ArrowSchema& schema,
-    ArrowArray& data,
-    size_t minStringLength,
-    size_t maxStringLength,
-    double null_prob) {
-  std::shared_ptr<arrow::Array> random_strings = gen.StringView(
-      kRowsPerVector, minStringLength, maxStringLength, null_prob);
-  ASSERT_OK(arrow::ExportType(*random_strings->type(), &schema));
-  ASSERT_OK(arrow::ExportArray(*random_strings, &data));
+  for (int32_t i = 0; i < kRowsPerVector; ++i) {
+    if (nullDistribution(generator)) {
+      ASSERT_OK(builder.AppendNull());
+      continue;
+    }
+
+    std::string value(lengthDistribution(generator), '\0');
+    std::generate(value.begin(), value.end(), [&]() {
+      return static_cast<char>(characterDistribution(generator));
+    });
+    ASSERT_OK(builder.Append(value));
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto randomStrings, builder.Finish());
+  ASSERT_OK(arrow::ExportType(*randomStrings->type(), &schema));
+  ASSERT_OK(arrow::ExportArray(*randomStrings, &data));
 }
 
 void createArrowArrays() {
-  arrow::random::RandomArrayGenerator generator(42);
+  std::mt19937 generator(42);
   size_t minStringLength = 0;
   size_t maxStringLength = 50;
-  createStringArray(
+  createStringArray<arrow::StringBuilder>(
       generator,
       stringSchema,
       stringArray,
       minStringLength,
       maxStringLength,
       0);
-  createStringViewArray(
+  createStringArray<arrow::StringViewBuilder>(
       generator,
       stringViewSchema,
       stringViewArray,
       minStringLength,
       maxStringLength,
       0);
-  createStringArray(
+  createStringArray<arrow::StringBuilder>(
       generator,
       stringSchema,
       stringArray_halfNull,
       minStringLength,
       maxStringLength,
       0.5);
-  createStringViewArray(
+  createStringArray<arrow::StringViewBuilder>(
       generator,
       stringViewSchema,
       stringViewArray_halfNull,

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -31,10 +31,10 @@
 #include <arrow/api.h>
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
-#include <arrow/testing/gtest_util.h>
 #include <gtest/gtest.h>
 
 #include "bolt/common/base/Nulls.h"
+#include "bolt/common/base/tests/ArrowTestUtils.h"
 #include "bolt/core/QueryCtx.h"
 #include "bolt/type/Type.h"
 #include "bolt/vector/arrow/Bridge.h"

--- a/bolt/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -30,14 +30,16 @@
 
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
-#include <arrow/testing/gtest_util.h>
+#include <arrow/type.h>
 #include <gtest/gtest.h>
 #include <string_view>
 #include "bolt/vector/ComplexVector.h"
 #include "bolt/vector/FlatVector.h"
 
+#include "bolt/common/base/tests/ArrowTestUtils.h"
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/vector/arrow/Bridge.h"
+
 namespace bytedance::bolt::test {
 namespace {
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -351,7 +351,7 @@ class BoltConan(ConanFile):
             self.options[arrow].with_protobuf = True
             self.options[arrow].with_grpc = True
             self.options[arrow].with_flight_rpc = True
-        self.options[arrow].with_test = True
+        self.options[arrow].with_test = False
         self.options[arrow].with_csv = True
         if self.options.get_safe("enable_jit"):
             self.options[llvm_core].with_libedit = False


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Bolt enables Arrow's `with_test` option because several tests and one benchmark depend on `arrow/testing` helpers. This builds `libarrow_testing` even though Bolt production code does not need it.

Bolt test utilities also size each executor from the full hardware concurrency visible to the process. When several test binaries run in parallel, CPU oversubscription can delay driver shutdown past the fixed five-second wait in `QueryAssertions`.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Add Bolt test helpers for Arrow status assertions and scoped traces.
- Replace Arrow testing data generators with public Arrow builders and local random generation.
- Set Arrow `with_test=False` and remove the benchmark link to `libarrow_testing`.
- Size both test executor pools with `min(folly::hardware_concurrency(), 4)`. This requires no environment variable or CTest configuration.

Validation:

- Built `bolt_dwio_parquet_arrow_test`, `bolt_arrow_bridge_test`, `import_arrow_bolt_bridge_benchmark`, `bolt_exec_infra_test`, `bolt_windows_test`, and `bolt_exec_table_writer_test` in Release mode.
- Passed all 72 Arrow bridge tests and all 611 Parquet Arrow tests.
- Repeated the affected Window test cases 30 times each, for 150 passing test runs.
- Repeated `columnStatsDataTypes/47` 30 times.
- Passed the Arrow import benchmark smoke run and `AssertQueryBuilderTest.basic`.
- Passed the pre-commit hooks except clang-tidy. The local clang-tidy run is blocked by existing missing GCS headers, mixed system and Conan Folly headers, and DuckDB incomplete-type errors outside this change.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Removed Bolt's dependency on the Arrow testing library.
- Limited test executor concurrency to reduce CI failures under CPU contention.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
