### PR TITLE
perf(parquet): cache ArrowSchema across write() calls

### DIFF
--- a/bolt/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -47,8 +47,11 @@ constexpr int64_t kNoSplitDataPageSize = 64 * 1024 * 1024;
 constexpr int64_t kNoSplitSinkCapacity = 8 * 1024 * 1024;
 constexpr int64_t kEncodedInputSinkCapacity = 16 * 1024 * 1024;
 
+enum class WritePath { kDirect, kStaging };
+
 struct WriteMetrics {
   uint64_t outputSize;
+  uint64_t rowCount;
   uint64_t rowGroupCount;
   uint64_t dataPageCount;
   uint64_t dictionaryPageCount;
@@ -61,7 +64,8 @@ class ParquetWriterBenchmark {
       const RowTypePtr& rowType,
       int64_t dataPageSize,
       bool useMemorySink,
-      int64_t memorySinkCapacity = kNoSplitSinkCapacity)
+      int64_t memorySinkCapacity = kNoSplitSinkCapacity,
+      WritePath writePath = WritePath::kDirect)
       : disableDictionary_(disableDictionary) {
     rootPool_ = memory::memoryManager()->addRootPool("ParquetWriterBenchmark");
     leafPool_ = rootPool_->addLeafChild("ParquetWriterBenchmark");
@@ -79,7 +83,7 @@ class ParquetWriterBenchmark {
       sink = std::make_unique<WriteFileSink>(std::move(localWriteFile), path);
     }
     bytedance::bolt::parquet::WriterOptions options;
-    options.enableFlushBasedOnBlockSize = true;
+    options.enableFlushBasedOnBlockSize = writePath == WritePath::kDirect;
     options.parquetWriteTimestampUnit = TimestampUnit::kNano;
     options.writeInt96AsTimestamp = true;
     options.dataPageSize = dataPageSize;
@@ -155,6 +159,7 @@ class ParquetWriterBenchmark {
     }
     return {
         .outputSize = static_cast<uint64_t>(sink_->size()),
+        .rowCount = static_cast<uint64_t>(metadata.numRows()),
         .rowGroupCount = static_cast<uint64_t>(metadata.numRowGroups()),
         .dataPageCount = dataPageCount,
         .dictionaryPageCount = dictionaryPageCount};
@@ -179,10 +184,11 @@ void reportLayoutOnce(
   std::lock_guard<std::mutex> lock(mutex);
   if (reportedBenchmarks.insert(benchmarkName).second) {
     std::cerr << fmt::format(
-        "LAYOUT {} output_bytes={} row_groups={} data_pages={} "
+        "LAYOUT {} output_bytes={} rows={} row_groups={} data_pages={} "
         "dictionary_pages={}\n",
         benchmarkName,
         metrics.outputSize,
+        metrics.rowCount,
         metrics.rowGroupCount,
         metrics.dataPageCount,
         metrics.dictionaryPageCount);
@@ -209,6 +215,10 @@ void runImpl(
         disableDictionary, rowType, dataPageSize, reportLayout);
     const auto batches = benchmark.makeSingleColumnData(
         columnName, type, nullsRateX100, numBatches, batchSize);
+    uint64_t expectedRows = 0;
+    for (const auto& batch : *batches) {
+      expectedRows += batch->size();
+    }
     suspender.dismiss();
     benchmark.writeToSink(*batches, true);
     suspender.rehire();
@@ -216,7 +226,9 @@ void runImpl(
     if (reportLayout) {
       const auto metrics = benchmark.collectMetrics();
       folly::doNotOptimizeAway(metrics.outputSize);
+      folly::doNotOptimizeAway(metrics.rowCount);
       folly::doNotOptimizeAway(metrics.dataPageCount);
+      BOLT_CHECK_EQ(metrics.rowCount, expectedRows);
       BOLT_CHECK_EQ(metrics.dataPageCount, 1);
       reportLayoutOnce(
           fmt::format(
@@ -356,7 +368,8 @@ void runEncodedInputBenchmark(
     uint32_t iterations,
     const std::string& benchmarkName,
     const RowTypePtr& rowType,
-    MakeBatches makeBatches) {
+    MakeBatches makeBatches,
+    WritePath writePath = WritePath::kDirect) {
   for (uint32_t i = 0; i < iterations; ++i) {
     folly::BenchmarkSuspender suspender;
     ParquetWriterBenchmark benchmark(
@@ -364,17 +377,24 @@ void runEncodedInputBenchmark(
         rowType,
         bytedance::bolt::parquet::WriterOptions{}.dataPageSize,
         true,
-        kEncodedInputSinkCapacity);
+        kEncodedInputSinkCapacity,
+        writePath);
     auto batches = makeBatches(benchmark.memoryPool());
+    uint64_t expectedRows = 0;
+    for (const auto& batch : batches) {
+      expectedRows += batch->size();
+    }
     suspender.dismiss();
     benchmark.writeToSink(batches, false);
     suspender.rehire();
 
     const auto metrics = benchmark.collectMetrics();
     folly::doNotOptimizeAway(metrics.outputSize);
+    folly::doNotOptimizeAway(metrics.rowCount);
     folly::doNotOptimizeAway(metrics.rowGroupCount);
     folly::doNotOptimizeAway(metrics.dataPageCount);
     folly::doNotOptimizeAway(metrics.dictionaryPageCount);
+    BOLT_CHECK_EQ(metrics.rowCount, expectedRows);
     reportLayoutOnce(benchmarkName, metrics);
   }
 }
@@ -486,12 +506,17 @@ void runMultiColumnInputDictionary(uint32_t iterations, int32_t numColumns) {
 
 void runSchemaMultiBatch(
     uint32_t iterations,
+    WritePath writePath,
     int32_t numColumns,
     int32_t numBatches) {
+  const auto pathName = writePath == WritePath::kDirect ? "Direct" : "Staging";
   runEncodedInputBenchmark(
       iterations,
       fmt::format(
-          "SchemaMultiBatch_{}Columns_{}Batches", numColumns, numBatches),
+          "SchemaMultiBatch_{}_{}Columns_{}Batches",
+          pathName,
+          numColumns,
+          numBatches),
       makeRepeatedRowType(numColumns, VARCHAR()),
       [numColumns, numBatches](memory::MemoryPool* pool) {
         test::VectorMaker maker(pool);
@@ -505,7 +530,8 @@ void runSchemaMultiBatch(
         }
         auto batch = maker.rowVector(std::move(names), columns);
         return std::vector<RowVectorPtr>(numBatches, std::move(batch));
-      });
+      },
+      writePath);
 }
 
 void runMapVarcharInteger(uint32_t iterations, int32_t entriesPerRow) {
@@ -649,10 +675,42 @@ BENCHMARK_NAMED_PARAM(runMultiColumnInputDictionary, FiveColumns, 5);
 BENCHMARK_NAMED_PARAM(runMultiColumnInputDictionary, TenColumns, 10);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(runSchemaMultiBatch, FiveColumns50Batches, 5, 50);
-BENCHMARK_NAMED_PARAM(runSchemaMultiBatch, TenColumns50Batches, 10, 50);
-BENCHMARK_NAMED_PARAM(runSchemaMultiBatch, TwentyColumns50Batches, 20, 50);
-BENCHMARK_NAMED_PARAM(runSchemaMultiBatch, TenColumns200Batches, 10, 200);
+BENCHMARK_NAMED_PARAM(
+    runSchemaMultiBatch,
+    DirectFiveColumns50Batches,
+    WritePath::kDirect,
+    5,
+    50);
+BENCHMARK_NAMED_PARAM(
+    runSchemaMultiBatch,
+    DirectTenColumns50Batches,
+    WritePath::kDirect,
+    10,
+    50);
+BENCHMARK_NAMED_PARAM(
+    runSchemaMultiBatch,
+    DirectTwentyColumns50Batches,
+    WritePath::kDirect,
+    20,
+    50);
+BENCHMARK_NAMED_PARAM(
+    runSchemaMultiBatch,
+    DirectTenColumns200Batches,
+    WritePath::kDirect,
+    10,
+    200);
+BENCHMARK_NAMED_PARAM(
+    runSchemaMultiBatch,
+    StagingTenColumns50Batches,
+    WritePath::kStaging,
+    10,
+    50);
+BENCHMARK_NAMED_PARAM(
+    runSchemaMultiBatch,
+    StagingTenColumns200Batches,
+    WritePath::kStaging,
+    10,
+    200);
 BENCHMARK_DRAW_LINE();
 
 BENCHMARK_NAMED_PARAM(runMapVarcharInteger, ThreeEntries, 3);

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -399,6 +399,54 @@ TEST_F(ParquetWriterTest, dictToArrow) {
   assertWrite(parquetPath, kRows, schema, data);
 };
 
+TEST_F(ParquetWriterTest, reuseArrowSchemaAcrossEncodings) {
+  const vector_size_t kRows = 64;
+  auto makeBatch = [&](int32_t offset) {
+    return makeRowVector(
+        {"id", "items", "attributes"},
+        {makeFlatVector<int32_t>(kRows, [&](auto row) { return offset + row; }),
+         makeArrayVector<int64_t>(
+             kRows,
+             [](auto row) { return row % 3; },
+             [&](auto row, auto index) { return offset + row * 10 + index; }),
+         makeMapVector<int64_t, int32_t>(
+             kRows,
+             [](auto row) { return row % 2 + 1; },
+             [&](auto index) { return offset + index; },
+             [&](auto index) { return offset - index; })});
+  };
+  auto first = makeBatch(0);
+  auto second = makeBatch(1'000);
+  auto schema = std::static_pointer_cast<const RowType>(first->type());
+
+  auto& children = second->children();
+  for (auto& child : children) {
+    child = BaseVector::wrapInDictionary(
+        makeNulls(kRows, [](auto row) { return row % 19 == 0; }),
+        makeIndicesInReverse(kRows),
+        kRows,
+        child);
+  }
+
+  auto expected = BaseVector::create(schema, 2 * kRows, pool_.get());
+  expected->copy(first.get(), 0, 0, kRows);
+  expected->copy(second.get(), kRows, 0, kRows);
+
+  std::string parquetPath = tempPath_->path + "/cachedArrowSchema.parquet";
+  auto writer = createWriter(
+      createSink(parquetPath),
+      [&]() {
+        return std::make_unique<LambdaFlushPolicy>(
+            kRowsInRowGroup, kBytesInRowGroup, []() { return false; });
+      },
+      schema);
+  writer->write(first);
+  writer->write(second);
+  writer->close();
+
+  assertRead(parquetPath, 2 * kRows, schema, expected);
+}
+
 TEST_F(ParquetWriterTest, constantComplexToArrow) {
   const size_t kRows = 1100;
   auto type = getType();
@@ -516,9 +564,20 @@ TEST_F(ParquetWriterTest, columnNullable) {
   auto writer = createLocalWriter(
       parquetPath, schema, writerOptions, ::arrow::schema(newFields));
   writer->write(data);
+  writer->write(data);
   writer->close();
 
-  assertRead(parquetPath, kRows, schema, data);
+  auto expected = BaseVector::create(schema, 2 * kRows, pool_.get());
+  expected->copy(data.get(), 0, 0, kRows);
+  expected->copy(data.get(), kRows, 0, kRows);
+  assertRead(parquetPath, 2 * kRows, schema, expected);
+
+  auto fileReader = vp::arrow::ParquetFileReader::OpenFile(parquetPath);
+  const auto* parquetSchema = fileReader->metadata()->schema()->group_node();
+  ASSERT_EQ(parquetSchema->field_count(), childSize);
+  for (auto i = 0; i < childSize; ++i) {
+    EXPECT_EQ(parquetSchema->field(i)->is_optional(), i % 2 == 0);
+  }
 };
 
 TEST_F(ParquetWriterTest, emptyParquet) {
@@ -541,6 +600,18 @@ TEST_F(ParquetWriterTest, emptyParquet) {
           std::static_pointer_cast<const Type>(schema), 0, leafPool_.get())),
       *leafPool_);
 };
+
+TEST_F(ParquetWriterTest, emptyBatch) {
+  auto schema = ROW({"c0", "c1"}, {INTEGER(), DOUBLE()});
+  auto data = BaseVector::create(schema, 0, leafPool_.get());
+  std::string parquetPath = tempPath_->path + "/emptyBatch.parquet";
+  vp::WriterOptions writerOptions{};
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, 0, schema, data);
+}
 
 TEST_F(ParquetWriterTest, allNulls) {
   auto schema = ROW({"c0"}, {INTEGER()});

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -440,11 +440,18 @@ TEST_F(ParquetWriterTest, reuseArrowSchemaAcrossEncodings) {
             kRowsInRowGroup, kBytesInRowGroup, []() { return false; });
       },
       schema);
+  writer->write(BaseVector::create(schema, 0, leafPool_.get()));
   writer->write(first);
+  writer->flush();
   writer->write(second);
   writer->close();
 
   assertRead(parquetPath, 2 * kRows, schema, expected);
+  auto reader = createLocalParquetReader(parquetPath);
+  const auto& metadata = reader->fileMetaData();
+  ASSERT_EQ(2, metadata.numRowGroups());
+  EXPECT_EQ(kRows, metadata.rowGroup(0).numRows());
+  EXPECT_EQ(kRows, metadata.rowGroup(1).numRows());
 }
 
 TEST_F(ParquetWriterTest, constantComplexToArrow) {
@@ -483,18 +490,38 @@ TEST_F(ParquetWriterTest, constantToArrow) {
 };
 
 TEST_F(ParquetWriterTest, splitWrite) {
-  const size_t kRows = 4 * 1024;
+  const vector_size_t kRows = 4 * 1024;
 
   auto type = getType();
   auto schema = std::static_pointer_cast<const RowType>(type);
-  auto data = bytedance::bolt::test::BatchMaker::createBatch(
+  auto first = bytedance::bolt::test::BatchMaker::createBatch(
       type, kRows, *leafPool_, [](auto row) { return row % 10 == 0; });
+  auto second = bytedance::bolt::test::BatchMaker::createBatch(
+      type, kRows, *leafPool_, [](auto row) { return row % 7 == 0; });
+  auto& children = std::dynamic_pointer_cast<RowVector>(second)->children();
+  for (auto& child : children) {
+    child = BaseVector::wrapInDictionary(
+        makeNulls(kRows, [](auto row) { return row % 19 == 0; }),
+        makeIndicesInReverse(kRows),
+        kRows,
+        child);
+  }
+
+  auto expected = BaseVector::create(schema, 2 * kRows, pool_.get());
+  expected->copy(first.get(), 0, 0, kRows);
+  expected->copy(second.get(), kRows, 0, kRows);
 
   std::string parquetPath = tempPath_->path + "/splitWrite.parquet";
   vp::WriterOptions writerOptions{};
-  // Set a smaller value to trigger split write and verify it.
+  // Set a smaller value to exercise multiple record batches per write.
   writerOptions.writeBatchBytes = 1024;
-  assertWrite(parquetPath, kRows, schema, data, writerOptions);
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(first);
+  writer->flush();
+  writer->write(second);
+  writer->close();
+
+  assertRead(parquetPath, 2 * kRows, schema, expected);
 };
 
 TEST_F(ParquetWriterTest, flush) {
@@ -545,7 +572,6 @@ TEST_F(ParquetWriterTest, columnNullable) {
   VectorPtr data = bytedance::bolt::test::BatchMaker::createBatch(
       type, kRows, *leafPool_, [](auto row) { return false; });
 
-  std::string parquetPath = tempPath_->path + "/columnNullable.parquet";
   vp::WriterOptions writerOptions{};
   ArrowSchema cArrowSchema;
   exportToArrow(
@@ -561,23 +587,59 @@ TEST_F(ParquetWriterTest, columnNullable) {
   for (auto i = 0; i < childSize; i++) {
     newFields.push_back(arrowSchema->field(i)->WithNullable(i % 2 == 0));
   }
-  auto writer = createLocalWriter(
-      parquetPath, schema, writerOptions, ::arrow::schema(newFields));
-  writer->write(data);
-  writer->write(data);
-  writer->close();
+  auto nullableSchema = ::arrow::schema(newFields);
+
+  auto assertNullability = [&](const std::string& parquetPath,
+                               int64_t expectedRows,
+                               int expectedRowGroups) {
+    SCOPED_TRACE(parquetPath);
+    auto fileReader = vp::arrow::ParquetFileReader::OpenFile(parquetPath);
+    const auto metadata = fileReader->metadata();
+    EXPECT_EQ(metadata->num_rows(), expectedRows);
+    EXPECT_EQ(metadata->num_row_groups(), expectedRowGroups);
+
+    const auto* parquetSchema = metadata->schema()->group_node();
+    ASSERT_EQ(parquetSchema->field_count(), childSize);
+    for (auto i = 0; i < childSize; ++i) {
+      EXPECT_EQ(parquetSchema->field(i)->is_optional(), i % 2 == 0);
+    }
+  };
+
+  const auto parquetPath = tempPath_->path + "/columnNullable.parquet";
+  {
+    auto writer =
+        createLocalWriter(parquetPath, schema, writerOptions, nullableSchema);
+    writer->write(data);
+    writer->write(data);
+    writer->close();
+  }
 
   auto expected = BaseVector::create(schema, 2 * kRows, pool_.get());
   expected->copy(data.get(), 0, 0, kRows);
   expected->copy(data.get(), kRows, 0, kRows);
   assertRead(parquetPath, 2 * kRows, schema, expected);
+  assertNullability(parquetPath, 2 * kRows, 1);
 
-  auto fileReader = vp::arrow::ParquetFileReader::OpenFile(parquetPath);
-  const auto* parquetSchema = fileReader->metadata()->schema()->group_node();
-  ASSERT_EQ(parquetSchema->field_count(), childSize);
-  for (auto i = 0; i < childSize; ++i) {
-    EXPECT_EQ(parquetSchema->field(i)->is_optional(), i % 2 == 0);
+  auto emptyData = BaseVector::create(schema, 0, leafPool_.get());
+  const auto emptyWritePath =
+      tempPath_->path + "/columnNullableEmptyWrite.parquet";
+  {
+    auto writer = createLocalWriter(
+        emptyWritePath, schema, writerOptions, nullableSchema);
+    writer->write(emptyData);
+    writer->close();
   }
+  assertRead(emptyWritePath, 0, schema, emptyData);
+  assertNullability(emptyWritePath, 0, 0);
+
+  const auto noWritePath = tempPath_->path + "/columnNullableNoWrite.parquet";
+  {
+    auto writer =
+        createLocalWriter(noWritePath, schema, writerOptions, nullableSchema);
+    writer->close();
+  }
+  assertRead(noWritePath, 0, schema, emptyData);
+  assertNullability(noWritePath, 0, 0);
 };
 
 TEST_F(ParquetWriterTest, emptyParquet) {

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -742,17 +742,8 @@ void Writer::close() {
 void Writer::createEmptyFile() {
   BOLT_CHECK_NULL(arrowContext_->writer);
   if (!arrowContext_->schema) {
-    ArrowSchema arrowSchema;
-    exportToArrow(
-        BaseVector::create(
-            std::static_pointer_cast<const Type>(schema_),
-            0,
-            exportPool_.get()),
-        arrowSchema,
-        options_,
-        {},
-        exportPool_.get());
-    arrowContext_->schema = ::arrow::ImportSchema(&arrowSchema).ValueOrDie();
+    initializeArrowSchema(BaseVector::create(
+        std::static_pointer_cast<const Type>(schema_), 0, exportPool_.get()));
   }
   createFileWriterIfNotExist();
 }

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -589,6 +589,26 @@ void Writer::createFileWriterIfNotExist() {
   }
 }
 
+void Writer::initializeArrowSchema(const VectorPtr& data) {
+  BOLT_CHECK_NULL(arrowContext_->schema);
+
+  ArrowSchema schema;
+  exportToArrow(data, schema, options_, {}, exportPool_.get());
+  auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
+
+  std::vector<std::shared_ptr<::arrow::Field>> fields;
+  fields.reserve(schema_->size());
+  for (auto i = 0; i < schema_->size(); ++i) {
+    fields.push_back(updateFieldNameRecursive(
+        arrowSchema->fields()[i],
+        *schema_->childAt(i),
+        (arrowSchemaFromHive_ ? arrowSchemaFromHive_->fields()[i]
+                              : arrowSchema->fields()[i]),
+        schema_->nameOf(i)));
+  }
+  arrowContext_->schema = ::arrow::schema(std::move(fields));
+}
+
 dwio::common::StripeProgress getStripeProgress(
     uint64_t stagingRows,
     int64_t stagingBytes) {
@@ -596,9 +616,7 @@ dwio::common::StripeProgress getStripeProgress(
       .stripeRowCount = stagingRows, .stripeSizeEstimate = stagingBytes};
 }
 
-void Writer::splitWriteRecordBatch(
-    const VectorPtr& data,
-    std::shared_ptr<::arrow::Schema> arraySchemaPtr) {
+void Writer::splitWriteRecordBatch(const VectorPtr& data) {
   vector_size_t rowNumPerBatch = data->size();
   if (rowNumPerBatch > minBatchSize_) {
     auto exportSize =
@@ -626,10 +644,8 @@ void Writer::splitWriteRecordBatch(
         options_);
 
     PARQUET_ASSIGN_OR_THROW(
-        auto recordBatch, ::arrow::ImportRecordBatch(&array, arraySchemaPtr));
-    if (!arrowContext_->schema) {
-      arrowContext_->schema = recordBatch->schema();
-    }
+        auto recordBatch,
+        ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
     writeRecordBatch(recordBatch);
     offset += size;
   }
@@ -650,25 +666,15 @@ void Writer::write(const VectorPtr& data) {
       data->type()->equivalent(*schema_),
       "The file schema type should be equal with the input rowvector type.");
 
-  ArrowSchema schema;
-  exportToArrow(data, schema, options_, {}, exportPool_.get());
-
-  // Convert the arrow schema to Schema and then update the column names based
-  // on schema_.
-  auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
-  std::vector<std::shared_ptr<::arrow::Field>> newFields;
-  auto childSize = schema_->size();
-  for (auto i = 0; i < childSize; i++) {
-    newFields.push_back(updateFieldNameRecursive(
-        arrowSchema->fields()[i],
-        *schema_->childAt(i),
-        (arrowSchemaFromHive_ ? arrowSchemaFromHive_->fields()[i]
-                              : arrowSchema->fields()[i]),
-        schema_->nameOf(i)));
+  if (!arrowContext_->schema) {
+    initializeArrowSchema(data);
+    if (enableRowGroupAlignedWrite_ || !enableFlushBasedOnBlockSize_) {
+      arrowContext_->stagingChunks.resize(arrowContext_->schema->num_fields());
+    }
   }
 
   if (!enableRowGroupAlignedWrite_ && enableFlushBasedOnBlockSize_) {
-    splitWriteRecordBatch(data, ::arrow::schema(newFields));
+    splitWriteRecordBatch(data);
     return;
   }
 
@@ -676,15 +682,7 @@ void Writer::write(const VectorPtr& data) {
   exportToArrow(data, array, exportPool_.get(), options_);
   PARQUET_ASSIGN_OR_THROW(
       auto recordBatch,
-      ::arrow::ImportRecordBatch(&array, ::arrow::schema(newFields)));
-  if (!arrowContext_->schema) {
-    arrowContext_->schema = recordBatch->schema();
-    for (int colIdx = 0; colIdx < arrowContext_->schema->num_fields();
-         colIdx++) {
-      arrowContext_->stagingChunks.push_back(
-          std::vector<std::shared_ptr<::arrow::Array>>());
-    }
-  }
+      ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
 
   auto bytes = data->estimateFlatSize();
   auto numRows = data->size();
@@ -742,17 +740,20 @@ void Writer::close() {
 }
 
 void Writer::createEmptyFile() {
-  BOLT_CHECK_NULL(arrowContext_->schema);
   BOLT_CHECK_NULL(arrowContext_->writer);
-  ArrowSchema arrowSchema;
-  exportToArrow(
-      BaseVector::create(
-          std::static_pointer_cast<const Type>(schema_), 0, exportPool_.get()),
-      arrowSchema,
-      options_,
-      {},
-      exportPool_.get());
-  arrowContext_->schema = ::arrow::ImportSchema(&arrowSchema).ValueOrDie();
+  if (!arrowContext_->schema) {
+    ArrowSchema arrowSchema;
+    exportToArrow(
+        BaseVector::create(
+            std::static_pointer_cast<const Type>(schema_),
+            0,
+            exportPool_.get()),
+        arrowSchema,
+        options_,
+        {},
+        exportPool_.get());
+    arrowContext_->schema = ::arrow::ImportSchema(&arrowSchema).ValueOrDie();
+  }
   createFileWriterIfNotExist();
 }
 

--- a/bolt/dwio/parquet/writer/Writer.h
+++ b/bolt/dwio/parquet/writer/Writer.h
@@ -266,9 +266,9 @@ class Writer : public dwio::common::Writer {
       std::shared_ptr<::arrow::RecordBatch>& recordBatch);
 
  private:
-  void splitWriteRecordBatch(
-      const VectorPtr& data,
-      std::shared_ptr<::arrow::Schema> arraySchemaPtr);
+  void initializeArrowSchema(const VectorPtr& data);
+
+  void splitWriteRecordBatch(const VectorPtr& data);
 
   // Sets the memory reclaimers for all the memory pools used by this writer.
   void setMemoryReclaimers();


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
`parquet::Writer::write()` rebuilds the same Arrow schema for every batch. This
repeats schema export/import and recursive field-name/nullability updates even
though a writer's file schema is fixed.

Closing a writer without calling `write()` can also bypass Hive nullability
normalization for the generated empty file.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Cache the finalized Arrow schema after the first `write()` and reuse it for later batches. The cache is shared by Bolt's Direct, Staging, and row-aligned branches while preserving field names, Hive nullability, type checks, and empty
file behavior. No-write files now use the same schema initialization path, so they preserve custom Hive nullability as well.

Benchmarks cover Direct and Staging paths and validate the written row count. Tests cover true split writes, Staging across flush/encoding changes, nested types, Hive nullability, and empty batches.
The nullability test covers multi-write, empty-write, and no-write lifecycles. Pre-existing row-aligned write correctness issues are out of scope and will be handled in a separate bug-fix PR.

The approach is adapted from [Velox PR #17985](https://github.com/facebookincubator/velox/pull/17985) to Bolt's writer paths and lifecycle.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    | Workload | Before | After | Improvement |
    |---|---:|---:|---:|
    | 5 columns × 50 batches | 123.53 ms | 120.61 ms | 2.36% |
    | 10 columns × 50 batches | 245.40 ms | 237.12 ms | 3.37% |
    | 20 columns × 50 batches | 487.78 ms | 477.86 ms | 2.03% |
    | 10 columns × 200 batches | 972.45 ms | 954.79 ms | 1.82% |

    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Optimize: Cache the Arrow schema across Parquet writer batches.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
