### PR TITLE
fix(dwrf): add DirectInputStream proto parse error prefix

### DIFF
--- a/bolt/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/bolt/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -47,6 +47,50 @@ using namespace bytedance::bolt::dwrf::encryption;
 using namespace bytedance::bolt::memory;
 using namespace bytedance::bolt::type::fbhive;
 
+namespace {
+
+class NamedBadProtoStream : public SeekableInputStream {
+ public:
+  explicit NamedBadProtoStream(std::string name) : name_{std::move(name)} {}
+
+  bool Next(const void** buffer, int32_t* size) override {
+    if (returned_) {
+      return false;
+    }
+    returned_ = true;
+    *buffer = badProto_;
+    *size = sizeof(badProto_);
+    return true;
+  }
+
+  void BackUp(int32_t /*count*/) override {}
+
+  int64_t ByteCount() const override {
+    return returned_ ? sizeof(badProto_) : 0;
+  }
+
+  void seekToPosition(PositionProvider& /*position*/) override {}
+
+  std::string getName() const override {
+    return name_;
+  }
+
+  size_t positionSize() override {
+    return 1;
+  }
+
+  bool SkipInt64(int64_t /*count*/) override {
+    return false;
+  }
+
+ private:
+  const std::string name_;
+  bool returned_{false};
+  const char badProto_[1]{static_cast<char>(0xff)};
+};
+
+} // namespace
+
 void addStats(
     ProtoWriter& writer,
     const Encrypter& encrypter,
@@ -241,4 +285,31 @@ TEST_F(ReaderBaseTest, InvalidPostScriptThrows) {
       { createCorruptedFileReader(1'000'000, 0); }, exception::LoggedException);
   EXPECT_THROW(
       { createCorruptedFileReader(0, 1'000'000); }, exception::LoggedException);
+}
+
+TEST(ProtoUtilsTest, DirectInputStreamParseErrorPrefix) {
+  try {
+    ProtoUtils::readProto<proto::PostScript>(
+        std::make_unique<NamedBadProtoStream>(
+            "DirectInputStream 49 of 49"));
+    FAIL() << "Expected readProto to throw";
+  } catch (const std::exception& e) {
+    const std::string message = e.what();
+    EXPECT_NE(
+        message.find(kDwrfDirectInputStreamProtoParseErrorPrefix),
+        std::string::npos);
+  }
+
+  try {
+    ProtoUtils::readProto<proto::PostScript>(
+        std::make_unique<NamedBadProtoStream>(
+            "SeekableArrayInputStream 49 of 49"));
+    FAIL() << "Expected readProto to throw";
+  } catch (const std::exception& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("Failed to parse proto from "), std::string::npos);
+    EXPECT_EQ(
+        message.find(kDwrfDirectInputStreamProtoParseErrorPrefix),
+        std::string::npos);
+  }
 }

--- a/bolt/dwio/dwrf/utils/ProtoUtils.h
+++ b/bolt/dwio/dwrf/utils/ProtoUtils.h
@@ -35,6 +35,9 @@
 #include "bolt/type/Type.h"
 namespace bytedance::bolt::dwrf {
 
+inline constexpr const char* kDwrfDirectInputStreamProtoParseErrorPrefix =
+    "Failed to parse proto from DirectInputStream";
+
 class ProtoUtils final {
  public:
   static void writeType(


### PR DESCRIPTION
### What problem does this PR solve?

Expose a stable DWRF proto parse error prefix for `DirectInputStream` failures so downstream corrupt-file handling can match this specific production HDFS read path without matching `SeekableArrayInputStream` failures.

Issue Number: close #xxx

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add `kDwrfDirectInputStreamProtoParseErrorPrefix` to `ProtoUtils.h` for `Failed to parse proto from DirectInputStream`.

The test validates that a bad proto stream named `DirectInputStream 49 of 49` contains the new prefix and that a `SeekableArrayInputStream 49 of 49` failure does not.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Added a stable DWRF DirectInputStream proto parse error prefix for downstream corrupt-file handling.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Tested with:

```text
cmake --build --preset conan-release --target bolt_dwio_dwrf_reader_base_test
_build/Release/bolt/dwio/dwrf/test/bolt_dwio_dwrf_reader_base_test --gtest_filter=ProtoUtilsTest.DirectInputStreamParseErrorPrefix --gtest_color=no
git diff --check
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    N/A
    ```
    </details>

Co-authored-by: TRAE CLI <noreply@bytedance.com>
