### PR TITLE
fix: add proto parse error prefix

### DIFF
--- a/bolt/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/bolt/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -47,6 +47,50 @@ using namespace bytedance::bolt::dwrf::encryption;
 using namespace bytedance::bolt::memory;
 using namespace bytedance::bolt::type::fbhive;
 
+namespace {
+
+class NamedBadProtoStream : public SeekableInputStream {
+ public:
+  explicit NamedBadProtoStream(std::string name) : name_{std::move(name)} {}
+
+  bool Next(const void** buffer, int32_t* size) override {
+    if (returned_) {
+      return false;
+    }
+    returned_ = true;
+    *buffer = badProto_;
+    *size = sizeof(badProto_);
+    return true;
+  }
+
+  void BackUp(int32_t /*count*/) override {}
+
+  int64_t ByteCount() const override {
+    return returned_ ? sizeof(badProto_) : 0;
+  }
+
+  void seekToPosition(PositionProvider& /*position*/) override {}
+
+  std::string getName() const override {
+    return name_;
+  }
+
+  size_t positionSize() override {
+    return 1;
+  }
+
+  bool SkipInt64(int64_t /*count*/) override {
+    return false;
+  }
+
+ private:
+  const std::string name_;
+  bool returned_{false};
+  const char badProto_[1]{static_cast<char>(0xff)};
+};
+
+} // namespace
+
 void addStats(
     ProtoWriter& writer,
     const Encrypter& encrypter,
@@ -241,4 +285,30 @@ TEST_F(ReaderBaseTest, InvalidPostScriptThrows) {
       { createCorruptedFileReader(1'000'000, 0); }, exception::LoggedException);
   EXPECT_THROW(
       { createCorruptedFileReader(0, 1'000'000); }, exception::LoggedException);
+}
+
+TEST(ProtoUtilsTest, ProtoParseErrorPrefix) {
+  try {
+    ProtoUtils::readProto<proto::PostScript>(
+        std::make_unique<NamedBadProtoStream>("DirectInputStream 49 of 49"));
+    FAIL() << "Expected readProto to throw";
+  } catch (const std::exception& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find(kDwrfProtoParseErrorPrefix), std::string::npos);
+    EXPECT_NE(message.find("DirectInputStream 49 of 49"), std::string::npos);
+  }
+
+  try {
+    proto::PostScript postScript;
+    ProtoUtils::readProtoInto<proto::PostScript>(
+        std::make_unique<NamedBadProtoStream>(
+            "SeekableArrayInputStream 49 of 49"),
+        &postScript);
+    FAIL() << "Expected readProto to throw";
+  } catch (const std::exception& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find(kDwrfProtoParseErrorPrefix), std::string::npos);
+    EXPECT_NE(
+        message.find("SeekableArrayInputStream 49 of 49"), std::string::npos);
+  }
 }

--- a/bolt/dwio/dwrf/utils/ProtoUtils.h
+++ b/bolt/dwio/dwrf/utils/ProtoUtils.h
@@ -35,6 +35,9 @@
 #include "bolt/type/Type.h"
 namespace bytedance::bolt::dwrf {
 
+inline constexpr const char* kDwrfProtoParseErrorPrefix =
+    "Failed to parse proto from";
+
 class ProtoUtils final {
  public:
   static void writeType(
@@ -58,7 +61,8 @@ class ProtoUtils final {
     }
     DWIO_ENSURE(
         ret->ParseFromZeroCopyStream(stream.get()),
-        "Failed to parse proto from ",
+        kDwrfProtoParseErrorPrefix,
+        " ",
         stream->getName());
     return ret;
   }
@@ -74,7 +78,8 @@ class ProtoUtils final {
     DWIO_ENSURE(ret);
     DWIO_ENSURE(
         ret->ParseFromZeroCopyStream(stream.get()),
-        "Failed to parse proto from ",
+        kDwrfProtoParseErrorPrefix,
+        " ",
         stream->getName());
     return ret;
   }


### PR DESCRIPTION
### What problem does this PR solve?

Expose a stable DWRF proto parse error prefix from `ProtoUtils` so downstream corrupt-file handling can match proto parse failures without depending on the exact stream-specific error text construction. The stream name is still preserved in the final error message, e.g. `DirectInputStream ...` or `SeekableArrayInputStream ...`.

Issue Number: close #xxx

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add `kDwrfProtoParseErrorPrefix` to `ProtoUtils.h` and use it directly at both `readProto` and `readProtoInto` throw sites.

The test validates that bad proto streams for both `DirectInputStream 49 of 49` and `SeekableArrayInputStream 49 of 49` contain the stable prefix while preserving the stream name.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Added a stable DWRF proto parse error prefix for downstream corrupt-file handling.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Tested with:

```text
cmake --build --preset conan-release --target bolt_dwio_dwrf_reader_base_test
_build/Release/bolt/dwio/dwrf/test/bolt_dwio_dwrf_reader_base_test --gtest_filter=ProtoUtilsTest.ProtoParseErrorPrefix --gtest_color=no
git diff --check
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    N/A
    ```
    </details>

Co-authored-by: TRAE CLI <noreply@bytedance.com>
