### PR TITLE
build: fix static library packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -752,16 +752,6 @@ if(${BOLT_ENABLE_SUBSTRAIT})
   )
 endif()
 
-file(GLOB_RECURSE SHARED_LIBS "${CMAKE_BINARY_DIR}/bolt/*${CMAKE_SHARED_LIBRARY_SUFFIX}")
-file(GLOB_RECURSE STATIC_LIBS "${CMAKE_BINARY_DIR}/bolt/*${CMAKE_STATIC_LIBRARY_SUFFIX}")
-
-list(APPEND ALL_LIBS ${SHARED_LIBS} ${STATIC_LIBS})
-
-list(FILTER ALL_LIBS EXCLUDE REGEX "benchmarks")
-list(FILTER ALL_LIBS EXCLUDE REGEX "benchmark")
-
-install(FILES ${ALL_LIBS} DESTINATION "lib")
-
 find_package(cityhash REQUIRED CONFIG)
 
 # Adding this down here prevents warnings in dependencies from stopping the build
@@ -781,6 +771,10 @@ endif()
 
 if(BOLT_ENABLE_TORCH)
   find_package(Torch CONFIG REQUIRED)
+endif()
+
+if(BOLT_BUILD_PYTHON_PACKAGE)
+  find_package(pybind11 CONFIG REQUIRED)
 endif()
 
 if(BOLT_ENABLE_CUDF)

--- a/bolt/CMakeLists.txt
+++ b/bolt/CMakeLists.txt
@@ -32,6 +32,7 @@ set(BOLT_FUNCTIONS_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_IO_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_SUBSTRAIT_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_SHUFFLE_OBJECT_TARGETS "" CACHE INTERNAL "")
+set(BOLT_EXTENSIONS_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_TESTUTILS_OBJECT_TARGETS "" CACHE INTERNAL "")
 
 function(bolt_add_library target_name)
@@ -76,6 +77,7 @@ function(bolt_add_library target_name)
       "functions/prestosql/tests/utils"
       "connectors/fuzzer"
       "connectors/tpch"
+      "cudf/tests"
       "exec/fuzzer"
       "exec/tests/utils"
       "exec/prefixsort/tests/utils"
@@ -149,8 +151,8 @@ function(bolt_add_library target_name)
   endif()
 
   if(FIRST_LEVEL_DIR IN_LIST EXTENSIONS_COMP_LIST)
-    list(APPEND EXTENSIONS_OBJECT_TARGETS $<TARGET_OBJECTS:${target_name}>)
-    set(EXTENSIONS_OBJECT_TARGETS ${EXTENSIONS_OBJECT_TARGETS} CACHE INTERNAL "")
+    list(APPEND BOLT_EXTENSIONS_OBJECT_TARGETS $<TARGET_OBJECTS:${target_name}>)
+    set(BOLT_EXTENSIONS_OBJECT_TARGETS ${BOLT_EXTENSIONS_OBJECT_TARGETS} CACHE INTERNAL "")
     return()
   endif()
 
@@ -240,13 +242,15 @@ add_library(bolt_engine
   ${BOLT_BASE_OBJECT_TARGETS}
   ${BOLT_IO_OBJECT_TARGETS}
   ${BOLT_SUBSTRAIT_OBJECT_TARGETS}
-  ${BOLT_SHUFFLE_OBJECT_TARGETS})
+  ${BOLT_SHUFFLE_OBJECT_TARGETS}
+  ${BOLT_EXTENSIONS_OBJECT_TARGETS})
 
 target_link_libraries(bolt_engine PUBLIC
                                   $<$<CONFIG:Debug>:bolt_debug_util>
                                   arrow::arrow
                                   $<$<BOOL:${ENABLE_BOLT_JIT}>:llvm-core::llvm-core>
                                   Folly::folly
+                                  gflags::gflags
                                   gfx::timsort
                                   date::date
                                   re2::re2
@@ -270,14 +274,43 @@ target_link_libraries(bolt_engine PUBLIC
                                   $<$<BOOL:${BOLT_ENABLE_ABFS}>:Azure::azure-storage-blobs Azure::azure-storage-files-datalake Azure::azure-identity>
 )
 
+if(${BOLT_ENABLE_TORCH})
+  target_link_libraries(bolt_engine PUBLIC ${TORCH_LIBRARIES})
+  target_compile_definitions(bolt_engine PUBLIC BOLT_HAS_TORCH=1)
+endif()
+
+if(${BOLT_BUILD_PYTHON_PACKAGE})
+  target_link_libraries(bolt_engine PUBLIC pybind11::pybind11)
+  target_compile_definitions(bolt_engine PUBLIC BOLT_HAS_PYTHON=1)
+endif()
+
+if(${BOLT_ENABLE_CUDF})
+  target_link_libraries(bolt_engine PUBLIC cudf::cudf)
+  target_compile_definitions(
+    bolt_engine PUBLIC BOLT_HAS_CUDF=1 LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+  )
+endif()
+
 if(${BOLT_BUILD_TEST_UTILS})
-  add_library(bolt_testutils ${BOLT_TESTUTILS_OBJECT_TARGETS})
+  add_library(bolt_testutils ${BOLT_TESTUTILS_OBJECT_TARGETS} common/testutil/BoltTestFlags.cpp)
   target_link_libraries(bolt_testutils PUBLIC
                                   bolt_engine
-                                  bolt_test_flags
                                   $<$<CONFIG:Debug>:bolt_debug_util>
                                   duckdb::duckdb
+                                  gflags::gflags
                                   GTest::gtest
   )
   target_include_directories(bolt_testutils PUBLIC ${CMAKE_BINARY_DIR})
 endif()
+
+set(BOLT_INSTALL_TARGETS bolt_engine)
+if(${BOLT_BUILD_TEST_UTILS})
+  list(APPEND BOLT_INSTALL_TARGETS bolt_testutils)
+endif()
+
+install(
+  TARGETS ${BOLT_INSTALL_TARGETS}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/bolt/common/testutil/CMakeLists.txt
+++ b/bolt/common/testutil/CMakeLists.txt
@@ -24,11 +24,6 @@
 #
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
-if(${BOLT_BUILD_TEST_UTILS})
-  add_library(bolt_test_flags STATIC BoltTestFlags.cpp)
-  target_link_libraries(bolt_test_flags PRIVATE gflags::gflags)
-endif()
-
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_library(bolt_debug_util OBJECT ScopedTestTime.cpp TestValue.cpp)
   target_link_libraries(bolt_debug_util PUBLIC bolt_exception)

--- a/bolt/cudf/exec/CMakeLists.txt
+++ b/bolt/cudf/exec/CMakeLists.txt
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(bolt_cudf_exec HashAggregation.cpp InterOp.cpp OrderBy.cpp)
+bolt_add_library(bolt_cudf_exec HashAggregation.cpp InterOp.cpp OrderBy.cpp)
 
 target_include_directories(bolt_cudf_exec PRIVATE ${cudf_INCLUDE_DIRS})
 
 target_link_libraries(
-  bolt_cudf_exec PRIVATE arrow cudf::cudf bolt_arrow_bridge bolt_exception bolt_common_base
-                         bolt_exec
+  bolt_cudf_exec PRIVATE arrow::arrow cudf::cudf
 )
 
 # The LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE macro enables the experimental
@@ -28,10 +27,8 @@ target_link_libraries(
 #
 # References: - RMM Fix: https://github.com/rapidsai/rmm/pull/1852 - libcudacxx Docs:
 # https://nvidia.github.io/cccl/libcudacxx/extended_api/memory_resource.html
-target_compile_options(
-  bolt_cudf_exec
-  PUBLIC -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-  PRIVATE -Wno-missing-field-initializers -fcoroutines
-)
+target_compile_options(bolt_cudf_exec PRIVATE -Wno-missing-field-initializers -fcoroutines)
 
-target_compile_definitions(bolt_cudf_exec PRIVATE BOLT_HAS_CUDF=1)
+target_compile_definitions(
+  bolt_cudf_exec PUBLIC LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE PRIVATE BOLT_HAS_CUDF=1
+)

--- a/bolt/cudf/tests/CMakeLists.txt
+++ b/bolt/cudf/tests/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(bolt_cudf_test_util CudfResource.cpp)
+bolt_add_library(bolt_cudf_test_util CudfResource.cpp)
 
 target_include_directories(bolt_cudf_test_util PRIVATE ${cudf_INCLUDE_DIRS})
 
@@ -29,6 +29,6 @@ target_link_libraries(
 #
 # References: - RMM Fix: https://github.com/rapidsai/rmm/pull/1852 - libcudacxx Docs:
 # https://nvidia.github.io/cccl/libcudacxx/extended_api/memory_resource.html
-target_compile_options(
-  bolt_cudf_test_util PUBLIC -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE -DBOLT_HAS_CUDF=1
+target_compile_definitions(
+  bolt_cudf_test_util PUBLIC LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE BOLT_HAS_CUDF=1
 )

--- a/bolt/python/CMakeLists.txt
+++ b/bolt/python/CMakeLists.txt
@@ -25,7 +25,7 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_library(
+bolt_add_library(
   bolt_python Aggregate.cpp Function.cpp Operator.cpp PlanNode.cpp PythonScalarFunction.cpp
               Utils.cpp
 )
@@ -54,5 +54,5 @@ if(${ENABLE_BOLT_JIT})
 endif()
 
 # icu is needed as a result of a transitive include calling a function from icu library.
-target_link_libraries(bolt_python PRIVATE ${pybind11_LIBRARIES} icu::icu folly::folly)
+target_link_libraries(bolt_python PRIVATE pybind11::pybind11 icu::icu folly::folly)
 target_compile_definitions(bolt_python PRIVATE ${glog_DEFINITIONS})

--- a/bolt/torch/CMakeLists.txt
+++ b/bolt/torch/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(bolt_torch Compatibility.cpp Operator.cpp PlanNode.cpp Tensor.cpp Utils.cpp)
+bolt_add_library(bolt_torch Compatibility.cpp Operator.cpp PlanNode.cpp Tensor.cpp Utils.cpp)
 
 target_include_directories(
   bolt_torch

--- a/conanfile.py
+++ b/conanfile.py
@@ -99,6 +99,7 @@ class BoltConan(ConanFile):
         "enable_colocate": [True, False],
         "io_uring_supported": [True, False],
         "enable_torch": TorchOption.all(),
+        "enable_cudf": [True, False],
         "enable_perf": [True, False],
     }
     default_options = {
@@ -128,6 +129,7 @@ class BoltConan(ConanFile):
         "enable_colocate": False,
         "io_uring_supported": True,
         "enable_torch": TorchOption().value,
+        "enable_cudf": False,
         "enable_perf": False,
     }
 
@@ -249,6 +251,7 @@ class BoltConan(ConanFile):
         self.requires(
             "glog/0.7.1", headers=True, transitive_headers=True, transitive_libs=True
         )
+        self.requires("gflags/2.2.2", transitive_headers=True, transitive_libs=True)
         self.requires("thrift/0.17.0", headers=True, force=True)
         self.requires("roaring/4.3.1", headers=True)
         self.requires("boost/1.85.0", transitive_headers=True, transitive_libs=True)
@@ -262,6 +265,8 @@ class BoltConan(ConanFile):
             self.requires("liburing/2.6")
         if self.options.get_safe("python_bind"):
             self.requires("pybind11/2.13.1")
+        if self.options.get_safe("enable_cudf"):
+            self.requires("cudf/25.06")
         if self.options.get_safe("enable_colocate"):
             self.requires("grpc/1.50.0")
 
@@ -450,6 +455,10 @@ class BoltConan(ConanFile):
         else:
             tc.cache_variables["BOLT_ENABLE_TORCH"] = "OFF"
 
+        tc.cache_variables["BOLT_ENABLE_CUDF"] = (
+            "ON" if self.options.get_safe("enable_cudf") else "OFF"
+        )
+
         if self.options.enable_asan:
             tc.cache_variables["CMAKE_CXX_FLAGS"] += " -fsanitize=address "
             tc.cache_variables["CMAKE_C_FLAGS"] += " -fsanitize=address"
@@ -519,8 +528,9 @@ class BoltConan(ConanFile):
         if self.options.es_build:
             tc.cache_variables["BOLT_ENABLE_SIMDJSON"] = "ON"
 
-        if self.options.python_bind:
-            tc.cache_variables["BOLT_BUILD_PYTHON_PACKAGE"] = "ON"
+        tc.cache_variables["BOLT_BUILD_PYTHON_PACKAGE"] = (
+            "ON" if self.options.python_bind else "OFF"
+        )
 
         if self.options.enable_arrow_connector:
             tc.cache_variables["BOLT_ENABLE_ARROW_CONNECTOR"] = "ON"
@@ -655,6 +665,7 @@ class BoltConan(ConanFile):
                 "openssl::openssl",
                 "libunwind::libunwind",
                 "snappy::snappy",
+                "gflags::gflags",
                 "glog::glog",
                 "thrift::thrift",
                 "roaring::roaring",
@@ -684,6 +695,27 @@ class BoltConan(ConanFile):
                 self.cpp_info.components["bolt_engine"].exelinkflags.append(
                     "-Wl,--export-dynamic-symbol=jit_*"
                 )
+        if (
+            self.options.enable_torch is not None
+            and self.options.enable_torch.value is not None
+        ):
+            self.cpp_info.components["bolt_engine"].requires.append(
+                "libtorch::libtorch"
+            )
+            self.cpp_info.components["bolt_engine"].defines.append("BOLT_HAS_TORCH=1")
+        if self.options.get_safe("python_bind"):
+            self.cpp_info.components["bolt_engine"].requires.append(
+                "pybind11::pybind11_"
+            )
+            self.cpp_info.components["bolt_engine"].defines.append("BOLT_HAS_PYTHON=1")
+        if self.options.get_safe("enable_cudf"):
+            self.cpp_info.components["bolt_engine"].requires.append("cudf::cudf")
+            self.cpp_info.components["bolt_engine"].defines.extend(
+                [
+                    "BOLT_HAS_CUDF=1",
+                    "LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE",
+                ]
+            )
         if self.options.get_safe("enable_s3"):
             self.cpp_info.components["bolt_engine"].requires.append(
                 "aws-c-common::aws-c-common"
@@ -710,6 +742,7 @@ class BoltConan(ConanFile):
             )
             self.cpp_info.components["bolt_testutils"].requires = [
                 "bolt_engine",
+                "gflags::gflags",
                 "gtest::gtest",
                 "duckdb::duckdb",
             ]

--- a/scripts/conan/recipes/cudf/all/conandata.yml
+++ b/scripts/conan/recipes/cudf/all/conandata.yml
@@ -1,0 +1,18 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sources:
+  "25.06":
+    url: "https://github.com/rapidsai/cudf/archive/refs/tags/v25.06.00.tar.gz"
+    sha256: "4fdcac02be1e0022643a1cd2afa9bae6091bb7d7525cdf0edb9d481bca737fa2"

--- a/scripts/conan/recipes/cudf/all/conanfile.py
+++ b/scripts/conan/recipes/cudf/all/conanfile.py
@@ -1,0 +1,112 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+
+required_conan_version = ">=2.0"
+
+
+class CudfConan(ConanFile):
+    name = "cudf"
+    description = "The libcudf CUDA/C++ columnar data processing library"
+    license = "Apache-2.0"
+    url = "https://github.com/bytedance/bolt"
+    homepage = "https://github.com/rapidsai/cudf"
+    topics = ("cuda", "dataframe", "gpu", "rapids")
+    package_type = "library"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "cuda_architectures": ["ANY"],
+    }
+    default_options = {
+        "shared": True,
+        "fPIC": True,
+        "cuda_architectures": "RAPIDS",
+    }
+    implements = ["auto_shared_fpic"]
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires(
+            "zlib/[>=1.3.1 <2]",
+            transitive_headers=True,
+            transitive_libs=True,
+        )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/3.31.10")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][str(self.version)], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TESTS"] = False
+        tc.cache_variables["BUILD_BENCHMARKS"] = False
+        tc.cache_variables["BUILD_SHARED_LIBS"] = bool(self.options.shared)
+        tc.cache_variables["CMAKE_CUDA_ARCHITECTURES"] = str(
+            self.options.cuda_architectures
+        )
+        tc.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        tc.cache_variables["CUDF_BUILD_TESTUTIL"] = False
+        tc.cache_variables["CUDF_BUILD_STREAMS_TEST_UTIL"] = False
+        tc.generate()
+        CMakeDeps(self).generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, "cpp"))
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        CMake(self).install()
+
+    def package_info(self):
+        # Keep libcudf's installed CMake package because it reconstructs the
+        # RMM, CCCL, CUDA, and RAPIDS Logger interface targets.
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        self.cpp_info.builddirs = ["."]
+
+        cudf = self.cpp_info.components["cudf"]
+        cudf.libs = ["cudf"]
+        cudf.includedirs = [
+            "include",
+            os.path.join("include", "rapids"),
+            os.path.join("include", "rapids", "libcudacxx"),
+        ]
+        cudf.set_property("cmake_target_name", "cudf::cudf")

--- a/scripts/conan/recipes/cudf/all/test_package/CMakeLists.txt
+++ b/scripts/conan/recipes/cudf/all/test_package/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.30.4)
+project(test_package LANGUAGES CXX CUDA)
+
+find_package(cudf REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} PRIVATE cudf::cudf)

--- a/scripts/conan/recipes/cudf/all/test_package/conanfile.py
+++ b/scripts/conan/recipes/cudf/all/test_package/conanfile.py
@@ -1,0 +1,44 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/3.31.10")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            executable = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(executable, env="conanrun")

--- a/scripts/conan/recipes/cudf/all/test_package/test_package.cpp
+++ b/scripts/conan/recipes/cudf/all/test_package/test_package.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/table/table.hpp>
+
+int main() {
+  cudf::table table;
+  return table.num_columns() == 0 ? 0 : 1;
+}

--- a/scripts/conan/recipes/cudf/config.yml
+++ b/scripts/conan/recipes/cudf/config.yml
@@ -1,0 +1,17 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+versions:
+  "25.06":
+    folder: all


### PR DESCRIPTION
### What problem does this PR solve?

Bolt's static package exported only `libbolt_engine.a`, while optional Torch,
Python, and cuDF implementations could remain in separate archives. Consumers
could therefore see unresolved symbols when an enabled feature was used.

The install logic also scanned every `.a` file in the build directory. A reused
build directory could consequently leak stale or disabled archives into a Conan
package. In addition, test flag definitions were packaged separately from
`libbolt_testutils.a`, so consumers of the test utilities did not receive a
complete static link interface.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Aggregate optional Torch, Python, and cuDF object libraries into
  `bolt_engine` when their features are enabled.
- Compile `BoltTestFlags.cpp` and the optional cuDF test helpers directly into
  `bolt_testutils`.
- Replace build-directory archive scanning with explicit, conditional
  `install(TARGETS ...)` rules.
- Export direct gflags and optional-feature dependencies through Conan package
  metadata.
- Add a minimal `cudf/25.06` Conan recipe for the Python-independent libcudf C++
  library. The recipe does not pin RAPIDS helper repositories or CUDA versions;
  those remain under upstream libcudf CMake control.

Validation performed:

- Built `bolt_testutils` and `bolt_exec_aggregation_test` in Release mode.
- Passed `AggregationTest.manyGlobalAggregations`.
- Verified installation contains only `libbolt_engine.a` and
  `libbolt_testutils.a`.
- Verified `BoltTestFlags.cpp.o` is included in `libbolt_testutils.a`.
- Passed all pre-commit hooks for the 14 changed files.
- Resolved the Torch, Python, and cuDF Conan dependency graphs.
- Validated the libcudf recipe with `conan inspect`, local-index graph
  resolution, option variants, and source extraction.

libcudf itself was not compiled because this environment does not have a CUDA
toolkit.

### Performance Impact

- [x] **No Impact**: This change only affects build, packaging, and dependency
  metadata; it does not change Bolt's runtime critical path.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Fixed static package exports for Bolt engine and test utility libraries.
- Added a minimal Conan recipe for libcudf 25.06.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
