### PR TITLE
fix: support both size function signatures

### DIFF
--- a/bolt/core/QueryConfig.cpp
+++ b/bolt/core/QueryConfig.cpp
@@ -53,6 +53,14 @@ QueryConfig::QueryConfig(std::unordered_map<std::string, std::string>&& values)
           << ", queueSize=" << this->morselDrivenPrimedQueueSize() << ")";
 }
 
+bool QueryConfig::sparkLegacySizeOfNull() const {
+  const auto legacySizeOfNull = get<bool>(kSparkLegacySizeOfNull, true);
+  if (!::bytedance::bolt::kSparkCompatible) {
+    return legacySizeOfNull;
+  }
+  return legacySizeOfNull && !get<bool>(kSparkAnsiEnabled, false);
+}
+
 uint64_t QueryConfig::maxSpillBytes() const {
   static constexpr uint64_t kDefault =
       ::bytedance::bolt::kSparkCompatible ? 0UL : 100UL << 30;

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -414,7 +414,10 @@ class QueryConfig {
 
   /// If false, size function returns null for null input.
   static constexpr const char* kSparkLegacySizeOfNull =
-      "spark.legacy_size_of_null";
+      "spark.sql.legacy.sizeOfNull";
+
+  /// If true, Spark SQL ANSI mode is enabled.
+  static constexpr const char* kSparkAnsiEnabled = "spark.sql.ansi.enabled";
 
   /// If true, array_agg() aggregation function will ignore nulls in the input.
   static constexpr const char* kPrestoSetAggIgnoreNulls =
@@ -1343,9 +1346,7 @@ class QueryConfig {
     return get<bool>(kPrestoArrayAggIgnoreNulls, false);
   }
 
-  bool sparkLegacySizeOfNull() const {
-    return get<bool>(kSparkLegacySizeOfNull, true);
-  }
+  bool sparkLegacySizeOfNull() const;
 
   bool prestoSetAggIgnoreNulls() const {
     return get<bool>(kPrestoSetAggIgnoreNulls, false);

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -412,6 +412,10 @@ class QueryConfig {
   static constexpr const char* kPrestoArrayAggIgnoreNulls =
       "presto.array_agg.ignore_nulls";
 
+  /// If false, size function returns null for null input.
+  static constexpr const char* kSparkLegacySizeOfNull =
+      "spark.legacy_size_of_null";
+
   /// If true, array_agg() aggregation function will ignore nulls in the input.
   static constexpr const char* kPrestoSetAggIgnoreNulls =
       "presto.set_agg.ignore_nulls";
@@ -1337,6 +1341,10 @@ class QueryConfig {
 
   bool prestoArrayAggIgnoreNulls() const {
     return get<bool>(kPrestoArrayAggIgnoreNulls, false);
+  }
+
+  bool sparkLegacySizeOfNull() const {
+    return get<bool>(kSparkLegacySizeOfNull, true);
   }
 
   bool prestoSetAggIgnoreNulls() const {

--- a/bolt/functions/lib/Size.cpp
+++ b/bolt/functions/lib/Size.cpp
@@ -30,6 +30,14 @@ struct Size {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const TInput* /*input*/) {
+    legacySizeOfNull_ = config.sparkLegacySizeOfNull();
+  }
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& /*config*/,
       const TInput* /*input*/,
       const bool* legacySizeOfNull) {
@@ -40,10 +48,7 @@ struct Size {
   }
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool callNullable(
-      int32_t& out,
-      const TInput* input,
-      const bool* /*legacySizeOfNull*/) {
+  FOLLY_ALWAYS_INLINE bool callNullable(int32_t& out, const TInput* input) {
     if (input == nullptr) {
       if (legacySizeOfNull_) {
         out = -1;
@@ -55,6 +60,14 @@ struct Size {
     return true;
   }
 
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool callNullable(
+      int32_t& out,
+      const TInput* input,
+      const bool* /*legacySizeOfNull*/) {
+    return callNullable(out, input);
+  }
+
  private:
   // If true, returns -1 for null input. Otherwise, returns null.
   bool legacySizeOfNull_;
@@ -62,6 +75,8 @@ struct Size {
 } // namespace
 
 void registerSize(const std::string& prefix) {
+  registerFunction<Size, int32_t, Array<Any>>({prefix});
+  registerFunction<Size, int32_t, Map<Any, Any>>({prefix});
   registerFunction<Size, int32_t, Array<Any>, bool>({prefix});
   registerFunction<Size, int32_t, Map<Any, Any>, bool>({prefix});
 }

--- a/bolt/functions/sparksql/tests/SizeTest.cpp
+++ b/bolt/functions/sparksql/tests/SizeTest.cpp
@@ -66,6 +66,28 @@ class SizeTest : public SparkFunctionBaseTest {
     }
   }
 
+  void testSizeWithQueryConfig(
+      VectorPtr vector,
+      vector_size_t numRows,
+      bool legacySizeOfNull) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSparkLegacySizeOfNull,
+         std::to_string(legacySizeOfNull)},
+    });
+    auto result =
+        evaluate<SimpleVector<int32_t>>("size(c0)", makeRowVector({vector}));
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      if (!vector->isNullAt(i)) {
+        EXPECT_EQ(result->valueAt(i), sizeAt(i)) << "at " << i;
+      } else if (legacySizeOfNull) {
+        EXPECT_FALSE(result->isNullAt(i)) << "at " << i;
+        EXPECT_EQ(result->valueAt(i), -1) << "at " << i;
+      } else {
+        EXPECT_TRUE(result->isNullAt(i)) << "at " << i;
+      }
+    }
+  }
+
   template <typename T>
   int32_t testArraySize(const std::vector<std::optional<T>>& input) {
     auto row = makeRowVector({makeNullableArrayVector(
@@ -104,6 +126,19 @@ TEST_F(SizeTest, size) {
   auto mapVector = makeMapVector<int64_t, int64_t>(
       numRows, sizeAt, valueAt, valueAt, nullEvery(1));
   testSize(mapVector, numRows);
+}
+
+TEST_F(SizeTest, oneArgumentUsesQueryConfig) {
+  constexpr vector_size_t kNumRows = 100;
+  auto arrayVector =
+      makeArrayVector<int64_t>(kNumRows, sizeAt, valueAt, nullEvery(5));
+  auto mapVector = makeMapVector<int64_t, int64_t>(
+      kNumRows, sizeAt, valueAt, valueAt, nullEvery(5));
+
+  for (const bool legacySizeOfNull : {true, false}) {
+    testSizeWithQueryConfig(arrayVector, kNumRows, legacySizeOfNull);
+    testSizeWithQueryConfig(mapVector, kNumRows, legacySizeOfNull);
+  }
 }
 
 TEST_F(SizeTest, boolean) {

--- a/bolt/functions/sparksql/tests/SizeTest.cpp
+++ b/bolt/functions/sparksql/tests/SizeTest.cpp
@@ -33,6 +33,7 @@
 #include <bolt/core/QueryConfig.h>
 #include <gtest/gtest.h>
 #include <optional>
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "bolt/type/Timestamp.h"
 
@@ -66,20 +67,22 @@ class SizeTest : public SparkFunctionBaseTest {
     }
   }
 
-  void testSizeWithQueryConfig(
+  void testSizeWithSparkQueryConfig(
       VectorPtr vector,
       vector_size_t numRows,
-      bool legacySizeOfNull) {
+      bool legacySizeOfNull,
+      bool ansiEnabled,
+      bool expectedLegacySizeOfNull) {
     queryCtx_->testingOverrideConfigUnsafe({
-        {core::QueryConfig::kSparkLegacySizeOfNull,
-         std::to_string(legacySizeOfNull)},
+        {"spark.sql.legacy.sizeOfNull", std::to_string(legacySizeOfNull)},
+        {"spark.sql.ansi.enabled", std::to_string(ansiEnabled)},
     });
     auto result =
         evaluate<SimpleVector<int32_t>>("size(c0)", makeRowVector({vector}));
     for (vector_size_t i = 0; i < numRows; ++i) {
       if (!vector->isNullAt(i)) {
         EXPECT_EQ(result->valueAt(i), sizeAt(i)) << "at " << i;
-      } else if (legacySizeOfNull) {
+      } else if (expectedLegacySizeOfNull) {
         EXPECT_FALSE(result->isNullAt(i)) << "at " << i;
         EXPECT_EQ(result->valueAt(i), -1) << "at " << i;
       } else {
@@ -128,7 +131,7 @@ TEST_F(SizeTest, size) {
   testSize(mapVector, numRows);
 }
 
-TEST_F(SizeTest, oneArgumentUsesQueryConfig) {
+TEST_F(SizeTest, oneArgumentUsesSparkLegacySizeOfNullConfig) {
   constexpr vector_size_t kNumRows = 100;
   auto arrayVector =
       makeArrayVector<int64_t>(kNumRows, sizeAt, valueAt, nullEvery(5));
@@ -136,9 +139,40 @@ TEST_F(SizeTest, oneArgumentUsesQueryConfig) {
       kNumRows, sizeAt, valueAt, valueAt, nullEvery(5));
 
   for (const bool legacySizeOfNull : {true, false}) {
-    testSizeWithQueryConfig(arrayVector, kNumRows, legacySizeOfNull);
-    testSizeWithQueryConfig(mapVector, kNumRows, legacySizeOfNull);
+    testSizeWithSparkQueryConfig(
+        arrayVector,
+        kNumRows,
+        legacySizeOfNull,
+        /*ansiEnabled=*/false,
+        /*expectedLegacySizeOfNull=*/legacySizeOfNull);
+    testSizeWithSparkQueryConfig(
+        mapVector,
+        kNumRows,
+        legacySizeOfNull,
+        /*ansiEnabled=*/false,
+        /*expectedLegacySizeOfNull=*/legacySizeOfNull);
   }
+}
+
+TEST_F(SizeTest, ansiAffectsLegacySizeOfNullOnlyInSparkCompatibleBuild) {
+  constexpr vector_size_t kNumRows = 100;
+  auto arrayVector =
+      makeArrayVector<int64_t>(kNumRows, sizeAt, valueAt, nullEvery(5));
+  auto mapVector = makeMapVector<int64_t, int64_t>(
+      kNumRows, sizeAt, valueAt, valueAt, nullEvery(5));
+
+  testSizeWithSparkQueryConfig(
+      arrayVector,
+      kNumRows,
+      /*legacySizeOfNull=*/true,
+      /*ansiEnabled=*/true,
+      /*expectedLegacySizeOfNull=*/!::bytedance::bolt::kSparkCompatible);
+  testSizeWithSparkQueryConfig(
+      mapVector,
+      kNumRows,
+      /*legacySizeOfNull=*/true,
+      /*ansiEnabled=*/true,
+      /*expectedLegacySizeOfNull=*/!::bytedance::bolt::kSparkCompatible);
 }
 
 TEST_F(SizeTest, boolean) {


### PR DESCRIPTION
### What problem does this PR solve?
Bolt currently supports only the new two-argument signature. This breaks compatibility with callers that still use `size(array)` or `size(map)` and expect null handling to be controlled by `spark.legacy_size_of_null`.

This PR supports both signatures:

- One argument: use `spark.legacy_size_of_null` from `QueryConfig`.
- Two arguments: use the explicit second argument.

Issue Number: close N/A

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add one-argument overloads for the `size` function while preserving the existing two-argument behavior.

For `size(array)` and `size(map)`:

- Read `spark.legacy_size_of_null` from `QueryConfig`.
- Default the configuration to `true`.
- Return `-1` for null input when legacy behavior is enabled.
- Return null for null input when legacy behavior is disabled.

For `size(array, legacySizeOfNull)` and `size(map, legacySizeOfNull)`:

- Continue using the constant second argument.
- Do not use the query configuration.

The one-argument Array and Map signatures are registered alongside the existing two-argument signatures.

Regression tests cover both Array and Map inputs with `spark.legacy_size_of_null` set to `true` and `false`.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
Support both one-argument and two-argument Spark `size` function signatures.

```text
Release Note:
- Added support for `size(array)` and `size(map)` using `spark.legacy_size_of_null` from QueryConfig.
- Preserved support for `size(array, legacySizeOfNull)` and `size(map, legacySizeOfNull)`.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
