### PR TITLE
perf: guard reusable table scan outputs

### DIFF
--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -641,19 +641,19 @@ HiveDataSource::prepareReaderOutputForNextRead() {
     return nullptr;
   }
 
+  output_.reset();
   for (auto i = 0; i < reusableOutputPool_->slots.size(); ++i) {
     auto& slot = reusableOutputPool_->slots[i];
     if (slot.inUse) {
       continue;
     }
     slot.inUse = true;
-    output_ = slot.output;
-    if (!output_ || *output_->type() != *readerOutputType_) {
-      output_ = BaseVector::create(readerOutputType_, 0, pool_);
-      slot.output = output_;
+    if (!slot.output || *slot.output->type() != *readerOutputType_) {
+      slot.output = BaseVector::create(readerOutputType_, 0, pool_);
     } else {
-      BaseVector::prepareForReuse(output_, 0);
+      BaseVector::prepareForReuse(slot.output, 0);
     }
+    output_ = slot.output;
     return std::make_shared<ReusableOutputLease>(reusableOutputPool_, i);
   }
 

--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -70,6 +70,11 @@ HiveDataSource::HiveDataSource(
       outputType_(outputType),
       expressionEvaluator_(connectorQueryCtx->expressionEvaluator()),
       runtimeStats_(std::make_unique<dwio::common::RuntimeStatistics>()) {
+  const auto reusableOutputCount = queryConfig.tableScanReusableOutputCount();
+  if (reusableOutputCount > 0) {
+    reusableOutputPool_ =
+        std::make_shared<ReusableOutputPool>(reusableOutputCount);
+  }
   for (const auto& key : HiveConfig::hms_session_key) {
     std::optional<std::string> value = queryConfig.get<std::string>(key);
     if (value.has_value()) {
@@ -624,13 +629,36 @@ vector_size_t getLength(std::shared_ptr<ConnectorSplit>& split) {
   BOLT_FAIL("Unsupported split type for getting length");
 }
 
-void HiveDataSource::prepareReaderOutputForNextRead() {
-  if (!output_ || *output_->type() != *readerOutputType_) {
-    output_ = BaseVector::create(readerOutputType_, 0, pool_);
-    return;
+std::shared_ptr<HiveDataSource::ReusableOutputLease>
+HiveDataSource::prepareReaderOutputForNextRead() {
+  if (!reusableOutputPool_) {
+    if (!output_ || *output_->type() != *readerOutputType_) {
+      output_ = BaseVector::create(readerOutputType_, 0, pool_);
+      return nullptr;
+    }
+
+    BaseVector::prepareForReuse(output_, 0);
+    return nullptr;
   }
 
-  BaseVector::prepareForReuse(output_, 0);
+  for (auto i = 0; i < reusableOutputPool_->slots.size(); ++i) {
+    auto& slot = reusableOutputPool_->slots[i];
+    if (slot.inUse) {
+      continue;
+    }
+    slot.inUse = true;
+    output_ = slot.output;
+    if (!output_ || *output_->type() != *readerOutputType_) {
+      output_ = BaseVector::create(readerOutputType_, 0, pool_);
+      slot.output = output_;
+    } else {
+      BaseVector::prepareForReuse(output_, 0);
+    }
+    return std::make_shared<ReusableOutputLease>(reusableOutputPool_, i);
+  }
+
+  output_ = BaseVector::create(readerOutputType_, 0, pool_);
+  return nullptr;
 }
 
 std::optional<RowVectorPtr> HiveDataSource::next(
@@ -652,7 +680,7 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     return nullptr;
   }
 
-  prepareReaderOutputForNextRead();
+  auto outputLease = prepareReaderOutputForNextRead();
 
   // TODO Check if remaining filter has a conjunct that doesn't depend on
   // any column, e.g. rand() < 0.1. Evaluate that conjunct first, then scan
@@ -702,8 +730,9 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     }
 
     if (outputType_->size() == 0) {
-      return exec::wrapAndCombineDict(
-          rowsRemaining, remainingIndices, rowVector);
+      return retainReusableOutputLease(
+          exec::wrapAndCombineDict(rowsRemaining, remainingIndices, rowVector),
+          outputLease);
     }
 
     std::vector<VectorPtr> outputColumns;
@@ -715,12 +744,14 @@ std::optional<RowVectorPtr> HiveDataSource::next(
         // don't need to reallocate the result for every batch.
         child->disableMemo();
       }
-      outputColumns.emplace_back(
-          exec::wrapChild(rowsRemaining, remainingIndices, child));
+      outputColumns.emplace_back(retainReusableOutputLease(
+          exec::wrapChild(rowsRemaining, remainingIndices, child),
+          outputLease));
     }
 
-    return std::make_shared<RowVector>(
+    auto result = std::make_shared<RowVector>(
         pool_, outputType_, BufferPtr(nullptr), rowsRemaining, outputColumns);
+    return result;
   }
 
   resetSplit();

--- a/bolt/connectors/hive/HiveDataSource.h
+++ b/bolt/connectors/hive/HiveDataSource.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "bolt/common/io/IoStatistics.h"
 #include "bolt/common/memory/MemoryPool.h"
 #include "bolt/connectors/Connector.h"
@@ -128,6 +130,24 @@ class HiveDataSource : public DataSource {
   memory::MemoryPool* pool_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
   VectorPtr output_;
+  struct ReusableOutputSlot {
+    VectorPtr output;
+    bool inUse{false};
+  };
+  struct ReusableOutputPool {
+    explicit ReusableOutputPool(size_t size) : slots(size) {}
+    std::vector<ReusableOutputSlot> slots;
+  };
+  struct ReusableOutputLease {
+    ReusableOutputLease(std::shared_ptr<ReusableOutputPool> pool, size_t index)
+        : pool(std::move(pool)), index(index) {}
+    ~ReusableOutputLease() {
+      pool->slots[index].inUse = false;
+    }
+    std::shared_ptr<ReusableOutputPool> pool;
+    size_t index;
+  };
+  std::shared_ptr<ReusableOutputPool> reusableOutputPool_;
   std::unique_ptr<HiveSplitReaderBase> splitReader_;
 
   // Output type from file reader.  This is different from outputType_ that it
@@ -147,7 +167,23 @@ class HiveDataSource : public DataSource {
   std::shared_ptr<io::IoStatistics> ioStats_;
 
  private:
-  void prepareReaderOutputForNextRead();
+  std::shared_ptr<ReusableOutputLease> prepareReaderOutputForNextRead();
+  template <typename T>
+  std::shared_ptr<T> retainReusableOutputLease(
+      std::shared_ptr<T> vector,
+      const std::shared_ptr<ReusableOutputLease>& lease) {
+    if (!lease) {
+      return vector;
+    }
+
+    struct LeasedVector {
+      std::shared_ptr<T> vector;
+      std::shared_ptr<ReusableOutputLease> lease;
+    };
+    auto leased =
+        std::make_shared<LeasedVector>(LeasedVector{std::move(vector), lease});
+    return std::shared_ptr<T>(leased, leased->vector.get());
+  }
 
   // Evaluates remainingFilter_ on the specified vector. Returns number of
   // rows passed. Populates filterEvalCtx_.selectedIndices and selectedBits

--- a/bolt/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/bolt/connectors/hive/tests/HiveConnectorTest.cpp
@@ -460,6 +460,7 @@ class SequentialSplitReader : public HiveSplitReaderBase {
     if (rowOutput == nullptr) {
       return 0;
     }
+    readerOutputs_.push_back(output.get());
     rowOutput->unsafeResize(1);
 
     auto values = AlignedBuffer::allocate<int64_t>(1, pool_);
@@ -490,10 +491,15 @@ class SequentialSplitReader : public HiveSplitReaderBase {
 
   void resetSplit() override {}
 
+  const std::vector<BaseVector*>& readerOutputs() const {
+    return readerOutputs_;
+  }
+
  private:
   RowTypePtr rowType_;
   memory::MemoryPool* pool_;
   int32_t calls_{0};
+  std::vector<BaseVector*> readerOutputs_;
 };
 
 class TestingHiveDataSource : public HiveDataSource {
@@ -722,6 +728,31 @@ TEST_F(HiveConnectorTest, tableScanReusableOutputDoesNotOverwriteHeldChild) {
   ASSERT_NE(secondFlat, nullptr);
   EXPECT_EQ(secondFlat->valueAt(0), 2);
   EXPECT_EQ(heldFlat->valueAt(0), 1);
+}
+
+TEST_F(HiveConnectorTest, tableScanReusableOutputReusesReleasedRoot) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto dataSource = makeTestingDataSource(
+      rowType, {{core::QueryConfig::kTableScanReusableOutputCount, "1"}});
+  auto splitReader =
+      std::make_unique<SequentialSplitReader>(rowType, pool_.get());
+  auto* rawSplitReader = splitReader.get();
+  dataSource->setSplitReader(std::move(splitReader));
+
+  ContinueFuture future;
+  {
+    auto first = dataSource->next(1, future);
+    ASSERT_TRUE(first.has_value());
+    ASSERT_NE(first.value(), nullptr);
+  }
+  ASSERT_EQ(rawSplitReader->readerOutputs().size(), 1);
+  auto* firstReaderOutput = rawSplitReader->readerOutputs()[0];
+
+  auto second = dataSource->next(1, future);
+  ASSERT_TRUE(second.has_value());
+  ASSERT_NE(second.value(), nullptr);
+  ASSERT_EQ(rawSplitReader->readerOutputs().size(), 2);
+  EXPECT_EQ(rawSplitReader->readerOutputs()[1], firstReaderOutput);
 }
 
 TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_multilevel) {

--- a/bolt/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/bolt/connectors/hive/tests/HiveConnectorTest.cpp
@@ -64,7 +64,8 @@ class HiveConnectorTest : public exec::test::HiveConnectorTestBase {
   }
 
   std::unique_ptr<TestingHiveDataSource> makeTestingDataSource(
-      const RowTypePtr& rowType);
+      const RowTypePtr& rowType,
+      std::unordered_map<std::string, std::string> queryConfig = {});
 };
 
 class FailingVectorLoader : public VectorLoader {
@@ -444,6 +445,57 @@ class TrackingSplitReader : public HiveSplitReaderBase {
   int32_t createdMapShells_{0};
 };
 
+class SequentialSplitReader : public HiveSplitReaderBase {
+ public:
+  SequentialSplitReader(RowTypePtr rowType, memory::MemoryPool* pool)
+      : rowType_(std::move(rowType)), pool_(pool) {}
+
+  uint64_t next(int64_t /*size*/, VectorPtr& output) override {
+    if (calls_ >= 2) {
+      return 0;
+    }
+
+    auto rowOutput = std::dynamic_pointer_cast<RowVector>(output);
+    EXPECT_NE(rowOutput, nullptr);
+    if (rowOutput == nullptr) {
+      return 0;
+    }
+    rowOutput->unsafeResize(1);
+
+    auto values = AlignedBuffer::allocate<int64_t>(1, pool_);
+    values->asMutable<int64_t>()[0] = calls_ + 1;
+    values->setSize(sizeof(int64_t));
+    rowOutput->childAt(0) = std::make_shared<FlatVector<int64_t>>(
+        pool_, BIGINT(), nullptr, 1, values, std::vector<BufferPtr>{});
+
+    ++calls_;
+    return 1;
+  }
+
+  bool allPrefetchIssued() const override {
+    return true;
+  }
+
+  bool emptySplit() const override {
+    return false;
+  }
+
+  void resetFilterCaches() override {}
+
+  int64_t estimatedRowSize() const override {
+    return sizeof(int64_t);
+  }
+
+  void updateRuntimeStats(dwio::common::RuntimeStatistics&) const override {}
+
+  void resetSplit() override {}
+
+ private:
+  RowTypePtr rowType_;
+  memory::MemoryPool* pool_;
+  int32_t calls_{0};
+};
+
 class TestingHiveDataSource : public HiveDataSource {
  public:
   TestingHiveDataSource(
@@ -477,7 +529,8 @@ class TestingHiveDataSource : public HiveDataSource {
 };
 
 std::unique_ptr<TestingHiveDataSource> HiveConnectorTest::makeTestingDataSource(
-    const RowTypePtr& rowType) {
+    const RowTypePtr& rowType,
+    std::unordered_map<std::string, std::string> queryConfig) {
   auto tableHandle = makeTableHandle({}, nullptr, "test_table", rowType);
   ColumnHandleMap assignments;
   for (const auto& name : rowType->names()) {
@@ -504,7 +557,7 @@ std::unique_ptr<TestingHiveDataSource> HiveConnectorTest::makeTestingDataSource(
       tableHandle,
       assignments,
       nullptr,
-      core::QueryConfig(std::unordered_map<std::string, std::string>{}),
+      core::QueryConfig(std::move(queryConfig)),
       nullptr,
       connectorQueryCtx,
       hiveConfig);
@@ -641,6 +694,34 @@ TEST_F(HiveConnectorTest, emptyOutputDoesNotExposeReaderOutput) {
   EXPECT_EQ(second.value()->childrenSize(), 0);
   EXPECT_EQ(second.value()->size(), 3);
   EXPECT_EQ(first.value()->size(), 2);
+}
+
+TEST_F(HiveConnectorTest, tableScanReusableOutputDoesNotOverwriteHeldChild) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto dataSource = makeTestingDataSource(
+      rowType, {{core::QueryConfig::kTableScanReusableOutputCount, "1"}});
+  dataSource->setSplitReader(
+      std::make_unique<SequentialSplitReader>(rowType, pool_.get()));
+
+  ContinueFuture future;
+  auto first = dataSource->next(1, future);
+  ASSERT_TRUE(first.has_value());
+  ASSERT_NE(first.value(), nullptr);
+  ASSERT_EQ(first.value()->childrenSize(), 1);
+  auto heldChild = first.value()->childAt(0);
+  ASSERT_NE(heldChild, nullptr);
+  auto* heldFlat = heldChild->as<FlatVector<int64_t>>();
+  ASSERT_NE(heldFlat, nullptr);
+  EXPECT_EQ(heldFlat->valueAt(0), 1);
+
+  auto second = dataSource->next(1, future);
+  ASSERT_TRUE(second.has_value());
+  ASSERT_NE(second.value(), nullptr);
+  ASSERT_EQ(second.value()->childrenSize(), 1);
+  auto* secondFlat = second.value()->childAt(0)->as<FlatVector<int64_t>>();
+  ASSERT_NE(secondFlat, nullptr);
+  EXPECT_EQ(secondFlat->valueAt(0), 2);
+  EXPECT_EQ(heldFlat->valueAt(0), 1);
 }
 
 TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_multilevel) {

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -225,6 +225,9 @@ class QueryConfig {
 
   static constexpr const char* kMinOutputBatchRows = "min_output_batch_rows";
 
+  static constexpr const char* kTableScanReusableOutputCount =
+      "table_scan_reusable_output_count";
+
   /// TableScan operator will exit getOutput() method after this many
   /// milliseconds even if it has no data to return yet. Zero means 'no time
   /// limit'.
@@ -971,6 +974,10 @@ class QueryConfig {
 
   uint32_t minOutputBatchRows() const {
     return get<uint32_t>(kMinOutputBatchRows, 1);
+  }
+
+  uint32_t tableScanReusableOutputCount() const {
+    return get<uint32_t>(kTableScanReusableOutputCount, 0);
   }
 
   uint32_t tableScanGetOutputTimeLimitMs() const {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: N/A

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add an opt-in `table_scan_reusable_output_count` setting for Hive table scan output reuse.

When enabled, `HiveDataSource` keeps a small pool of reusable reader output vectors. Each reused output is protected by a lease that is retained by returned child vectors, so a slot is not reused while downstream still holds references to data from that output. If all configured slots are still in use, `HiveDataSource` allocates a one-off output instead of overwriting a retained batch.

The setting defaults to `0`, so the existing single-output behavior remains unchanged unless explicitly enabled.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A. This is an opt-in reuse-path safety improvement. No benchmark was run.
    ```
    </details>
- [x] **Negative Impact**: Explained below (e.g., trade-off for correctness).

When `table_scan_reusable_output_count` is enabled and downstream holds more batches than the configured reusable slots, Hive table scan allocates one-off output vectors to avoid overwriting retained data. The default is disabled, so there is no impact unless the setting is enabled.

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Added an opt-in Hive table scan output reuse pool guarded by leases.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - N/A
    ```
    </details>

