### PR TITLE
[wip]perf: Optimize nested dictionary decoding

### DIFF
--- a/bolt/vector/DecodedVector.cpp
+++ b/bolt/vector/DecodedVector.cpp
@@ -222,23 +222,30 @@ void DecodedVector::applyDictionaryWrapper(
       copyNulls(end(rows));
     }
   }
-  auto copiedNulls = copiedNulls_.data();
   auto currentIndices = indices_;
   if (indicesNotCopied()) {
     copiedIndices_.resize(size_);
     indices_ = copiedIndices_.data();
   }
+  auto copiedIndices = copiedIndices_.data();
 
-  applyToRows(rows, [&](vector_size_t row) {
-    if (!nulls_ || !bits::isBitNull(nulls_, row)) {
-      auto wrappedIndex = currentIndices[row];
-      if (newNulls && bits::isBitNull(newNulls, wrappedIndex)) {
-        bits::setNull(copiedNulls, row);
-      } else {
-        copiedIndices_[row] = newIndices[wrappedIndex];
+  if (!nulls_ && !newNulls) {
+    applyToRows(rows, [&](vector_size_t row) {
+      copiedIndices[row] = newIndices[currentIndices[row]];
+    });
+  } else {
+    auto copiedNulls = copiedNulls_.data();
+    applyToRows(rows, [&](vector_size_t row) {
+      if (!nulls_ || !bits::isBitNull(nulls_, row)) {
+        auto wrappedIndex = currentIndices[row];
+        if (newNulls && bits::isBitNull(newNulls, wrappedIndex)) {
+          bits::setNull(copiedNulls, row);
+        } else {
+          copiedIndices[row] = newIndices[wrappedIndex];
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 void DecodedVector::fillInIndices() {
@@ -285,14 +292,16 @@ void DecodedVector::setFlatNulls(
       copyNulls(end(rows));
     }
     auto leafNulls = vector.rawNulls();
-    auto copiedNulls = &copiedNulls_[0];
-    applyToRows(rows, [&](vector_size_t row) {
-      if (!bits::isBitNull(nulls_, row) &&
-          (leafNulls && bits::isBitNull(leafNulls, indices_[row]))) {
-        bits::setNull(copiedNulls, row);
-      }
-    });
-    nulls_ = &copiedNulls_[0];
+    if (leafNulls) {
+      auto copiedNulls = copiedNulls_.data();
+      applyToRows(rows, [&](vector_size_t row) {
+        if (!bits::isBitNull(nulls_, row) &&
+            bits::isBitNull(leafNulls, indices_[row])) {
+          bits::setNull(copiedNulls, row);
+        }
+      });
+    }
+    nulls_ = copiedNulls_.data();
   } else {
     nulls_ = vector.rawNulls();
     mayHaveNulls_ = nulls_ != nullptr;


### PR DESCRIPTION
## Summary

- add a no-null fast path for nested dictionary index remapping
- skip the per-row leaf-null scan when the leaf vector has no nulls
- port the optimization from facebookincubator/velox#18403

## Validation

- `cmake --build --preset conan-release --target bolt_vector_test --parallel 16`
- `_build/Release/bolt/vector/tests/bolt_vector_test --gtest_filter='DecodedVectorTest.*' --gtest_color=no`
- 19 DecodedVector tests passed
