### PR TITLE
feat(parquet): replace invalid UTF-8 in top-level varchars on write

### DIFF
--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -30,6 +30,8 @@
 
 #include "bolt/connectors/hive/HiveDataSink.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include "bolt/common/base/Counters.h"
 #include "bolt/common/base/Fs.h"
 #include "bolt/common/base/StatsReporter.h"
@@ -43,6 +45,7 @@
 #include "bolt/dwio/common/SortingWriter.h"
 #include "bolt/exec/OperatorUtils.h"
 #include "bolt/exec/SortBuffer.h"
+#include "bolt/vector/Utf8Utils.h"
 
 using bytedance::bolt::common::testutil::TestValue;
 namespace bytedance::bolt::connector::hive {
@@ -83,6 +86,18 @@ RowVectorPtr makeDataInput(
       input->size(),
       std::move(childVectors),
       input->getNullCount());
+}
+
+bool replaceInvalidUtf8ForParquetSerde(
+    const std::shared_ptr<const HiveInsertTableHandle>& insertTableHandle) {
+  constexpr const char* kParquetSerdeMarker =
+      "spark.gluten.sql.native.writer.hive.parquet.serde";
+  const auto& serdeParameters = insertTableHandle->serdeParameters();
+  const auto marker = serdeParameters.find(kParquetSerdeMarker);
+  return insertTableHandle->storageFormat() ==
+      dwio::common::FileFormat::PARQUET &&
+      marker != serdeParameters.end() &&
+      boost::algorithm::iequals(marker->second, "true");
 }
 
 // Returns a subset of column indices corresponding to partition keys.
@@ -448,11 +463,20 @@ void HiveDataSink::appendData(RowVectorPtr input) {
 
   // Lazy load all the input columns.
   input->loadedVector();
+  auto dataInput = makeDataInput(dataChannels_, input);
+
+  auto sanitizeDataInput = [&]() {
+    if (replaceInvalidUtf8ForParquetSerde(insertTableHandle_)) {
+      dataInput = utf8::replaceInvalidUtf8InTopLevelVarchars(
+          dataInput, dataInput->pool());
+    }
+  };
 
   // Write to unpartitioned (and unbucketed) table.
   if (!isPartitioned() && !isBucketed()) {
     const auto index = ensureWriter(HiveWriterId::unpartitionedId());
-    write(index, input);
+    sanitizeDataInput();
+    write(index, dataInput);
     return;
   }
 
@@ -463,11 +487,33 @@ void HiveDataSink::appendData(RowVectorPtr input) {
   // must be zero.
   if (!isBucketed() && partitionIdGenerator_->numPartitions() == 1) {
     const auto index = ensureWriter(HiveWriterId{0});
-    write(index, input);
+    sanitizeDataInput();
+    write(index, dataInput);
     return;
   }
 
   splitInputRowsAndEnsureWriters();
+
+  // wrapAndCombineDict drops top-level row nulls when it slices a batch. The
+  // old per-writer sanitizer therefore visited the backing child values of
+  // these rows. Use a null-free view only when this batch is actually sliced
+  // to preserve that behavior while sanitizing the batch once.
+  const bool needsSlice = std::any_of(
+      partitionSizes_.begin(),
+      partitionSizes_.end(),
+      [&](vector_size_t partitionSize) {
+        return partitionSize != 0 && partitionSize != dataInput->size();
+      });
+  if (needsSlice && dataInput->nulls()) {
+    dataInput = std::make_shared<RowVector>(
+        dataInput->pool(),
+        dataInput->type(),
+        nullptr,
+        dataInput->size(),
+        dataInput->children(),
+        0);
+  }
+  sanitizeDataInput();
 
   for (auto index = 0; index < writers_.size(); ++index) {
     const vector_size_t partitionSize = partitionSizes_[index];
@@ -475,17 +521,16 @@ void HiveDataSink::appendData(RowVectorPtr input) {
       continue;
     }
 
-    RowVectorPtr writerInput = partitionSize == input->size()
-        ? input
-        : exec::wrapAndCombineDict(partitionSize, partitionRows_[index], input);
+    RowVectorPtr writerInput = partitionSize == dataInput->size()
+        ? dataInput
+        : exec::wrapAndCombineDict(
+              partitionSize, partitionRows_[index], dataInput);
     write(index, writerInput);
   }
 }
 
-void HiveDataSink::write(size_t index, RowVectorPtr input) {
+void HiveDataSink::write(size_t index, RowVectorPtr dataInput) {
   WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
-  auto dataInput = makeDataInput(dataChannels_, input);
-
   writers_[index]->write(dataInput);
   writerInfo_[index]->numWrittenRows += dataInput->size();
 }

--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -466,10 +466,58 @@ void HiveDataSink::appendData(RowVectorPtr input) {
   auto dataInput = makeDataInput(dataChannels_, input);
 
   auto sanitizeDataInput = [&]() {
-    if (replaceInvalidUtf8ForParquetSerde(insertTableHandle_)) {
+    const bool enabled = replaceInvalidUtf8ForParquetSerde(insertTableHandle_);
+    const bool logDiagnostic = !utf8DiagnosticLogged_;
+    if (logDiagnostic) {
+      constexpr const char* kParquetSerdeMarker =
+          "spark.gluten.sql.native.writer.hive.parquet.serde";
+      const auto& serdeParameters = insertTableHandle_->serdeParameters();
+      const auto marker = serdeParameters.find(kParquetSerdeMarker);
+      LOG(WARNING) << "[invalid-utf8-debug] parquet="
+                   << (insertTableHandle_->storageFormat() ==
+                       dwio::common::FileFormat::PARQUET)
+                   << " markerPresent=" << (marker != serdeParameters.end())
+                   << " markerValue="
+                   << (marker == serdeParameters.end() ? "<missing>"
+                                                       : marker->second)
+                   << " enabled=" << enabled;
+      for (auto column = 0; column < dataInput->childrenSize(); ++column) {
+        const auto& child = dataInput->childAt(column);
+        if (!child || child->typeKind() != TypeKind::VARCHAR) {
+          continue;
+        }
+        const auto* simple = child->asUnchecked<SimpleVector<StringView>>();
+        const auto isAscii = simple->isAscii();
+        LOG(WARNING) << "[invalid-utf8-debug] column=" << column << " encoding="
+                     << VectorEncoding::mapSimpleToName(child->encoding())
+                     << " wrappedEncoding="
+                     << VectorEncoding::mapSimpleToName(
+                            child->wrappedVector()->encoding())
+                     << " rows=" << child->size()
+                     << " allIsAscii=" << simple->getAllIsAscii()
+                     << " isAsciiKnown=" << isAscii.has_value()
+                     << " isAscii=" << isAscii.value_or(false);
+      }
+    }
+
+    if (enabled) {
+      auto original = dataInput;
       dataInput = utf8::replaceInvalidUtf8InTopLevelVarchars(
           dataInput, dataInput->pool());
+      if (logDiagnostic) {
+        LOG(WARNING) << "[invalid-utf8-debug] rowVectorChanged="
+                     << (dataInput.get() != original.get());
+        for (auto column = 0; column < dataInput->childrenSize(); ++column) {
+          const auto& child = dataInput->childAt(column);
+          if (child && child->typeKind() == TypeKind::VARCHAR) {
+            LOG(WARNING) << "[invalid-utf8-debug] column=" << column
+                         << " childChanged="
+                         << (child.get() != original->childAt(column).get());
+          }
+        }
+      }
     }
+    utf8DiagnosticLogged_ = true;
   };
 
   // Write to unpartitioned (and unbucketed) table.

--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -466,58 +466,10 @@ void HiveDataSink::appendData(RowVectorPtr input) {
   auto dataInput = makeDataInput(dataChannels_, input);
 
   auto sanitizeDataInput = [&]() {
-    const bool enabled = replaceInvalidUtf8ForParquetSerde(insertTableHandle_);
-    const bool logDiagnostic = !utf8DiagnosticLogged_;
-    if (logDiagnostic) {
-      constexpr const char* kParquetSerdeMarker =
-          "spark.gluten.sql.native.writer.hive.parquet.serde";
-      const auto& serdeParameters = insertTableHandle_->serdeParameters();
-      const auto marker = serdeParameters.find(kParquetSerdeMarker);
-      LOG(WARNING) << "[invalid-utf8-debug] parquet="
-                   << (insertTableHandle_->storageFormat() ==
-                       dwio::common::FileFormat::PARQUET)
-                   << " markerPresent=" << (marker != serdeParameters.end())
-                   << " markerValue="
-                   << (marker == serdeParameters.end() ? "<missing>"
-                                                       : marker->second)
-                   << " enabled=" << enabled;
-      for (auto column = 0; column < dataInput->childrenSize(); ++column) {
-        const auto& child = dataInput->childAt(column);
-        if (!child || child->typeKind() != TypeKind::VARCHAR) {
-          continue;
-        }
-        const auto* simple = child->asUnchecked<SimpleVector<StringView>>();
-        const auto isAscii = simple->isAscii();
-        LOG(WARNING) << "[invalid-utf8-debug] column=" << column << " encoding="
-                     << VectorEncoding::mapSimpleToName(child->encoding())
-                     << " wrappedEncoding="
-                     << VectorEncoding::mapSimpleToName(
-                            child->wrappedVector()->encoding())
-                     << " rows=" << child->size()
-                     << " allIsAscii=" << simple->getAllIsAscii()
-                     << " isAsciiKnown=" << isAscii.has_value()
-                     << " isAscii=" << isAscii.value_or(false);
-      }
-    }
-
-    if (enabled) {
-      auto original = dataInput;
+    if (replaceInvalidUtf8ForParquetSerde(insertTableHandle_)) {
       dataInput = utf8::replaceInvalidUtf8InTopLevelVarchars(
           dataInput, dataInput->pool());
-      if (logDiagnostic) {
-        LOG(WARNING) << "[invalid-utf8-debug] rowVectorChanged="
-                     << (dataInput.get() != original.get());
-        for (auto column = 0; column < dataInput->childrenSize(); ++column) {
-          const auto& child = dataInput->childAt(column);
-          if (child && child->typeKind() == TypeKind::VARCHAR) {
-            LOG(WARNING) << "[invalid-utf8-debug] column=" << column
-                         << " childChanged="
-                         << (child.get() != original->childAt(column).get());
-          }
-        }
-      }
     }
-    utf8DiagnosticLogged_ = true;
   };
 
   // Write to unpartitioned (and unbucketed) table.

--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -89,14 +89,16 @@ RowVectorPtr makeDataInput(
 }
 
 bool replaceInvalidUtf8ForParquetSerde(
-    const std::shared_ptr<const HiveInsertTableHandle>& insertTableHandle) {
+    const HiveInsertTableHandle& insertTableHandle) {
+  if (insertTableHandle.storageFormat() != dwio::common::FileFormat::PARQUET) {
+    return false;
+  }
+
   constexpr const char* kParquetSerdeMarker =
       "spark.gluten.sql.native.writer.hive.parquet.serde";
-  const auto& serdeParameters = insertTableHandle->serdeParameters();
+  const auto& serdeParameters = insertTableHandle.serdeParameters();
   const auto marker = serdeParameters.find(kParquetSerdeMarker);
-  return insertTableHandle->storageFormat() ==
-      dwio::common::FileFormat::PARQUET &&
-      marker != serdeParameters.end() &&
+  return marker != serdeParameters.end() &&
       boost::algorithm::iequals(marker->second, "true");
 }
 
@@ -380,6 +382,8 @@ HiveDataSink::HiveDataSink(
     const core::QueryConfig& queryConfig)
     : inputType_(std::move(inputType)),
       insertTableHandle_(std::move(insertTableHandle)),
+      replaceInvalidUtf8ForParquetSerde_(
+          replaceInvalidUtf8ForParquetSerde(*insertTableHandle_)),
       connectorQueryCtx_(connectorQueryCtx),
       commitStrategy_(commitStrategy),
       hiveConfig_(hiveConfig),
@@ -466,7 +470,7 @@ void HiveDataSink::appendData(RowVectorPtr input) {
   auto dataInput = makeDataInput(dataChannels_, input);
 
   auto sanitizeDataInput = [&]() {
-    if (replaceInvalidUtf8ForParquetSerde(insertTableHandle_)) {
+    if (replaceInvalidUtf8ForParquetSerde_) {
       dataInput = utf8::replaceInvalidUtf8InTopLevelVarchars(
           dataInput, dataInput->pool());
     }
@@ -494,24 +498,24 @@ void HiveDataSink::appendData(RowVectorPtr input) {
 
   splitInputRowsAndEnsureWriters();
 
-  // wrapAndCombineDict drops top-level row nulls when it slices a batch. The
-  // old per-writer sanitizer therefore visited the backing child values of
-  // these rows. Use a null-free view only when this batch is actually sliced
-  // to preserve that behavior while sanitizing the batch once.
-  const bool needsSlice = std::any_of(
-      partitionSizes_.begin(),
-      partitionSizes_.end(),
-      [&](vector_size_t partitionSize) {
-        return partitionSize != 0 && partitionSize != dataInput->size();
-      });
-  if (needsSlice && dataInput->nulls()) {
-    dataInput = std::make_shared<RowVector>(
-        dataInput->pool(),
-        dataInput->type(),
-        nullptr,
-        dataInput->size(),
-        dataInput->children(),
-        0);
+  if (replaceInvalidUtf8ForParquetSerde_ && dataInput->nulls()) {
+    // wrapAndCombineDict drops top-level row nulls when it slices a batch. Use
+    // a null-free view to sanitize the same backing values before slicing.
+    const bool needsSlice = std::any_of(
+        partitionSizes_.begin(),
+        partitionSizes_.end(),
+        [&](vector_size_t partitionSize) {
+          return partitionSize != 0 && partitionSize != dataInput->size();
+        });
+    if (needsSlice) {
+      dataInput = std::make_shared<RowVector>(
+          dataInput->pool(),
+          dataInput->type(),
+          nullptr,
+          dataInput->size(),
+          dataInput->children(),
+          0);
+    }
   }
   sanitizeDataInput();
 

--- a/bolt/connectors/hive/HiveDataSink.h
+++ b/bolt/connectors/hive/HiveDataSink.h
@@ -562,7 +562,8 @@ class HiveDataSink : public DataSink {
   }
 
   // Invoked to write 'input' to the specified file writer.
-  void write(size_t index, RowVectorPtr input);
+  // Writes a data-only vector. Partition columns must already be removed.
+  void write(size_t index, RowVectorPtr dataInput);
 
   void closeInternal();
 

--- a/bolt/connectors/hive/HiveDataSink.h
+++ b/bolt/connectors/hive/HiveDataSink.h
@@ -587,6 +587,7 @@ class HiveDataSink : public DataSink {
   std::vector<CompareFlags> sortCompareFlags_;
 
   State state_{State::kRunning};
+  bool utf8DiagnosticLogged_{false};
 
   tsan_atomic<bool> nonReclaimableSection_{false};
 

--- a/bolt/connectors/hive/HiveDataSink.h
+++ b/bolt/connectors/hive/HiveDataSink.h
@@ -587,7 +587,6 @@ class HiveDataSink : public DataSink {
   std::vector<CompareFlags> sortCompareFlags_;
 
   State state_{State::kRunning};
-  bool utf8DiagnosticLogged_{false};
 
   tsan_atomic<bool> nonReclaimableSection_{false};
 

--- a/bolt/connectors/hive/HiveDataSink.h
+++ b/bolt/connectors/hive/HiveDataSink.h
@@ -569,6 +569,7 @@ class HiveDataSink : public DataSink {
 
   const RowTypePtr inputType_;
   const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
+  const bool replaceInvalidUtf8ForParquetSerde_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
   const CommitStrategy commitStrategy_;
   const std::shared_ptr<const HiveConfig> hiveConfig_;

--- a/bolt/connectors/hive/benchmarks/CMakeLists.txt
+++ b/bolt/connectors/hive/benchmarks/CMakeLists.txt
@@ -34,10 +34,7 @@ target_link_libraries(
 )
 
 if(${BOLT_ENABLE_PARQUET})
-  add_executable(
-    bolt_hive_data_sink_utf8_benchmark
-    HiveDataSinkUtf8Benchmark.cpp
-  )
+  add_executable(bolt_hive_data_sink_utf8_benchmark HiveDataSinkUtf8Benchmark.cpp)
   target_link_libraries(
     bolt_hive_data_sink_utf8_benchmark
     bolt_testutils

--- a/bolt/connectors/hive/benchmarks/CMakeLists.txt
+++ b/bolt/connectors/hive/benchmarks/CMakeLists.txt
@@ -32,3 +32,16 @@ target_link_libraries(
   bolt_testutils
   ${FOLLY_BENCHMARK}
 )
+
+if(${BOLT_ENABLE_PARQUET})
+  add_executable(
+    bolt_hive_data_sink_utf8_benchmark
+    HiveDataSinkUtf8Benchmark.cpp
+  )
+  target_link_libraries(
+    bolt_hive_data_sink_utf8_benchmark
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+  )
+endif()

--- a/bolt/connectors/hive/benchmarks/HiveDataSinkUtf8Benchmark.cpp
+++ b/bolt/connectors/hive/benchmarks/HiveDataSinkUtf8Benchmark.cpp
@@ -33,6 +33,7 @@
 #include "bolt/exec/MemoryReclaimer.h"
 #include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/vector/Utf8Utils.h"
 
 namespace bytedance::bolt::connector::hive {
 namespace {
@@ -51,6 +52,7 @@ enum class InputKind {
   kAsciiKnown,
   kValidUtf8,
   kInvalidRare,
+  kInvalidComplex,
   kInvalidAll,
   kInlineOutput,
   kInlineToNonInline,
@@ -98,6 +100,7 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
     asciiKnown_ = makeInputBatches(InputKind::kAsciiKnown);
     validUtf8_ = makeInputBatches(InputKind::kValidUtf8);
     invalidRare_ = makeInputBatches(InputKind::kInvalidRare);
+    invalidComplex_ = makeInputBatches(InputKind::kInvalidComplex);
     invalidAll_ = makeInputBatches(InputKind::kInvalidAll);
     inlineOutput_ = makeInputBatches(InputKind::kInlineOutput);
     inlineToNonInline_ = makeInputBatches(InputKind::kInlineToNonInline);
@@ -112,6 +115,7 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
     inlineToNonInline_.clear();
     inlineOutput_.clear();
     invalidAll_.clear();
+    invalidComplex_.clear();
     invalidRare_.clear();
     validUtf8_.clear();
     asciiKnown_.clear();
@@ -142,6 +146,16 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
 
     suspender.rehire();
     reportOutputSizeOnce(benchmarkName, outputDirectory->path);
+    return static_cast<size_t>(kRowsPerBatch) * kNumBatches;
+  }
+
+  size_t runSanitizer(InputKind inputKind) {
+    const auto& inputs = inputsFor(inputKind);
+    for (const auto& input : inputs) {
+      auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(
+          input, connectorQueryCtx_->memoryPool());
+      folly::doNotOptimizeAway(output.get());
+    }
     return static_cast<size_t>(kRowsPerBatch) * kNumBatches;
   }
 
@@ -203,6 +217,11 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
             if (inputKind == InputKind::kValidUtf8) {
               return makeValidUtf8Value(globalRow);
             }
+            if (inputKind == InputKind::kInvalidComplex) {
+              auto value = makeValidUtf8Value(globalRow);
+              value[kStringBytes / 2] = '\xD5';
+              return value;
+            }
             if (inputKind == InputKind::kInvalidAll) {
               return std::string(kStringBytes, '\xD5');
             }
@@ -238,6 +257,8 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
         return validUtf8_;
       case InputKind::kInvalidRare:
         return invalidRare_;
+      case InputKind::kInvalidComplex:
+        return invalidComplex_;
       case InputKind::kInvalidAll:
         return invalidAll_;
       case InputKind::kInlineOutput:
@@ -324,6 +345,7 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
   std::vector<RowVectorPtr> asciiKnown_;
   std::vector<RowVectorPtr> validUtf8_;
   std::vector<RowVectorPtr> invalidRare_;
+  std::vector<RowVectorPtr> invalidComplex_;
   std::vector<RowVectorPtr> invalidAll_;
   std::vector<RowVectorPtr> inlineOutput_;
   std::vector<RowVectorPtr> inlineToNonInline_;
@@ -348,6 +370,8 @@ HIVE_DATA_SINK_UTF8_BENCHMARK(validUtf8Enabled, kValidUtf8, true);
 BENCHMARK_DRAW_LINE();
 HIVE_DATA_SINK_UTF8_BENCHMARK(invalidRareDisabled, kInvalidRare, false);
 HIVE_DATA_SINK_UTF8_BENCHMARK(invalidRareEnabled, kInvalidRare, true);
+HIVE_DATA_SINK_UTF8_BENCHMARK(invalidComplexDisabled, kInvalidComplex, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(invalidComplexEnabled, kInvalidComplex, true);
 HIVE_DATA_SINK_UTF8_BENCHMARK(invalidAllDisabled, kInvalidAll, false);
 HIVE_DATA_SINK_UTF8_BENCHMARK(invalidAllEnabled, kInvalidAll, true);
 BENCHMARK_DRAW_LINE();
@@ -372,6 +396,21 @@ HIVE_DATA_SINK_UTF8_BENCHMARK(
     dictionaryInvalidRareEnabled,
     kDictionaryInvalidRare,
     true);
+
+#define UTF8_SANITIZER_BENCHMARK(name, inputKind)         \
+  BENCHMARK_MULTI(name) {                                 \
+    return benchmark->runSanitizer(InputKind::inputKind); \
+  }
+
+BENCHMARK_DRAW_LINE();
+UTF8_SANITIZER_BENCHMARK(sanitizeAscii, kAscii);
+UTF8_SANITIZER_BENCHMARK(sanitizeValidUtf8, kValidUtf8);
+UTF8_SANITIZER_BENCHMARK(sanitizeInvalidRare, kInvalidRare);
+UTF8_SANITIZER_BENCHMARK(sanitizeInvalidComplex, kInvalidComplex);
+UTF8_SANITIZER_BENCHMARK(sanitizeInvalidAll, kInvalidAll);
+UTF8_SANITIZER_BENCHMARK(sanitizeInlineOutput, kInlineOutput);
+UTF8_SANITIZER_BENCHMARK(sanitizeDictionaryValid, kDictionaryValid);
+UTF8_SANITIZER_BENCHMARK(sanitizeDictionaryInvalidRare, kDictionaryInvalidRare);
 
 } // namespace
 } // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/benchmarks/HiveDataSinkUtf8Benchmark.cpp
+++ b/bolt/connectors/hive/benchmarks/HiveDataSinkUtf8Benchmark.cpp
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "bolt/common/config/Config.h"
+#include "bolt/connectors/hive/HiveDataSink.h"
+#include "bolt/exec/MemoryReclaimer.h"
+#include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
+
+namespace bytedance::bolt::connector::hive {
+namespace {
+
+using namespace bytedance::bolt::common;
+using namespace bytedance::bolt::exec::test;
+
+constexpr const char* kParquetSerdeMarker =
+    "spark.gluten.sql.native.writer.hive.parquet.serde";
+constexpr vector_size_t kRowsPerBatch = 10'000;
+constexpr int32_t kNumBatches = 10;
+constexpr int32_t kStringBytes = 64;
+
+enum class InputKind {
+  kAscii,
+  kAsciiKnown,
+  kValidUtf8,
+  kInvalidRare,
+  kInvalidAll,
+  kInlineOutput,
+  kInlineToNonInline,
+  kDictionaryValid,
+  kDictionaryInvalidRare
+};
+
+class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
+ public:
+  void TestBody() override {}
+
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+  }
+
+  static void TearDownTestCase() {
+    OperatorTestBase::TearDownTestCase();
+  }
+
+  HiveDataSinkUtf8Benchmark() {
+    HiveConnectorTestBase::SetUp();
+    Type::registerSerDe();
+    HiveSortingColumn::registerSerDe();
+    HiveBucketProperty::registerSerDe();
+
+    root_ = memory::memoryManager()->addRootPool(
+        "HiveDataSinkUtf8Benchmark", 1L << 30, exec::MemoryReclaimer::create());
+    opPool_ = root_->addLeafChild("operator");
+    connectorPool_ =
+        root_->addAggregateChild("connector", exec::MemoryReclaimer::create());
+    connectorQueryCtx_ = std::make_unique<ConnectorQueryCtx>(
+        opPool_.get(),
+        connectorPool_.get(),
+        sessionProperties_.get(),
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        "query.HiveDataSinkUtf8Benchmark",
+        "task.HiveDataSinkUtf8Benchmark",
+        "planNodeId.HiveDataSinkUtf8Benchmark",
+        0);
+
+    ascii_ = makeInputBatches(InputKind::kAscii);
+    asciiKnown_ = makeInputBatches(InputKind::kAsciiKnown);
+    validUtf8_ = makeInputBatches(InputKind::kValidUtf8);
+    invalidRare_ = makeInputBatches(InputKind::kInvalidRare);
+    invalidAll_ = makeInputBatches(InputKind::kInvalidAll);
+    inlineOutput_ = makeInputBatches(InputKind::kInlineOutput);
+    inlineToNonInline_ = makeInputBatches(InputKind::kInlineToNonInline);
+    dictionaryValid_ = makeInputBatches(InputKind::kDictionaryValid);
+    dictionaryInvalidRare_ =
+        makeInputBatches(InputKind::kDictionaryInvalidRare);
+  }
+
+  ~HiveDataSinkUtf8Benchmark() override {
+    dictionaryInvalidRare_.clear();
+    dictionaryValid_.clear();
+    inlineToNonInline_.clear();
+    inlineOutput_.clear();
+    invalidAll_.clear();
+    invalidRare_.clear();
+    validUtf8_.clear();
+    asciiKnown_.clear();
+    ascii_.clear();
+    connectorQueryCtx_.reset();
+    connectorPool_.reset();
+    opPool_.reset();
+    root_.reset();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  size_t run(InputKind inputKind, bool sanitize, const char* benchmarkName) {
+    // Keep input generation, HiveDataSink construction and result inspection
+    // outside the timed region. The first append lazily creates the Parquet
+    // writer, so the measured interval covers writer creation, all appends,
+    // UTF-8 sanitization when enabled, encoding, ZSTD compression, file I/O
+    // and close/flush.
+    folly::BenchmarkSuspender suspender;
+    const auto outputDirectory = TempDirectoryPath::create();
+    auto dataSink = createDataSink(outputDirectory->path, sanitize);
+    const auto& inputs = inputsFor(inputKind);
+    suspender.dismiss();
+
+    for (const auto& input : inputs) {
+      dataSink->appendData(input);
+    }
+    dataSink->close();
+
+    suspender.rehire();
+    reportOutputSizeOnce(benchmarkName, outputDirectory->path);
+    return static_cast<size_t>(kRowsPerBatch) * kNumBatches;
+  }
+
+ private:
+  static std::string makeAsciiValue(int64_t globalRow) {
+    std::string value(kStringBytes, 'x');
+    uint64_t state = static_cast<uint64_t>(globalRow) + 1;
+    for (int32_t index = 0; index < kStringBytes; ++index) {
+      state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+      value[index] = static_cast<char>('!' + state % 94);
+    }
+    return value;
+  }
+
+  static std::string makeValidUtf8Value(int64_t globalRow) {
+    std::string value;
+    value.reserve(kStringBytes);
+    for (int32_t index = 0; index < 20; ++index) {
+      value.append("\xE4\xB8\xAD");
+    }
+    constexpr char kDigits[] =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    for (int32_t index = 0; index < 4; ++index) {
+      value.push_back(kDigits[globalRow % 62]);
+      globalRow /= 62;
+    }
+    return value;
+  }
+
+  std::vector<RowVectorPtr> makeInputBatches(InputKind inputKind) {
+    std::vector<RowVectorPtr> inputs;
+    inputs.reserve(kNumBatches);
+    for (int32_t batch = 0; batch < kNumBatches; ++batch) {
+      if (inputKind == InputKind::kDictionaryValid ||
+          inputKind == InputKind::kDictionaryInvalidRare) {
+        constexpr vector_size_t kDictionarySize = 100;
+        auto base = makeFlatVector<std::string>(
+            kDictionarySize, [&](vector_size_t baseRow) {
+              auto value = makeAsciiValue(
+                  static_cast<int64_t>(batch) * kDictionarySize + baseRow);
+              if (inputKind == InputKind::kDictionaryInvalidRare &&
+                  baseRow == 0) {
+                value[kStringBytes / 2] = '\xD5';
+              }
+              return value;
+            });
+        auto indices = makeIndices(kRowsPerBatch, [](vector_size_t row) {
+          return row % kDictionarySize;
+        });
+        inputs.push_back(makeRowVector({BaseVector::wrapInDictionary(
+            nullptr, indices, kRowsPerBatch, std::move(base))}));
+        continue;
+      }
+
+      auto values =
+          makeFlatVector<std::string>(kRowsPerBatch, [&](vector_size_t row) {
+            const int64_t globalRow =
+                static_cast<int64_t>(batch) * kRowsPerBatch + row;
+            if (inputKind == InputKind::kValidUtf8) {
+              return makeValidUtf8Value(globalRow);
+            }
+            if (inputKind == InputKind::kInvalidAll) {
+              return std::string(kStringBytes, '\xD5');
+            }
+            if (inputKind == InputKind::kInlineOutput ||
+                inputKind == InputKind::kInlineToNonInline) {
+              std::string value(
+                  inputKind == InputKind::kInlineOutput ? 6 : 7, 'x');
+              value.append("\xD5\xD5", 2);
+              return value;
+            }
+
+            auto value = makeAsciiValue(globalRow);
+            if (inputKind == InputKind::kInvalidRare && globalRow % 100 == 0) {
+              value[kStringBytes / 2] = '\xD5';
+            }
+            return value;
+          });
+      if (inputKind == InputKind::kAsciiKnown) {
+        values->as<SimpleVector<StringView>>()->setAllIsAscii(true);
+      }
+      inputs.push_back(makeRowVector({values}));
+    }
+    return inputs;
+  }
+
+  const std::vector<RowVectorPtr>& inputsFor(InputKind inputKind) const {
+    switch (inputKind) {
+      case InputKind::kAscii:
+        return ascii_;
+      case InputKind::kAsciiKnown:
+        return asciiKnown_;
+      case InputKind::kValidUtf8:
+        return validUtf8_;
+      case InputKind::kInvalidRare:
+        return invalidRare_;
+      case InputKind::kInvalidAll:
+        return invalidAll_;
+      case InputKind::kInlineOutput:
+        return inlineOutput_;
+      case InputKind::kInlineToNonInline:
+        return inlineToNonInline_;
+      case InputKind::kDictionaryValid:
+        return dictionaryValid_;
+      case InputKind::kDictionaryInvalidRare:
+        return dictionaryInvalidRare_;
+    }
+    BOLT_UNREACHABLE();
+  }
+
+  std::shared_ptr<HiveDataSink> createDataSink(
+      const std::string& outputDirectory,
+      bool sanitize) {
+    const auto rowType = ROW({"c0"}, {VARCHAR()});
+    auto tableHandle = makeHiveInsertTableHandle(
+        rowType->names(),
+        rowType->children(),
+        {},
+        nullptr,
+        makeLocationHandle(
+            outputDirectory, std::nullopt, LocationHandle::TableType::kNew),
+        dwio::common::FileFormat::PARQUET,
+        CompressionKind::CompressionKind_ZSTD);
+    tableHandle = std::make_shared<HiveInsertTableHandle>(
+        tableHandle->inputColumns(),
+        tableHandle->locationHandle(),
+        tableHandle->storageFormat(),
+        nullptr,
+        tableHandle->compressionKind(),
+        std::unordered_map<std::string, std::string>{
+            {kParquetSerdeMarker, sanitize ? "true" : "false"}});
+    return std::make_shared<HiveDataSink>(
+        rowType,
+        std::move(tableHandle),
+        connectorQueryCtx_.get(),
+        CommitStrategy::kNoCommit,
+        hiveConfig_,
+        queryConfig_);
+  }
+
+  static void reportOutputSizeOnce(
+      const std::string& benchmarkName,
+      const std::string& outputDirectory) {
+    static std::mutex mutex;
+    static std::unordered_set<std::string> reportedBenchmarks;
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!reportedBenchmarks.insert(benchmarkName).second) {
+      return;
+    }
+
+    uint64_t outputBytes = 0;
+    int32_t outputFiles = 0;
+    for (const auto& entry :
+         std::filesystem::recursive_directory_iterator(outputDirectory)) {
+      if (entry.is_regular_file()) {
+        outputBytes += entry.file_size();
+        ++outputFiles;
+      }
+    }
+    BOLT_CHECK_EQ(outputFiles, 1);
+    std::cerr << fmt::format(
+        "OUTPUT {} rows={} bytes={}\n",
+        benchmarkName,
+        static_cast<int64_t>(kRowsPerBatch) * kNumBatches,
+        outputBytes);
+  }
+
+  std::shared_ptr<memory::MemoryPool> root_;
+  std::shared_ptr<memory::MemoryPool> opPool_;
+  std::shared_ptr<memory::MemoryPool> connectorPool_;
+  std::shared_ptr<config::ConfigBase> sessionProperties_ =
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>{});
+  std::unique_ptr<ConnectorQueryCtx> connectorQueryCtx_;
+  std::shared_ptr<HiveConfig> hiveConfig_ =
+      std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>{}));
+  core::QueryConfig queryConfig_{{}};
+  std::vector<RowVectorPtr> ascii_;
+  std::vector<RowVectorPtr> asciiKnown_;
+  std::vector<RowVectorPtr> validUtf8_;
+  std::vector<RowVectorPtr> invalidRare_;
+  std::vector<RowVectorPtr> invalidAll_;
+  std::vector<RowVectorPtr> inlineOutput_;
+  std::vector<RowVectorPtr> inlineToNonInline_;
+  std::vector<RowVectorPtr> dictionaryValid_;
+  std::vector<RowVectorPtr> dictionaryInvalidRare_;
+};
+
+std::unique_ptr<HiveDataSinkUtf8Benchmark> benchmark;
+
+#define HIVE_DATA_SINK_UTF8_BENCHMARK(name, inputKind, sanitize)  \
+  BENCHMARK_MULTI(name) {                                         \
+    return benchmark->run(InputKind::inputKind, sanitize, #name); \
+  }
+
+HIVE_DATA_SINK_UTF8_BENCHMARK(asciiDisabled, kAscii, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(asciiEnabled, kAscii, true);
+HIVE_DATA_SINK_UTF8_BENCHMARK(asciiKnownDisabled, kAsciiKnown, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(asciiKnownEnabled, kAsciiKnown, true);
+BENCHMARK_DRAW_LINE();
+HIVE_DATA_SINK_UTF8_BENCHMARK(validUtf8Disabled, kValidUtf8, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(validUtf8Enabled, kValidUtf8, true);
+BENCHMARK_DRAW_LINE();
+HIVE_DATA_SINK_UTF8_BENCHMARK(invalidRareDisabled, kInvalidRare, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(invalidRareEnabled, kInvalidRare, true);
+HIVE_DATA_SINK_UTF8_BENCHMARK(invalidAllDisabled, kInvalidAll, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(invalidAllEnabled, kInvalidAll, true);
+BENCHMARK_DRAW_LINE();
+HIVE_DATA_SINK_UTF8_BENCHMARK(inlineOutputDisabled, kInlineOutput, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(inlineOutputEnabled, kInlineOutput, true);
+HIVE_DATA_SINK_UTF8_BENCHMARK(
+    inlineToNonInlineDisabled,
+    kInlineToNonInline,
+    false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(
+    inlineToNonInlineEnabled,
+    kInlineToNonInline,
+    true);
+BENCHMARK_DRAW_LINE();
+HIVE_DATA_SINK_UTF8_BENCHMARK(dictionaryValidDisabled, kDictionaryValid, false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(dictionaryValidEnabled, kDictionaryValid, true);
+HIVE_DATA_SINK_UTF8_BENCHMARK(
+    dictionaryInvalidRareDisabled,
+    kDictionaryInvalidRare,
+    false);
+HIVE_DATA_SINK_UTF8_BENCHMARK(
+    dictionaryInvalidRareEnabled,
+    kDictionaryInvalidRare,
+    true);
+
+} // namespace
+} // namespace bytedance::bolt::connector::hive
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  using bytedance::bolt::connector::hive::HiveDataSinkUtf8Benchmark;
+  HiveDataSinkUtf8Benchmark::SetUpTestCase();
+  bytedance::bolt::connector::hive::benchmark =
+      std::make_unique<HiveDataSinkUtf8Benchmark>();
+  folly::runBenchmarks();
+  bytedance::bolt::connector::hive::benchmark.reset();
+  HiveDataSinkUtf8Benchmark::TearDownTestCase();
+  return 0;
+}

--- a/bolt/connectors/hive/benchmarks/HiveDataSinkUtf8Benchmark.cpp
+++ b/bolt/connectors/hive/benchmarks/HiveDataSinkUtf8Benchmark.cpp
@@ -18,12 +18,14 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -46,19 +48,35 @@ constexpr const char* kParquetSerdeMarker =
 constexpr vector_size_t kRowsPerBatch = 10'000;
 constexpr int32_t kNumBatches = 10;
 constexpr int32_t kStringBytes = 64;
+constexpr int32_t kLongStringBytes = 1'024;
+constexpr int32_t kNumPartitions = 16;
+// ASCII, two-byte, three-byte and four-byte code points, interleaved.
+constexpr std::string_view kMixedUtf8Pattern =
+    "A\xC2\xA2\xE4\xB8\xAD\xF0\x9F\x99\x82";
 
 enum class InputKind {
   kAscii,
   kAsciiKnown,
   kValidUtf8,
+  kValidMixedUtf8,
+  kLongValidUtf8,
   kInvalidRare,
   kInvalidComplex,
   kInvalidAll,
+  kInvalidAlternating,
+  kLongInvalidAlternating,
   kInlineOutput,
   kInlineToNonInline,
   kDictionaryValid,
-  kDictionaryInvalidRare
+  kDictionaryInvalidRare,
+  kNullableValid,
+  kNullableInvalidDense,
+  kNullableInvalidAlternating,
+  kMultiPartitionInvalid,
+  kCount,
 };
+
+constexpr size_t kNumInputKinds = static_cast<size_t>(InputKind::kCount);
 
 class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
  public:
@@ -96,30 +114,15 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
         "planNodeId.HiveDataSinkUtf8Benchmark",
         0);
 
-    ascii_ = makeInputBatches(InputKind::kAscii);
-    asciiKnown_ = makeInputBatches(InputKind::kAsciiKnown);
-    validUtf8_ = makeInputBatches(InputKind::kValidUtf8);
-    invalidRare_ = makeInputBatches(InputKind::kInvalidRare);
-    invalidComplex_ = makeInputBatches(InputKind::kInvalidComplex);
-    invalidAll_ = makeInputBatches(InputKind::kInvalidAll);
-    inlineOutput_ = makeInputBatches(InputKind::kInlineOutput);
-    inlineToNonInline_ = makeInputBatches(InputKind::kInlineToNonInline);
-    dictionaryValid_ = makeInputBatches(InputKind::kDictionaryValid);
-    dictionaryInvalidRare_ =
-        makeInputBatches(InputKind::kDictionaryInvalidRare);
+    for (size_t index = 0; index < inputs_.size(); ++index) {
+      inputs_[index] = makeInputBatches(static_cast<InputKind>(index));
+    }
   }
 
   ~HiveDataSinkUtf8Benchmark() override {
-    dictionaryInvalidRare_.clear();
-    dictionaryValid_.clear();
-    inlineToNonInline_.clear();
-    inlineOutput_.clear();
-    invalidAll_.clear();
-    invalidComplex_.clear();
-    invalidRare_.clear();
-    validUtf8_.clear();
-    asciiKnown_.clear();
-    ascii_.clear();
+    for (auto& inputs : inputs_) {
+      inputs.clear();
+    }
     connectorQueryCtx_.reset();
     connectorPool_.reset();
     opPool_.reset();
@@ -135,8 +138,8 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
     // and close/flush.
     folly::BenchmarkSuspender suspender;
     const auto outputDirectory = TempDirectoryPath::create();
-    auto dataSink = createDataSink(outputDirectory->path, sanitize);
     const auto& inputs = inputsFor(inputKind);
+    auto dataSink = createDataSink(outputDirectory->path, inputKind, sanitize);
     suspender.dismiss();
 
     for (const auto& input : inputs) {
@@ -145,7 +148,10 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
     dataSink->close();
 
     suspender.rehire();
-    reportOutputSizeOnce(benchmarkName, outputDirectory->path);
+    reportOutputSizeOnce(
+        benchmarkName,
+        outputDirectory->path,
+        inputKind == InputKind::kMultiPartitionInvalid ? kNumPartitions : 1);
     return static_cast<size_t>(kRowsPerBatch) * kNumBatches;
   }
 
@@ -185,22 +191,107 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
     return value;
   }
 
+  static std::string makeMixedUtf8Value(
+      int64_t globalRow,
+      int32_t stringBytes) {
+    std::string value;
+    value.reserve(stringBytes);
+    while (value.size() + kMixedUtf8Pattern.size() <= stringBytes - 4) {
+      value.append(kMixedUtf8Pattern);
+    }
+    constexpr std::string_view kDigits =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    while (value.size() < stringBytes) {
+      value.push_back(kDigits[globalRow % kDigits.size()]);
+      globalRow /= kDigits.size();
+    }
+    return value;
+  }
+
+  static std::string makeAlternatingInvalidValue(
+      int64_t globalRow,
+      int32_t stringBytes = kStringBytes) {
+    // Prevent adjacent malformed units from coalescing into a single run.
+    std::string value(stringBytes, '\xD5');
+    for (int32_t index = 1; index < stringBytes; index += 2) {
+      value[index] = static_cast<char>('a' + (globalRow + index) % 26);
+    }
+    return value;
+  }
+
+  static std::string makeStringValue(InputKind inputKind, int64_t globalRow) {
+    switch (inputKind) {
+      case InputKind::kAscii:
+      case InputKind::kAsciiKnown:
+      case InputKind::kDictionaryValid:
+        return makeAsciiValue(globalRow);
+      case InputKind::kValidUtf8:
+        return makeValidUtf8Value(globalRow);
+      case InputKind::kValidMixedUtf8:
+      case InputKind::kNullableValid:
+        return makeMixedUtf8Value(globalRow, kStringBytes);
+      case InputKind::kLongValidUtf8:
+        return makeMixedUtf8Value(globalRow, kLongStringBytes);
+      case InputKind::kInvalidRare:
+      case InputKind::kDictionaryInvalidRare: {
+        auto value = makeAsciiValue(globalRow);
+        if (globalRow % 100 == 0) {
+          value[kStringBytes / 2] = '\xD5';
+        }
+        return value;
+      }
+      case InputKind::kInvalidComplex: {
+        auto value = makeValidUtf8Value(globalRow);
+        value[kStringBytes / 2] = '\xD5';
+        return value;
+      }
+      case InputKind::kInvalidAll:
+      case InputKind::kNullableInvalidDense:
+        return std::string(kStringBytes, '\xD5');
+      case InputKind::kInvalidAlternating:
+      case InputKind::kNullableInvalidAlternating:
+      case InputKind::kMultiPartitionInvalid:
+        return makeAlternatingInvalidValue(globalRow);
+      case InputKind::kLongInvalidAlternating:
+        return makeAlternatingInvalidValue(globalRow, kLongStringBytes);
+      case InputKind::kInlineOutput: {
+        std::string value(6, 'x');
+        value.append("\xD5\xD5", 2);
+        return value;
+      }
+      case InputKind::kInlineToNonInline: {
+        std::string value(7, 'x');
+        value.append("\xD5\xD5", 2);
+        return value;
+      }
+      case InputKind::kCount:
+        BOLT_UNREACHABLE();
+    }
+    BOLT_UNREACHABLE();
+  }
+
+  static bool isDictionaryInput(InputKind inputKind) {
+    return inputKind == InputKind::kDictionaryValid ||
+        inputKind == InputKind::kDictionaryInvalidRare;
+  }
+
+  static bool isNullableInput(InputKind inputKind) {
+    return inputKind == InputKind::kNullableValid ||
+        inputKind == InputKind::kNullableInvalidDense ||
+        inputKind == InputKind::kNullableInvalidAlternating;
+  }
+
   std::vector<RowVectorPtr> makeInputBatches(InputKind inputKind) {
     std::vector<RowVectorPtr> inputs;
     inputs.reserve(kNumBatches);
     for (int32_t batch = 0; batch < kNumBatches; ++batch) {
-      if (inputKind == InputKind::kDictionaryValid ||
-          inputKind == InputKind::kDictionaryInvalidRare) {
+      if (isDictionaryInput(inputKind)) {
         constexpr vector_size_t kDictionarySize = 100;
         auto base = makeFlatVector<std::string>(
             kDictionarySize, [&](vector_size_t baseRow) {
-              auto value = makeAsciiValue(
+              return makeStringValue(
+                  inputKind,
                   static_cast<int64_t>(batch) * kDictionarySize + baseRow);
-              if (inputKind == InputKind::kDictionaryInvalidRare &&
-                  baseRow == 0) {
-                value[kStringBytes / 2] = '\xD5';
-              }
-              return value;
             });
         auto indices = makeIndices(kRowsPerBatch, [](vector_size_t row) {
           return row % kDictionarySize;
@@ -210,77 +301,54 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
         continue;
       }
 
-      auto values =
-          makeFlatVector<std::string>(kRowsPerBatch, [&](vector_size_t row) {
-            const int64_t globalRow =
-                static_cast<int64_t>(batch) * kRowsPerBatch + row;
-            if (inputKind == InputKind::kValidUtf8) {
-              return makeValidUtf8Value(globalRow);
-            }
-            if (inputKind == InputKind::kInvalidComplex) {
-              auto value = makeValidUtf8Value(globalRow);
-              value[kStringBytes / 2] = '\xD5';
-              return value;
-            }
-            if (inputKind == InputKind::kInvalidAll) {
-              return std::string(kStringBytes, '\xD5');
-            }
-            if (inputKind == InputKind::kInlineOutput ||
-                inputKind == InputKind::kInlineToNonInline) {
-              std::string value(
-                  inputKind == InputKind::kInlineOutput ? 6 : 7, 'x');
-              value.append("\xD5\xD5", 2);
-              return value;
-            }
-
-            auto value = makeAsciiValue(globalRow);
-            if (inputKind == InputKind::kInvalidRare && globalRow % 100 == 0) {
-              value[kStringBytes / 2] = '\xD5';
-            }
-            return value;
-          });
+      auto valueAt = [&](vector_size_t row) {
+        const int64_t globalRow =
+            static_cast<int64_t>(batch) * kRowsPerBatch + row;
+        return makeStringValue(inputKind, globalRow);
+      };
+      auto values = isNullableInput(inputKind)
+          ? makeFlatVector<std::string>(
+                kRowsPerBatch,
+                valueAt,
+                // Keep enough non-null rows to make each string shape
+                // measurable while forcing the nullable scanner path.
+                [](vector_size_t row) { return row % 8 == 0; })
+          : makeFlatVector<std::string>(kRowsPerBatch, valueAt);
       if (inputKind == InputKind::kAsciiKnown) {
         values->as<SimpleVector<StringView>>()->setAllIsAscii(true);
       }
-      inputs.push_back(makeRowVector({values}));
+      if (inputKind == InputKind::kMultiPartitionInvalid) {
+        auto partitions =
+            makeFlatVector<int32_t>(kRowsPerBatch, [&](vector_size_t row) {
+              const int64_t globalRow =
+                  static_cast<int64_t>(batch) * kRowsPerBatch + row;
+              return globalRow % kNumPartitions;
+            });
+        inputs.push_back(makeRowVector({"c0", "p0"}, {values, partitions}));
+      } else {
+        inputs.push_back(makeRowVector({values}));
+      }
     }
     return inputs;
   }
 
   const std::vector<RowVectorPtr>& inputsFor(InputKind inputKind) const {
-    switch (inputKind) {
-      case InputKind::kAscii:
-        return ascii_;
-      case InputKind::kAsciiKnown:
-        return asciiKnown_;
-      case InputKind::kValidUtf8:
-        return validUtf8_;
-      case InputKind::kInvalidRare:
-        return invalidRare_;
-      case InputKind::kInvalidComplex:
-        return invalidComplex_;
-      case InputKind::kInvalidAll:
-        return invalidAll_;
-      case InputKind::kInlineOutput:
-        return inlineOutput_;
-      case InputKind::kInlineToNonInline:
-        return inlineToNonInline_;
-      case InputKind::kDictionaryValid:
-        return dictionaryValid_;
-      case InputKind::kDictionaryInvalidRare:
-        return dictionaryInvalidRare_;
-    }
-    BOLT_UNREACHABLE();
+    return inputs_.at(static_cast<size_t>(inputKind));
   }
 
   std::shared_ptr<HiveDataSink> createDataSink(
       const std::string& outputDirectory,
+      InputKind inputKind,
       bool sanitize) {
-    const auto rowType = ROW({"c0"}, {VARCHAR()});
+    const bool isPartitioned = inputKind == InputKind::kMultiPartitionInvalid;
+    const auto rowType = isPartitioned
+        ? ROW({"c0", "p0"}, {VARCHAR(), INTEGER()})
+        : ROW({"c0"}, {VARCHAR()});
     auto tableHandle = makeHiveInsertTableHandle(
         rowType->names(),
         rowType->children(),
-        {},
+        isPartitioned ? std::vector<std::string>{"p0"}
+                      : std::vector<std::string>{},
         nullptr,
         makeLocationHandle(
             outputDirectory, std::nullopt, LocationHandle::TableType::kNew),
@@ -305,7 +373,8 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
 
   static void reportOutputSizeOnce(
       const std::string& benchmarkName,
-      const std::string& outputDirectory) {
+      const std::string& outputDirectory,
+      int32_t expectedOutputFiles) {
     static std::mutex mutex;
     static std::unordered_set<std::string> reportedBenchmarks;
     std::lock_guard<std::mutex> lock(mutex);
@@ -322,7 +391,7 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
         ++outputFiles;
       }
     }
-    BOLT_CHECK_EQ(outputFiles, 1);
+    BOLT_CHECK_EQ(outputFiles, expectedOutputFiles);
     std::cerr << fmt::format(
         "OUTPUT {} rows={} bytes={}\n",
         benchmarkName,
@@ -341,16 +410,7 @@ class HiveDataSinkUtf8Benchmark : public HiveConnectorTestBase {
       std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
           std::unordered_map<std::string, std::string>{}));
   core::QueryConfig queryConfig_{{}};
-  std::vector<RowVectorPtr> ascii_;
-  std::vector<RowVectorPtr> asciiKnown_;
-  std::vector<RowVectorPtr> validUtf8_;
-  std::vector<RowVectorPtr> invalidRare_;
-  std::vector<RowVectorPtr> invalidComplex_;
-  std::vector<RowVectorPtr> invalidAll_;
-  std::vector<RowVectorPtr> inlineOutput_;
-  std::vector<RowVectorPtr> inlineToNonInline_;
-  std::vector<RowVectorPtr> dictionaryValid_;
-  std::vector<RowVectorPtr> dictionaryInvalidRare_;
+  std::array<std::vector<RowVectorPtr>, kNumInputKinds> inputs_;
 };
 
 std::unique_ptr<HiveDataSinkUtf8Benchmark> benchmark;
@@ -360,42 +420,36 @@ std::unique_ptr<HiveDataSinkUtf8Benchmark> benchmark;
     return benchmark->run(InputKind::inputKind, sanitize, #name); \
   }
 
-HIVE_DATA_SINK_UTF8_BENCHMARK(asciiDisabled, kAscii, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(asciiEnabled, kAscii, true);
-HIVE_DATA_SINK_UTF8_BENCHMARK(asciiKnownDisabled, kAsciiKnown, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(asciiKnownEnabled, kAsciiKnown, true);
+#define HIVE_DATA_SINK_UTF8_BENCHMARKS(name, inputKind)           \
+  HIVE_DATA_SINK_UTF8_BENCHMARK(name##Disabled, inputKind, false) \
+  HIVE_DATA_SINK_UTF8_BENCHMARK(name##Enabled, inputKind, true)
+
+HIVE_DATA_SINK_UTF8_BENCHMARKS(ascii, kAscii)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(asciiKnown, kAsciiKnown)
 BENCHMARK_DRAW_LINE();
-HIVE_DATA_SINK_UTF8_BENCHMARK(validUtf8Disabled, kValidUtf8, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(validUtf8Enabled, kValidUtf8, true);
+HIVE_DATA_SINK_UTF8_BENCHMARKS(validUtf8, kValidUtf8)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(validMixedUtf8, kValidMixedUtf8)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(longValidUtf8, kLongValidUtf8)
 BENCHMARK_DRAW_LINE();
-HIVE_DATA_SINK_UTF8_BENCHMARK(invalidRareDisabled, kInvalidRare, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(invalidRareEnabled, kInvalidRare, true);
-HIVE_DATA_SINK_UTF8_BENCHMARK(invalidComplexDisabled, kInvalidComplex, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(invalidComplexEnabled, kInvalidComplex, true);
-HIVE_DATA_SINK_UTF8_BENCHMARK(invalidAllDisabled, kInvalidAll, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(invalidAllEnabled, kInvalidAll, true);
+HIVE_DATA_SINK_UTF8_BENCHMARKS(invalidRare, kInvalidRare)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(invalidComplex, kInvalidComplex)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(invalidAll, kInvalidAll)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(invalidAlternating, kInvalidAlternating)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(longInvalidAlternating, kLongInvalidAlternating)
 BENCHMARK_DRAW_LINE();
-HIVE_DATA_SINK_UTF8_BENCHMARK(inlineOutputDisabled, kInlineOutput, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(inlineOutputEnabled, kInlineOutput, true);
-HIVE_DATA_SINK_UTF8_BENCHMARK(
-    inlineToNonInlineDisabled,
-    kInlineToNonInline,
-    false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(
-    inlineToNonInlineEnabled,
-    kInlineToNonInline,
-    true);
+HIVE_DATA_SINK_UTF8_BENCHMARKS(inlineOutput, kInlineOutput)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(inlineToNonInline, kInlineToNonInline)
 BENCHMARK_DRAW_LINE();
-HIVE_DATA_SINK_UTF8_BENCHMARK(dictionaryValidDisabled, kDictionaryValid, false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(dictionaryValidEnabled, kDictionaryValid, true);
-HIVE_DATA_SINK_UTF8_BENCHMARK(
-    dictionaryInvalidRareDisabled,
-    kDictionaryInvalidRare,
-    false);
-HIVE_DATA_SINK_UTF8_BENCHMARK(
-    dictionaryInvalidRareEnabled,
-    kDictionaryInvalidRare,
-    true);
+HIVE_DATA_SINK_UTF8_BENCHMARKS(dictionaryValid, kDictionaryValid)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(dictionaryInvalidRare, kDictionaryInvalidRare)
+BENCHMARK_DRAW_LINE();
+HIVE_DATA_SINK_UTF8_BENCHMARKS(nullableValid, kNullableValid)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(nullableInvalidDense, kNullableInvalidDense)
+HIVE_DATA_SINK_UTF8_BENCHMARKS(
+    nullableInvalidAlternating,
+    kNullableInvalidAlternating)
+BENCHMARK_DRAW_LINE();
+HIVE_DATA_SINK_UTF8_BENCHMARKS(multiPartitionInvalid, kMultiPartitionInvalid)
 
 #define UTF8_SANITIZER_BENCHMARK(name, inputKind)         \
   BENCHMARK_MULTI(name) {                                 \
@@ -404,13 +458,27 @@ HIVE_DATA_SINK_UTF8_BENCHMARK(
 
 BENCHMARK_DRAW_LINE();
 UTF8_SANITIZER_BENCHMARK(sanitizeAscii, kAscii);
+UTF8_SANITIZER_BENCHMARK(sanitizeAsciiKnown, kAsciiKnown);
 UTF8_SANITIZER_BENCHMARK(sanitizeValidUtf8, kValidUtf8);
+UTF8_SANITIZER_BENCHMARK(sanitizeValidMixedUtf8, kValidMixedUtf8);
+UTF8_SANITIZER_BENCHMARK(sanitizeLongValidUtf8, kLongValidUtf8);
 UTF8_SANITIZER_BENCHMARK(sanitizeInvalidRare, kInvalidRare);
 UTF8_SANITIZER_BENCHMARK(sanitizeInvalidComplex, kInvalidComplex);
 UTF8_SANITIZER_BENCHMARK(sanitizeInvalidAll, kInvalidAll);
+UTF8_SANITIZER_BENCHMARK(sanitizeInvalidAlternating, kInvalidAlternating);
+UTF8_SANITIZER_BENCHMARK(
+    sanitizeLongInvalidAlternating,
+    kLongInvalidAlternating);
 UTF8_SANITIZER_BENCHMARK(sanitizeInlineOutput, kInlineOutput);
+UTF8_SANITIZER_BENCHMARK(sanitizeInlineToNonInline, kInlineToNonInline);
 UTF8_SANITIZER_BENCHMARK(sanitizeDictionaryValid, kDictionaryValid);
 UTF8_SANITIZER_BENCHMARK(sanitizeDictionaryInvalidRare, kDictionaryInvalidRare);
+UTF8_SANITIZER_BENCHMARK(sanitizeNullableValid, kNullableValid);
+UTF8_SANITIZER_BENCHMARK(sanitizeNullableInvalidDense, kNullableInvalidDense);
+UTF8_SANITIZER_BENCHMARK(
+    sanitizeNullableInvalidAlternating,
+    kNullableInvalidAlternating);
+UTF8_SANITIZER_BENCHMARK(sanitizeMultiPartitionInvalid, kMultiPartitionInvalid);
 
 } // namespace
 } // namespace bytedance::bolt::connector::hive

--- a/bolt/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/bolt/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -217,8 +217,8 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
 
   RowVectorPtr writeAndReadInvalidUtf8(
       dwio::common::FileFormat fileFormat,
-      const std::unordered_map<std::string, std::string>& serdeParameters) {
-    const std::string invalid{"\xD5", 1};
+      const std::unordered_map<std::string, std::string>& serdeParameters,
+      const std::string& invalid = std::string{"\xD5", 1}) {
     const auto rowType = ROW({"invalid_varchar"}, {VARCHAR()});
     const auto input = makeRowVector({makeFlatVector<std::string>({invalid})});
     const auto outputDirectory = TempDirectoryPath::create();
@@ -595,6 +595,24 @@ TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8Enabled) {
       dwio::common::FileFormat::PARQUET, {{kParquetSerdeMarker, "true"}});
 
   EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 0));
+}
+
+TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8BinaryPayload) {
+  const std::string input{
+      "\x20\x02\x0F\x00\x01\x00\x00\x00\x9C\xA9\x06\x60\x00\x00"
+      "\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x01\x00\x00\x00",
+      28};
+  const std::string expected{
+      "\x20\x02\x0F\x00\x01\x00\x00\x00\xEF\xBF\xBD\xEF\xBF"
+      "\xBD\x06\x60\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00"
+      "\x00\x00\x01\x00\x00\x00",
+      32};
+  const auto output = writeAndReadInvalidUtf8(
+      dwio::common::FileFormat::PARQUET,
+      {{kParquetSerdeMarker, "true"}},
+      input);
+
+  EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
 }
 
 TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8Disabled) {

--- a/bolt/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/bolt/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -36,9 +36,12 @@
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/config/Config.h"
 #include "bolt/common/testutil/TestValue.h"
+#include "bolt/connectors/hive/HivePartitionFunction.h"
 #include "bolt/dwio/common/Options.h"
+#include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/vector/DecodedVector.h"
 #include "bolt/vector/fuzzer/VectorFuzzer.h"
 namespace bytedance::bolt::connector::hive {
 namespace {
@@ -47,9 +50,18 @@ using namespace bytedance::bolt::exec::test;
 using namespace bytedance::bolt::common::testutil;
 
 constexpr const char* kHiveConnectorId = "test-hive";
+constexpr const char* kParquetSerdeMarker =
+    "spark.gluten.sql.native.writer.hive.parquet.serde";
 
 class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
  protected:
+  static std::string decodedStringAt(
+      const VectorPtr& vector,
+      vector_size_t row) {
+    DecodedVector decoded(*vector);
+    return decoded.valueAt<StringView>(row).str();
+  }
+
   static void SetUpTestCase() {
     FLAGS_bolt_testing_enable_arbitration = true;
     OperatorTestBase::SetUpTestCase();
@@ -156,8 +168,10 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
       dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF,
       const std::vector<std::string>& partitionedBy = {},
       const std::shared_ptr<connector::hive::HiveBucketProperty>&
-          bucketProperty = nullptr) {
-    return makeHiveInsertTableHandle(
+          bucketProperty = nullptr,
+      const std::unordered_map<std::string, std::string>& serdeParameters =
+          {}) {
+    auto tableHandle = makeHiveInsertTableHandle(
         outputRowType->names(),
         outputRowType->children(),
         partitionedBy,
@@ -168,6 +182,13 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
             connector::hive::LocationHandle::TableType::kNew),
         fileFormat,
         CompressionKind::CompressionKind_ZSTD);
+    return std::make_shared<HiveInsertTableHandle>(
+        tableHandle->inputColumns(),
+        tableHandle->locationHandle(),
+        tableHandle->storageFormat(),
+        bucketProperty,
+        tableHandle->compressionKind(),
+        serdeParameters);
   }
 
   std::shared_ptr<HiveDataSink> createDataSink(
@@ -176,7 +197,9 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
       dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF,
       const std::vector<std::string>& partitionedBy = {},
       const std::shared_ptr<connector::hive::HiveBucketProperty>&
-          bucketProperty = nullptr) {
+          bucketProperty = nullptr,
+      const std::unordered_map<std::string, std::string>& serdeParameters =
+          {}) {
     return std::make_shared<HiveDataSink>(
         rowType,
         createHiveInsertTableHandle(
@@ -184,11 +207,41 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
             outputDirectoryPath,
             fileFormat,
             partitionedBy,
-            bucketProperty),
+            bucketProperty,
+            serdeParameters),
         connectorQueryCtx_.get(),
         CommitStrategy::kNoCommit,
         connectorConfig_,
         queryConfig_);
+  }
+
+  RowVectorPtr writeAndReadInvalidUtf8(
+      dwio::common::FileFormat fileFormat,
+      const std::unordered_map<std::string, std::string>& serdeParameters) {
+    const std::string invalid{"\xD5", 1};
+    const auto rowType = ROW({"invalid_varchar"}, {VARCHAR()});
+    const auto input = makeRowVector({makeFlatVector<std::string>({invalid})});
+    const auto outputDirectory = TempDirectoryPath::create();
+    auto dataSink = createDataSink(
+        rowType,
+        outputDirectory->path,
+        fileFormat,
+        {},
+        nullptr,
+        serdeParameters);
+    dataSink->appendData(input);
+    dataSink->close();
+
+    const auto files = listFiles(outputDirectory->path);
+    BOLT_CHECK_EQ(1, files.size());
+    auto split = connector::hive::HiveConnectorSplitBuilder(files.at(0))
+                     .connectorId(kHiveConnectorId)
+                     .fileFormat(fileFormat)
+                     .build();
+    return exec::test::AssertQueryBuilder(
+               PlanBuilder().tableScan(rowType).planNode())
+        .split(split)
+        .copyResults(pool());
   }
 
   std::vector<std::string> listFiles(const std::string& dirPath) {
@@ -533,6 +586,160 @@ TEST_F(HiveDataSinkTest, basic) {
 
   createDuckDbTable(vectors);
   verifyWrittenData(outputDirectory->path);
+}
+
+#ifdef BOLT_ENABLE_PARQUET
+TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8Enabled) {
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+  const auto output = writeAndReadInvalidUtf8(
+      dwio::common::FileFormat::PARQUET, {{kParquetSerdeMarker, "true"}});
+
+  EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 0));
+}
+
+TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8Disabled) {
+  const std::string invalid{"\xD5", 1};
+  const auto output =
+      writeAndReadInvalidUtf8(dwio::common::FileFormat::PARQUET, {});
+
+  EXPECT_EQ(invalid, decodedStringAt(output->childAt(0), 0));
+}
+
+TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8AcrossPartitions) {
+  const std::string invalid{"\xD5", 1};
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+  const auto inputType = ROW({"v", "p"}, {VARCHAR(), INTEGER()});
+  auto input = makeRowVector(
+      {makeFlatVector<std::string>({invalid, invalid, invalid, "valid"}),
+       makeFlatVector<int32_t>({0, 1, 0, 1})},
+      [](vector_size_t row) { return row == 2; });
+  const auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      inputType,
+      outputDirectory->path,
+      dwio::common::FileFormat::PARQUET,
+      {"p"},
+      nullptr,
+      {{kParquetSerdeMarker, "TrUe"}});
+
+  dataSink->appendData(input);
+  const auto partitions = dataSink->close();
+  ASSERT_EQ(2, partitions.size());
+
+  std::vector<exec::Split> splits;
+  for (const auto& file : listFiles(outputDirectory->path)) {
+    splits.emplace_back(
+        connector::hive::HiveConnectorSplitBuilder(file)
+            .connectorId(kHiveConnectorId)
+            .fileFormat(dwio::common::FileFormat::PARQUET)
+            .build());
+  }
+  ASSERT_EQ(2, splits.size());
+  const auto outputType = ROW({"v"}, {VARCHAR()});
+  auto output = exec::test::AssertQueryBuilder(
+                    PlanBuilder().tableScan(outputType).planNode())
+                    .splits(std::move(splits))
+                    .copyResults(pool());
+
+  ASSERT_EQ(4, output->size());
+  size_t replacementCount = 0;
+  for (vector_size_t row = 0; row < output->size(); ++row) {
+    replacementCount += decodedStringAt(output->childAt(0), row) == replacement;
+  }
+  EXPECT_EQ(3, replacementCount);
+}
+
+TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8BucketedAndSorted) {
+  const std::string invalid{"\xD5", 1};
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+  const auto inputType = ROW({"bucket_key", "v"}, {BIGINT(), VARCHAR()});
+  const std::vector<int64_t> keys = {0, 1, 2, 3, 4, 5, 6, 7};
+  const std::vector<std::string> values = {
+      "m", invalid + "0", "a", "z", "b", invalid + "1", "x", "c"};
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(keys), makeFlatVector<std::string>(values)});
+
+  constexpr int32_t kNumBuckets = 2;
+  auto bucketProperty = std::make_shared<HiveBucketProperty>(
+      HiveBucketProperty::Kind::kHiveCompatible,
+      kNumBuckets,
+      std::vector<std::string>{"bucket_key"},
+      std::vector<TypePtr>{BIGINT()},
+      std::vector<std::shared_ptr<const HiveSortingColumn>>{
+          std::make_shared<HiveSortingColumn>(
+              "v", core::SortOrder{true, true})});
+  const auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      inputType,
+      outputDirectory->path,
+      dwio::common::FileFormat::PARQUET,
+      {},
+      bucketProperty,
+      {{kParquetSerdeMarker, "true"}});
+
+  HivePartitionFunction partitionFunction(kNumBuckets, {0});
+  std::vector<uint32_t> bucketIds(input->size());
+  partitionFunction.partition(*input, bucketIds);
+  std::vector<std::vector<std::pair<int64_t, std::string>>> expected(
+      kNumBuckets);
+  for (vector_size_t row = 0; row < input->size(); ++row) {
+    auto value = values[row];
+    const auto invalidPosition = value.find(invalid);
+    if (invalidPosition != std::string::npos) {
+      value.replace(invalidPosition, invalid.size(), replacement);
+    }
+    expected[bucketIds[row]].emplace_back(keys[row], std::move(value));
+  }
+  size_t expectedFiles = 0;
+  for (auto& rows : expected) {
+    expectedFiles += !rows.empty();
+    std::sort(
+        rows.begin(), rows.end(), [](const auto& left, const auto& right) {
+          return left.second < right.second;
+        });
+  }
+
+  dataSink->appendData(input);
+  const auto partitions = dataSink->close();
+  ASSERT_EQ(expectedFiles, partitions.size());
+
+  const auto files = listFiles(outputDirectory->path);
+  ASSERT_EQ(expectedFiles, files.size());
+  for (const auto& file : files) {
+    const auto fileName = fs::path(file).filename().string();
+    const auto separator = fileName.find('_');
+    ASSERT_NE(std::string::npos, separator);
+    const auto bucketId =
+        folly::to<uint32_t>(fileName.substr(1, separator - 1));
+    ASSERT_LT(bucketId, kNumBuckets);
+
+    auto split = connector::hive::HiveConnectorSplitBuilder(file)
+                     .connectorId(kHiveConnectorId)
+                     .fileFormat(dwio::common::FileFormat::PARQUET)
+                     .build();
+    auto output = exec::test::AssertQueryBuilder(
+                      PlanBuilder().tableScan(inputType).planNode())
+                      .split(split)
+                      .copyResults(pool());
+    ASSERT_EQ(expected[bucketId].size(), output->size());
+    DecodedVector outputKeys(*output->childAt(0));
+    for (vector_size_t row = 0; row < output->size(); ++row) {
+      EXPECT_EQ(
+          expected[bucketId][row].first, outputKeys.valueAt<int64_t>(row));
+      EXPECT_EQ(
+          expected[bucketId][row].second,
+          decodedStringAt(output->childAt(1), row));
+    }
+  }
+}
+#endif
+
+TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8IgnoredForDwrf) {
+  const std::string invalid{"\xD5", 1};
+  const auto output = writeAndReadInvalidUtf8(
+      dwio::common::FileFormat::DWRF, {{kParquetSerdeMarker, "true"}});
+
+  EXPECT_EQ(invalid, decodedStringAt(output->childAt(0), 0));
 }
 
 TEST_F(HiveDataSinkTest, basicBucket) {

--- a/bolt/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/bolt/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -628,11 +628,10 @@ TEST_F(HiveDataSinkTest, hiveParquetSerdeInvalidUtf8AcrossPartitions) {
 
   std::vector<exec::Split> splits;
   for (const auto& file : listFiles(outputDirectory->path)) {
-    splits.emplace_back(
-        connector::hive::HiveConnectorSplitBuilder(file)
-            .connectorId(kHiveConnectorId)
-            .fileFormat(dwio::common::FileFormat::PARQUET)
-            .build());
+    splits.emplace_back(connector::hive::HiveConnectorSplitBuilder(file)
+                            .connectorId(kHiveConnectorId)
+                            .fileFormat(dwio::common::FileFormat::PARQUET)
+                            .build());
   }
   ASSERT_EQ(2, splits.size());
   const auto outputType = ROW({"v"}, {VARCHAR()});

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -347,6 +347,26 @@ TEST_F(ParquetWriterTest, defaultCreatedBy) {
   EXPECT_EQ(::bytedance::bolt::BuildInfo::shortHash, version.build_);
 }
 
+TEST_F(ParquetWriterTest, optionallyReplacesInvalidUtf8) {
+  auto schema = ROW({"value"}, {VARCHAR()});
+  auto input = makeRowVector({makeFlatVector<std::string>(
+      {std::string("\xD5", 1), std::string("\xC2\xA2", 2), "ascii"})});
+
+  auto defaultPath = tempPath_->path + "/invalidUtf8Default.parquet";
+  assertWrite(defaultPath, input->size(), schema, input);
+
+  auto sanitizedPath = tempPath_->path + "/invalidUtf8Sanitized.parquet";
+  vp::WriterOptions writerOptions;
+  writerOptions.replaceInvalidUtf8 = true;
+  auto writer = createLocalWriter(sanitizedPath, schema, writerOptions);
+  writer->write(input);
+  writer->close();
+
+  auto expected = makeRowVector({makeFlatVector<std::string>(
+      {std::string("\xEF\xBF\xBD", 3), std::string("\xC2\xA2", 2), "ascii"})});
+  assertRead(sanitizedPath, input->size(), schema, expected);
+}
+
 TEST_F(ParquetWriterTest, lz4Hadoop) {
   const int64_t kRows = 10'000'000;
   bytedance::bolt::type::fbhive::HiveTypeParser parser;

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "bolt/dwio/parquet/writer/Writer.h"
+
 #include <arrow/array.h>
 #include <arrow/c/bridge.h>
 #include <arrow/io/interfaces.h>
@@ -45,6 +46,7 @@
 #include "bolt/dwio/parquet/arrow/Writer.h"
 #include "bolt/dwio/parquet/writer/ArrowDataBufferSink.h"
 #include "bolt/exec/MemoryReclaimer.h"
+#include "bolt/vector/Utf8Utils.h"
 #include "bolt/vector/arrow/Bridge.h"
 
 #include <iostream>
@@ -212,6 +214,8 @@ std::string WriterOptionsToString(const WriterOptions& options) {
   oss << "WriterOptions:" << std::endl;
   oss << "  enableDictionary: " << (options.enableDictionary ? "true" : "false")
       << std::endl;
+  oss << "  replaceInvalidUtf8: "
+      << (options.replaceInvalidUtf8 ? "true" : "false") << std::endl;
   oss << "  columnEnableDictionaryMap: {";
   for (const auto& [key, value] : options.columnEnableDictionaryMap) {
     oss << key << ": " << (value ? "true" : "false") << ", ";
@@ -459,6 +463,7 @@ Writer::Writer(
       arrowSchemaFromHive_(std::move(arrowSchema)),
       bufferGrowRatio_(options.bufferGrowRatio),
       bufferReserveRatio_(options.bufferReserveRatio),
+      replaceInvalidUtf8_(options.replaceInvalidUtf8),
       enableRowGroupAlignedWrite_(options.enableRowGroupAlignedWrite),
       expectedRowsInEachBlock_(options.expectedRowsInEachBlock),
       enableFlushBasedOnBlockSize_(options.enableFlushBasedOnBlockSize),
@@ -674,15 +679,21 @@ void Writer::write(const VectorPtr& data) {
       data->type()->equivalent(*schema_),
       "The file schema type should be equal with the input rowvector type.");
 
+  VectorPtr writeData = data;
+  if (replaceInvalidUtf8_) {
+    writeData = utf8::replaceInvalidUtf8InTopLevelVarchars(
+        std::static_pointer_cast<RowVector>(data), generalPool_.get());
+  }
+
   if (!arrowContext_->schema) {
-    initializeArrowSchema(data);
+    initializeArrowSchema(writeData);
     if (enableRowGroupAlignedWrite_ || !enableFlushBasedOnBlockSize_) {
       arrowContext_->stagingChunks.resize(arrowContext_->schema->num_fields());
     }
   }
 
   if (!enableRowGroupAlignedWrite_ && enableFlushBasedOnBlockSize_) {
-    splitWriteRecordBatch(data);
+    splitWriteRecordBatch(writeData);
     return;
   }
 
@@ -690,13 +701,13 @@ void Writer::write(const VectorPtr& data) {
   {
     WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
     ArrowArray array;
-    exportToArrow(data, array, exportPool_.get(), options_);
+    exportToArrow(writeData, array, exportPool_.get(), options_);
     PARQUET_ASSIGN_OR_THROW(
         recordBatch, ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
   }
 
-  auto bytes = data->estimateFlatSize();
-  auto numRows = data->size();
+  auto bytes = writeData->estimateFlatSize();
+  auto numRows = writeData->size();
   if (enableRowGroupAlignedWrite_) {
     rowGroupAlignedFlush(numRows, bytes, recordBatch);
     return;

--- a/bolt/dwio/parquet/writer/Writer.h
+++ b/bolt/dwio/parquet/writer/Writer.h
@@ -209,6 +209,9 @@ struct WriterOptions {
   // and a global static thread pool with this number of threads is created.
   // If 0 or less, threading is disabled (`set_use_threads` is set to false).
   int32_t threadPoolSize = 0;
+  // Replaces malformed UTF-8 in top-level VARCHAR columns before writing.
+  // Disabled by default so regular Parquet writes preserve their input bytes.
+  bool replaceInvalidUtf8 = false;
 
   std::shared_ptr<arrow::WriterProperties::Builder> getWriterPropertiesBuilder(
       arrow::MemoryPool* arrowPool) const;
@@ -311,6 +314,7 @@ class Writer : public dwio::common::Writer {
 
   const double bufferGrowRatio_;
   const double bufferReserveRatio_;
+  const bool replaceInvalidUtf8_;
   const bool enableRowGroupAlignedWrite_;
   const std::vector<int32_t> expectedRowsInEachBlock_;
   const bool enableFlushBasedOnBlockSize_;

--- a/bolt/vector/CMakeLists.txt
+++ b/bolt/vector/CMakeLists.txt
@@ -36,6 +36,7 @@ bolt_add_library(
   SelectivityVector.cpp
   SequenceVector.cpp
   SimpleVector.cpp
+  Utf8Utils.cpp
   VariantToVector.cpp
   VariantVector.cpp
   VectorEncoding.cpp

--- a/bolt/vector/SimpleVector.h
+++ b/bolt/vector/SimpleVector.h
@@ -270,6 +270,22 @@ class SimpleVector : public BaseVector {
     return std::nullopt;
   }
 
+  /// Returns ASCII-ness when it is known for every row in this vector, or
+  /// std::nullopt otherwise. Unlike isAscii(rows), this does not require the
+  /// caller to allocate and populate a SelectivityVector.
+  template <typename U = T>
+  typename std::enable_if_t<std::is_same_v<U, StringView>, std::optional<bool>>
+  isAscii() const {
+    auto computedRows{asciiInfo.readLockedAsciiComputedRows()};
+    if (computedRows->size() == BaseVector::length_ &&
+        computedRows->begin() == 0 &&
+        computedRows->end() == BaseVector::length_ &&
+        bits::isAllSet(computedRows->allBits(), 0, BaseVector::length_, true)) {
+      return asciiInfo.isAllAscii();
+    }
+    return std::nullopt;
+  }
+
   /// This function takes an index and returns:
   /// 1. True if the string at that index is ASCII
   /// 2. False if the string at that index is not ASCII

--- a/bolt/vector/Utf8Utils.cpp
+++ b/bolt/vector/Utf8Utils.cpp
@@ -17,6 +17,7 @@
 #include "bolt/vector/Utf8Utils.h"
 
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cstdint>
 #include <cstring>
@@ -26,7 +27,6 @@
 
 #include <folly/lang/Bits.h>
 
-#include "bolt/common/base/CheckedArithmetic.h"
 #include "bolt/common/base/SimdUtil.h"
 #include "bolt/vector/ConstantVector.h"
 #include "bolt/vector/DictionaryVector.h"
@@ -39,10 +39,29 @@ namespace {
 // subpart emits a single U+FFFD replacement (3 bytes).
 constexpr char kReplacement[3] = {'\xEF', '\xBF', '\xBD'};
 constexpr int32_t kReplacementSize = 3;
+constexpr int32_t kReplacementsPerBlock = 64;
+alignas(64) constexpr auto kReplacementBlock = [] {
+  std::array<char, kReplacementSize * kReplacementsPerBlock> block{};
+  for (int32_t index = 0; index < kReplacementsPerBlock; ++index) {
+    for (int32_t byte = 0; byte < kReplacementSize; ++byte) {
+      block[index * kReplacementSize + byte] = kReplacement[byte];
+    }
+  }
+  return block;
+}();
 constexpr int32_t kMaxStringSize = std::numeric_limits<int32_t>::max();
+// vector_size_t and per-row VARCHAR sizes are both bounded by INT32_MAX, so
+// their vector-wide byte product fits in the required 64-bit size_t.
+static_assert(
+    sizeof(size_t) >= sizeof(uint64_t),
+    "Vector-wide VARCHAR byte counts require 64-bit size_t");
 
 inline bool isCont(uint8_t b) {
   return (b & 0xC0) == 0x80;
+}
+
+inline bool isRegularThreeByteLead(uint8_t b) {
+  return b >= 0xE1 && b <= 0xEF && b != 0xED;
 }
 
 // Returns (validBytes, malformedBytes) for the UTF-8 code unit at p[0].
@@ -66,42 +85,39 @@ inline std::pair<int32_t, int32_t> nextSegment(
     return {2, 0};
   }
   if (c >= 0xE0 && c <= 0xEF) {
-    const bool overlong = (c == 0xE0);
-    const bool surrogate = (c == 0xED);
-    if (remaining < 3) {
-      if (remaining > 1 && ((overlong && p[1] < 0xA0) || !isCont(p[1]))) {
-        return {0, 1};
-      }
-      return {0, remaining};
-    }
-    if ((overlong && p[1] < 0xA0) || !isCont(p[1])) {
+    if (remaining == 1) {
       return {0, 1};
+    }
+    if (!isCont(p[1]) || (c == 0xE0 && p[1] < 0xA0)) {
+      return {0, 1};
+    }
+    if (remaining == 2) {
+      return {0, 2};
     }
     if (!isCont(p[2])) {
       return {0, 2};
     }
-    if (surrogate && p[1] >= 0xA0) {
+    if (c == 0xED && p[1] >= 0xA0) {
       return {0, 3};
     }
     return {3, 0};
   }
   if (c >= 0xF0 && c <= 0xF4) {
-    auto bad2nd = [&]() {
-      if (!isCont(p[1]))
-        return true;
-      return (c == 0xF0 && p[1] < 0x90) || (c == 0xF4 && p[1] > 0x8F);
-    };
-    if (remaining < 4) {
-      if (remaining > 1 && bad2nd())
-        return {0, 1};
-      if (remaining > 2 && !isCont(p[2]))
-        return {0, 2};
-      return {0, remaining};
-    }
-    if (bad2nd())
+    if (remaining == 1) {
       return {0, 1};
+    }
+    if (!isCont(p[1]) || (c == 0xF0 && p[1] < 0x90) ||
+        (c == 0xF4 && p[1] > 0x8F)) {
+      return {0, 1};
+    }
+    if (remaining == 2) {
+      return {0, 2};
+    }
     if (!isCont(p[2]))
       return {0, 2};
+    if (remaining == 3) {
+      return {0, 3};
+    }
     if (!isCont(p[3]))
       return {0, 3};
     return {4, 0};
@@ -119,12 +135,55 @@ regularThreeBytePrefixLength(const uint8_t* data, int32_t remaining) {
   int32_t offset = 0;
   while (offset <= remaining - 3) {
     const auto lead = data[offset];
-    if (!((lead >= 0xE1 && lead <= 0xEC) || (lead >= 0xEE && lead <= 0xEF)) ||
-        !isCont(data[offset + 1]) || !isCont(data[offset + 2])) {
+    if (!isRegularThreeByteLead(lead) || !isCont(data[offset + 1]) ||
+        !isCont(data[offset + 2])) {
       break;
     }
     offset += 3;
   }
+  return offset;
+}
+
+// Validates several ordinary 3-byte code points per SIMD batch. Kept out of
+// scanUtf8 so binary-heavy inputs retain the compact scalar state machine.
+FOLLY_NOINLINE int32_t
+regularThreeBytePrefixLengthSimd(const uint8_t* data, int32_t remaining) {
+  using Batch = xsimd::batch<uint8_t>;
+  constexpr int32_t kBatchSize = Batch::size;
+  constexpr int32_t kTripletsPerBatch = (kBatchSize - 2) / 3;
+  constexpr int32_t kBytesPerBatch = kTripletsPerBatch * 3;
+  static_assert(kBatchSize <= sizeof(uint32_t) * 8);
+  constexpr uint32_t kTripletStarts = [] {
+    uint32_t mask = 0;
+    for (int32_t index = 0; index < kBytesPerBatch; index += 3) {
+      mask |= uint32_t{1} << index;
+    }
+    return mask;
+  }();
+  const auto leadLow = Batch::broadcast(0xE1);
+  const auto leadHigh = Batch::broadcast(0xEF);
+  const auto surrogateLead = Batch::broadcast(0xED);
+  const auto continuationLow = Batch::broadcast(0x80);
+  const auto continuationHigh = Batch::broadcast(0xBF);
+
+  int32_t offset = 0;
+  for (; offset <= remaining - kBatchSize; offset += kBytesPerBatch) {
+    const auto bytes = Batch::load_unaligned(data + offset);
+    const auto ordinaryLead =
+        (bytes >= leadLow) & (bytes <= leadHigh) & (bytes != surrogateLead);
+    const auto continuation =
+        (bytes >= continuationLow) & (bytes <= continuationHigh);
+    const auto leadMask = static_cast<uint32_t>(simd::toBitMask(ordinaryLead));
+    const auto continuationMask =
+        static_cast<uint32_t>(simd::toBitMask(continuation));
+    const auto validTriplets =
+        leadMask & (continuationMask >> 1) & (continuationMask >> 2);
+    if (FOLLY_UNLIKELY((validTriplets & kTripletStarts) != kTripletStarts)) {
+      break;
+    }
+  }
+
+  offset += regularThreeBytePrefixLength(data + offset, remaining - offset);
   return offset;
 }
 
@@ -165,6 +224,21 @@ FOLLY_ALWAYS_INLINE int32_t asciiPrefixLength(const char* data, int32_t size) {
   return offset;
 }
 
+// Fast validator for the common text shape of ordinary 3-byte code points
+// followed by an ASCII suffix. Other valid UTF-8 shapes fall back to scanUtf8.
+FOLLY_NOINLINE bool isValidThreeBytePrefixWithAsciiTail(
+    const char* data,
+    int32_t size) {
+  const auto threeByteSize = regularThreeBytePrefixLengthSimd(
+      reinterpret_cast<const uint8_t*>(data), size);
+  if (threeByteSize == 0) {
+    return false;
+  }
+  return threeByteSize +
+      asciiPrefixLength(data + threeByteSize, size - threeByteSize) ==
+      size;
+}
+
 struct MalformedRun {
   vector_size_t row;
   int32_t offset;
@@ -186,14 +260,65 @@ FOLLY_ALWAYS_INLINE bool isSingleByteMalformed(
       (remaining == 1 || !isCont(data[1]));
 }
 
-// Returns the number of consecutive bytes that each form a one-byte malformed
-// unit. Looking at the following byte is sufficient for 2-byte leading bytes;
-// all other qualifying byte ranges are unconditionally malformed. The SIMD
-// loop is especially useful for binary data containing dense high-byte runs.
+// Returns a prefix where every byte is a UTF-8 lead byte and therefore makes
+// the preceding lead malformed. This is the common shape of binary payloads
+// such as repeated 0xD5. The final lead is included only when its following
+// byte cannot be a continuation (or the input ends), preserving valid tails
+// such as D5 80.
+FOLLY_ALWAYS_INLINE int32_t
+denseLeadMalformedPrefixLength(const uint8_t* data, int32_t remaining) {
+  if (data[0] < 0xC0 || (remaining > 1 && isCont(data[1]))) {
+    return 0;
+  }
+
+  using Batch = xsimd::batch<uint8_t>;
+  constexpr int32_t kBatchSize = Batch::size;
+  static_assert(kBatchSize <= sizeof(uint32_t) * 8);
+  const auto leadLow = Batch::broadcast(0xC0);
+  const auto kAllLanes = simd::allSetBitMask<uint8_t>();
+
+  int32_t offset = 0;
+  for (; offset <= remaining - kBatchSize; offset += kBatchSize) {
+    const auto bytes = Batch::load_unaligned(data + offset);
+    const auto mask = static_cast<uint32_t>(simd::toBitMask(bytes >= leadLow));
+    if (FOLLY_UNLIKELY(mask != kAllLanes)) {
+      const auto leadBytes = static_cast<int32_t>(std::countr_one(mask));
+      BOLT_DCHECK_LT(leadBytes, kBatchSize);
+      return offset + leadBytes -
+          (leadBytes > 0 && isCont(data[offset + leadBytes]));
+    }
+    if (offset + kBatchSize == remaining) {
+      return remaining;
+    }
+    if (FOLLY_UNLIKELY(isCont(data[offset + kBatchSize]))) {
+      return offset + kBatchSize - 1;
+    }
+  }
+
+  while (offset < remaining && data[offset] >= 0xC0 &&
+         (offset + 1 == remaining || !isCont(data[offset + 1]))) {
+    ++offset;
+  }
+  return offset;
+}
+
+// Coalesces consecutive one-byte malformed units, using SIMD for mixed binary
+// payloads and the cheaper lead-only scan when possible.
 FOLLY_ALWAYS_INLINE int32_t
 singleByteMalformedPrefixLength(const uint8_t* data, int32_t remaining) {
   if (!isSingleByteMalformed(data, remaining)) {
     return 0;
+  }
+
+  constexpr uint32_t kFourLeadBytes = 0xC0C0C0C0U;
+  if (remaining >= static_cast<int32_t>(sizeof(uint32_t)) &&
+      (folly::loadUnaligned<uint32_t>(data) & kFourLeadBytes) ==
+          kFourLeadBytes) {
+    const auto denseLeadPrefix =
+        denseLeadMalformedPrefixLength(data, remaining);
+    if (denseLeadPrefix > 0) {
+      return denseLeadPrefix;
+    }
   }
 
   using Batch = xsimd::batch<uint8_t>;
@@ -274,10 +399,6 @@ int32_t scanUtf8(
     if (malformedPrefix > 0) {
       const int64_t replacementBytes =
           static_cast<int64_t>(malformedPrefix) * kReplacementSize;
-      BOLT_USER_CHECK_LE(
-          outputSize,
-          static_cast<int64_t>(kMaxStringSize) - replacementBytes,
-          "UTF-8 replacement result exceeds the maximum VARCHAR size");
       appendMalformedRun(
           row, offset, malformedPrefix, malformedPrefix, malformed);
       offset += malformedPrefix;
@@ -296,10 +417,6 @@ int32_t scanUtf8(
     const auto [validSize, malformedSize] =
         nextSegment(bytes + offset, size - offset);
     if (malformedSize > 0) {
-      BOLT_USER_CHECK_LE(
-          outputSize,
-          kMaxStringSize - kReplacementSize,
-          "UTF-8 replacement result exceeds the maximum VARCHAR size");
       appendMalformedRun(row, offset, malformedSize, 1, malformed);
       offset += malformedSize;
       outputSize += kReplacementSize;
@@ -320,8 +437,9 @@ FOLLY_ALWAYS_INLINE void writeReplacementRun(
     char* output,
     int32_t replacements) {
   BOLT_DCHECK_GT(replacements, 0);
-  std::memcpy(output, kReplacement, kReplacementSize);
-  int32_t written = 1;
+  const auto seedCount = std::min(replacements, kReplacementsPerBlock);
+  std::memcpy(output, kReplacementBlock.data(), seedCount * kReplacementSize);
+  int32_t written = seedCount;
   while (written < replacements) {
     const auto copyCount = std::min(written, replacements - written);
     std::memcpy(
@@ -330,6 +448,63 @@ FOLLY_ALWAYS_INLINE void writeReplacementRun(
         copyCount * kReplacementSize);
     written += copyCount;
   }
+}
+
+VectorPtr buildReplacementOnlyVector(
+    const MalformedRuns& malformed,
+    vector_size_t numRows,
+    bool uniformReplacementCount,
+    size_t totalStringBytes,
+    uint64_t maxStringLength,
+    memory::MemoryPool* pool) {
+  const auto maxOutputSize = static_cast<int32_t>(maxStringLength);
+  auto newValues = AlignedBuffer::allocate<StringView>(numRows, pool);
+  auto* outputValues = newValues->asMutable<StringView>();
+
+  BufferPtr newStrings;
+  const char* replacementData;
+  if (StringView::isInline(maxOutputSize)) {
+    replacementData = kReplacementBlock.data();
+  } else {
+    newStrings = AlignedBuffer::allocate<char>(maxOutputSize, pool);
+    newStrings->setSize(maxOutputSize);
+    auto* mutableReplacementData = newStrings->asMutable<char>();
+    writeReplacementRun(
+        mutableReplacementData, maxOutputSize / kReplacementSize);
+    replacementData = mutableReplacementData;
+  }
+
+  if (uniformReplacementCount) {
+    std::fill_n(
+        outputValues,
+        numRows,
+        StringView(
+            replacementData,
+            malformed.front().replacements * kReplacementSize));
+  } else {
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      outputValues[row] = StringView(
+          replacementData, malformed[row].replacements * kReplacementSize);
+    }
+  }
+
+  std::vector<BufferPtr> stringBuffers;
+  if (newStrings) {
+    stringBuffers.push_back(std::move(newStrings));
+  }
+  auto result = std::make_shared<FlatVector<StringView>>(
+      pool,
+      VARCHAR(),
+      nullptr,
+      numRows,
+      std::move(newValues),
+      std::move(stringBuffers),
+      SimpleVectorStats<StringView>{},
+      std::nullopt,
+      0);
+  result->setStringViewStats(
+      StringViewStats{totalStringBytes, maxStringLength});
+  return result;
 }
 
 // Constructs output using runs produced by scanUtf8. This performs memcpy and
@@ -427,26 +602,114 @@ VectorPtr buildSanitizedFlat(
 
   vector_size_t nullCount = 0;
   size_t totalStringBytes = 0;
+  size_t changedStringBytes = 0;
   uint64_t maxStringLength = 0;
   MalformedRuns malformed{memory::StlAllocator<MalformedRun>(pool)};
+  constexpr vector_size_t kSampleRows = 8;
+  constexpr vector_size_t kMaxSampledRunReserve = 16 * 1024;
 
-  auto probeString = [&](vector_size_t row, const char* data, int32_t size) {
-    const auto outputSize = scanUtf8(row, data, size, malformed);
+  auto recordString = [&](int32_t outputSize, bool changed) {
     maxStringLength = std::max<uint64_t>(maxStringLength, outputSize);
     if (!StringView::isInline(outputSize)) {
-      totalStringBytes = checkedPlus(
-          totalStringBytes,
-          static_cast<size_t>(outputSize),
-          "VARCHAR buffer size");
+      totalStringBytes += static_cast<size_t>(outputSize);
+      if (changed) {
+        changedStringBytes += static_cast<size_t>(outputSize);
+      }
     }
+  };
+
+  auto probeScalar = [&](vector_size_t row, const char* data, int32_t size) {
+    const auto malformedCount = malformed.size();
+    const auto outputSize = scanUtf8(row, data, size, malformed);
+    const bool changed = malformed.size() != malformedCount;
+    recordString(outputSize, changed);
+    return changed;
+  };
+
+  auto probeDenseLead = [&](vector_size_t row, const char* data, int32_t size) {
+    if (size == 0) {
+      probeScalar(row, data, size);
+      return false;
+    }
+    const auto malformedSize = denseLeadMalformedPrefixLength(
+        reinterpret_cast<const uint8_t*>(data), size);
+    if (malformedSize != size) {
+      probeScalar(row, data, size);
+      return false;
+    }
+    BOLT_USER_CHECK_LE(
+        size,
+        kMaxStringSize / kReplacementSize,
+        "UTF-8 replacement result exceeds the maximum VARCHAR size");
+    malformed.push_back({row, 0, size, size});
+    recordString(size * kReplacementSize, true);
+    return true;
+  };
+
+  auto probeThreeByte = [&](vector_size_t row, const char* data, int32_t size) {
+    if (isValidThreeBytePrefixWithAsciiTail(data, size)) {
+      recordString(size, false);
+      return true;
+    }
+    probeScalar(row, data, size);
+    return false;
   };
 
   if (plainFlatNoNulls) {
     const auto* flat = child->asUnchecked<FlatVector<StringView>>();
     const StringView* __restrict__ svs = flat->rawValues();
-    for (vector_size_t row = 0; row < numRows; ++row) {
+    const auto sampleRows = std::min(numRows, kSampleRows);
+    bool useThreeByteFastValidator = numRows > kSampleRows;
+    bool useDenseLeadFastScanner = numRows > kSampleRows;
+    bool reserveOneRunPerRow = numRows > kSampleRows;
+    vector_size_t row = 0;
+    for (; row < sampleRows; ++row) {
       const StringView& sv = svs[row];
-      probeString(row, sv.data(), static_cast<int32_t>(sv.size()));
+      const auto* data = sv.data();
+      const auto size = static_cast<int32_t>(sv.size());
+      const auto malformedCount = malformed.size();
+      const bool changed = probeScalar(row, data, size);
+      if (changed && malformed.capacity() < sampleRows) {
+        malformed.reserve(sampleRows);
+      }
+      reserveOneRunPerRow &= changed && malformed.size() == malformedCount + 1;
+      if (useThreeByteFastValidator &&
+          (changed || !isValidThreeBytePrefixWithAsciiTail(data, size))) {
+        useThreeByteFastValidator = false;
+      }
+      if (useDenseLeadFastScanner &&
+          (!changed || malformed.size() != malformedCount + 1 ||
+           malformed.back().offset != 0 || malformed.back().size != size ||
+           malformed.back().replacements != size)) {
+        useDenseLeadFastScanner = false;
+      }
+    }
+    if (reserveOneRunPerRow) {
+      // Bound speculative capacity for batches whose first rows are not
+      // representative. This still covers common writer batch sizes.
+      malformed.reserve(std::min(numRows, kMaxSampledRunReserve));
+    }
+    if (useDenseLeadFastScanner) {
+      for (; row < numRows; ++row) {
+        const StringView& sv = svs[row];
+        if (!probeDenseLead(row, sv.data(), static_cast<int32_t>(sv.size()))) {
+          ++row;
+          break;
+        }
+      }
+    }
+    if (useThreeByteFastValidator) {
+      for (; row < numRows; ++row) {
+        const StringView& sv = svs[row];
+        if (!probeThreeByte(row, sv.data(), static_cast<int32_t>(sv.size()))) {
+          ++row;
+          break;
+        }
+      }
+    }
+    for (; row < numRows; ++row) {
+      const StringView& sv = svs[row];
+      probeScalar(row, sv.data(), static_cast<int32_t>(sv.size()));
     }
   } else {
     PeeledVarchar pv = peelVarchar(*child);
@@ -461,13 +724,51 @@ VectorPtr buildSanitizedFlat(
         ++nullCount;
         continue;
       }
-      probeString(row, rs.data, rs.size);
+      probeScalar(row, rs.data, rs.size);
     }
   }
 
   if (malformed.empty()) {
     return nullptr;
   }
+
+  // A fully malformed row materializes as a prefix of the same repeated
+  // replacement sequence. When every row has this shape, build the sequence
+  // once instead of allocating and filling one copy per row.
+  if (plainFlatNoNulls && malformed.size() == numRows) {
+    const auto* sourceValues =
+        child->asUnchecked<FlatVector<StringView>>()->rawValues();
+    bool allReplacementOnly = true;
+    bool uniformReplacementCount = true;
+    const auto firstReplacementCount = malformed.front().replacements;
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      const auto& run = malformed[row];
+      if (run.row != row || run.offset != 0 ||
+          run.size != sourceValues[row].size()) {
+        allReplacementOnly = false;
+        break;
+      }
+      uniformReplacementCount &= run.replacements == firstReplacementCount;
+    }
+
+    if (allReplacementOnly) {
+      return buildReplacementOnlyVector(
+          malformed,
+          numRows,
+          uniformReplacementCount,
+          totalStringBytes,
+          maxStringLength,
+          pool);
+    }
+  }
+
+  // Retaining the source buffers avoids copying unchanged strings, but can
+  // increase peak memory when most values changed. Share only when doing so
+  // reduces the newly allocated non-inline bytes by at least half.
+  const bool shareUnchangedStrings =
+      totalStringBytes > 0 && changedStringBytes <= totalStringBytes / 2;
+  const auto allocatedStringBytes =
+      shareUnchangedStrings ? changedStringBytes : totalStringBytes;
 
   const bool hasAnyNull = (nullCount > 0);
   BufferPtr newNulls;
@@ -484,9 +785,9 @@ VectorPtr buildSanitizedFlat(
 
   BufferPtr newStrings;
   char* cur = nullptr;
-  if (totalStringBytes > 0) {
-    newStrings = AlignedBuffer::allocate<char>(totalStringBytes, pool);
-    newStrings->setSize(totalStringBytes);
+  if (allocatedStringBytes > 0) {
+    newStrings = AlignedBuffer::allocate<char>(allocatedStringBytes, pool);
+    newStrings->setSize(allocatedStringBytes);
     cur = newStrings->asMutable<char>();
   }
 
@@ -511,6 +812,11 @@ VectorPtr buildSanitizedFlat(
         writeFromRuns(data, size, malformed, begin, malformedIndex, inlineData);
         rnv[row] = StringView(inlineData, outputSize32);
       }
+      return;
+    }
+
+    if (shareUnchangedStrings && begin == malformedIndex) {
+      rnv[row] = StringView(data, size);
       return;
     }
 
@@ -560,7 +866,8 @@ VectorPtr buildSanitizedFlat(
   BOLT_DCHECK_EQ(malformedIndex, malformed.size());
   BOLT_DCHECK_EQ(
       cur,
-      newStrings ? newStrings->asMutable<char>() + totalStringBytes : nullptr);
+      newStrings ? newStrings->asMutable<char>() + allocatedStringBytes
+                 : nullptr);
 
   std::vector<BufferPtr> sbs;
   if (newStrings) {
@@ -578,6 +885,9 @@ VectorPtr buildSanitizedFlat(
       nullCount);
   result->setStringViewStats(
       StringViewStats{totalStringBytes, maxStringLength});
+  if (shareUnchangedStrings) {
+    result->acquireSharedStringBuffers(child.get());
+  }
   return result;
 }
 
@@ -636,10 +946,7 @@ std::optional<VectorPtr> buildSanitizedDictionary(
     const auto outputSize = scanUtf8(
         baseRow, value.data(), static_cast<int32_t>(value.size()), malformed);
     if (malformed.size() != begin && !StringView::isInline(outputSize)) {
-      changedStringBytes = checkedPlus(
-          changedStringBytes,
-          static_cast<size_t>(outputSize),
-          "VARCHAR buffer size");
+      changedStringBytes += static_cast<size_t>(outputSize);
     }
   });
 

--- a/bolt/vector/Utf8Utils.cpp
+++ b/bolt/vector/Utf8Utils.cpp
@@ -148,24 +148,98 @@ FOLLY_ALWAYS_INLINE int32_t asciiPrefixLength(const char* data, int32_t size) {
   return offset;
 }
 
-struct MalformedSpan {
+struct MalformedRun {
   vector_size_t row;
   int32_t offset;
   int32_t size;
+  int32_t replacements;
 };
 
-using MalformedSpans =
-    std::vector<MalformedSpan, memory::StlAllocator<MalformedSpan>>;
+using MalformedRuns =
+    std::vector<MalformedRun, memory::StlAllocator<MalformedRun>>;
+
+FOLLY_ALWAYS_INLINE bool isSingleByteMalformed(
+    const uint8_t* data,
+    int32_t remaining) {
+  const auto current = data[0];
+  if ((current >= 0x80 && current <= 0xC1) || current >= 0xF5) {
+    return true;
+  }
+  return current >= 0xC2 && current <= 0xDF &&
+      (remaining == 1 || !isCont(data[1]));
+}
+
+// Returns the number of consecutive bytes that each form a one-byte malformed
+// unit. Looking at the following byte is sufficient for 2-byte leading bytes;
+// all other qualifying byte ranges are unconditionally malformed. The SIMD
+// loop is especially useful for binary data containing dense high-byte runs.
+FOLLY_ALWAYS_INLINE int32_t
+singleByteMalformedPrefixLength(const uint8_t* data, int32_t remaining) {
+  if (!isSingleByteMalformed(data, remaining)) {
+    return 0;
+  }
+
+  using Batch = xsimd::batch<uint8_t>;
+  constexpr int32_t kBatchSize = Batch::size;
+  static_assert(kBatchSize <= sizeof(uint32_t) * 8);
+  const auto continuationLow = Batch::broadcast(0x80);
+  const auto continuationHigh = Batch::broadcast(0xBF);
+  const auto invalidTwoByteHigh = Batch::broadcast(0xC1);
+  const auto twoByteLow = Batch::broadcast(0xC2);
+  const auto twoByteHigh = Batch::broadcast(0xDF);
+  const auto invalidLeadLow = Batch::broadcast(0xF5);
+  const auto kAllLanes = simd::allSetBitMask<uint8_t>();
+
+  int32_t offset = 0;
+  for (; offset <= remaining - kBatchSize - 1; offset += kBatchSize) {
+    const auto current = Batch::load_unaligned(data + offset);
+    const auto next = Batch::load_unaligned(data + offset + 1);
+    const auto alwaysMalformed =
+        ((current >= continuationLow) & (current <= invalidTwoByteHigh)) |
+        (current >= invalidLeadLow);
+    const auto twoByteLead = (current >= twoByteLow) & (current <= twoByteHigh);
+    const auto nextIsContinuation =
+        (next >= continuationLow) & (next <= continuationHigh);
+    const auto malformed =
+        alwaysMalformed | (twoByteLead & ~nextIsContinuation);
+    const auto mask = static_cast<uint32_t>(simd::toBitMask(malformed));
+    if (FOLLY_UNLIKELY(mask != kAllLanes)) {
+      return offset + std::countr_one(mask);
+    }
+  }
+  while (offset < remaining &&
+         isSingleByteMalformed(data + offset, remaining - offset)) {
+    ++offset;
+  }
+  return offset;
+}
+
+FOLLY_ALWAYS_INLINE void appendMalformedRun(
+    vector_size_t row,
+    int32_t offset,
+    int32_t size,
+    int32_t replacements,
+    MalformedRuns& malformed) {
+  if (!malformed.empty()) {
+    auto& previous = malformed.back();
+    if (previous.row == row && previous.offset + previous.size == offset) {
+      previous.size += size;
+      previous.replacements += replacements;
+      return;
+    }
+  }
+  malformed.push_back({row, offset, size, replacements});
+}
 
 // Scans a string exactly once. ASCII runs are consumed using xsimd and only
 // high-bit bytes enter the scalar OpenJDK-compatible UTF-8 state machine.
-// Malformed byte ranges are recorded so output construction never needs to
-// decode the input again.
+// Adjacent malformed units are coalesced so dense invalid input uses one run
+// per row instead of one record per byte.
 int32_t scanUtf8(
     vector_size_t row,
     const char* data,
     int32_t size,
-    MalformedSpans& malformed) {
+    MalformedRuns& malformed) {
   const auto* bytes = reinterpret_cast<const uint8_t*>(data);
   int32_t offset = 0;
   int64_t outputSize = 0;
@@ -177,6 +251,22 @@ int32_t scanUtf8(
       continue;
     }
 
+    const auto malformedPrefix =
+        singleByteMalformedPrefixLength(bytes + offset, size - offset);
+    if (malformedPrefix > 0) {
+      const int64_t replacementBytes =
+          static_cast<int64_t>(malformedPrefix) * kReplacementSize;
+      BOLT_USER_CHECK_LE(
+          outputSize,
+          static_cast<int64_t>(kMaxStringSize) - replacementBytes,
+          "UTF-8 replacement result exceeds the maximum VARCHAR size");
+      appendMalformedRun(
+          row, offset, malformedPrefix, malformedPrefix, malformed);
+      offset += malformedPrefix;
+      outputSize += replacementBytes;
+      continue;
+    }
+
     const auto [validSize, malformedSize] =
         nextSegment(bytes + offset, size - offset);
     if (malformedSize > 0) {
@@ -184,7 +274,7 @@ int32_t scanUtf8(
           outputSize,
           kMaxStringSize - kReplacementSize,
           "UTF-8 replacement result exceeds the maximum VARCHAR size");
-      malformed.push_back({row, offset, malformedSize});
+      appendMalformedRun(row, offset, malformedSize, 1, malformed);
       offset += malformedSize;
       outputSize += kReplacementSize;
     } else {
@@ -200,29 +290,45 @@ int32_t scanUtf8(
   return static_cast<int32_t>(outputSize);
 }
 
-// Constructs output using spans produced by scanUtf8. This performs memcpy
-// and replacement only; it does not inspect or decode UTF-8 bytes.
-FOLLY_ALWAYS_INLINE void writeFromSpans(
+FOLLY_ALWAYS_INLINE void writeReplacementRun(
+    char* output,
+    int32_t replacements) {
+  BOLT_DCHECK_GT(replacements, 0);
+  std::memcpy(output, kReplacement, kReplacementSize);
+  int32_t written = 1;
+  while (written < replacements) {
+    const auto copyCount = std::min(written, replacements - written);
+    std::memcpy(
+        output + written * kReplacementSize,
+        output,
+        copyCount * kReplacementSize);
+    written += copyCount;
+  }
+}
+
+// Constructs output using runs produced by scanUtf8. This performs memcpy and
+// replacement only; it does not inspect or decode UTF-8 bytes.
+FOLLY_ALWAYS_INLINE void writeFromRuns(
     const char* data,
     int32_t size,
-    const MalformedSpans& malformed,
+    const MalformedRuns& malformed,
     size_t begin,
     size_t end,
     char* output) {
   int32_t inputOffset = 0;
   int32_t outputOffset = 0;
   for (auto index = begin; index < end; ++index) {
-    const auto& span = malformed[index];
-    BOLT_DCHECK_GE(span.offset, inputOffset);
-    BOLT_DCHECK_LE(span.offset + span.size, size);
-    const auto validSize = span.offset - inputOffset;
+    const auto& run = malformed[index];
+    BOLT_DCHECK_GE(run.offset, inputOffset);
+    BOLT_DCHECK_LE(run.offset + run.size, size);
+    const auto validSize = run.offset - inputOffset;
     if (validSize > 0) {
       std::memcpy(output + outputOffset, data + inputOffset, validSize);
       outputOffset += validSize;
     }
-    std::memcpy(output + outputOffset, kReplacement, kReplacementSize);
-    outputOffset += kReplacementSize;
-    inputOffset = span.offset + span.size;
+    writeReplacementRun(output + outputOffset, run.replacements);
+    outputOffset += run.replacements * kReplacementSize;
+    inputOffset = run.offset + run.size;
   }
   if (inputOffset < size) {
     std::memcpy(output + outputOffset, data + inputOffset, size - inputOffset);
@@ -277,10 +383,10 @@ readPeeled(const PeeledVarchar& pv, vector_size_t row, bool& isNull) {
 }
 
 // Single-function FLAT builder.
-// The probe pass decodes every byte at most once and records only malformed
-// spans. Returns nullptr without allocating output when no replacement is
-// needed. The construction pass uses the recorded spans to copy into one
-// exactly-sized, contiguous buffer without decoding UTF-8 again.
+// The probe pass decodes every byte at most once and records coalesced
+// malformed runs. Returns nullptr without allocating output when no
+// replacement is needed. The construction pass uses these runs to copy into
+// one exactly-sized, contiguous buffer without decoding UTF-8 again.
 //
 // A non-virtual FLAT fast path covers the common case (plain FLAT child, no
 // outer nulls) used by Hive/Parquet writer for top-level varchar columns.
@@ -296,7 +402,7 @@ VectorPtr buildSanitizedFlat(
   vector_size_t nullCount = 0;
   size_t totalStringBytes = 0;
   uint64_t maxStringLength = 0;
-  MalformedSpans malformed{memory::StlAllocator<MalformedSpan>(pool)};
+  MalformedRuns malformed{memory::StlAllocator<MalformedRun>(pool)};
 
   auto probeString = [&](vector_size_t row, const char* data, int32_t size) {
     const auto outputSize = scanUtf8(row, data, size, malformed);
@@ -364,7 +470,8 @@ VectorPtr buildSanitizedFlat(
     int64_t outputSize = size;
     while (malformedIndex < malformed.size() &&
            malformed[malformedIndex].row == row) {
-      outputSize += kReplacementSize - malformed[malformedIndex].size;
+      outputSize += malformed[malformedIndex].replacements * kReplacementSize -
+          malformed[malformedIndex].size;
       ++malformedIndex;
     }
     BOLT_DCHECK_LE(outputSize, kMaxStringSize);
@@ -375,8 +482,7 @@ VectorPtr buildSanitizedFlat(
         rnv[row] = StringView(data, size);
       } else {
         char inlineData[StringView::kInlineSize];
-        writeFromSpans(
-            data, size, malformed, begin, malformedIndex, inlineData);
+        writeFromRuns(data, size, malformed, begin, malformedIndex, inlineData);
         rnv[row] = StringView(inlineData, outputSize32);
       }
       return;
@@ -386,7 +492,7 @@ VectorPtr buildSanitizedFlat(
     if (begin == malformedIndex) {
       std::memcpy(output, data, size);
     } else {
-      writeFromSpans(data, size, malformed, begin, malformedIndex, output);
+      writeFromRuns(data, size, malformed, begin, malformedIndex, output);
     }
     cur += outputSize32;
     rnv[row] = StringView(output, outputSize32);
@@ -496,7 +602,7 @@ std::optional<VectorPtr> buildSanitizedDictionary(
 
   const auto* flat = base->asUnchecked<FlatVector<StringView>>();
   const auto* sourceValues = flat->rawValues();
-  MalformedSpans malformed{memory::StlAllocator<MalformedSpan>(pool)};
+  MalformedRuns malformed{memory::StlAllocator<MalformedRun>(pool)};
   size_t changedStringBytes = 0;
   referenced.applyToSelected([&](vector_size_t baseRow) {
     const auto& value = sourceValues[baseRow];
@@ -535,14 +641,15 @@ std::optional<VectorPtr> buildSanitizedDictionary(
     int64_t outputSize = source.size();
     while (malformedIndex < malformed.size() &&
            malformed[malformedIndex].row == baseRow) {
-      outputSize += kReplacementSize - malformed[malformedIndex].size;
+      outputSize += malformed[malformedIndex].replacements * kReplacementSize -
+          malformed[malformedIndex].size;
       ++malformedIndex;
     }
     BOLT_DCHECK_LE(outputSize, kMaxStringSize);
     const auto outputSize32 = static_cast<int32_t>(outputSize);
     if (StringView::isInline(outputSize32)) {
       char inlineData[StringView::kInlineSize];
-      writeFromSpans(
+      writeFromRuns(
           source.data(),
           source.size(),
           malformed,
@@ -551,7 +658,7 @@ std::optional<VectorPtr> buildSanitizedDictionary(
           inlineData);
       outputValues[baseRow] = StringView(inlineData, outputSize32);
     } else {
-      writeFromSpans(
+      writeFromRuns(
           source.data(),
           source.size(),
           malformed,

--- a/bolt/vector/Utf8Utils.cpp
+++ b/bolt/vector/Utf8Utils.cpp
@@ -111,6 +111,23 @@ inline std::pair<int32_t, int32_t> nextSegment(
   return {0, 1};
 }
 
+// Consumes a run of ordinary 3-byte code points without returning to the outer
+// malformed-input state machine for each code point. E0 and ED retain their
+// specialized checks in nextSegment().
+FOLLY_ALWAYS_INLINE int32_t
+regularThreeBytePrefixLength(const uint8_t* data, int32_t remaining) {
+  int32_t offset = 0;
+  while (offset <= remaining - 3) {
+    const auto lead = data[offset];
+    if (!((lead >= 0xE1 && lead <= 0xEC) || (lead >= 0xEE && lead <= 0xEF)) ||
+        !isCont(data[offset + 1]) || !isCont(data[offset + 2])) {
+      break;
+    }
+    offset += 3;
+  }
+  return offset;
+}
+
 // Returns the number of leading ASCII bytes. A SIMD comparison plus bit-mask
 // conversion locates the first high byte without a scalar rescan of the batch.
 // The UTF-8 state machine starts at that byte, so no successfully screened
@@ -231,10 +248,11 @@ FOLLY_ALWAYS_INLINE void appendMalformedRun(
   malformed.push_back({row, offset, size, replacements});
 }
 
-// Scans a string exactly once. ASCII runs are consumed using xsimd and only
-// high-bit bytes enter the scalar OpenJDK-compatible UTF-8 state machine.
-// Adjacent malformed units are coalesced so dense invalid input uses one run
-// per row instead of one record per byte.
+// Scans forward without a separate validation pass. ASCII runs use xsimd and
+// ordinary 3-byte runs stay in a tight loop; other high-bit bytes enter the
+// OpenJDK-compatible UTF-8 state machine. Adjacent malformed units are
+// coalesced so dense invalid input uses one run per row instead of one record
+// per byte.
 int32_t scanUtf8(
     vector_size_t row,
     const char* data,
@@ -264,6 +282,14 @@ int32_t scanUtf8(
           row, offset, malformedPrefix, malformedPrefix, malformed);
       offset += malformedPrefix;
       outputSize += replacementBytes;
+      continue;
+    }
+
+    const auto validPrefix =
+        regularThreeBytePrefixLength(bytes + offset, size - offset);
+    if (validPrefix > 0) {
+      offset += validPrefix;
+      outputSize += validPrefix;
       continue;
     }
 

--- a/bolt/vector/Utf8Utils.cpp
+++ b/bolt/vector/Utf8Utils.cpp
@@ -1,0 +1,642 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/vector/Utf8Utils.h"
+
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include <folly/lang/Bits.h>
+
+#include "bolt/common/base/CheckedArithmetic.h"
+#include "bolt/common/base/SimdUtil.h"
+#include "bolt/vector/ConstantVector.h"
+#include "bolt/vector/DictionaryVector.h"
+#include "bolt/vector/FlatVector.h"
+
+namespace bytedance::bolt::utf8 {
+namespace {
+
+// OpenJDK sun.nio.cs.UTF_8 malformed-input grouping: each maximal malformed
+// subpart emits a single U+FFFD replacement (3 bytes).
+constexpr char kReplacement[3] = {'\xEF', '\xBF', '\xBD'};
+constexpr int32_t kReplacementSize = 3;
+constexpr int32_t kMaxStringSize = std::numeric_limits<int32_t>::max();
+
+inline bool isCont(uint8_t b) {
+  return (b & 0xC0) == 0x80;
+}
+
+// Returns (validBytes, malformedBytes) for the UTF-8 code unit at p[0].
+// Implements OpenJDK's "maximal malformed subpart" rule: when a leading byte
+// declares N continuation bytes but the k-th continuation is missing or
+// invalid, bytes [0, k-1] are consumed as a single malformed unit and replaced
+// by one U+FFFD. Stray continuation bytes (0x80..0xBF) and 0xC0/0xC1/0xF5+
+// are each replaced individually.
+inline std::pair<int32_t, int32_t> nextSegment(
+    const uint8_t* p,
+    int32_t remaining) {
+  const uint8_t c = p[0];
+  if (c <= 0x7F) {
+    return {1, 0};
+  }
+  if (c >= 0xC2 && c <= 0xDF) {
+    if (remaining < 2)
+      return {0, remaining};
+    if (!isCont(p[1]))
+      return {0, 1};
+    return {2, 0};
+  }
+  if (c >= 0xE0 && c <= 0xEF) {
+    const bool overlong = (c == 0xE0);
+    const bool surrogate = (c == 0xED);
+    if (remaining < 3) {
+      if (remaining > 1 && ((overlong && p[1] < 0xA0) || !isCont(p[1]))) {
+        return {0, 1};
+      }
+      return {0, remaining};
+    }
+    if ((overlong && p[1] < 0xA0) || !isCont(p[1])) {
+      return {0, 1};
+    }
+    if (!isCont(p[2])) {
+      return {0, 2};
+    }
+    if (surrogate && p[1] >= 0xA0) {
+      return {0, 3};
+    }
+    return {3, 0};
+  }
+  if (c >= 0xF0 && c <= 0xF4) {
+    auto bad2nd = [&]() {
+      if (!isCont(p[1]))
+        return true;
+      return (c == 0xF0 && p[1] < 0x90) || (c == 0xF4 && p[1] > 0x8F);
+    };
+    if (remaining < 4) {
+      if (remaining > 1 && bad2nd())
+        return {0, 1};
+      if (remaining > 2 && !isCont(p[2]))
+        return {0, 2};
+      return {0, remaining};
+    }
+    if (bad2nd())
+      return {0, 1};
+    if (!isCont(p[2]))
+      return {0, 2};
+    if (!isCont(p[3]))
+      return {0, 3};
+    return {4, 0};
+  }
+  // 0x80..0xBF stray continuation, 0xC0/0xC1 overlong 2-byte, 0xF5..0xFF
+  // invalid lead.
+  return {0, 1};
+}
+
+// Returns the number of leading ASCII bytes. A SIMD comparison plus bit-mask
+// conversion locates the first high byte without a scalar rescan of the batch.
+// The UTF-8 state machine starts at that byte, so no successfully screened
+// ASCII prefix is inspected again.
+FOLLY_ALWAYS_INLINE int32_t asciiPrefixLength(const char* data, int32_t size) {
+  using Batch = xsimd::batch<uint8_t>;
+  constexpr int32_t kBatchSize = Batch::size;
+  const auto highBit = Batch::broadcast(0x80);
+  const auto* bytes = reinterpret_cast<const uint8_t*>(data);
+
+  int32_t offset = 0;
+  for (; offset <= size - kBatchSize; offset += kBatchSize) {
+    const auto batch = Batch::load_unaligned(bytes + offset);
+    const auto highBytes =
+        static_cast<uint32_t>(simd::toBitMask(batch >= highBit));
+    if (FOLLY_UNLIKELY(highBytes != 0)) {
+      return offset + std::countr_zero(highBytes);
+    }
+  }
+
+  constexpr uint64_t kAsciiMask64 = 0x8080808080808080ULL;
+  for (; offset <= size - static_cast<int32_t>(sizeof(uint64_t));
+       offset += sizeof(uint64_t)) {
+    const auto highBytes =
+        folly::loadUnaligned<uint64_t>(data + offset) & kAsciiMask64;
+    if (FOLLY_UNLIKELY(highBytes != 0)) {
+      return offset + std::countr_zero(highBytes) / 8;
+    }
+  }
+  for (; offset < size; ++offset) {
+    if (FOLLY_UNLIKELY((bytes[offset] & 0x80) != 0)) {
+      break;
+    }
+  }
+  return offset;
+}
+
+struct MalformedSpan {
+  vector_size_t row;
+  int32_t offset;
+  int32_t size;
+};
+
+using MalformedSpans =
+    std::vector<MalformedSpan, memory::StlAllocator<MalformedSpan>>;
+
+// Scans a string exactly once. ASCII runs are consumed using xsimd and only
+// high-bit bytes enter the scalar OpenJDK-compatible UTF-8 state machine.
+// Malformed byte ranges are recorded so output construction never needs to
+// decode the input again.
+int32_t scanUtf8(
+    vector_size_t row,
+    const char* data,
+    int32_t size,
+    MalformedSpans& malformed) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(data);
+  int32_t offset = 0;
+  int64_t outputSize = 0;
+  while (offset < size) {
+    if (bytes[offset] <= 0x7F) {
+      const auto asciiSize = asciiPrefixLength(data + offset, size - offset);
+      offset += asciiSize;
+      outputSize += asciiSize;
+      continue;
+    }
+
+    const auto [validSize, malformedSize] =
+        nextSegment(bytes + offset, size - offset);
+    if (malformedSize > 0) {
+      BOLT_USER_CHECK_LE(
+          outputSize,
+          kMaxStringSize - kReplacementSize,
+          "UTF-8 replacement result exceeds the maximum VARCHAR size");
+      malformed.push_back({row, offset, malformedSize});
+      offset += malformedSize;
+      outputSize += kReplacementSize;
+    } else {
+      offset += validSize;
+      outputSize += validSize;
+    }
+  }
+
+  BOLT_USER_CHECK_LE(
+      outputSize,
+      kMaxStringSize,
+      "UTF-8 replacement result exceeds the maximum VARCHAR size");
+  return static_cast<int32_t>(outputSize);
+}
+
+// Constructs output using spans produced by scanUtf8. This performs memcpy
+// and replacement only; it does not inspect or decode UTF-8 bytes.
+FOLLY_ALWAYS_INLINE void writeFromSpans(
+    const char* data,
+    int32_t size,
+    const MalformedSpans& malformed,
+    size_t begin,
+    size_t end,
+    char* output) {
+  int32_t inputOffset = 0;
+  int32_t outputOffset = 0;
+  for (auto index = begin; index < end; ++index) {
+    const auto& span = malformed[index];
+    BOLT_DCHECK_GE(span.offset, inputOffset);
+    BOLT_DCHECK_LE(span.offset + span.size, size);
+    const auto validSize = span.offset - inputOffset;
+    if (validSize > 0) {
+      std::memcpy(output + outputOffset, data + inputOffset, validSize);
+      outputOffset += validSize;
+    }
+    std::memcpy(output + outputOffset, kReplacement, kReplacementSize);
+    outputOffset += kReplacementSize;
+    inputOffset = span.offset + span.size;
+  }
+  if (inputOffset < size) {
+    std::memcpy(output + outputOffset, data + inputOffset, size - inputOffset);
+  }
+}
+
+struct RowStr {
+  const char* data;
+  int32_t size;
+};
+
+// Unified reader across FLAT / CONSTANT / DICTIONARY / SEQUENCE wrappers.
+// BaseVector::wrappedVector() peels through any nesting of wrappers to the
+// underlying scalar storage; wrappedIndex() translates an outer row index
+// through dict indirection, sequence offsets, and constant mappings into a
+// position in the peeled base's raw values array. The peeled base for a
+// VARCHAR is either a FLAT<StringView> or a CONSTANT<StringView> holding a
+// raw value (valueVector_ = nullptr).
+struct PeeledVarchar {
+  const BaseVector* outer; // original (wrapped) vector, for isNullAt
+  const StringView* values; // rawValues on peeled FLAT, or &value_ on CONSTANT
+};
+
+inline PeeledVarchar peelVarchar(const BaseVector& v) {
+  // One wrappedVector() call recurses through all DICT / SEQUENCE /
+  // CONSTANT(valueVector_) / LAZY wrappers to the underlying scalar storage,
+  // which for VARCHAR must be a FLAT<StringView> or a "bare"
+  // CONSTANT<StringView> (valueVector_ == nullptr).
+  const BaseVector* base = v.wrappedVector();
+  const StringView* values;
+  if (base->encoding() == VectorEncoding::Simple::CONSTANT) {
+    values = base->asUnchecked<ConstantVector<StringView>>()->rawValues();
+  } else {
+    BOLT_CHECK_EQ(
+        base->encoding(),
+        VectorEncoding::Simple::FLAT,
+        "replaceInvalidUtf8InTopLevelVarchars: unexpected VARCHAR encoding {}",
+        static_cast<int>(base->encoding()));
+    values = base->asUnchecked<FlatVector<StringView>>()->rawValues();
+  }
+  return {&v, values};
+}
+
+inline RowStr
+readPeeled(const PeeledVarchar& pv, vector_size_t row, bool& isNull) {
+  isNull = pv.outer->isNullAt(row);
+  if (isNull)
+    return {nullptr, 0};
+  const vector_size_t idx = pv.outer->wrappedIndex(row);
+  const StringView& sv = pv.values[idx];
+  return {sv.data(), static_cast<int32_t>(sv.size())};
+}
+
+// Single-function FLAT builder.
+// The probe pass decodes every byte at most once and records only malformed
+// spans. Returns nullptr without allocating output when no replacement is
+// needed. The construction pass uses the recorded spans to copy into one
+// exactly-sized, contiguous buffer without decoding UTF-8 again.
+//
+// A non-virtual FLAT fast path covers the common case (plain FLAT child, no
+// outer nulls) used by Hive/Parquet writer for top-level varchar columns.
+VectorPtr buildSanitizedFlat(
+    const VectorPtr& child,
+    vector_size_t numRows,
+    const uint64_t* outerNulls,
+    memory::MemoryPool* pool) {
+  const bool plainFlatNoNulls = !outerNulls &&
+      child->encoding() == VectorEncoding::Simple::FLAT &&
+      !child->mayHaveNulls();
+
+  vector_size_t nullCount = 0;
+  size_t totalStringBytes = 0;
+  uint64_t maxStringLength = 0;
+  MalformedSpans malformed{memory::StlAllocator<MalformedSpan>(pool)};
+
+  auto probeString = [&](vector_size_t row, const char* data, int32_t size) {
+    const auto outputSize = scanUtf8(row, data, size, malformed);
+    maxStringLength = std::max<uint64_t>(maxStringLength, outputSize);
+    if (!StringView::isInline(outputSize)) {
+      totalStringBytes = checkedPlus(
+          totalStringBytes,
+          static_cast<size_t>(outputSize),
+          "VARCHAR buffer size");
+    }
+  };
+
+  if (plainFlatNoNulls) {
+    const auto* flat = child->asUnchecked<FlatVector<StringView>>();
+    const StringView* __restrict__ svs = flat->rawValues();
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      const StringView& sv = svs[row];
+      probeString(row, sv.data(), static_cast<int32_t>(sv.size()));
+    }
+  } else {
+    PeeledVarchar pv = peelVarchar(*child);
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      if (outerNulls && bits::isBitNull(outerNulls, row)) {
+        ++nullCount;
+        continue;
+      }
+      bool isN = false;
+      const auto rs = readPeeled(pv, row, isN);
+      if (isN) {
+        ++nullCount;
+        continue;
+      }
+      probeString(row, rs.data, rs.size);
+    }
+  }
+
+  if (malformed.empty()) {
+    return nullptr;
+  }
+
+  const bool hasAnyNull = (nullCount > 0);
+  BufferPtr newNulls;
+  uint64_t* dstNulls = nullptr;
+  if (hasAnyNull) {
+    const auto nBytes = bits::nbytes(numRows);
+    newNulls = AlignedBuffer::allocate<char>(nBytes, pool);
+    dstNulls = newNulls->asMutable<uint64_t>();
+    std::memset(dstNulls, bits::kNotNullByte, newNulls->capacity());
+  }
+
+  BufferPtr newValues = AlignedBuffer::allocate<StringView>(numRows, pool);
+  auto* rnv = newValues->asMutable<StringView>();
+
+  BufferPtr newStrings;
+  char* cur = nullptr;
+  if (totalStringBytes > 0) {
+    newStrings = AlignedBuffer::allocate<char>(totalStringBytes, pool);
+    newStrings->setSize(totalStringBytes);
+    cur = newStrings->asMutable<char>();
+  }
+
+  size_t malformedIndex = 0;
+  auto writeString = [&](vector_size_t row, const char* data, int32_t size) {
+    const auto begin = malformedIndex;
+    int64_t outputSize = size;
+    while (malformedIndex < malformed.size() &&
+           malformed[malformedIndex].row == row) {
+      outputSize += kReplacementSize - malformed[malformedIndex].size;
+      ++malformedIndex;
+    }
+    BOLT_DCHECK_LE(outputSize, kMaxStringSize);
+    const auto outputSize32 = static_cast<int32_t>(outputSize);
+
+    if (StringView::isInline(outputSize32)) {
+      if (begin == malformedIndex) {
+        rnv[row] = StringView(data, size);
+      } else {
+        char inlineData[StringView::kInlineSize];
+        writeFromSpans(
+            data, size, malformed, begin, malformedIndex, inlineData);
+        rnv[row] = StringView(inlineData, outputSize32);
+      }
+      return;
+    }
+
+    char* output = cur;
+    if (begin == malformedIndex) {
+      std::memcpy(output, data, size);
+    } else {
+      writeFromSpans(data, size, malformed, begin, malformedIndex, output);
+    }
+    cur += outputSize32;
+    rnv[row] = StringView(output, outputSize32);
+  };
+
+  if (plainFlatNoNulls) {
+    const auto* flat = child->asUnchecked<FlatVector<StringView>>();
+    const StringView* __restrict__ svs = flat->rawValues();
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      const StringView& sv = svs[row];
+      writeString(row, sv.data(), static_cast<int32_t>(sv.size()));
+    }
+  } else {
+    PeeledVarchar pv = peelVarchar(*child);
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      if (outerNulls && bits::isBitNull(outerNulls, row)) {
+        if (dstNulls) {
+          bits::setNull(dstNulls, row);
+        }
+        rnv[row] = StringView();
+        continue;
+      }
+      bool isN = false;
+      const auto rs = readPeeled(pv, row, isN);
+      if (isN) {
+        if (dstNulls) {
+          bits::setNull(dstNulls, row);
+        }
+        rnv[row] = StringView();
+        continue;
+      }
+      if (dstNulls) {
+        bits::clearNull(dstNulls, row);
+      }
+      writeString(row, rs.data, rs.size);
+    }
+  }
+
+  BOLT_DCHECK_EQ(malformedIndex, malformed.size());
+  BOLT_DCHECK_EQ(
+      cur,
+      newStrings ? newStrings->asMutable<char>() + totalStringBytes : nullptr);
+
+  std::vector<BufferPtr> sbs;
+  if (newStrings) {
+    sbs.push_back(std::move(newStrings));
+  }
+  auto result = std::make_shared<FlatVector<StringView>>(
+      pool,
+      VARCHAR(),
+      std::move(newNulls),
+      numRows,
+      std::move(newValues),
+      std::move(sbs),
+      SimpleVectorStats<StringView>{},
+      std::nullopt,
+      nullCount);
+  result->setStringViewStats(
+      StringViewStats{totalStringBytes, maxStringLength});
+  return result;
+}
+
+// Sanitizes a single-layer DICTIONARY over a FLAT VARCHAR without decoding
+// the same base value once per logical row. Only referenced, logically
+// non-null base rows are scanned. When replacement is needed, the original
+// indices and nulls are retained and unchanged StringViews keep sharing the
+// source FlatVector's string buffers.
+std::optional<VectorPtr> buildSanitizedDictionary(
+    const VectorPtr& child,
+    vector_size_t numRows,
+    const uint64_t* outerNulls,
+    memory::MemoryPool* pool) {
+  if (child->encoding() != VectorEncoding::Simple::DICTIONARY) {
+    return std::nullopt;
+  }
+
+  const auto* dictionary = child->asUnchecked<DictionaryVector<StringView>>();
+  const auto& base = dictionary->valueVector();
+  if (base->encoding() != VectorEncoding::Simple::FLAT) {
+    return std::nullopt;
+  }
+
+  const auto baseSize = base->size();
+  if (baseSize == 0 || numRows == 0) {
+    return VectorPtr{};
+  }
+  // Preserving the dictionary requires a bitmap and, when replacement is
+  // needed, a StringView array sized to the full base. Fall back to the
+  // logical-row path unless the base is known to be substantially reused.
+  if (baseSize > numRows / 2) {
+    return std::nullopt;
+  }
+
+  SelectivityVector referenced(baseSize, false);
+  const auto* rawIndices = dictionary->indices()->as<vector_size_t>();
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    if ((outerNulls && bits::isBitNull(outerNulls, row)) ||
+        dictionary->isNullAt(row)) {
+      continue;
+    }
+    referenced.setValid(rawIndices[row], true);
+  }
+  referenced.updateBounds();
+  if (!referenced.hasSelections()) {
+    return VectorPtr{};
+  }
+
+  const auto* flat = base->asUnchecked<FlatVector<StringView>>();
+  const auto* sourceValues = flat->rawValues();
+  MalformedSpans malformed{memory::StlAllocator<MalformedSpan>(pool)};
+  size_t changedStringBytes = 0;
+  referenced.applyToSelected([&](vector_size_t baseRow) {
+    const auto& value = sourceValues[baseRow];
+    const auto begin = malformed.size();
+    const auto outputSize = scanUtf8(
+        baseRow, value.data(), static_cast<int32_t>(value.size()), malformed);
+    if (malformed.size() != begin && !StringView::isInline(outputSize)) {
+      changedStringBytes = checkedPlus(
+          changedStringBytes,
+          static_cast<size_t>(outputSize),
+          "VARCHAR buffer size");
+    }
+  });
+
+  if (malformed.empty()) {
+    return VectorPtr{};
+  }
+
+  auto newValues = AlignedBuffer::allocate<StringView>(baseSize, pool);
+  auto* outputValues = newValues->asMutable<StringView>();
+  std::memcpy(outputValues, sourceValues, baseSize * sizeof(StringView));
+
+  BufferPtr newStrings;
+  char* currentString = nullptr;
+  if (changedStringBytes > 0) {
+    newStrings = AlignedBuffer::allocate<char>(changedStringBytes, pool);
+    newStrings->setSize(changedStringBytes);
+    currentString = newStrings->asMutable<char>();
+  }
+
+  size_t malformedIndex = 0;
+  while (malformedIndex < malformed.size()) {
+    const auto baseRow = malformed[malformedIndex].row;
+    const auto& source = sourceValues[baseRow];
+    const auto begin = malformedIndex;
+    int64_t outputSize = source.size();
+    while (malformedIndex < malformed.size() &&
+           malformed[malformedIndex].row == baseRow) {
+      outputSize += kReplacementSize - malformed[malformedIndex].size;
+      ++malformedIndex;
+    }
+    BOLT_DCHECK_LE(outputSize, kMaxStringSize);
+    const auto outputSize32 = static_cast<int32_t>(outputSize);
+    if (StringView::isInline(outputSize32)) {
+      char inlineData[StringView::kInlineSize];
+      writeFromSpans(
+          source.data(),
+          source.size(),
+          malformed,
+          begin,
+          malformedIndex,
+          inlineData);
+      outputValues[baseRow] = StringView(inlineData, outputSize32);
+    } else {
+      writeFromSpans(
+          source.data(),
+          source.size(),
+          malformed,
+          begin,
+          malformedIndex,
+          currentString);
+      outputValues[baseRow] = StringView(currentString, outputSize32);
+      currentString += outputSize32;
+    }
+  }
+
+  BOLT_DCHECK_EQ(
+      currentString,
+      newStrings ? newStrings->asMutable<char>() + changedStringBytes
+                 : nullptr);
+  std::vector<BufferPtr> stringBuffers;
+  if (newStrings) {
+    stringBuffers.push_back(std::move(newStrings));
+  }
+  auto sanitizedBase = std::make_shared<FlatVector<StringView>>(
+      pool,
+      base->type(),
+      base->nulls(),
+      baseSize,
+      std::move(newValues),
+      std::move(stringBuffers),
+      SimpleVectorStats<StringView>{},
+      std::nullopt,
+      base->getNullCount());
+  sanitizedBase->acquireSharedStringBuffers(base.get());
+
+  return BaseVector::wrapInDictionary(
+      child->nulls(), dictionary->indices(), numRows, std::move(sanitizedBase));
+}
+
+} // namespace
+
+RowVectorPtr replaceInvalidUtf8InTopLevelVarchars(
+    const RowVectorPtr& input,
+    memory::MemoryPool* pool) {
+  std::optional<std::vector<VectorPtr>> children;
+  const auto numRows = input->size();
+  const auto& outerNulls = input->nulls();
+  const uint64_t* outerRaw = outerNulls ? outerNulls->as<uint64_t>() : nullptr;
+
+  for (auto c = 0; c < input->childrenSize(); ++c) {
+    const auto& child = input->childAt(c);
+    if (!child || child->typeKind() != TypeKind::VARCHAR) {
+      continue;
+    }
+    if (child->encoding() == VectorEncoding::Simple::CONSTANT) {
+      continue;
+    }
+    const auto* simple = child->asUnchecked<SimpleVector<StringView>>();
+    if (simple->getAllIsAscii() && simple->isAscii().value_or(false)) {
+      continue;
+    }
+
+    VectorPtr replacement;
+    auto dictionaryReplacement =
+        buildSanitizedDictionary(child, numRows, outerRaw, pool);
+    if (dictionaryReplacement.has_value()) {
+      replacement = std::move(dictionaryReplacement.value());
+    } else {
+      replacement = buildSanitizedFlat(child, numRows, outerRaw, pool);
+    }
+    if (!replacement) {
+      continue;
+    }
+    if (!children.has_value()) {
+      children = input->children();
+    }
+    children.value()[c] = std::move(replacement);
+  }
+
+  if (!children.has_value()) {
+    return input;
+  }
+  return std::make_shared<RowVector>(
+      pool,
+      input->type(),
+      input->nulls(),
+      numRows,
+      std::move(children.value()),
+      input->getNullCount());
+}
+
+} // namespace bytedance::bolt::utf8

--- a/bolt/vector/Utf8Utils.cpp
+++ b/bolt/vector/Utf8Utils.cpp
@@ -224,31 +224,6 @@ FOLLY_ALWAYS_INLINE int32_t asciiPrefixLength(const char* data, int32_t size) {
   return offset;
 }
 
-// Fast validator for the common text shape of ordinary 3-byte code points
-// followed by an ASCII suffix. Other valid UTF-8 shapes fall back to scanUtf8.
-FOLLY_NOINLINE bool isValidThreeBytePrefixWithAsciiTail(
-    const char* data,
-    int32_t size) {
-  const auto threeByteSize = regularThreeBytePrefixLengthSimd(
-      reinterpret_cast<const uint8_t*>(data), size);
-  if (threeByteSize == 0) {
-    return false;
-  }
-  return threeByteSize +
-      asciiPrefixLength(data + threeByteSize, size - threeByteSize) ==
-      size;
-}
-
-struct MalformedRun {
-  vector_size_t row;
-  int32_t offset;
-  int32_t size;
-  int32_t replacements;
-};
-
-using MalformedRuns =
-    std::vector<MalformedRun, memory::StlAllocator<MalformedRun>>;
-
 FOLLY_ALWAYS_INLINE bool isSingleByteMalformed(
     const uint8_t* data,
     int32_t remaining) {
@@ -309,6 +284,9 @@ singleByteMalformedPrefixLength(const uint8_t* data, int32_t remaining) {
   if (!isSingleByteMalformed(data, remaining)) {
     return 0;
   }
+  if (remaining == 1 || data[1] <= 0x7F) {
+    return 1;
+  }
 
   constexpr uint32_t kFourLeadBytes = 0xC0C0C0C0U;
   if (remaining >= static_cast<int32_t>(sizeof(uint32_t)) &&
@@ -356,87 +334,14 @@ singleByteMalformedPrefixLength(const uint8_t* data, int32_t remaining) {
   return offset;
 }
 
-FOLLY_ALWAYS_INLINE void appendMalformedRun(
-    vector_size_t row,
-    int32_t offset,
-    int32_t size,
-    int32_t replacements,
-    MalformedRuns& malformed) {
-  if (!malformed.empty()) {
-    auto& previous = malformed.back();
-    if (previous.row == row && previous.offset + previous.size == offset) {
-      previous.size += size;
-      previous.replacements += replacements;
-      return;
-    }
-  }
-  malformed.push_back({row, offset, size, replacements});
-}
-
-// Scans forward without a separate validation pass. ASCII runs use xsimd and
-// ordinary 3-byte runs stay in a tight loop; other high-bit bytes enter the
-// OpenJDK-compatible UTF-8 state machine. Adjacent malformed units are
-// coalesced so dense invalid input uses one run per row instead of one record
-// per byte.
-int32_t scanUtf8(
-    vector_size_t row,
-    const char* data,
-    int32_t size,
-    MalformedRuns& malformed) {
-  const auto* bytes = reinterpret_cast<const uint8_t*>(data);
-  int32_t offset = 0;
-  int64_t outputSize = 0;
-  while (offset < size) {
-    if (bytes[offset] <= 0x7F) {
-      const auto asciiSize = asciiPrefixLength(data + offset, size - offset);
-      offset += asciiSize;
-      outputSize += asciiSize;
-      continue;
-    }
-
-    const auto malformedPrefix =
-        singleByteMalformedPrefixLength(bytes + offset, size - offset);
-    if (malformedPrefix > 0) {
-      const int64_t replacementBytes =
-          static_cast<int64_t>(malformedPrefix) * kReplacementSize;
-      appendMalformedRun(
-          row, offset, malformedPrefix, malformedPrefix, malformed);
-      offset += malformedPrefix;
-      outputSize += replacementBytes;
-      continue;
-    }
-
-    const auto validPrefix =
-        regularThreeBytePrefixLength(bytes + offset, size - offset);
-    if (validPrefix > 0) {
-      offset += validPrefix;
-      outputSize += validPrefix;
-      continue;
-    }
-
-    const auto [validSize, malformedSize] =
-        nextSegment(bytes + offset, size - offset);
-    if (malformedSize > 0) {
-      appendMalformedRun(row, offset, malformedSize, 1, malformed);
-      offset += malformedSize;
-      outputSize += kReplacementSize;
-    } else {
-      offset += validSize;
-      outputSize += validSize;
-    }
-  }
-
-  BOLT_USER_CHECK_LE(
-      outputSize,
-      kMaxStringSize,
-      "UTF-8 replacement result exceeds the maximum VARCHAR size");
-  return static_cast<int32_t>(outputSize);
-}
-
 FOLLY_ALWAYS_INLINE void writeReplacementRun(
     char* output,
     int32_t replacements) {
   BOLT_DCHECK_GT(replacements, 0);
+  if (replacements == 1) {
+    std::memcpy(output, kReplacement, kReplacementSize);
+    return;
+  }
   const auto seedCount = std::min(replacements, kReplacementsPerBlock);
   std::memcpy(output, kReplacementBlock.data(), seedCount * kReplacementSize);
   int32_t written = seedCount;
@@ -450,452 +355,415 @@ FOLLY_ALWAYS_INLINE void writeReplacementRun(
   }
 }
 
-VectorPtr buildReplacementOnlyVector(
-    const MalformedRuns& malformed,
-    vector_size_t numRows,
-    bool uniformReplacementCount,
-    size_t totalStringBytes,
-    uint64_t maxStringLength,
-    memory::MemoryPool* pool) {
-  const auto maxOutputSize = static_cast<int32_t>(maxStringLength);
-  auto newValues = AlignedBuffer::allocate<StringView>(numRows, pool);
-  auto* outputValues = newValues->asMutable<StringView>();
-
-  BufferPtr newStrings;
-  const char* replacementData;
-  if (StringView::isInline(maxOutputSize)) {
-    replacementData = kReplacementBlock.data();
-  } else {
-    newStrings = AlignedBuffer::allocate<char>(maxOutputSize, pool);
-    newStrings->setSize(maxOutputSize);
-    auto* mutableReplacementData = newStrings->asMutable<char>();
-    writeReplacementRun(
-        mutableReplacementData, maxOutputSize / kReplacementSize);
-    replacementData = mutableReplacementData;
-  }
-
-  if (uniformReplacementCount) {
-    std::fill_n(
-        outputValues,
-        numRows,
-        StringView(
-            replacementData,
-            malformed.front().replacements * kReplacementSize));
-  } else {
-    for (vector_size_t row = 0; row < numRows; ++row) {
-      outputValues[row] = StringView(
-          replacementData, malformed[row].replacements * kReplacementSize);
-    }
-  }
-
-  std::vector<BufferPtr> stringBuffers;
-  if (newStrings) {
-    stringBuffers.push_back(std::move(newStrings));
-  }
-  auto result = std::make_shared<FlatVector<StringView>>(
-      pool,
-      VARCHAR(),
-      nullptr,
-      numRows,
-      std::move(newValues),
-      std::move(stringBuffers),
-      SimpleVectorStats<StringView>{},
-      std::nullopt,
-      0);
-  result->setStringViewStats(
-      StringViewStats{totalStringBytes, maxStringLength});
-  return result;
-}
-
-// Constructs output using runs produced by scanUtf8. This performs memcpy and
-// replacement only; it does not inspect or decode UTF-8 bytes.
-FOLLY_ALWAYS_INLINE void writeFromRuns(
+// Enumerates malformed runs without retaining per-byte metadata. Analysis and
+// materialization share the same scanner and OpenJDK grouping rules.
+template <typename Consumer>
+void forEachMalformedRun(
     const char* data,
     int32_t size,
-    const MalformedRuns& malformed,
-    size_t begin,
-    size_t end,
-    char* output) {
-  int32_t inputOffset = 0;
-  int32_t outputOffset = 0;
-  for (auto index = begin; index < end; ++index) {
-    const auto& run = malformed[index];
-    BOLT_DCHECK_GE(run.offset, inputOffset);
-    BOLT_DCHECK_LE(run.offset + run.size, size);
-    const auto validSize = run.offset - inputOffset;
-    if (validSize > 0) {
-      std::memcpy(output + outputOffset, data + inputOffset, validSize);
-      outputOffset += validSize;
+    int32_t offset,
+    Consumer&& consume) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(data);
+  while (offset < size) {
+    if (bytes[offset] <= 0x7F) {
+      if (offset + 1 == size || bytes[offset + 1] > 0x7F) {
+        ++offset;
+      } else {
+        offset += asciiPrefixLength(data + offset, size - offset);
+      }
+      continue;
     }
-    writeReplacementRun(output + outputOffset, run.replacements);
-    outputOffset += run.replacements * kReplacementSize;
-    inputOffset = run.offset + run.size;
-  }
-  if (inputOffset < size) {
-    std::memcpy(output + outputOffset, data + inputOffset, size - inputOffset);
-  }
-}
-
-struct RowStr {
-  const char* data;
-  int32_t size;
-};
-
-// Unified reader across FLAT / CONSTANT / DICTIONARY / SEQUENCE wrappers.
-// BaseVector::wrappedVector() peels through any nesting of wrappers to the
-// underlying scalar storage; wrappedIndex() translates an outer row index
-// through dict indirection, sequence offsets, and constant mappings into a
-// position in the peeled base's raw values array. The peeled base for a
-// VARCHAR is either a FLAT<StringView> or a CONSTANT<StringView> holding a
-// raw value (valueVector_ = nullptr).
-struct PeeledVarchar {
-  const BaseVector* outer; // original (wrapped) vector, for isNullAt
-  const StringView* values; // rawValues on peeled FLAT, or &value_ on CONSTANT
-};
-
-inline PeeledVarchar peelVarchar(const BaseVector& v) {
-  // One wrappedVector() call recurses through all DICT / SEQUENCE /
-  // CONSTANT(valueVector_) / LAZY wrappers to the underlying scalar storage,
-  // which for VARCHAR must be a FLAT<StringView> or a "bare"
-  // CONSTANT<StringView> (valueVector_ == nullptr).
-  const BaseVector* base = v.wrappedVector();
-  const StringView* values;
-  if (base->encoding() == VectorEncoding::Simple::CONSTANT) {
-    values = base->asUnchecked<ConstantVector<StringView>>()->rawValues();
-  } else {
-    BOLT_CHECK_EQ(
-        base->encoding(),
-        VectorEncoding::Simple::FLAT,
-        "replaceInvalidUtf8InTopLevelVarchars: unexpected VARCHAR encoding {}",
-        static_cast<int>(base->encoding()));
-    values = base->asUnchecked<FlatVector<StringView>>()->rawValues();
-  }
-  return {&v, values};
-}
-
-inline RowStr
-readPeeled(const PeeledVarchar& pv, vector_size_t row, bool& isNull) {
-  isNull = pv.outer->isNullAt(row);
-  if (isNull)
-    return {nullptr, 0};
-  const vector_size_t idx = pv.outer->wrappedIndex(row);
-  const StringView& sv = pv.values[idx];
-  return {sv.data(), static_cast<int32_t>(sv.size())};
-}
-
-// Single-function FLAT builder.
-// The probe pass decodes every byte at most once and records coalesced
-// malformed runs. Returns nullptr without allocating output when no
-// replacement is needed. The construction pass uses these runs to copy into
-// one exactly-sized, contiguous buffer without decoding UTF-8 again.
-//
-// A non-virtual FLAT fast path covers the common case (plain FLAT child, no
-// outer nulls) used by Hive/Parquet writer for top-level varchar columns.
-VectorPtr buildSanitizedFlat(
-    const VectorPtr& child,
-    vector_size_t numRows,
-    const uint64_t* outerNulls,
-    memory::MemoryPool* pool) {
-  const bool plainFlatNoNulls = !outerNulls &&
-      child->encoding() == VectorEncoding::Simple::FLAT &&
-      !child->mayHaveNulls();
-
-  vector_size_t nullCount = 0;
-  size_t totalStringBytes = 0;
-  size_t changedStringBytes = 0;
-  uint64_t maxStringLength = 0;
-  MalformedRuns malformed{memory::StlAllocator<MalformedRun>(pool)};
-  constexpr vector_size_t kSampleRows = 8;
-  constexpr vector_size_t kMaxSampledRunReserve = 16 * 1024;
-
-  auto recordString = [&](int32_t outputSize, bool changed) {
-    maxStringLength = std::max<uint64_t>(maxStringLength, outputSize);
-    if (!StringView::isInline(outputSize)) {
-      totalStringBytes += static_cast<size_t>(outputSize);
-      if (changed) {
-        changedStringBytes += static_cast<size_t>(outputSize);
+    const auto malformedPrefix =
+        singleByteMalformedPrefixLength(bytes + offset, size - offset);
+    if (malformedPrefix > 0) {
+      consume(offset, malformedPrefix, malformedPrefix);
+      offset += malformedPrefix;
+      continue;
+    }
+    if (isRegularThreeByteLead(bytes[offset])) {
+      const auto remaining = size - offset;
+      // Short or interleaved code points do not amortize a SIMD call.
+      const auto validPrefix = remaining >= xsimd::batch<uint8_t>::size &&
+              isCont(bytes[offset + 1]) && isCont(bytes[offset + 2]) &&
+              isRegularThreeByteLead(bytes[offset + 3])
+          ? regularThreeBytePrefixLengthSimd(bytes + offset, remaining)
+          : regularThreeBytePrefixLength(bytes + offset, remaining);
+      if (validPrefix > 0) {
+        offset += validPrefix;
+        continue;
       }
     }
-  };
-
-  auto probeScalar = [&](vector_size_t row, const char* data, int32_t size) {
-    const auto malformedCount = malformed.size();
-    const auto outputSize = scanUtf8(row, data, size, malformed);
-    const bool changed = malformed.size() != malformedCount;
-    recordString(outputSize, changed);
-    return changed;
-  };
-
-  auto probeDenseLead = [&](vector_size_t row, const char* data, int32_t size) {
-    if (size == 0) {
-      probeScalar(row, data, size);
-      return false;
+    const auto [validSize, malformedSize] =
+        nextSegment(bytes + offset, size - offset);
+    if (malformedSize > 0) {
+      consume(offset, malformedSize, 1);
+      offset += malformedSize;
+    } else {
+      offset += validSize;
     }
-    const auto malformedSize = denseLeadMalformedPrefixLength(
-        reinterpret_cast<const uint8_t*>(data), size);
-    if (malformedSize != size) {
-      probeScalar(row, data, size);
-      return false;
-    }
+  }
+}
+
+struct MalformedRun {
+  int32_t offset;
+  int32_t length;
+  int32_t replacements;
+};
+
+constexpr int32_t kMaxCachedMalformedRuns = 64;
+using MalformedRuns = std::array<MalformedRun, kMaxCachedMalformedRuns>;
+
+struct StringAnalysis {
+  StringAnalysis(int32_t size, int32_t runs, bool onlyReplacement)
+      : outputSize(size), replacementOnly(onlyReplacement), runCount(runs) {}
+
+  // VARCHAR sizes fit in 31 bits. Keep the complete result in one register.
+  uint32_t outputSize : 31;
+  uint32_t replacementOnly : 1;
+  int32_t runCount;
+};
+static_assert(sizeof(StringAnalysis) == sizeof(uint64_t));
+
+FOLLY_NOINLINE StringAnalysis
+analyzeStringSuffix(StringView value, MalformedRuns& runs, int32_t prefix) {
+  const auto size = static_cast<int32_t>(value.size());
+  int64_t outputSize = size;
+  int32_t malformedBytes = 0;
+  int32_t runCount = 0;
+  forEachMalformedRun(
+      value.data(),
+      size,
+      prefix,
+      [&](int32_t offset, int32_t length, int32_t count) {
+        if (runCount < kMaxCachedMalformedRuns) {
+          runs[runCount] = {offset, length, count};
+        }
+        ++runCount;
+        malformedBytes += length;
+        outputSize += static_cast<int64_t>(count) * kReplacementSize - length;
+      });
+  BOLT_USER_CHECK_LE(
+      outputSize,
+      kMaxStringSize,
+      "UTF-8 replacement result exceeds the maximum VARCHAR size");
+  return {
+      static_cast<int32_t>(outputSize),
+      runCount,
+      runCount > 0 && malformedBytes == size};
+}
+
+// Keep common complete strings out of the malformed-run state machine.
+FOLLY_ALWAYS_INLINE StringAnalysis
+analyzeString(const StringView& value, MalformedRuns& runs) {
+  const auto size = static_cast<int32_t>(value.size());
+  const auto* data = reinterpret_cast<const uint8_t*>(value.data());
+  int32_t prefix = 0;
+  if (size > 0 && data[0] <= 0x7F) {
+    prefix = asciiPrefixLength(value.data(), size);
+  } else if (
+      size >= sizeof(uint32_t) &&
+      (folly::loadUnaligned<uint32_t>(data) & 0xC0C0C0C0U) == 0xC0C0C0C0U &&
+      denseLeadMalformedPrefixLength(data, size) == size) {
     BOLT_USER_CHECK_LE(
         size,
         kMaxStringSize / kReplacementSize,
         "UTF-8 replacement result exceeds the maximum VARCHAR size");
-    malformed.push_back({row, 0, size, size});
-    recordString(size * kReplacementSize, true);
-    return true;
-  };
-
-  auto probeThreeByte = [&](vector_size_t row, const char* data, int32_t size) {
-    if (isValidThreeBytePrefixWithAsciiTail(data, size)) {
-      recordString(size, false);
-      return true;
-    }
-    probeScalar(row, data, size);
-    return false;
-  };
-
-  if (plainFlatNoNulls) {
-    const auto* flat = child->asUnchecked<FlatVector<StringView>>();
-    const StringView* __restrict__ svs = flat->rawValues();
-    const auto sampleRows = std::min(numRows, kSampleRows);
-    bool useThreeByteFastValidator = numRows > kSampleRows;
-    bool useDenseLeadFastScanner = numRows > kSampleRows;
-    bool reserveOneRunPerRow = numRows > kSampleRows;
-    vector_size_t row = 0;
-    for (; row < sampleRows; ++row) {
-      const StringView& sv = svs[row];
-      const auto* data = sv.data();
-      const auto size = static_cast<int32_t>(sv.size());
-      const auto malformedCount = malformed.size();
-      const bool changed = probeScalar(row, data, size);
-      if (changed && malformed.capacity() < sampleRows) {
-        malformed.reserve(sampleRows);
-      }
-      reserveOneRunPerRow &= changed && malformed.size() == malformedCount + 1;
-      if (useThreeByteFastValidator &&
-          (changed || !isValidThreeBytePrefixWithAsciiTail(data, size))) {
-        useThreeByteFastValidator = false;
-      }
-      if (useDenseLeadFastScanner &&
-          (!changed || malformed.size() != malformedCount + 1 ||
-           malformed.back().offset != 0 || malformed.back().size != size ||
-           malformed.back().replacements != size)) {
-        useDenseLeadFastScanner = false;
-      }
-    }
-    if (reserveOneRunPerRow) {
-      // Bound speculative capacity for batches whose first rows are not
-      // representative. This still covers common writer batch sizes.
-      malformed.reserve(std::min(numRows, kMaxSampledRunReserve));
-    }
-    if (useDenseLeadFastScanner) {
-      for (; row < numRows; ++row) {
-        const StringView& sv = svs[row];
-        if (!probeDenseLead(row, sv.data(), static_cast<int32_t>(sv.size()))) {
-          ++row;
-          break;
-        }
-      }
-    }
-    if (useThreeByteFastValidator) {
-      for (; row < numRows; ++row) {
-        const StringView& sv = svs[row];
-        if (!probeThreeByte(row, sv.data(), static_cast<int32_t>(sv.size()))) {
-          ++row;
-          break;
-        }
-      }
-    }
-    for (; row < numRows; ++row) {
-      const StringView& sv = svs[row];
-      probeScalar(row, sv.data(), static_cast<int32_t>(sv.size()));
-    }
-  } else {
-    PeeledVarchar pv = peelVarchar(*child);
-    for (vector_size_t row = 0; row < numRows; ++row) {
-      if (outerNulls && bits::isBitNull(outerNulls, row)) {
-        ++nullCount;
-        continue;
-      }
-      bool isN = false;
-      const auto rs = readPeeled(pv, row, isN);
-      if (isN) {
-        ++nullCount;
-        continue;
-      }
-      probeScalar(row, rs.data, rs.size);
+    runs[0] = {0, size, size};
+    return {size * kReplacementSize, 1, true};
+  } else if (size > 0 && isRegularThreeByteLead(data[0])) {
+    prefix = regularThreeBytePrefixLengthSimd(data, size);
+    if (prefix < size && data[prefix] <= 0x7F) {
+      prefix += asciiPrefixLength(value.data() + prefix, size - prefix);
     }
   }
+  if (prefix == size) {
+    return {size, 0, false};
+  }
+  return analyzeStringSuffix(value, runs, prefix);
+}
 
-  if (malformed.empty()) {
+struct StringWriter {
+  StringView source;
+  char* output;
+  int32_t copied{0};
+
+  void append(int32_t offset, int32_t length, int32_t replacements) {
+    const auto validSize = offset - copied;
+    if (validSize > 0) {
+      std::memcpy(output, source.data() + copied, validSize);
+      output += validSize;
+    }
+    writeReplacementRun(output, replacements);
+    output += replacements * kReplacementSize;
+    copied = offset + length;
+  }
+
+  void finish() {
+    if (copied < source.size()) {
+      std::memcpy(output, source.data() + copied, source.size() - copied);
+    }
+  }
+};
+
+// Keep the rare cache-overflow scanner out of the cached materialization path.
+FOLLY_NOINLINE void writeFromScan(StringWriter& writer, int32_t offset) {
+  forEachMalformedRun(
+      writer.source.data(),
+      writer.source.size(),
+      offset,
+      [&](int32_t start, int32_t length, int32_t count) {
+        writer.append(start, length, count);
+      });
+}
+
+FOLLY_ALWAYS_INLINE void writeSanitizedString(
+    StringView source,
+    const StringAnalysis& analysis,
+    const MalformedRuns& runs,
+    char* output) {
+  StringWriter writer{source, output};
+  if (analysis.runCount > kMaxCachedMalformedRuns) {
+    writeFromScan(writer, runs[0].offset);
+  } else {
+    for (int32_t index = 0; index < analysis.runCount; ++index) {
+      const auto& run = runs[index];
+      writer.append(run.offset, run.length, run.replacements);
+    }
+  }
+  writer.finish();
+}
+
+// Inline inputs need at most 3 * kInlineSize output bytes. Materialize them
+// directly on the stack instead of caching and replaying malformed runs.
+StringAnalysis analyzeInlineString(const StringView& value, char* output) {
+  const auto size = static_cast<int32_t>(value.size());
+  const auto prefix = asciiPrefixLength(value.data(), size);
+  if (prefix == size) {
+    return {size, 0, false};
+  }
+  StringWriter writer{value, output};
+  int32_t runCount = 0;
+  int32_t malformedBytes = 0;
+  forEachMalformedRun(
+      value.data(),
+      size,
+      prefix,
+      [&](int32_t offset, int32_t length, int32_t count) {
+        writer.append(offset, length, count);
+        malformedBytes += length;
+        ++runCount;
+      });
+  const auto outputSize = writer.output - output + size - writer.copied;
+  if (runCount > 0) {
+    writer.finish();
+  }
+  return {static_cast<int32_t>(outputSize), runCount, malformedBytes == size};
+}
+
+// Returns nullptr for unchanged input. 'selected' is only used for a dictionary
+// base: unreferenced values must survive unchanged, without being scanned.
+VectorPtr buildSanitizedFlat(
+    const VectorPtr& child,
+    vector_size_t numRows,
+    const uint64_t* outerNulls,
+    memory::MemoryPool* pool,
+    const SelectivityVector* selected = nullptr) {
+  const auto* flat = child->isFlatEncoding()
+      ? child->asUnchecked<FlatVector<StringView>>()
+      : nullptr;
+  const StringView* flatValues = flat ? flat->rawValues() : nullptr;
+  const auto* childNulls = flat ? flat->rawNulls() : nullptr;
+  const auto* base = flat ? child.get() : child->wrappedVector();
+  const auto* baseValues = base->isConstantEncoding()
+      ? base->asUnchecked<ConstantVector<StringView>>()->rawValues()
+      : base->asUnchecked<FlatVector<StringView>>()->rawValues();
+
+  auto isNull = [&](vector_size_t row) {
+    return (outerNulls && bits::isBitNull(outerNulls, row)) ||
+        (flat ? childNulls && bits::isBitNull(childNulls, row)
+              : child->isNullAt(row));
+  };
+  auto valueAt = [&](vector_size_t row) -> const StringView& {
+    return flat ? flatValues[row] : baseValues[child->wrappedIndex(row)];
+  };
+
+  vector_size_t nullCount = 0;
+  size_t totalStringBytes = 0;
+  size_t unchangedStringBytes = 0;
+  uint64_t maxStringLength = 0;
+  std::shared_ptr<FlatVector<StringView>> result;
+  StringView* outputValues = nullptr;
+  const char* replacementData = kReplacementBlock.data();
+  static_assert(StringView::kInlineSize % kReplacementSize == 0);
+  int32_t replacementCapacity = StringView::kInlineSize;
+
+  auto initializeOutput = [&](vector_size_t firstChanged) FOLLY_NOINLINE {
+    BufferPtr nulls;
+    const bool combineNulls = outerNulls || !flat;
+    if (combineNulls) {
+      bool hasNull = false;
+      for (vector_size_t row = 0; row < numRows; ++row) {
+        if (isNull(row)) {
+          hasNull = true;
+          break;
+        }
+      }
+      if (hasNull) {
+        nulls = AlignedBuffer::allocate<uint64_t>(bits::nwords(numRows), pool);
+        auto* rawNulls = nulls->asMutable<uint64_t>();
+        std::memset(rawNulls, bits::kNotNullByte, nulls->size());
+        for (vector_size_t row = 0; row < numRows; ++row) {
+          if (isNull(row)) {
+            bits::setNull(rawNulls, row);
+          }
+        }
+      }
+    } else {
+      nulls = child->nulls();
+    }
+
+    auto values = AlignedBuffer::allocate<StringView>(numRows, pool);
+    outputValues = values->asMutable<StringView>();
+    if (flat) {
+      const auto copyRows = selected ? numRows : firstChanged;
+      std::memcpy(outputValues, flatValues, copyRows * sizeof(StringView));
+    } else {
+      for (vector_size_t row = 0; row < firstChanged; ++row) {
+        outputValues[row] = isNull(row) ? StringView() : valueAt(row);
+      }
+    }
+    result = std::make_shared<FlatVector<StringView>>(
+        pool,
+        child->type(),
+        std::move(nulls),
+        numRows,
+        std::move(values),
+        std::vector<BufferPtr>{},
+        SimpleVectorStats<StringView>{});
+  };
+
+  auto writeChanged = [&](vector_size_t row,
+                          StringView value,
+                          StringAnalysis analysis,
+                          const MalformedRuns& runs,
+                          const char* inlineOutput) {
+    if (!result) {
+      initializeOutput(row);
+    }
+    if (analysis.replacementOnly) {
+      if (analysis.outputSize > replacementCapacity) {
+        constexpr int32_t kMaxReplacementBufferSize =
+            kMaxStringSize - kMaxStringSize % kReplacementSize;
+        const auto grownSize = std::min<int64_t>(
+            kMaxReplacementBufferSize,
+            std::max<int64_t>(
+                analysis.outputSize,
+                static_cast<int64_t>(replacementCapacity) * 2));
+        auto* grown = result->getRawStringBufferWithSpace(grownSize, true);
+        writeReplacementRun(grown, grownSize / kReplacementSize);
+        replacementData = grown;
+        replacementCapacity = static_cast<int32_t>(grownSize);
+      }
+      outputValues[row] = StringView(replacementData, analysis.outputSize);
+      return;
+    }
+    if (StringView::isInline(analysis.outputSize)) {
+      if (value.isInline()) {
+        outputValues[row] = StringView(inlineOutput, analysis.outputSize);
+        return;
+      }
+      char inlineData[StringView::kInlineSize];
+      writeSanitizedString(value, analysis, runs, inlineData);
+      outputValues[row] = StringView(inlineData, analysis.outputSize);
+      return;
+    }
+    auto* output = result->getRawStringBufferWithSpace(analysis.outputSize);
+    if (value.isInline()) {
+      std::memcpy(output, inlineOutput, analysis.outputSize);
+    } else {
+      writeSanitizedString(value, analysis, runs, output);
+    }
+    outputValues[row] = StringView(output, analysis.outputSize);
+  };
+
+  auto probe = [&](vector_size_t row, const StringView& value)
+      __attribute__((always_inline)) {
+    MalformedRuns runs;
+    char inlineOutput[StringView::kInlineSize * kReplacementSize];
+    const auto analysis = value.isInline()
+        ? analyzeInlineString(value, inlineOutput)
+        : analyzeString(value, runs);
+    maxStringLength = std::max<uint64_t>(maxStringLength, analysis.outputSize);
+    if (!StringView::isInline(analysis.outputSize)) {
+      totalStringBytes += analysis.outputSize;
+    }
+    if (analysis.runCount > 0) {
+      if (analysis.replacementOnly && outputValues &&
+          analysis.outputSize <= replacementCapacity) {
+        outputValues[row] = StringView(replacementData, analysis.outputSize);
+      } else {
+        writeChanged(row, value, analysis, runs, inlineOutput);
+      }
+    } else {
+      if (outputValues) {
+        outputValues[row] = value;
+      }
+      if (!value.isInline()) {
+        unchangedStringBytes += value.size();
+      }
+    }
+  };
+  if (selected) {
+    selected->applyToSelected(
+        [&](vector_size_t row) { probe(row, flatValues[row]); });
+  } else if (flat && !childNulls && !outerNulls) {
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      probe(row, flatValues[row]);
+    }
+  } else {
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      if (isNull(row)) {
+        ++nullCount;
+        if (outputValues) {
+          outputValues[row] = StringView();
+        }
+      } else {
+        probe(row, valueAt(row));
+      }
+    }
+  }
+  if (!result) {
     return nullptr;
   }
-
-  // A fully malformed row materializes as a prefix of the same repeated
-  // replacement sequence. When every row has this shape, build the sequence
-  // once instead of allocating and filling one copy per row.
-  if (plainFlatNoNulls && malformed.size() == numRows) {
-    const auto* sourceValues =
-        child->asUnchecked<FlatVector<StringView>>()->rawValues();
-    bool allReplacementOnly = true;
-    bool uniformReplacementCount = true;
-    const auto firstReplacementCount = malformed.front().replacements;
-    for (vector_size_t row = 0; row < numRows; ++row) {
-      const auto& run = malformed[row];
-      if (run.row != row || run.offset != 0 ||
-          run.size != sourceValues[row].size()) {
-        allReplacementOnly = false;
-        break;
-      }
-      uniformReplacementCount &= run.replacements == firstReplacementCount;
-    }
-
-    if (allReplacementOnly) {
-      return buildReplacementOnlyVector(
-          malformed,
-          numRows,
-          uniformReplacementCount,
-          totalStringBytes,
-          maxStringLength,
-          pool);
-    }
+  if (!selected) {
+    result->setNullCount(nullCount);
+    result->setStringViewStats(
+        StringViewStats{totalStringBytes, maxStringLength});
+  } else if (const auto sourceNullCount = child->getNullCount()) {
+    result->setNullCount(sourceNullCount.value());
   }
-
-  // Retaining the source buffers avoids copying unchanged strings, but can
-  // increase peak memory when most values changed. Share only when doing so
-  // reduces the newly allocated non-inline bytes by at least half.
-  const bool shareUnchangedStrings =
-      totalStringBytes > 0 && changedStringBytes <= totalStringBytes / 2;
-  const auto allocatedStringBytes =
-      shareUnchangedStrings ? changedStringBytes : totalStringBytes;
-
-  const bool hasAnyNull = (nullCount > 0);
-  BufferPtr newNulls;
-  uint64_t* dstNulls = nullptr;
-  if (hasAnyNull) {
-    const auto nBytes = bits::nbytes(numRows);
-    newNulls = AlignedBuffer::allocate<char>(nBytes, pool);
-    dstNulls = newNulls->asMutable<uint64_t>();
-    std::memset(dstNulls, bits::kNotNullByte, newNulls->capacity());
-  }
-
-  BufferPtr newValues = AlignedBuffer::allocate<StringView>(numRows, pool);
-  auto* rnv = newValues->asMutable<StringView>();
-
-  BufferPtr newStrings;
-  char* cur = nullptr;
-  if (allocatedStringBytes > 0) {
-    newStrings = AlignedBuffer::allocate<char>(allocatedStringBytes, pool);
-    newStrings->setSize(allocatedStringBytes);
-    cur = newStrings->asMutable<char>();
-  }
-
-  size_t malformedIndex = 0;
-  auto writeString = [&](vector_size_t row, const char* data, int32_t size) {
-    const auto begin = malformedIndex;
-    int64_t outputSize = size;
-    while (malformedIndex < malformed.size() &&
-           malformed[malformedIndex].row == row) {
-      outputSize += malformed[malformedIndex].replacements * kReplacementSize -
-          malformed[malformedIndex].size;
-      ++malformedIndex;
-    }
-    BOLT_DCHECK_LE(outputSize, kMaxStringSize);
-    const auto outputSize32 = static_cast<int32_t>(outputSize);
-
-    if (StringView::isInline(outputSize32)) {
-      if (begin == malformedIndex) {
-        rnv[row] = StringView(data, size);
-      } else {
-        char inlineData[StringView::kInlineSize];
-        writeFromRuns(data, size, malformed, begin, malformedIndex, inlineData);
-        rnv[row] = StringView(inlineData, outputSize32);
-      }
-      return;
-    }
-
-    if (shareUnchangedStrings && begin == malformedIndex) {
-      rnv[row] = StringView(data, size);
-      return;
-    }
-
-    char* output = cur;
-    if (begin == malformedIndex) {
-      std::memcpy(output, data, size);
-    } else {
-      writeFromRuns(data, size, malformed, begin, malformedIndex, output);
-    }
-    cur += outputSize32;
-    rnv[row] = StringView(output, outputSize32);
-  };
-
-  if (plainFlatNoNulls) {
-    const auto* flat = child->asUnchecked<FlatVector<StringView>>();
-    const StringView* __restrict__ svs = flat->rawValues();
+  // Avoid retaining the whole input for a few unchanged strings in a densely
+  // modified batch. Dictionary bases also retain unreferenced source values.
+  if (!selected && unchangedStringBytes > 0 &&
+      unchangedStringBytes < totalStringBytes - unchangedStringBytes) {
     for (vector_size_t row = 0; row < numRows; ++row) {
-      const StringView& sv = svs[row];
-      writeString(row, sv.data(), static_cast<int32_t>(sv.size()));
-    }
-  } else {
-    PeeledVarchar pv = peelVarchar(*child);
-    for (vector_size_t row = 0; row < numRows; ++row) {
-      if (outerNulls && bits::isBitNull(outerNulls, row)) {
-        if (dstNulls) {
-          bits::setNull(dstNulls, row);
-        }
-        rnv[row] = StringView();
+      if (isNull(row) || outputValues[row].isInline()) {
         continue;
       }
-      bool isN = false;
-      const auto rs = readPeeled(pv, row, isN);
-      if (isN) {
-        if (dstNulls) {
-          bits::setNull(dstNulls, row);
-        }
-        rnv[row] = StringView();
-        continue;
+      const auto value = valueAt(row);
+      if (outputValues[row].data() == value.data()) {
+        auto* output = result->getRawStringBufferWithSpace(value.size());
+        std::memcpy(output, value.data(), value.size());
+        outputValues[row] = StringView(output, value.size());
       }
-      if (dstNulls) {
-        bits::clearNull(dstNulls, row);
-      }
-      writeString(row, rs.data, rs.size);
     }
-  }
-
-  BOLT_DCHECK_EQ(malformedIndex, malformed.size());
-  BOLT_DCHECK_EQ(
-      cur,
-      newStrings ? newStrings->asMutable<char>() + allocatedStringBytes
-                 : nullptr);
-
-  std::vector<BufferPtr> sbs;
-  if (newStrings) {
-    sbs.push_back(std::move(newStrings));
-  }
-  auto result = std::make_shared<FlatVector<StringView>>(
-      pool,
-      VARCHAR(),
-      std::move(newNulls),
-      numRows,
-      std::move(newValues),
-      std::move(sbs),
-      SimpleVectorStats<StringView>{},
-      std::nullopt,
-      nullCount);
-  result->setStringViewStats(
-      StringViewStats{totalStringBytes, maxStringLength});
-  if (shareUnchangedStrings) {
+  } else if (selected || unchangedStringBytes > 0) {
     result->acquireSharedStringBuffers(child.get());
   }
   return result;
 }
 
-// Sanitizes a single-layer DICTIONARY over a FLAT VARCHAR without decoding
-// the same base value once per logical row. Only referenced, logically
-// non-null base rows are scanned. When replacement is needed, the original
-// indices and nulls are retained and unchanged StringViews keep sharing the
-// source FlatVector's string buffers.
+// Analyze each referenced base value once and reuse the flat materializer.
 std::optional<VectorPtr> buildSanitizedDictionary(
     const VectorPtr& child,
     vector_size_t numRows,
@@ -904,127 +772,33 @@ std::optional<VectorPtr> buildSanitizedDictionary(
   if (child->encoding() != VectorEncoding::Simple::DICTIONARY) {
     return std::nullopt;
   }
-
   const auto* dictionary = child->asUnchecked<DictionaryVector<StringView>>();
   const auto& base = dictionary->valueVector();
-  if (base->encoding() != VectorEncoding::Simple::FLAT) {
+  if (!base->isFlatEncoding() || base->size() > numRows / 2) {
     return std::nullopt;
   }
-
-  const auto baseSize = base->size();
-  if (baseSize == 0 || numRows == 0) {
-    return VectorPtr{};
-  }
-  // Preserving the dictionary requires a bitmap and, when replacement is
-  // needed, a StringView array sized to the full base. Fall back to the
-  // logical-row path unless the base is known to be substantially reused.
-  if (baseSize > numRows / 2) {
-    return std::nullopt;
-  }
-
-  SelectivityVector referenced(baseSize, false);
-  const auto* rawIndices = dictionary->indices()->as<vector_size_t>();
-  for (vector_size_t row = 0; row < numRows; ++row) {
-    if ((outerNulls && bits::isBitNull(outerNulls, row)) ||
-        dictionary->isNullAt(row)) {
-      continue;
+  SelectivityVector referenced(base->size(), false);
+  const auto* indices = dictionary->indices()->as<vector_size_t>();
+  if (!outerNulls && !dictionary->mayHaveNulls()) {
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      referenced.setValid(indices[row], true);
     }
-    referenced.setValid(rawIndices[row], true);
+  } else {
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      if ((!outerNulls || !bits::isBitNull(outerNulls, row)) &&
+          !dictionary->isNullAt(row)) {
+        referenced.setValid(indices[row], true);
+      }
+    }
   }
   referenced.updateBounds();
-  if (!referenced.hasSelections()) {
+  auto sanitized =
+      buildSanitizedFlat(base, base->size(), nullptr, pool, &referenced);
+  if (!sanitized) {
     return VectorPtr{};
   }
-
-  const auto* flat = base->asUnchecked<FlatVector<StringView>>();
-  const auto* sourceValues = flat->rawValues();
-  MalformedRuns malformed{memory::StlAllocator<MalformedRun>(pool)};
-  size_t changedStringBytes = 0;
-  referenced.applyToSelected([&](vector_size_t baseRow) {
-    const auto& value = sourceValues[baseRow];
-    const auto begin = malformed.size();
-    const auto outputSize = scanUtf8(
-        baseRow, value.data(), static_cast<int32_t>(value.size()), malformed);
-    if (malformed.size() != begin && !StringView::isInline(outputSize)) {
-      changedStringBytes += static_cast<size_t>(outputSize);
-    }
-  });
-
-  if (malformed.empty()) {
-    return VectorPtr{};
-  }
-
-  auto newValues = AlignedBuffer::allocate<StringView>(baseSize, pool);
-  auto* outputValues = newValues->asMutable<StringView>();
-  std::memcpy(outputValues, sourceValues, baseSize * sizeof(StringView));
-
-  BufferPtr newStrings;
-  char* currentString = nullptr;
-  if (changedStringBytes > 0) {
-    newStrings = AlignedBuffer::allocate<char>(changedStringBytes, pool);
-    newStrings->setSize(changedStringBytes);
-    currentString = newStrings->asMutable<char>();
-  }
-
-  size_t malformedIndex = 0;
-  while (malformedIndex < malformed.size()) {
-    const auto baseRow = malformed[malformedIndex].row;
-    const auto& source = sourceValues[baseRow];
-    const auto begin = malformedIndex;
-    int64_t outputSize = source.size();
-    while (malformedIndex < malformed.size() &&
-           malformed[malformedIndex].row == baseRow) {
-      outputSize += malformed[malformedIndex].replacements * kReplacementSize -
-          malformed[malformedIndex].size;
-      ++malformedIndex;
-    }
-    BOLT_DCHECK_LE(outputSize, kMaxStringSize);
-    const auto outputSize32 = static_cast<int32_t>(outputSize);
-    if (StringView::isInline(outputSize32)) {
-      char inlineData[StringView::kInlineSize];
-      writeFromRuns(
-          source.data(),
-          source.size(),
-          malformed,
-          begin,
-          malformedIndex,
-          inlineData);
-      outputValues[baseRow] = StringView(inlineData, outputSize32);
-    } else {
-      writeFromRuns(
-          source.data(),
-          source.size(),
-          malformed,
-          begin,
-          malformedIndex,
-          currentString);
-      outputValues[baseRow] = StringView(currentString, outputSize32);
-      currentString += outputSize32;
-    }
-  }
-
-  BOLT_DCHECK_EQ(
-      currentString,
-      newStrings ? newStrings->asMutable<char>() + changedStringBytes
-                 : nullptr);
-  std::vector<BufferPtr> stringBuffers;
-  if (newStrings) {
-    stringBuffers.push_back(std::move(newStrings));
-  }
-  auto sanitizedBase = std::make_shared<FlatVector<StringView>>(
-      pool,
-      base->type(),
-      base->nulls(),
-      baseSize,
-      std::move(newValues),
-      std::move(stringBuffers),
-      SimpleVectorStats<StringView>{},
-      std::nullopt,
-      base->getNullCount());
-  sanitizedBase->acquireSharedStringBuffers(base.get());
-
   return BaseVector::wrapInDictionary(
-      child->nulls(), dictionary->indices(), numRows, std::move(sanitizedBase));
+      child->nulls(), dictionary->indices(), numRows, std::move(sanitized));
 }
 
 } // namespace

--- a/bolt/vector/Utf8Utils.cpp
+++ b/bolt/vector/Utf8Utils.cpp
@@ -1038,10 +1038,13 @@ RowVectorPtr replaceInvalidUtf8InTopLevelVarchars(
   const uint64_t* outerRaw = outerNulls ? outerNulls->as<uint64_t>() : nullptr;
 
   for (auto c = 0; c < input->childrenSize(); ++c) {
-    const auto& child = input->childAt(c);
-    if (!child || child->typeKind() != TypeKind::VARCHAR) {
+    const auto& source = input->childAt(c);
+    if (!source || source->typeKind() != TypeKind::VARCHAR) {
       continue;
     }
+    // LazyVector is not a SimpleVector; inspect its loaded values instead.
+    const auto& child =
+        source->isLazy() ? BaseVector::loadedVectorShared(source) : source;
     if (child->encoding() == VectorEncoding::Simple::CONSTANT) {
       continue;
     }

--- a/bolt/vector/Utf8Utils.h
+++ b/bolt/vector/Utf8Utils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bolt/vector/ComplexVector.h"
+
+namespace bytedance::bolt::utf8 {
+
+/// Replaces malformed UTF-8 in top-level VARCHAR children using OpenJDK's
+/// malformed-input grouping. Top-level CONSTANT vectors, VARBINARY and nested
+/// VARCHAR values are left unchanged. Returns 'input' when no replacement is
+/// needed and never mutates the input vector.
+RowVectorPtr replaceInvalidUtf8InTopLevelVarchars(
+    const RowVectorPtr& input,
+    memory::MemoryPool* pool);
+
+} // namespace bytedance::bolt::utf8

--- a/bolt/vector/tests/CMakeLists.txt
+++ b/bolt/vector/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(
   VectorToStringTest.cpp
   SimpleVectorTest.cpp
   ToStringUtilityTest.cpp
+  Utf8UtilsTest.cpp
   BiasVectorTest.cpp
   VariantVectorTest.cpp
 )

--- a/bolt/vector/tests/SimpleVectorTest.cpp
+++ b/bolt/vector/tests/SimpleVectorTest.cpp
@@ -324,6 +324,28 @@ TEST_F(SimpleVectorNonParameterizedTest, isAscii) {
   }
 }
 
+TEST_F(SimpleVectorNonParameterizedTest, isAsciiAllRows) {
+  for (auto encoding : kAsciiEncodings) {
+    auto vector = maker_.encodedVector(encoding, stringData_);
+
+    EXPECT_FALSE(vector->isAscii().has_value());
+
+    SelectivityVector subset(stringData_.size(), false);
+    subset.setValidRange(1, stringData_.size(), true);
+    subset.updateBounds();
+    vector->setIsAscii(true, subset);
+    EXPECT_FALSE(vector->isAscii().has_value());
+
+    vector->setAllIsAscii(true);
+    ASSERT_TRUE(vector->isAscii().has_value());
+    EXPECT_TRUE(vector->isAscii().value());
+
+    vector->setAllIsAscii(false);
+    ASSERT_TRUE(vector->isAscii().has_value());
+    EXPECT_FALSE(vector->isAscii().value());
+  }
+}
+
 TEST_F(SimpleVectorNonParameterizedTest, isAsciiIndex) {
   for (auto encoding : kAsciiEncodings) {
     LOG(INFO) << "Running:" << encoding;

--- a/bolt/vector/tests/Utf8UtilsTest.cpp
+++ b/bolt/vector/tests/Utf8UtilsTest.cpp
@@ -45,6 +45,14 @@ class Utf8UtilsTest : public testing::Test, public VectorTestBase {
 
 TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
   const std::string replacement{"\xEF\xBF\xBD", 3};
+  auto replacementRun = [&](int32_t count) {
+    std::string result;
+    result.reserve(count * replacement.size());
+    for (int32_t index = 0; index < count; ++index) {
+      result.append(replacement);
+    }
+    return result;
+  };
   const std::vector<std::pair<std::string, std::string>> cases = {
       {{"\xD5\xE8\xD6\xC6\xEC", 5},
        replacement + replacement + replacement + replacement + replacement},
@@ -62,6 +70,8 @@ TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
       {{"\xF4\x90\x80\x80", 4},
        replacement + replacement + replacement + replacement},
       {{"\x9C\xA9", 2}, replacement + replacement},
+      {std::string(63, '\xD5') + std::string("\xD5\x80", 2),
+       replacementRun(63) + std::string("\xD5\x80", 2)},
   };
 
   std::vector<std::string> inputs;
@@ -95,6 +105,27 @@ TEST_F(Utf8UtilsTest, leavesValidInputsByteIdentical) {
   auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
 
   EXPECT_EQ(input.get(), output.get());
+}
+
+TEST_F(Utf8UtilsTest, denseMalformedInputUsesRowBoundedScratchMemory) {
+  constexpr vector_size_t kNumRows = 10'000;
+  constexpr int32_t kBytesPerRow = 64;
+  constexpr int64_t kMaxAdditionalBytes = 6L << 20;
+
+  auto densePool = rootPool_->addLeafChild("denseMalformedUtf8");
+  VectorMaker maker(densePool.get());
+  auto values = maker.flatVector<std::string>(kNumRows, [](vector_size_t) {
+    return std::string(kBytesPerRow, '\xD5');
+  });
+  auto input = maker.rowVector({values});
+  const auto bytesBefore = densePool->currentBytes();
+
+  auto output =
+      utf8::replaceInvalidUtf8InTopLevelVarchars(input, densePool.get());
+
+  ASSERT_NE(input.get(), output.get());
+  output->validate({});
+  EXPECT_LT(densePool->peakBytes() - bytesBefore, kMaxAdditionalBytes);
 }
 
 TEST_F(Utf8UtilsTest, trustsKnownAsciiMetadata) {

--- a/bolt/vector/tests/Utf8UtilsTest.cpp
+++ b/bolt/vector/tests/Utf8UtilsTest.cpp
@@ -41,18 +41,20 @@ class Utf8UtilsTest : public testing::Test, public VectorTestBase {
     DecodedVector decoded(*vector);
     return decoded.valueAt<StringView>(row).str();
   }
-};
 
-TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
-  const std::string replacement{"\xEF\xBF\xBD", 3};
-  auto replacementRun = [&](int32_t count) {
+  static std::string replacementRun(int32_t count) {
+    const std::string replacement{"\xEF\xBF\xBD", 3};
     std::string result;
     result.reserve(count * replacement.size());
     for (int32_t index = 0; index < count; ++index) {
       result.append(replacement);
     }
     return result;
-  };
+  }
+};
+
+TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
+  const std::string replacement{"\xEF\xBF\xBD", 3};
   const std::vector<std::pair<std::string, std::string>> cases = {
       {{"\xD5\xE8\xD6\xC6\xEC", 5},
        replacement + replacement + replacement + replacement + replacement},
@@ -70,6 +72,14 @@ TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
       {{"\xF4\x90\x80\x80", 4},
        replacement + replacement + replacement + replacement},
       {{"\x9C\xA9", 2}, replacement + replacement},
+      {{"\x20\x02\x0F\x00\x01\x00\x00\x00\x9C\xA9\x06\x60\x00\x00"
+        "\x00\x00\x02\x00\x00\x00\x05\x00\x00\x00\x01\x00\x00\x00",
+        28},
+       std::string(
+           "\x20\x02\x0F\x00\x01\x00\x00\x00\xEF\xBF\xBD\xEF\xBF"
+           "\xBD\x06\x60\x00\x00\x00\x00\x02\x00\x00\x00\x05\x00"
+           "\x00\x00\x01\x00\x00\x00",
+           32)},
       {std::string(63, '\xD5') + std::string("\xD5\x80", 2),
        replacementRun(63) + std::string("\xD5\x80", 2)},
       {{"\xE4\xB8\xAD\xE4\xB8\xD5\xE4\xB8\xAD", 9},
@@ -117,6 +127,41 @@ TEST_F(Utf8UtilsTest, leavesValidInputsByteIdentical) {
   EXPECT_EQ(input.get(), output.get());
 }
 
+TEST_F(Utf8UtilsTest, fallsBackAfterThreeByteFastValidation) {
+  std::string valid;
+  for (int32_t index = 0; index < 20; ++index) {
+    valid.append("\xE4\xB8\xAD", 3);
+  }
+  std::vector<std::string> inputs(10, valid);
+  inputs[8] = valid + std::string("\xD5", 1);
+  inputs[9] = valid + std::string("\xF0\x9F\x98\x80", 4);
+
+  auto input = makeRowVector({makeFlatVector<std::string>(inputs)});
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  EXPECT_EQ(
+      valid + std::string("\xEF\xBF\xBD", 3),
+      decodedStringAt(output->childAt(0), 8));
+  EXPECT_EQ(inputs[9], decodedStringAt(output->childAt(0), 9));
+}
+
+TEST_F(Utf8UtilsTest, fallsBackAfterDenseLeadFastScan) {
+  constexpr int32_t kMalformedBytes = 64;
+  std::vector<std::string> inputs(10, std::string(kMalformedBytes, '\xD5'));
+  inputs[8] = std::string(63, '\xD5') + std::string("\xD5\x80", 2);
+
+  auto input = makeRowVector({makeFlatVector<std::string>(inputs)});
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  EXPECT_EQ(
+      replacementRun(63) + std::string("\xD5\x80", 2),
+      decodedStringAt(output->childAt(0), 8));
+  EXPECT_EQ(
+      replacementRun(kMalformedBytes), decodedStringAt(output->childAt(0), 9));
+}
+
 TEST_F(Utf8UtilsTest, denseMalformedInputUsesRowBoundedScratchMemory) {
   constexpr vector_size_t kNumRows = 10'000;
   constexpr int32_t kBytesPerRow = 64;
@@ -136,6 +181,72 @@ TEST_F(Utf8UtilsTest, denseMalformedInputUsesRowBoundedScratchMemory) {
   ASSERT_NE(input.get(), output.get());
   output->validate({});
   EXPECT_LT(densePool->peakBytes() - bytesBefore, kMaxAdditionalBytes);
+}
+
+TEST_F(Utf8UtilsTest, sharesUniformReplacementOnlyOutputBuffer) {
+  constexpr vector_size_t kNumRows = 100;
+  constexpr int32_t kBytesPerRow = 65;
+  const auto expected = replacementRun(kBytesPerRow);
+
+  auto input = makeRowVector({makeFlatVector<std::string>(
+      std::vector<std::string>(kNumRows, std::string(kBytesPerRow, '\xD5')))});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  ASSERT_EQ(VectorEncoding::Simple::FLAT, output->childAt(0)->encoding());
+  auto* outputValues =
+      output->childAt(0)->asUnchecked<FlatVector<StringView>>();
+  EXPECT_EQ(outputValues->valueAt(0).data(), outputValues->valueAt(1).data());
+  EXPECT_EQ(
+      outputValues->valueAt(0).data(),
+      outputValues->valueAt(kNumRows - 1).data());
+  input.reset();
+  output->validate({});
+  EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(expected, decodedStringAt(output->childAt(0), kNumRows - 1));
+}
+
+TEST_F(Utf8UtilsTest, sharesReplacementOnlyOutputBuffer) {
+  auto values = makeFlatVector<std::string>(
+      {std::string(64, '\xD5'),
+       std::string(64, '\xF5'),
+       std::string(63, '\xD5')});
+  auto input = makeRowVector({values});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  ASSERT_EQ(VectorEncoding::Simple::FLAT, output->childAt(0)->encoding());
+  auto* outputValues =
+      output->childAt(0)->asUnchecked<FlatVector<StringView>>();
+  EXPECT_EQ(outputValues->valueAt(0).data(), outputValues->valueAt(1).data());
+  EXPECT_EQ(outputValues->valueAt(0).data(), outputValues->valueAt(2).data());
+  EXPECT_NE(outputValues->valueAt(0).size(), outputValues->valueAt(2).size());
+  input.reset();
+  values.reset();
+  output->validate({});
+  EXPECT_EQ(replacementRun(64), decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(replacementRun(64), decodedStringAt(output->childAt(0), 1));
+  EXPECT_EQ(replacementRun(63), decodedStringAt(output->childAt(0), 2));
+}
+
+TEST_F(Utf8UtilsTest, keepsVaryingInlineReplacementOnlyOutputInline) {
+  auto input = makeRowVector({makeFlatVector<std::string>(
+      {std::string(1, '\xD5'),
+       std::string(2, '\xD5'),
+       std::string(3, '\xD5')})});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  ASSERT_EQ(VectorEncoding::Simple::FLAT, output->childAt(0)->encoding());
+  auto* outputValues =
+      output->childAt(0)->asUnchecked<FlatVector<StringView>>();
+  EXPECT_TRUE(outputValues->stringBuffers().empty());
+  EXPECT_EQ(replacementRun(1), decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(replacementRun(2), decodedStringAt(output->childAt(0), 1));
+  EXPECT_EQ(replacementRun(3), decodedStringAt(output->childAt(0), 2));
 }
 
 TEST_F(Utf8UtilsTest, trustsKnownAsciiMetadata) {
@@ -183,6 +294,35 @@ TEST_F(Utf8UtilsTest, preservesDictionaryEncodingWhenReplacing) {
   EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 0));
   EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 1));
   EXPECT_EQ(invalid, decodedStringAt(outputDictionary->valueVector(), 2));
+}
+
+TEST_F(Utf8UtilsTest, sharesUnchangedFlatStringsWhenReplacementIsSparse) {
+  constexpr vector_size_t kNumRows = 100;
+  const std::string valid(64, 'v');
+  std::string invalid = valid;
+  invalid[32] = '\xD5';
+  const std::string expected =
+      valid.substr(0, 32) + std::string("\xEF\xBF\xBD", 3) + valid.substr(33);
+
+  std::vector<std::string> inputs(kNumRows, valid);
+  inputs[0] = invalid;
+  auto values = makeFlatVector<std::string>(inputs);
+  const auto unchangedValue =
+      values->asUnchecked<FlatVector<StringView>>()->valueAt(1);
+  const auto* unchangedData = unchangedValue.data();
+  auto input = makeRowVector({values});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  auto* outputValues =
+      output->childAt(0)->asUnchecked<FlatVector<StringView>>();
+  EXPECT_EQ(unchangedData, outputValues->valueAt(1).data());
+  input.reset();
+  values.reset();
+  output->validate({});
+  EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 1));
 }
 
 TEST_F(Utf8UtilsTest, handlesSequenceAndDictionaryNulls) {

--- a/bolt/vector/tests/Utf8UtilsTest.cpp
+++ b/bolt/vector/tests/Utf8UtilsTest.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/vector/Utf8Utils.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "bolt/vector/ConstantVector.h"
+#include "bolt/vector/DecodedVector.h"
+#include "bolt/vector/tests/utils/VectorTestBase.h"
+#include "gtest/gtest.h"
+
+namespace bytedance::bolt::test {
+namespace {
+
+class Utf8UtilsTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  static std::string decodedStringAt(
+      const VectorPtr& vector,
+      vector_size_t row) {
+    DecodedVector decoded(*vector);
+    return decoded.valueAt<StringView>(row).str();
+  }
+};
+
+TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+  const std::vector<std::pair<std::string, std::string>> cases = {
+      {{"\xD5\xE8\xD6\xC6\xEC", 5},
+       replacement + replacement + replacement + replacement + replacement},
+      {{"\xE2\x28\xA1", 3}, replacement + "(" + replacement},
+      {{"\xF0\x9F\x92", 3}, replacement},
+      {{"\xED\xA0\x80", 3}, replacement},
+      {{"\xC0\x80", 2}, replacement + replacement},
+      {{"\xE0\x80\x80", 3}, replacement + replacement + replacement},
+      {{"\xF5\x80\x80\x80", 4},
+       replacement + replacement + replacement + replacement},
+      {{"A\xE2\x28\xA1Z", 5}, "A" + replacement + "(" + replacement + "Z"},
+      {{"\xE2\x82\x41", 3}, replacement + "A"},
+      {{"\xF0\x9F\x41", 3}, replacement + "A"},
+      {{"\xF0\x9F\x92\x41", 4}, replacement + "A"},
+      {{"\xF4\x90\x80\x80", 4},
+       replacement + replacement + replacement + replacement},
+      {{"\x9C\xA9", 2}, replacement + replacement},
+  };
+
+  std::vector<std::string> inputs;
+  std::vector<std::string> expectedOutputs;
+  for (const auto& [inputValue, expectedValue] : cases) {
+    inputs.push_back(inputValue);
+    expectedOutputs.push_back(expectedValue);
+  }
+
+  auto values = makeFlatVector<std::string>(inputs);
+  auto input = makeRowVector({values});
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  for (auto row = 0; row < cases.size(); ++row) {
+    EXPECT_EQ(expectedOutputs[row], decodedStringAt(output->childAt(0), row));
+    EXPECT_EQ(inputs[row], decodedStringAt(values, row));
+  }
+}
+
+TEST_F(Utf8UtilsTest, leavesValidInputsByteIdentical) {
+  const std::vector<std::string> inputs = {
+      "Spark ASCII",
+      {"\xC2\xA2", 2},
+      {"Spark \xE4\xB8\xAD \xF0\x9F\x98\x80", 14},
+      {"\xE0\xA0\x80", 3},
+      {"\xF4\x8F\xBF\xBF", 4},
+  };
+
+  auto input = makeRowVector({makeFlatVector<std::string>(inputs)});
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  EXPECT_EQ(input.get(), output.get());
+}
+
+TEST_F(Utf8UtilsTest, trustsKnownAsciiMetadata) {
+  const std::string invalid{"\xD5", 1};
+  auto values = makeFlatVector<std::string>({invalid});
+  values->as<SimpleVector<StringView>>()->setAllIsAscii(true);
+  auto input = makeRowVector({values});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  EXPECT_EQ(input.get(), output.get());
+  EXPECT_EQ(invalid, decodedStringAt(output->childAt(0), 0));
+}
+
+TEST_F(Utf8UtilsTest, ignoresUnreferencedInvalidDictionaryValues) {
+  const std::string valid(64, 'v');
+  const std::string invalid{"\xD5", 1};
+  auto dictionary = wrapInDictionary(
+      makeIndices({0, 0, 0}),
+      makeFlatVector<std::string>({valid, invalid}, VARCHAR()));
+  auto input = makeRowVector({dictionary});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  EXPECT_EQ(input.get(), output.get());
+}
+
+TEST_F(Utf8UtilsTest, preservesDictionaryEncodingWhenReplacing) {
+  const std::string valid(64, 'v');
+  const std::string invalid{"\xD5", 1};
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+  auto base = makeFlatVector<std::string>({valid, invalid, invalid}, VARCHAR());
+  auto indices = makeIndices({1, 0, 1, 0, 1, 0});
+  auto dictionary = wrapInDictionary(indices, base);
+  auto input = makeRowVector({dictionary});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  ASSERT_EQ(VectorEncoding::Simple::DICTIONARY, output->childAt(0)->encoding());
+  auto* outputDictionary =
+      output->childAt(0)->asUnchecked<DictionaryVector<StringView>>();
+  EXPECT_EQ(indices.get(), outputDictionary->indices().get());
+  EXPECT_EQ(dictionary->nulls().get(), outputDictionary->nulls().get());
+  EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 1));
+  EXPECT_EQ(invalid, decodedStringAt(outputDictionary->valueVector(), 2));
+}
+
+TEST_F(Utf8UtilsTest, handlesSequenceAndDictionaryNulls) {
+  const std::string invalid{"\xD5", 1};
+  const std::string valid(64, 'v');
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+  auto sequence = vectorMaker_.sequenceVector<StringView>(
+      {StringView(invalid), StringView(invalid), StringView(valid)});
+
+  auto indices = makeIndices({0, 1, 0});
+  auto nulls = makeNulls(3, [](vector_size_t row) { return row != 1; });
+  auto nullMaskedDictionary = BaseVector::wrapInDictionary(
+      nulls,
+      indices,
+      3,
+      makeFlatVector<std::string>({invalid, valid}, VARCHAR()));
+  auto input = makeRowVector({sequence, nullMaskedDictionary});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  EXPECT_EQ(VectorEncoding::Simple::FLAT, output->childAt(0)->encoding());
+  EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 1));
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 2));
+  EXPECT_EQ(nullMaskedDictionary.get(), output->childAt(1).get());
+  EXPECT_TRUE(output->childAt(1)->isNullAt(0));
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(1), 1));
+  EXPECT_TRUE(output->childAt(1)->isNullAt(2));
+}
+
+TEST_F(Utf8UtilsTest, skipsConstantVectors) {
+  std::string invalid(64, 'v');
+  invalid[32] = '\xD5';
+  auto constant = makeConstant<StringView>(StringView(invalid), 3);
+  auto input = makeRowVector({constant});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  EXPECT_EQ(input.get(), output.get());
+  EXPECT_EQ(constant.get(), output->childAt(0).get());
+  EXPECT_EQ(invalid, decodedStringAt(constant, 0));
+}
+
+TEST_F(Utf8UtilsTest, replacesOnlyTopLevelVarcharsAcrossEncodings) {
+  const std::string invalid{"\xD5", 1};
+  const std::string valid(64, 'v');
+  const std::string replacement{"\xEF\xBF\xBD", 3};
+
+  auto flat = makeNullableFlatVector<std::string>(
+      {invalid, valid, std::nullopt}, VARCHAR());
+  auto constant = makeConstant<StringView>(StringView(invalid), 3);
+  auto dictionary = wrapInDictionary(
+      makeIndices({1, 0, 2}),
+      makeNullableFlatVector<std::string>(
+          {valid, invalid, std::nullopt}, VARCHAR()));
+  auto binary =
+      makeFlatVector<std::string>({invalid, invalid, invalid}, VARBINARY());
+  auto nested = makeArrayVector<std::string>({{invalid}, {invalid}, {invalid}});
+  auto unchangedVarchar = makeFlatVector<std::string>({valid, valid, valid});
+  auto input = makeRowVector(
+      {flat, constant, dictionary, unchangedVarchar, binary, nested},
+      [](auto row) { return row == 2; });
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  output->validate({});
+  EXPECT_EQ(replacement, decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 1));
+  EXPECT_TRUE(output->childAt(0)->isNullAt(2));
+  EXPECT_EQ(constant.get(), output->childAt(1).get());
+  EXPECT_EQ(invalid, decodedStringAt(output->childAt(1), 0));
+  EXPECT_EQ(replacement, decodedStringAt(output->childAt(2), 0));
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(2), 1));
+  EXPECT_TRUE(output->childAt(2)->isNullAt(2));
+
+  EXPECT_EQ(input->nulls().get(), output->nulls().get());
+  EXPECT_TRUE(output->isNullAt(2));
+  EXPECT_EQ(unchangedVarchar.get(), output->childAt(3).get());
+  EXPECT_EQ(binary.get(), output->childAt(4).get());
+  EXPECT_EQ(nested.get(), output->childAt(5).get());
+  EXPECT_EQ(invalid, decodedStringAt(output->childAt(4), 0));
+  EXPECT_EQ(
+      invalid,
+      output->childAt(5)
+          ->as<ArrayVector>()
+          ->elements()
+          ->as<FlatVector<StringView>>()
+          ->valueAt(0)
+          .str());
+  EXPECT_EQ(invalid, decodedStringAt(flat, 0));
+  EXPECT_EQ(invalid, decodedStringAt(constant, 0));
+  EXPECT_EQ(invalid, decodedStringAt(dictionary, 0));
+}
+
+} // namespace
+} // namespace bytedance::bolt::test

--- a/bolt/vector/tests/Utf8UtilsTest.cpp
+++ b/bolt/vector/tests/Utf8UtilsTest.cpp
@@ -72,6 +72,9 @@ TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
       {{"\x9C\xA9", 2}, replacement + replacement},
       {std::string(63, '\xD5') + std::string("\xD5\x80", 2),
        replacementRun(63) + std::string("\xD5\x80", 2)},
+      {{"\xE4\xB8\xAD\xE4\xB8\xD5\xE4\xB8\xAD", 9},
+       std::string("\xE4\xB8\xAD", 3) + replacement + replacement +
+           std::string("\xE4\xB8\xAD", 3)},
   };
 
   std::vector<std::string> inputs;
@@ -93,12 +96,19 @@ TEST_F(Utf8UtilsTest, replacesInvalidSequencesWithOpenJdkGrouping) {
 }
 
 TEST_F(Utf8UtilsTest, leavesValidInputsByteIdentical) {
+  std::string longThreeByte;
+  for (int32_t index = 0; index < 20; ++index) {
+    longThreeByte.append("\xE4\xB8\xAD", 3);
+  }
+  longThreeByte.append("tail");
+
   const std::vector<std::string> inputs = {
       "Spark ASCII",
       {"\xC2\xA2", 2},
       {"Spark \xE4\xB8\xAD \xF0\x9F\x98\x80", 14},
       {"\xE0\xA0\x80", 3},
       {"\xF4\x8F\xBF\xBF", 4},
+      longThreeByte,
   };
 
   auto input = makeRowVector({makeFlatVector<std::string>(inputs)});

--- a/bolt/vector/tests/Utf8UtilsTest.cpp
+++ b/bolt/vector/tests/Utf8UtilsTest.cpp
@@ -183,6 +183,122 @@ TEST_F(Utf8UtilsTest, denseMalformedInputUsesRowBoundedScratchMemory) {
   EXPECT_LT(densePool->peakBytes() - bytesBefore, kMaxAdditionalBytes);
 }
 
+TEST_F(Utf8UtilsTest, fragmentedMalformedInputUsesBoundedScratchMemory) {
+  constexpr vector_size_t kNumRows = 10'000;
+  std::string value;
+  std::string expected;
+  for (int32_t i = 0; i < 32; ++i) {
+    value.append(
+        "\xD5"
+        "a",
+        2);
+    expected.append(
+        "\xEF\xBF\xBD"
+        "a",
+        4);
+  }
+
+  for (bool dictionary : {false, true}) {
+    SCOPED_TRACE(dictionary);
+    auto boundedPool = rootPool_->addLeafChild("fragmentedUtf8");
+    VectorMaker maker(boundedPool.get());
+    VectorPtr values = maker.flatVector<std::string>(
+        kNumRows, [&](vector_size_t) { return value; });
+    if (dictionary) {
+      auto indices = AlignedBuffer::allocate<vector_size_t>(
+          2 * kNumRows, boundedPool.get());
+      auto* rawIndices = indices->asMutable<vector_size_t>();
+      for (vector_size_t row = 0; row < 2 * kNumRows; ++row) {
+        rawIndices[row] = row % kNumRows;
+      }
+      values =
+          BaseVector::wrapInDictionary(nullptr, indices, 2 * kNumRows, values);
+    }
+    auto input = maker.rowVector({values});
+    const auto bytesBefore = boundedPool->currentBytes();
+
+    auto output =
+        utf8::replaceInvalidUtf8InTopLevelVarchars(input, boundedPool.get());
+
+    output->validate({});
+    EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
+    EXPECT_EQ(
+        expected, decodedStringAt(output->childAt(0), output->size() - 1));
+    EXPECT_LT(boundedPool->peakBytes() - bytesBefore, 4L << 20);
+  }
+}
+
+TEST_F(Utf8UtilsTest, longMixedMalformedStringsPreserveGroupingAndLifetime) {
+  const auto replacement = replacementRun(1);
+  const std::vector<std::pair<std::string, std::string>> fragments = {
+      {"\xD5", replacement},
+      {"\xE2\x82", replacement},
+      {"\xED\xA0\x80", replacement},
+      {"\xF0\x9F\x92", replacement},
+      {"\xE0\x80\x80", replacementRun(3)},
+      {"\xC2\xA2", "\xC2\xA2"},
+      {"\xE4\xB8\xAD", "\xE4\xB8\xAD"},
+      {"\xF0\x9F\x99\x82", "\xF0\x9F\x99\x82"},
+  };
+  std::vector<std::string> inputs;
+  std::vector<std::string> expected;
+  for (int32_t row = 0; row < 128; ++row) {
+    inputs.emplace_back(row, 'p');
+    expected.emplace_back(row, 'p');
+    for (int32_t part = 0; part < 512 + row; ++part) {
+      const auto& fragment = fragments[(part * 5 + row) % fragments.size()];
+      inputs.back().append(fragment.first).append("a");
+      expected.back().append(fragment.second).append("a");
+    }
+  }
+  auto input = makeRowVector({makeFlatVector<std::string>(inputs)});
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+  input.reset();
+  output->validate({});
+  for (vector_size_t row = 0; row < expected.size(); ++row) {
+    EXPECT_EQ(expected[row], decodedStringAt(output->childAt(0), row)) << row;
+  }
+}
+
+TEST_F(Utf8UtilsTest, sharesReplacementOnlyStringsWithNulls) {
+  constexpr vector_size_t kNumRows = 10'000;
+  auto boundedPool = rootPool_->addLeafChild("nullableMalformedUtf8");
+  VectorMaker maker(boundedPool.get());
+  auto values = maker.flatVector<std::string>(
+      kNumRows, [](vector_size_t) { return std::string(64, '\xD5'); });
+  values->setNull(0, true);
+  auto input = maker.rowVector({values});
+  const auto bytesBefore = boundedPool->currentBytes();
+
+  auto output =
+      utf8::replaceInvalidUtf8InTopLevelVarchars(input, boundedPool.get());
+
+  output->validate({});
+  EXPECT_TRUE(output->childAt(0)->isNullAt(0));
+  EXPECT_EQ(replacementRun(64), decodedStringAt(output->childAt(0), 1));
+  EXPECT_LT(boundedPool->peakBytes() - bytesBefore, 1L << 20);
+}
+
+TEST_F(Utf8UtilsTest, growingReplacementOnlyStringsUseBoundedMemory) {
+  constexpr vector_size_t kNumRows = 512;
+  auto boundedPool = rootPool_->addLeafChild("growingMalformedUtf8");
+  VectorMaker maker(boundedPool.get());
+  auto input = maker.rowVector(
+      {maker.flatVector<std::string>(kNumRows, [](vector_size_t row) {
+        return std::string(64 + row, '\xD5');
+      })});
+  const auto bytesBefore = boundedPool->currentBytes();
+  auto output =
+      utf8::replaceInvalidUtf8InTopLevelVarchars(input, boundedPool.get());
+  EXPECT_LT(boundedPool->peakBytes() - bytesBefore, 64L << 10);
+  input.reset();
+  output->validate({});
+  for (vector_size_t row = 0; row < kNumRows; ++row) {
+    EXPECT_EQ(
+        replacementRun(64 + row), decodedStringAt(output->childAt(0), row));
+  }
+}
+
 TEST_F(Utf8UtilsTest, sharesUniformReplacementOnlyOutputBuffer) {
   constexpr vector_size_t kNumRows = 100;
   constexpr int32_t kBytesPerRow = 65;
@@ -323,6 +439,21 @@ TEST_F(Utf8UtilsTest, sharesUnchangedFlatStringsWhenReplacementIsSparse) {
   output->validate({});
   EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
   EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 1));
+}
+
+TEST_F(Utf8UtilsTest, releasesSourceBuffersWhenReplacementIsDense) {
+  const std::string valid(64, 'v');
+  std::vector<std::string> inputs(100, std::string(64, '\xD5'));
+  inputs.back() = valid;
+  auto input = makeRowVector({makeFlatVector<std::string>(inputs)});
+  auto sourceBuffer =
+      input->childAt(0)->as<FlatVector<StringView>>()->stringBuffers().front();
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+  input.reset();
+  EXPECT_EQ(1, sourceBuffer->refCount());
+  output->validate({});
+  EXPECT_EQ(valid, decodedStringAt(output->childAt(0), 99));
+  EXPECT_EQ(replacementRun(64), decodedStringAt(output->childAt(0), 0));
 }
 
 TEST_F(Utf8UtilsTest, handlesSequenceAndDictionaryNulls) {

--- a/bolt/vector/tests/Utf8UtilsTest.cpp
+++ b/bolt/vector/tests/Utf8UtilsTest.cpp
@@ -367,6 +367,33 @@ TEST_F(Utf8UtilsTest, skipsConstantVectors) {
   EXPECT_EQ(invalid, decodedStringAt(constant, 0));
 }
 
+TEST_F(Utf8UtilsTest, replacesLazyVarchars) {
+  const std::string invalid = std::string(32, 'v') + "\xD5";
+  const std::string expected = std::string(32, 'v') + "\xEF\xBF\xBD";
+  auto values =
+      makeNullableFlatVector<std::string>({invalid, "valid", std::nullopt});
+  auto lazy = std::make_shared<LazyVector>(
+      pool(),
+      VARCHAR(),
+      values->size(),
+      std::make_unique<SimpleVectorLoader>([&](RowSet) { return values; }));
+  auto input = makeRowVector({lazy});
+
+  auto output = utf8::replaceInvalidUtf8InTopLevelVarchars(input, pool());
+
+  ASSERT_NE(input.get(), output.get());
+  EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
+  EXPECT_EQ("valid", decodedStringAt(output->childAt(0), 1));
+  EXPECT_TRUE(output->childAt(0)->isNullAt(2));
+  EXPECT_EQ(lazy.get(), input->childAt(0).get());
+  EXPECT_EQ(invalid, decodedStringAt(values, 0));
+  input.reset();
+  lazy.reset();
+  values.reset();
+  output->validate({});
+  EXPECT_EQ(expected, decodedStringAt(output->childAt(0), 0));
+}
+
 TEST_F(Utf8UtilsTest, replacesOnlyTopLevelVarcharsAcrossEncodings) {
   const std::string invalid{"\xD5", 1};
   const std::string valid(64, 'v');


### PR DESCRIPTION
### What problem does this PR solve?
Spark replaces malformed UTF-8 with `U+FFFD` when a Spark string is materialized as a Java string and written through the Hive SerDe path.

The native Hive/Parquet writer previously preserved malformed bytes in `VARCHAR` values. This caused output differences between Spark and Spark-on-Bolt for Hive SerDe Parquet writes containing malformed UTF-8.

This PR adds Spark-compatible malformed UTF-8 replacement at the Hive Parquet writer boundary without changing native `CAST(BINARY AS STRING)` semantics.

Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR enables malformed UTF-8 replacement when all of the following conditions are met:

- The target format is Parquet.
- The Hive SerDe parameter
  `spark.gluten.sql.native.writer.hive.parquet.serde` is set to `true`.
- The value is stored in a top-level `VARCHAR` column.

The SerDe parameter value is matched case-insensitively.

Malformed input is replaced using OpenJDK-compatible maximal malformed-subpart grouping. Each malformed subpart produces one UTF-8 encoded `U+FFFD` replacement.

The implementation:

- Sanitizes the data-only `RowVector` after partition columns are removed.
- Sanitizes each input batch before partition or bucket slicing, avoiding repeated scans of the same source column.
- Preserves row-null behavior when partitioned input is sliced.
- Supports flat, dictionary, and sequence-encoded `VARCHAR` vectors.
- Preserves dictionary encoding and shared string buffers where possible.
- Returns the original vector when no replacement is required.
- Allocates one exactly sized output string buffer when replacement is required.
- Uses SIMD for ASCII detection and dense malformed-byte scanning.
- Coalesces adjacent malformed units to avoid per-byte scratch allocations.
- Processes consecutive ordinary three-byte UTF-8 characters in a tight loop.

The following values are intentionally unchanged:

- `VARBINARY` columns.
- Nested `VARCHAR` values.
- Top-level constant vectors.
- Other output formats, including DWRF.
- Native `CAST(BINARY AS STRING)` results.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [x] **Negative Impact**: Explained below (e.g., trade-off for correctness).
```text
| Scenario | Baseline | Sanitization Enabled | Latency Increase |
|---|---:|---:|---:|
| ASCII, 64 B | 383.48 ns/row | 400.76 ns/row | +4.5% |
| Valid non-ASCII, 64 B | 162.61 ns/row | 207.52 ns/row | +27.6% |
| 1% sparse invalid, 64 B | 379.89 ns/row | 455.05 ns/row | +19.8% |
| Complex invalid, 64 B | 158.88 ns/row | 260.31 ns/row | +63.8% |
| Fully invalid, 64 B | 58.58 ns/row | 290.90 ns/row | +396.6% |
| Inline output | 45.34 ns/row | 95.91 ns/row | +111.5% |
| Inline to non-inline | 47.14 ns/row | 96.67 ns/row | +105.1% |
| Valid dictionary | 80.27 ns/row | 84.93 ns/row | +5.8% |
| Sparse-invalid dictionary | 85.81 ns/row | 95.30 ns/row | +11.1% |
```


### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- feat(parquet): replace invalid UTF-8 in top-level varchars on write
- perf: optimize dense malformed UTF-8 replacement
- perf: accelerate valid three-byte UTF-8 runs
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
