### PR TITLE
feat(parquet): allow disabling implicit casts of parquet reader in Spark

### DIFF
--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -234,6 +234,7 @@ HiveDataSource::HiveDataSource(
   }
 
   recalculateRepDefConf(readerOutputType_, queryConfig);
+  parquetReaderImplicitCastMask_ = queryConfig.parquetReaderImplicitCastMask();
   parquetMaxBatchBytes_ =
       static_cast<int64_t>(queryConfig.preferredOutputBatchBytes());
   ioStats_ = std::make_shared<io::IoStatistics>();
@@ -382,6 +383,8 @@ std::unique_ptr<SplitReader> HiveDataSource::createConfiguredSplitReader(
       decodeRepDefPageCount_);
   splitReader->rowReaderOptions().setParquetRepDefMemoryLimit(
       parquetRepDefMemoryLimit_);
+  splitReader->rowReaderOptions().setParquetReaderImplicitCastMask(
+      parquetReaderImplicitCastMask_);
   splitReader->rowReaderOptions().setMaxBatchBytes(parquetMaxBatchBytes_);
 
   TRY_WITH_IGNORE(

--- a/bolt/connectors/hive/HiveDataSource.h
+++ b/bolt/connectors/hive/HiveDataSource.h
@@ -237,6 +237,7 @@ class HiveDataSource : public DataSource {
 
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
   int32_t decodeRepDefPageCount_{10};
+  int64_t parquetReaderImplicitCastMask_{0};
   int64_t parquetMaxBatchBytes_{0};
 };
 

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -623,6 +623,9 @@ class QueryConfig {
   static constexpr const char* kParquetRepDefMemoryLimit =
       "parquet_repdef_memory_limit";
 
+  static constexpr const char* kParquetReaderImplicitCastMask =
+      "parquet_reader_implicit_cast_mask";
+
   static constexpr const char* kHybridJoinEnabled = "hybrid_join_enabled";
 
   /// If true, reorder rows by containerId during hybrid join extraction for
@@ -1720,6 +1723,10 @@ class QueryConfig {
 
   int32_t parquetRepDefMemoryLimit() const {
     return get<int32_t>(kParquetRepDefMemoryLimit, 128UL << 20);
+  }
+
+  int64_t parquetReaderImplicitCastMask() const {
+    return get<int64_t>(kParquetReaderImplicitCastMask, 0);
   }
 
   bool enableDynamicConcurrencyAdjustment() const {

--- a/bolt/core/tests/QueryConfigTest.cpp
+++ b/bolt/core/tests/QueryConfigTest.cpp
@@ -49,6 +49,14 @@ TEST_F(QueryConfigTest, emptyConfig) {
   ASSERT_FALSE(config.isLegacyCast());
 }
 
+TEST_F(QueryConfigTest, parquetReaderImplicitCastMask) {
+  QueryConfig defaultConfig{{}};
+  EXPECT_EQ(defaultConfig.parquetReaderImplicitCastMask(), 0);
+
+  QueryConfig configured{{{QueryConfig::kParquetReaderImplicitCastMask, "-1"}}};
+  EXPECT_EQ(configured.parquetReaderImplicitCastMask(), -1);
+}
+
 TEST_F(QueryConfigTest, setConfig) {
   std::string path = "/tmp/setConfig";
   std::unordered_map<std::string, std::string> configData(

--- a/bolt/dwio/common/Options.h
+++ b/bolt/dwio/common/Options.h
@@ -122,6 +122,13 @@ struct RowNumberColumnInfo {
   std::string name;
 };
 
+enum class ParquetReaderImplicitCastMask : int64_t {
+  kNone = 0,
+  kVarcharInteger = 1,
+  kVarcharDate = 1 << 1,
+  kAll = -1,
+};
+
 /**
  * Options for creating a RowReader.
  */
@@ -174,6 +181,7 @@ class RowReaderOptions {
   /// selective queries. Defaults to true.
   bool enableDictionaryFilter_ = false;
   bool disableFloatingPointToVarcharMetadataFilter_{false};
+  int64_t parquetReaderImplicitCastMask_{0};
 
   int32_t decodeRepDefPageCount_{10};
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
@@ -484,6 +492,14 @@ class RowReaderOptions {
     return disableFloatingPointToVarcharMetadataFilter_;
   }
 
+  void setParquetReaderImplicitCastMask(int64_t parquetReaderImplicitCastMask) {
+    parquetReaderImplicitCastMask_ = parquetReaderImplicitCastMask;
+  }
+
+  int64_t parquetReaderImplicitCastMask() const {
+    return parquetReaderImplicitCastMask_;
+  }
+
   void setDecodeRepDefPageCount(int32_t pageCount) {
     decodeRepDefPageCount_ = pageCount;
   }
@@ -568,6 +584,8 @@ class RowReaderOptions {
     ss << "enableDictionaryFilter_=" << enableDictionaryFilter_ << ", ";
     ss << "disableFloatingPointToVarcharMetadataFilter_="
        << disableFloatingPointToVarcharMetadataFilter_ << ", ";
+    ss << "parquetReaderImplicitCastMask_=" << parquetReaderImplicitCastMask_
+       << ", ";
     ss << "decodeRepDefPageCount_=" << decodeRepDefPageCount_;
     ss << "parquetRepDefMemoryLimit_=" << parquetRepDefMemoryLimit_ << ", ";
     ss << "maxBatchBytes_=" << maxBatchBytes_ << ", ";

--- a/bolt/dwio/common/tests/OptionsTests.cpp
+++ b/bolt/dwio/common/tests/OptionsTests.cpp
@@ -79,6 +79,24 @@ TEST(OptionsTests, testRowNumberColumnInfoInCopy) {
   ASSERT_EQ(rowNumberColumnInfo.name, readBack->name);
 }
 
+TEST(OptionsTests, parquetReaderImplicitCastMask) {
+  using CastMask = ParquetReaderImplicitCastMask;
+  EXPECT_EQ(static_cast<int64_t>(CastMask::kNone), 0);
+  EXPECT_EQ(static_cast<int64_t>(CastMask::kVarcharInteger), 1);
+  EXPECT_EQ(static_cast<int64_t>(CastMask::kVarcharDate), 2);
+  EXPECT_EQ(static_cast<int64_t>(CastMask::kAll), -1);
+
+  RowReaderOptions options;
+  EXPECT_EQ(options.parquetReaderImplicitCastMask(), 0);
+
+  constexpr int64_t kCastMask = static_cast<int64_t>(CastMask::kVarcharInteger);
+  options.setParquetReaderImplicitCastMask(kCastMask);
+  EXPECT_EQ(options.parquetReaderImplicitCastMask(), kCastMask);
+
+  RowReaderOptions optionsCopy{options};
+  EXPECT_EQ(optionsCopy.parquetReaderImplicitCastMask(), kCastMask);
+}
+
 TEST_F(WriterOptionsSerDeTest, writerOptionsSerializeDeserializeRoundTrip) {
   WriterOptions opts;
 

--- a/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -110,6 +110,46 @@ bool matchType(TypeKind schemaType, TypeKind requestType) {
   return true;
 }
 
+bool isIntegerType(const Type& type) {
+  return type.equivalent(*TINYINT()) || type.equivalent(*SMALLINT()) ||
+      type.equivalent(*INTEGER()) || type.equivalent(*BIGINT()) ||
+      type.equivalent(*HUGEINT());
+}
+
+bool maskSparkImplicitCast(
+    const Type& fileType,
+    const Type& requestedType,
+    int64_t castMask) {
+  using CastMask = dwio::common::ParquetReaderImplicitCastMask;
+  if (!fileType.isPrimitiveType() || !requestedType.isPrimitiveType()) {
+    return false;
+  }
+  if (fileType.equivalent(requestedType) ||
+      castMask == static_cast<int64_t>(CastMask::kNone)) {
+    return false;
+  }
+  if (castMask == static_cast<int64_t>(CastMask::kAll)) {
+    return true;
+  }
+  const auto varcharIntegerMask =
+      static_cast<int64_t>(CastMask::kVarcharInteger);
+  const auto varcharDateMask = static_cast<int64_t>(CastMask::kVarcharDate);
+  const auto fileKind = fileType.kind();
+  const auto requestedKind = requestedType.kind();
+
+  // varchar <-> integer
+  const bool blockVarcharInteger = (castMask & varcharIntegerMask) != 0 &&
+      ((fileKind == TypeKind::VARCHAR && isIntegerType(requestedType)) ||
+       (isIntegerType(fileType) && requestedKind == TypeKind::VARCHAR));
+
+  // varchar <-> date
+  const bool blockVarcharDate = (castMask & varcharDateMask) != 0 &&
+      ((fileKind == TypeKind::VARCHAR && requestedType.isDate()) ||
+       (fileType.isDate() && requestedKind == TypeKind::VARCHAR));
+
+  return blockVarcharInteger || blockVarcharDate;
+}
+
 // static
 std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     const dwio::common::ColumnReaderOptions& columnReaderOptions,
@@ -126,7 +166,17 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
       fileType->childByName("value")->type()->isVarbinary() &&
       fileType->childByName("metadata")->type()->isVarbinary();
 
-  if (!::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
+    BOLT_CHECK(
+        canReadVariantStructAsVariant ||
+            !maskSparkImplicitCast(
+                *fileType->type(),
+                *requestedType->type(),
+                params.parquetReaderImplicitCastMask),
+        "file schema type {} can not convert to ddl type {}",
+        mapTypeKindToName(fileType->type()->kind()),
+        mapTypeKindToName(requestedType->type()->kind()));
+  } else {
     BOLT_CHECK(
         canReadVariantStructAsVariant ||
             matchType(fileType->type()->kind(), requestedType->type()->kind()),

--- a/bolt/dwio/parquet/reader/ParquetData.h
+++ b/bolt/dwio/parquet/reader/ParquetData.h
@@ -63,8 +63,10 @@ class ParquetParams : public dwio::common::FormatParams {
       bool disableFloatingPointToVarcharMetadataFilter,
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
-      int32_t parquetRepDefMemoryLimit)
+      int32_t parquetRepDefMemoryLimit,
+      int64_t parquetReaderImplicitCastMask = 0)
       : FormatParams(pool, stats),
+        parquetReaderImplicitCastMask(parquetReaderImplicitCastMask),
         metaData_(metaData),
         timestampPrecision_(timestampPrecision),
         fileDecryptor_(fileDecryptor),
@@ -75,6 +77,9 @@ class ParquetParams : public dwio::common::FormatParams {
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
         parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {}
+
+  // ParquetReaderImplicitCastMask selecting implicit casts to block.
+  int64_t parquetReaderImplicitCastMask{0};
 
   std::unique_ptr<dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1599,7 +1599,8 @@ class ParquetRowReader::Impl {
         options_.disableFloatingPointToVarcharMetadataFilter(),
         options_.isDictionaryFilterEnabled(),
         options_.getDecodeRepDefPageCount(),
-        options_.getParquetRepDefMemoryLimit());
+        options_.getParquetRepDefMemoryLimit(),
+        options_.parquetReaderImplicitCastMask());
 
     if (auto selector = options_.getSelector()) {
       requestedType_ = selector->getSchema();

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -796,7 +796,7 @@ TEST_F(ParquetReaderTest, parseUnsignedInt4) {
             2000000000000000000ULL,
             3000000000000000000ULL})});
 
-  if (::bytedance::bolt::kSparkCompatible) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
     const std::string sample(getExampleFilePath("uint.parquet"));
     dwio::common::ReaderOptions readerOptions{leafPool_.get()};
     readerOptions.setFileSchema(rowType);
@@ -812,7 +812,7 @@ TEST_F(ParquetReaderTest, parseUnsignedInt4) {
 }
 
 TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
-  if (!::bytedance::bolt::kSparkCompatible) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const std::vector<TypePtr> unsupportedTypes = {
@@ -874,6 +874,87 @@ TEST_F(ParquetReaderTest, parseDate) {
       dateSchema(), *rowReader, expected, *leafPool_);
 }
 
+TEST_F(ParquetReaderTest, dateToVarcharWithVarcharIntegerCastBlocked) {
+  functions::prestosql::registerAllScalarFunctions();
+
+  const std::string sample(getExampleFilePath("date.parquet"));
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+
+  auto readSchema = ROW({"date"}, {VARCHAR()});
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), leafPool_.get());
+  auto scanSpec = std::make_shared<ScanSpec>("");
+  scanSpec->setExpressionEvaluator(&evaluator);
+  scanSpec->addAllChildFields(*readSchema);
+
+  auto rowReaderOpts = getReaderOpts(readSchema);
+  rowReaderOpts.setScanSpec(scanSpec);
+  auto createRowReader = [&]() {
+    return createReader(sample, readerOptions)->createRowReader(rowReaderOpts);
+  };
+
+  if (::bytedance::bolt::kSparkCompatible) {
+    using CastMask = dwio::common::ParquetReaderImplicitCastMask;
+    rowReaderOpts.setParquetReaderImplicitCastMask(
+        static_cast<int64_t>(CastMask::kVarcharInteger));
+    EXPECT_NO_THROW(createRowReader());
+    rowReaderOpts.setParquetReaderImplicitCastMask(
+        static_cast<int64_t>(CastMask::kVarcharDate));
+    EXPECT_THROW(createRowReader(), BoltRuntimeError);
+    rowReaderOpts.setParquetReaderImplicitCastMask(
+        static_cast<int64_t>(CastMask::kAll));
+    EXPECT_THROW(createRowReader(), BoltRuntimeError);
+  }
+
+  rowReaderOpts.setParquetReaderImplicitCastMask(static_cast<int64_t>(
+      dwio::common::ParquetReaderImplicitCastMask::kVarcharInteger));
+  auto rowReader = createRowReader();
+
+  VectorPtr result = BaseVector::create(readSchema, 0, leafPool_.get());
+  ASSERT_EQ(rowReader->next(25, result), 25);
+  auto dates = loadedFlatChildAt<StringView>(result->as<RowVector>(), 0);
+  ASSERT_NE(dates, nullptr);
+  // DATE is stored as epoch days and this reader cast preserves the raw value.
+  EXPECT_EQ(dates->valueAt(0), "-5");
+  EXPECT_EQ(dates->valueAt(5), "0");
+  EXPECT_EQ(dates->valueAt(24), "19");
+}
+
+TEST_F(ParquetReaderTest, varcharToDateWithVarcharDateCastBlocked) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    return;
+  }
+
+  auto data = makeRowVector(
+      {makeFlatVector<StringView>({"1969-12-27", "1970-01-01", "1970-01-20"})});
+  auto file = writeTempParquet({data});
+
+  auto readSchema = ROW({"c0"}, {DATE()});
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), leafPool_.get());
+  auto scanSpec = std::make_shared<ScanSpec>("");
+  scanSpec->setExpressionEvaluator(&evaluator);
+  scanSpec->addAllChildFields(*readSchema);
+  auto rowReaderOpts = getReaderOpts(readSchema);
+  rowReaderOpts.setScanSpec(scanSpec);
+  auto createRowReader = [&]() {
+    return createReader(file->getPath(), readerOptions)
+        ->createRowReader(rowReaderOpts);
+  };
+
+  using CastMask = dwio::common::ParquetReaderImplicitCastMask;
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(CastMask::kVarcharInteger));
+  EXPECT_NO_THROW(createRowReader());
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(CastMask::kVarcharDate));
+  EXPECT_THROW(createRowReader(), BoltRuntimeError);
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(CastMask::kAll));
+  EXPECT_THROW(createRowReader(), BoltRuntimeError);
+}
+
 TEST_F(ParquetReaderTest, parseRowMapArray) {
   // sample.parquet holds one row of type (ROW(BIGINT c0, MAP(VARCHAR,
   // ARRAY(INTEGER)) c1) c)
@@ -924,6 +1005,56 @@ TEST_F(ParquetReaderTest, projectNoColumns) {
   ASSERT_TRUE(rowReader->next(kBatchSize, result));
   EXPECT_EQ(result->size(), 10);
   ASSERT_FALSE(rowReader->next(kBatchSize, result));
+}
+
+TEST_F(ParquetReaderTest, projectNoColumnsWithAllImplicitCastsBlocked) {
+  // A count(*) projection doesn't read any columns and therefore doesn't need
+  // any implicit casts, even when all of them are blocked.
+  auto rowType = ROW({}, {});
+  bytedance::bolt::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  auto reader = createReader(getExampleFilePath("sample.parquet"), readerOpts);
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(dwio::common::ParquetReaderImplicitCastMask::kAll));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto result = BaseVector::create(rowType, 1, leafPool_.get());
+  constexpr int kBatchSize = 100;
+  ASSERT_TRUE(rowReader->next(kBatchSize, result));
+  EXPECT_EQ(result->size(), 10);
+  ASSERT_TRUE(rowReader->next(kBatchSize, result));
+  EXPECT_EQ(result->size(), 10);
+  ASSERT_FALSE(rowReader->next(kBatchSize, result));
+}
+
+TEST_F(ParquetReaderTest, projectStructSubsetWithAllImplicitCastsBlocked) {
+  auto nested = makeRowVector(
+      {"a", "b", "c"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<StringView>({"x", "y", "z"}),
+       makeFlatVector<double>({1.5, 2.5, 3.5})});
+  auto data = makeRowVector(
+      {"id", "nested"}, {makeFlatVector<int32_t>({10, 20, 30}), nested});
+  auto file = writeTempParquet({data});
+
+  // Scan the nested struct, but project only a subset of its children.
+  auto projectedType = ROW({"nested"}, {ROW({"a", "c"}, {BIGINT(), DOUBLE()})});
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  auto reader = createReader(file->getPath(), readerOptions);
+  auto rowReaderOpts = getReaderOpts(projectedType);
+  rowReaderOpts.setScanSpec(makeScanSpec(projectedType));
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(dwio::common::ParquetReaderImplicitCastMask::kAll));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  auto expected = makeRowVector(
+      {"nested"},
+      {makeRowVector(
+          {"a", "c"},
+          {makeFlatVector<int64_t>({1, 2, 3}),
+           makeFlatVector<double>({1.5, 2.5, 3.5})})});
+  assertReadWithReaderAndExpected(
+      projectedType, *rowReader, expected, *leafPool_);
 }
 
 TEST_F(ParquetReaderTest, producesLazyVectorsForProjectedColumns) {
@@ -2768,6 +2899,18 @@ TEST_F(ParquetReaderTest, integerToVarcharSchemaMismatchCast) {
   auto rowReaderOpts = getReaderOpts(readSchema);
   rowReaderOpts.setScanSpec(scanSpec);
 
+  if (::bytedance::bolt::kSparkCompatible) {
+    using CastMask = dwio::common::ParquetReaderImplicitCastMask;
+    rowReaderOpts.setParquetReaderImplicitCastMask(
+        static_cast<int64_t>(CastMask::kVarcharInteger));
+    EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
+    rowReaderOpts.setParquetReaderImplicitCastMask(
+        static_cast<int64_t>(CastMask::kAll));
+    EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
+    rowReaderOpts.setParquetReaderImplicitCastMask(
+        static_cast<int64_t>(CastMask::kNone));
+  }
+
   // IntegerColumnReader's constructor calls makeCastExpr(), which
   // accesses scanSpec_->getExpressionEvaluator() on a child ScanSpec.
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -2827,11 +2970,21 @@ TEST_F(ParquetReaderTest, varcharToBigintSchemaMismatchCast) {
   auto rowReaderOpts = getReaderOpts(readSchema);
   rowReaderOpts.setScanSpec(scanSpec);
 
-  // In non-SPARK builds this is rejected by ParquetColumnReader::matchType.
   if (!::bytedance::bolt::kSparkCompatible) {
     EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
     return;
   }
+
+  // Spark allows this implicit cast by default, but callers can opt out.
+  using CastMask = dwio::common::ParquetReaderImplicitCastMask;
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(CastMask::kVarcharInteger));
+  EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(CastMask::kAll));
+  EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
+  rowReaderOpts.setParquetReaderImplicitCastMask(
+      static_cast<int64_t>(CastMask::kNone));
 
   // In SPARK-compatible builds, schema mismatch is allowed and cast is applied.
   auto rowReader = reader->createRowReader(rowReaderOpts);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
