### PR TITLE
perf(arrow): add reusable Arrow batch pool

### DIFF
--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -73,18 +73,10 @@ void appendArrowMetadataInt32(std::string& metadata, int32_t value) {
 class BoltToArrowBridgeHolder {
  public:
   struct ReusableReleaseState {
-    struct Entry {
-      ArrowArray* array;
-      BoltToArrowBridgeHolder* holder;
-    };
-
-    // Child nodes stay at stable addresses, but consumers may move the root
-    // ArrowArray before releasing it. Keep the stable tree here for flat reset.
-    std::vector<Entry> entries;
-
-    void add(ArrowArray& array, BoltToArrowBridgeHolder& holder) {
-      entries.push_back({&array, &holder});
-    }
+    // Child nodes stay at stable addresses, but consumers may move an
+    // ArrowArray before releasing it. Keep the stable tree here for reuse.
+    std::atomic_size_t activeCount{0};
+    std::atomic_bool inUse{false};
   };
 
   explicit BoltToArrowBridgeHolder(bool reusable = false)
@@ -120,17 +112,41 @@ class BoltToArrowBridgeHolder {
     return ownsReleaseState_;
   }
 
-  void markActive(ArrowArray& array) {
+  bool tryAcquireReusableSlot() {
+    BOLT_CHECK(reusable_);
+    BOLT_CHECK(ownsReleaseState_);
+    bool expected = false;
+    return releaseState_->inUse.compare_exchange_strong(
+        expected, true, std::memory_order_acq_rel, std::memory_order_acquire);
+  }
+
+  size_t reusableActiveCount() const {
+    return releaseState_ == nullptr
+        ? 0
+        : releaseState_->activeCount.load(std::memory_order_acquire);
+  }
+
+  void registerArray(ArrowArray& array) {
     if (!releaseState_) {
       return;
     }
     array.private_data = this;
     if (registeredArray_ == nullptr) {
       registeredArray_ = &array;
-      releaseState_->add(array, *this);
       return;
     }
     BOLT_CHECK(registeredArray_ == &array);
+  }
+
+  void markActive(ArrowArray& array) {
+    if (!releaseState_) {
+      return;
+    }
+    registerArray(array);
+    if (!active_) {
+      active_ = true;
+      releaseState_->activeCount.fetch_add(1, std::memory_order_relaxed);
+    }
   }
 
   void reset() {
@@ -189,27 +205,34 @@ class BoltToArrowBridgeHolder {
       return;
     }
     BOLT_CHECK(ownsReleaseState_);
-    bool registeredArray = false;
-    for (auto [entryArray, holder] : releaseState_->entries) {
-      registeredArray |= entryArray == &releasedArray;
-      holder->resetLocalBuffers();
-      resetArrowArray(*entryArray, holder->getArrowBuffers());
-    }
-    if (!registeredArray) {
-      resetArrowArray(releasedArray, nullptr);
-      releasedArray.private_data = nullptr;
-    }
+    resetReusableRecursive(releasedArray);
   }
 
   void resetReusableChild(ArrowArray& releasedArray) {
     BOLT_CHECK(reusable_);
     BOLT_CHECK(!ownsReleaseState_);
-    resetLocalBuffers();
-    resetArrowArray(releasedArray, getArrowBuffers());
+    resetReusableRecursive(releasedArray);
+  }
+
+  void abortReusableArray(ArrowArray& releasedArray) {
+    if (!releaseState_) {
+      return;
+    }
+    resetRecursive();
+    active_ = false;
+    releaseState_->activeCount.store(0, std::memory_order_release);
+    if (registeredArray_ != &releasedArray) {
+      resetArrowArray(releasedArray, nullptr);
+      releasedArray.private_data = nullptr;
+    }
   }
 
   void releaseResources() {
     resetRecursive();
+    if (releaseState_) {
+      releaseState_->activeCount.store(0, std::memory_order_release);
+      releaseState_->inUse.store(false, std::memory_order_release);
+    }
     for (auto& child : childrenPtrs_) {
       if (!child) {
         continue;
@@ -306,8 +329,8 @@ class BoltToArrowBridgeHolder {
     if (reusable_) {
       for (size_t i = oldSize; i < numChildren; ++i) {
         childrenPtrs_[i] = std::make_unique<ArrowArray>();
-        childrenPtrs_[i]->private_data =
-            new BoltToArrowBridgeHolder(/*reusable=*/true, releaseState_);
+        childrenPtrs_[i]->private_data = new BoltToArrowBridgeHolder(
+            /*reusable=*/true, releaseState_);
       }
     }
     children_ = (numChildren > 0)
@@ -327,8 +350,8 @@ class BoltToArrowBridgeHolder {
     if (!childrenPtrs_[i]) {
       childrenPtrs_[i] = std::make_unique<ArrowArray>();
       if (reusable_) {
-        childrenPtrs_[i]->private_data =
-            new BoltToArrowBridgeHolder(/*reusable=*/true, releaseState_);
+        childrenPtrs_[i]->private_data = new BoltToArrowBridgeHolder(
+            /*reusable=*/true, releaseState_);
       }
       children_[i] = childrenPtrs_[i].get();
     }
@@ -344,14 +367,54 @@ class BoltToArrowBridgeHolder {
     if (!dictionary_) {
       dictionary_ = std::make_unique<ArrowArray>();
       if (reusable_) {
-        dictionary_->private_data =
-            new BoltToArrowBridgeHolder(/*reusable=*/true, releaseState_);
+        dictionary_->private_data = new BoltToArrowBridgeHolder(
+            /*reusable=*/true, releaseState_);
       }
     }
     return dictionary_.get();
   }
 
  private:
+  void resetReusableRecursive(ArrowArray& releasedArray) {
+    for (int64_t i = 0; i < releasedArray.n_children; ++i) {
+      auto* child = releasedArray.children[i];
+      if (child != nullptr && child->release != nullptr) {
+        child->release(child);
+        BOLT_CHECK_NULL(child->release);
+      }
+    }
+
+    auto* dictionary = releasedArray.dictionary;
+    if (dictionary != nullptr && dictionary->release != nullptr) {
+      dictionary->release(dictionary);
+      BOLT_CHECK_NULL(dictionary->release);
+    }
+
+    resetReusableNode(releasedArray);
+  }
+
+  void resetReusableNode(ArrowArray& releasedArray) {
+    if (active_) {
+      resetLocalBuffers();
+      active_ = false;
+      const auto previousActiveCount =
+          releaseState_->activeCount.fetch_sub(1, std::memory_order_acq_rel);
+      BOLT_CHECK_GT(previousActiveCount, 0);
+      if (previousActiveCount == 1) {
+        releaseState_->inUse.store(false, std::memory_order_release);
+      }
+    }
+
+    if (registeredArray_ != nullptr) {
+      resetArrowArray(*registeredArray_, getArrowBuffers());
+      registeredArray_->private_data = this;
+    }
+    if (registeredArray_ != &releasedArray) {
+      resetArrowArray(releasedArray, nullptr);
+      releasedArray.private_data = nullptr;
+    }
+  }
+
   // Holds the count of total buffers
   size_t numBuffers_ = kMaxBuffers;
 
@@ -377,6 +440,7 @@ class BoltToArrowBridgeHolder {
   const bool ownsReleaseState_;
   std::shared_ptr<ReusableReleaseState> releaseState_;
   ArrowArray* registeredArray_{nullptr};
+  bool active_{false};
 };
 
 // Structure that will hold buffers needed by ArrowSchema. This is opaquely
@@ -2535,8 +2599,8 @@ void initializeReusableArrowArray(ArrowArray& arrowArray) {
   arrowArray.n_children = 0;
   arrowArray.children = nullptr;
   arrowArray.dictionary = nullptr;
-  holder->markActive(arrowArray);
-  arrowArray.private_data = holder.release();
+  holder->registerArray(arrowArray);
+  holder.release();
 }
 
 void exportToReusableArrowArray(
@@ -2570,7 +2634,7 @@ void exportToReusableArrowArray(
     exportToArrowImpl(
         *vector, Selection(vector->size()), options, arrowArray, pool, true);
   } catch (...) {
-    holder->resetReusableArray(arrowArray);
+    holder->abortReusableArray(arrowArray);
     throw;
   }
 }
@@ -3607,12 +3671,9 @@ class ArraySlot {
       const ArrowOptions& options) {
     // The consumer's array release callback returns this lease. The source
     // ArrowArray may already look released after ownership is moved.
-    bool expected = false;
-    if (!inUse_.compare_exchange_strong(
-            expected,
-            true,
-            std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
+    auto* holder = static_cast<BoltToArrowBridgeHolder*>(array_.private_data);
+    BOLT_CHECK_NOT_NULL(holder);
+    if (!holder->tryAcquireReusableSlot()) {
       return false;
     }
 
@@ -3622,7 +3683,6 @@ class ArraySlot {
     } catch (...) {
       releaseReusableArrowArray(array_);
       initializeReusableArrowArray(array_);
-      inUse_.store(false, std::memory_order_release);
       throw;
     }
   }
@@ -3635,12 +3695,10 @@ class ArraySlot {
     if (array_.release != nullptr) {
       array_.release(&array_);
     }
-    inUse_.store(false, std::memory_order_release);
   }
 
  private:
   ArrowArray array_{};
-  std::atomic_bool inUse_{false};
 };
 
 struct CachedSchema {
@@ -3669,11 +3727,11 @@ class SchemaCache {
       memory::MemoryPool* pool) {
     const auto signature = makeSchemaSignature(vector, options, fieldNames);
     std::lock_guard<std::mutex> lock(mutex_);
-    // The signature covers encoding and options; equivalent() validates the
-    // logical type and protects against hash collisions.
+    // The signature covers encoding and options; operator== validates the
+    // logical type, including RowType field names, and protects against hash
+    // collisions.
     if (schema_ != nullptr && signature_.has_value() &&
-        *signature_ == signature &&
-        schema_->type->equivalent(*vector->type())) {
+        *signature_ == signature && *schema_->type == *vector->type()) {
       return {schema_, false};
     }
 

--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -30,9 +30,12 @@
 
 #include "bolt/vector/arrow/Bridge.h"
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <iostream>
 #include <string_view>
+#include <utility>
 #include "bolt/buffer/Buffer.h"
 #include "bolt/common/base/BitUtil.h"
 #include "bolt/common/base/CheckedArithmetic.h"
@@ -53,6 +56,7 @@ namespace {
 // The supported conversions use one buffer for nulls (0), one for values (1),
 // and one for offsets (2).
 static constexpr size_t kMaxBuffers{3};
+static constexpr size_t kMaxReusableScratchBufferBytes{32UL << 10};
 constexpr const char kArrowExtensionNameKey[] = "ARROW:extension:name";
 constexpr const char kSparkVariantExtensionName[] = "spark.variant";
 
@@ -68,12 +72,176 @@ void appendArrowMetadataInt32(std::string& metadata, int32_t value) {
 // carried by ArrowArray.private_data
 class BoltToArrowBridgeHolder {
  public:
-  BoltToArrowBridgeHolder() {
+  struct ReusableReleaseState {
+    struct Entry {
+      ArrowArray* array;
+      BoltToArrowBridgeHolder* holder;
+    };
+
+    // Child nodes stay at stable addresses, but consumers may move the root
+    // ArrowArray before releasing it. Keep the stable tree here for flat reset.
+    std::vector<Entry> entries;
+
+    void add(ArrowArray& array, BoltToArrowBridgeHolder& holder) {
+      entries.push_back({&array, &holder});
+    }
+  };
+
+  explicit BoltToArrowBridgeHolder(bool reusable = false)
+      : reusable_(reusable),
+        ownsReleaseState_(reusable),
+        releaseState_(
+            reusable ? std::make_shared<ReusableReleaseState>() : nullptr) {
     buffers_.resize(numBuffers_);
     bufferPtrs_.resize(numBuffers_);
     for (size_t i = 0; i < numBuffers_; ++i) {
       buffers_[i] = nullptr;
     }
+  }
+
+  BoltToArrowBridgeHolder(
+      bool reusable,
+      std::shared_ptr<ReusableReleaseState> releaseState)
+      : reusable_(reusable),
+        ownsReleaseState_(false),
+        releaseState_(std::move(releaseState)) {
+    buffers_.resize(numBuffers_);
+    bufferPtrs_.resize(numBuffers_);
+    for (size_t i = 0; i < numBuffers_; ++i) {
+      buffers_[i] = nullptr;
+    }
+  }
+
+  bool reusable() const {
+    return reusable_;
+  }
+
+  bool ownsReleaseState() const {
+    return ownsReleaseState_;
+  }
+
+  void markActive(ArrowArray& array) {
+    if (!releaseState_) {
+      return;
+    }
+    array.private_data = this;
+    if (registeredArray_ == nullptr) {
+      registeredArray_ = &array;
+      releaseState_->add(array, *this);
+      return;
+    }
+    BOLT_CHECK(registeredArray_ == &array);
+  }
+
+  void reset() {
+    if (reusable_) {
+      resetLocalBuffers();
+      return;
+    }
+    resetRecursive();
+  }
+
+  void resetLocalBuffers() {
+    for (size_t i = 0; i < bufferPtrs_.size(); ++i) {
+      bufferPtrs_[i].reset();
+      buffers_[i] = nullptr;
+    }
+    // Arrow offsets contain rows + 1 entries. Allow the final sentinel so an
+    // 8192-row batch fits the 32 KiB retention limit.
+    if (offsetsScratch_ &&
+        offsetsScratch_->size() >
+            kMaxReusableScratchBufferBytes + sizeof(vector_size_t)) {
+      offsetsScratch_.reset();
+    }
+  }
+
+  void resetRecursive() {
+    for (auto& child : childrenPtrs_) {
+      if (child && child->release != nullptr) {
+        child->release(child.get());
+      }
+    }
+    if (dictionary_ && dictionary_->release != nullptr) {
+      dictionary_->release(dictionary_.get());
+    }
+    if (!reusable_) {
+      childrenPtrs_.clear();
+      children_.reset();
+      dictionary_.reset();
+    }
+    resetLocalBuffers();
+  }
+
+  static void resetArrowArray(ArrowArray& array, const void** buffers) {
+    array.buffers = buffers;
+    array.length = 0;
+    array.null_count = 0;
+    array.offset = 0;
+    array.n_buffers = 0;
+    array.n_children = 0;
+    array.children = nullptr;
+    array.dictionary = nullptr;
+    array.release = nullptr;
+  }
+
+  void resetReusableArray(ArrowArray& releasedArray) {
+    if (!releaseState_) {
+      return;
+    }
+    BOLT_CHECK(ownsReleaseState_);
+    bool registeredArray = false;
+    for (auto [entryArray, holder] : releaseState_->entries) {
+      registeredArray |= entryArray == &releasedArray;
+      holder->resetLocalBuffers();
+      resetArrowArray(*entryArray, holder->getArrowBuffers());
+    }
+    if (!registeredArray) {
+      resetArrowArray(releasedArray, nullptr);
+      releasedArray.private_data = nullptr;
+    }
+  }
+
+  void resetReusableChild(ArrowArray& releasedArray) {
+    BOLT_CHECK(reusable_);
+    BOLT_CHECK(!ownsReleaseState_);
+    resetLocalBuffers();
+    resetArrowArray(releasedArray, getArrowBuffers());
+  }
+
+  void releaseResources() {
+    resetRecursive();
+    for (auto& child : childrenPtrs_) {
+      if (!child) {
+        continue;
+      }
+      if (child->release != nullptr) {
+        child->release(child.get());
+      }
+      auto* childHolder =
+          static_cast<BoltToArrowBridgeHolder*>(child->private_data);
+      if (childHolder) {
+        childHolder->releaseResources();
+        delete childHolder;
+        child->private_data = nullptr;
+      }
+      child->release = nullptr;
+    }
+    if (dictionary_) {
+      if (dictionary_->release != nullptr) {
+        dictionary_->release(dictionary_.get());
+      }
+      auto* dictionaryHolder =
+          static_cast<BoltToArrowBridgeHolder*>(dictionary_->private_data);
+      if (dictionaryHolder) {
+        dictionaryHolder->releaseResources();
+        delete dictionaryHolder;
+        dictionary_->private_data = nullptr;
+      }
+      dictionary_->release = nullptr;
+    }
+    childrenPtrs_.clear();
+    children_.reset();
+    dictionary_.reset();
   }
 
   void resizeBuffers(size_t bufferCount) {
@@ -110,19 +278,60 @@ class BoltToArrowBridgeHolder {
     return bufferPtrs_[idx];
   }
 
+  BufferPtr getMutableOffsetsBuffer(size_t bytes, memory::MemoryPool* pool) {
+    if (!reusable_) {
+      return nullptr;
+    }
+    if (offsetsScratch_ && offsetsScratch_->pool() == pool &&
+        offsetsScratch_->isMutable()) {
+      if (offsetsScratch_->capacity() < bytes) {
+        AlignedBuffer::reallocate<uint8_t>(&offsetsScratch_, bytes);
+      } else {
+        offsetsScratch_->setSize(bytes);
+      }
+      return offsetsScratch_;
+    }
+    offsetsScratch_ = AlignedBuffer::allocate<uint8_t>(bytes, pool);
+    return offsetsScratch_;
+  }
+
   // Allocates space for `numChildren` ArrowArray pointers.
   void resizeChildren(size_t numChildren) {
-    childrenPtrs_.resize(numChildren);
+    const auto oldSize = childrenPtrs_.size();
+    // Reusable nodes only grow: registered addresses must remain stable. The
+    // current batch shape is represented by ArrowArray::n_children.
+    if (!reusable_ || oldSize < numChildren) {
+      childrenPtrs_.resize(numChildren);
+    }
+    if (reusable_) {
+      for (size_t i = oldSize; i < numChildren; ++i) {
+        childrenPtrs_[i] = std::make_unique<ArrowArray>();
+        childrenPtrs_[i]->private_data =
+            new BoltToArrowBridgeHolder(/*reusable=*/true, releaseState_);
+      }
+    }
     children_ = (numChildren > 0)
         ? std::make_unique<ArrowArray*[]>(sizeof(ArrowArray*) * numChildren)
         : nullptr;
+    for (size_t i = 0; i < numChildren; ++i) {
+      if (!childrenPtrs_[i]) {
+        childrenPtrs_[i] = std::make_unique<ArrowArray>();
+      }
+      children_[i] = childrenPtrs_[i].get();
+    }
   }
 
   // Allocates and properly acquires buffers for a child ArrowArray structure.
   ArrowArray* allocateChild(size_t i) {
     BOLT_CHECK_LT(i, childrenPtrs_.size());
-    childrenPtrs_[i] = std::make_unique<ArrowArray>();
-    children_[i] = childrenPtrs_[i].get();
+    if (!childrenPtrs_[i]) {
+      childrenPtrs_[i] = std::make_unique<ArrowArray>();
+      if (reusable_) {
+        childrenPtrs_[i]->private_data =
+            new BoltToArrowBridgeHolder(/*reusable=*/true, releaseState_);
+      }
+      children_[i] = childrenPtrs_[i].get();
+    }
     return children_[i];
   }
 
@@ -132,7 +341,13 @@ class BoltToArrowBridgeHolder {
   }
 
   ArrowArray* allocateDictionary() {
-    dictionary_ = std::make_unique<ArrowArray>();
+    if (!dictionary_) {
+      dictionary_ = std::make_unique<ArrowArray>();
+      if (reusable_) {
+        dictionary_->private_data =
+            new BoltToArrowBridgeHolder(/*reusable=*/true, releaseState_);
+      }
+    }
     return dictionary_.get();
   }
 
@@ -147,6 +362,8 @@ class BoltToArrowBridgeHolder {
   // above.
   std::vector<BufferPtr> bufferPtrs_{numBuffers_};
 
+  BufferPtr offsetsScratch_;
+
   // Auxiliary buffers to hold ownership over ArrowArray children structures.
   std::vector<std::unique_ptr<ArrowArray>> childrenPtrs_;
 
@@ -155,6 +372,11 @@ class BoltToArrowBridgeHolder {
   std::unique_ptr<ArrowArray*[]> children_;
 
   std::unique_ptr<ArrowArray> dictionary_;
+
+  const bool reusable_;
+  const bool ownsReleaseState_;
+  std::shared_ptr<ReusableReleaseState> releaseState_;
+  ArrowArray* registeredArray_{nullptr};
 };
 
 // Structure that will hold buffers needed by ArrowSchema. This is opaquely
@@ -224,6 +446,17 @@ static void releaseArrowArray(ArrowArray* arrowArray) {
     return;
   }
 
+  auto* bridgeHolder =
+      static_cast<BoltToArrowBridgeHolder*>(arrowArray->private_data);
+  if (bridgeHolder && bridgeHolder->reusable()) {
+    if (bridgeHolder->ownsReleaseState()) {
+      bridgeHolder->resetReusableArray(*arrowArray);
+    } else {
+      bridgeHolder->resetReusableChild(*arrowArray);
+    }
+    return;
+  }
+
   // Recurse down to release children arrays.
   for (int64_t i = 0; i < arrowArray->n_children; ++i) {
     ArrowArray* child = arrowArray->children[i];
@@ -241,8 +474,6 @@ static void releaseArrowArray(ArrowArray* arrowArray) {
   }
 
   // Destroy the current holder.
-  auto* bridgeHolder =
-      static_cast<BoltToArrowBridgeHolder*>(arrowArray->private_data);
   delete bridgeHolder;
 
   // Finally, mark the array as released.
@@ -1176,7 +1407,8 @@ void exportToArrowImpl(
     const Selection&,
     const ArrowOptions& options,
     ArrowArray&,
-    memory::MemoryPool*);
+    memory::MemoryPool*,
+    bool allowReuse = false);
 
 template <typename T>
 void exportRowsImpl(
@@ -1198,11 +1430,14 @@ void exportRowsImpl(
           rows,
           options,
           *holder.allocateChild(i),
-          pool);
+          pool,
+          holder.reusable());
     } catch (const BoltException&) {
-      for (column_index_t j = 0; j < i; ++j) {
-        // When exception is thrown, i th child is guaranteed unset.
-        out.children[j]->release(out.children[j]);
+      if (!holder.reusable()) {
+        for (column_index_t j = 0; j < i; ++j) {
+          // When exception is thrown, i th child is guaranteed unset.
+          out.children[j]->release(out.children[j]);
+        }
       }
       throw;
     }
@@ -1251,8 +1486,13 @@ void exportOffsets(
     memory::MemoryPool* pool,
     BoltToArrowBridgeHolder& holder,
     Selection& childRows) {
-  auto offsets = AlignedBuffer::allocate<vector_size_t>(
-      checkedPlus<size_t>(out.length, 1), pool);
+  const auto offsetsBytes = checkedMultiply<size_t>(
+      checkedPlus<size_t>(out.length, 1), sizeof(vector_size_t));
+  auto offsets = holder.getMutableOffsetsBuffer(offsetsBytes, pool);
+  if (!offsets) {
+    offsets = AlignedBuffer::allocate<vector_size_t>(
+        checkedPlus<size_t>(out.length, 1), pool);
+  }
   auto rawOffsets = offsets->asMutable<vector_size_t>();
   if (!rows.changed() && !hasNulls(vec, out.length) && isCompact(vec)) {
     auto copiedSize = vec.size() > out.length ? out.length : vec.size();
@@ -1315,8 +1555,13 @@ void exportOffsetsIPC(
     memory::MemoryPool* pool,
     BoltToArrowBridgeHolder& holder,
     Selection& childRows) {
-  auto offsets = AlignedBuffer::allocate<vector_size_t>(
-      checkedPlus<size_t>(out.length, 1), pool);
+  const auto offsetsBytes = checkedMultiply<size_t>(
+      checkedPlus<size_t>(out.length, 1), sizeof(vector_size_t));
+  auto offsets = holder.getMutableOffsetsBuffer(offsetsBytes, pool);
+  if (!offsets) {
+    offsets = AlignedBuffer::allocate<vector_size_t>(
+        checkedPlus<size_t>(out.length, 1), pool);
+  }
   auto rawOffsets = offsets->asMutable<vector_size_t>();
   if (!rows.changed() && !hasNulls(vec, out.length) && isCompact(vec)) {
     const vector_size_t m = out.length;
@@ -1390,7 +1635,8 @@ void exportArrays(
       childRows,
       options,
       *holder.allocateChild(0),
-      pool);
+      pool,
+      holder.reusable());
   out.n_children = 1;
   out.children = holder.getChildrenArrays();
 }
@@ -1416,7 +1662,13 @@ void exportMaps(
   }
 
   holder.resizeChildren(1);
-  exportToArrowImpl(child, childRows, options, *holder.allocateChild(0), pool);
+  exportToArrowImpl(
+      child,
+      childRows,
+      options,
+      *holder.allocateChild(0),
+      pool,
+      holder.reusable());
   out.n_children = 1;
   out.children = holder.getChildrenArrays();
 }
@@ -1597,7 +1849,12 @@ void exportDictionary(
       holder.setBuffer(1, composed);
       out.dictionary = holder.allocateDictionary();
       exportToArrowImpl(
-          *cur, Selection(cur->size()), options, *out.dictionary, pool);
+          *cur,
+          Selection(cur->size()),
+          options,
+          *out.dictionary,
+          pool,
+          holder.reusable());
       return;
     }
   }
@@ -1612,7 +1869,12 @@ void exportDictionary(
   auto& values = *vec.valueVector()->loadedVector();
   out.dictionary = holder.allocateDictionary();
   exportToArrowImpl(
-      values, Selection(values.size()), options, *out.dictionary, pool);
+      values,
+      Selection(values.size()),
+      options,
+      *out.dictionary,
+      pool,
+      holder.reusable());
 }
 
 void exportFlattenedVector(
@@ -1705,7 +1967,8 @@ void exportConstantValue(
     const BaseVector& vec,
     const ArrowOptions& options,
     ArrowArray& out,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    const BoltToArrowBridgeHolder& parentHolder) {
   VectorPtr valuesVector;
   Selection selection(1);
 
@@ -1760,7 +2023,8 @@ void exportConstantValue(
           vec.mayHaveNulls() ? 1 : 0);
     }
   }
-  exportToArrowImpl(*valuesVector, selection, options, out, pool);
+  exportToArrowImpl(
+      *valuesVector, selection, options, out, pool, parentHolder.reusable());
 }
 
 // Bolt constant vectors are exported as Arrow REE containing a single run
@@ -1780,11 +2044,26 @@ void exportConstant(
   out.n_children = 2;
   holder.resizeChildren(2);
   out.children = holder.getChildrenArrays();
-  exportConstantValue(vec, options, *holder.allocateChild(1), pool);
+  exportConstantValue(vec, options, *holder.allocateChild(1), pool, holder);
 
   // Create the run ends child.
   auto* runEnds = holder.allocateChild(0);
-  auto runEndsHolder = std::make_unique<BoltToArrowBridgeHolder>();
+  std::unique_ptr<BoltToArrowBridgeHolder> runEndsHolderOwner;
+  auto* runEndsHolder =
+      static_cast<BoltToArrowBridgeHolder*>(runEnds->private_data);
+  if (holder.reusable()) {
+    BOLT_CHECK_NOT_NULL(runEndsHolder);
+    BOLT_CHECK(runEndsHolder->reusable());
+    if (runEnds->release != nullptr) {
+      runEnds->release(runEnds);
+    } else {
+      runEndsHolder->reset();
+    }
+  } else {
+    runEndsHolderOwner = std::make_unique<BoltToArrowBridgeHolder>();
+    runEndsHolder = runEndsHolderOwner.get();
+  }
+  runEndsHolder->markActive(*runEnds);
 
   runEnds->buffers = runEndsHolder->getArrowBuffers();
   runEnds->length = 1;
@@ -1800,7 +2079,9 @@ void exportConstant(
   runsBuffer->asMutable<int32_t>()[0] = vec.size();
   runEndsHolder->setBuffer(1, runsBuffer);
 
-  runEnds->private_data = runEndsHolder.release();
+  if (runEndsHolderOwner) {
+    runEnds->private_data = runEndsHolderOwner.release();
+  }
   runEnds->release = releaseArrowArray;
 }
 
@@ -1809,8 +2090,19 @@ void exportToArrowImpl(
     const Selection& rows,
     const ArrowOptions& options,
     ArrowArray& out,
-    memory::MemoryPool* pool) {
-  auto holder = std::make_unique<BoltToArrowBridgeHolder>();
+    memory::MemoryPool* pool,
+    bool allowReuse) {
+  BoltToArrowBridgeHolder* holder = nullptr;
+  std::unique_ptr<BoltToArrowBridgeHolder> holderOwner;
+  if (allowReuse && out.private_data != nullptr) {
+    holder = static_cast<BoltToArrowBridgeHolder*>(out.private_data);
+    BOLT_CHECK(holder->reusable());
+    holder->reset();
+  } else {
+    holderOwner = std::make_unique<BoltToArrowBridgeHolder>();
+    holder = holderOwner.get();
+  }
+  holder->markActive(out);
   out.buffers = holder->getArrowBuffers();
   out.length = rows.count();
   out.offset = 0;
@@ -1850,7 +2142,9 @@ void exportToArrowImpl(
     default:
       BOLT_NYI("{} cannot be exported to Arrow yet.", vec.encoding());
   }
-  out.private_data = holder.release();
+  if (holderOwner) {
+    out.private_data = holderOwner.release();
+  }
   out.release = releaseArrowArray;
 }
 
@@ -2226,6 +2520,77 @@ void exportToArrow(
   exportToArrowImpl(
       *vector, Selection(vector->size()), options, arrowArray, pool);
 }
+
+namespace {
+
+void initializeReusableArrowArray(ArrowArray& arrowArray) {
+  BOLT_CHECK_NULL(arrowArray.release);
+  BOLT_CHECK_NULL(arrowArray.private_data);
+  auto holder = std::make_unique<BoltToArrowBridgeHolder>(true);
+  arrowArray.buffers = holder->getArrowBuffers();
+  arrowArray.length = 0;
+  arrowArray.null_count = 0;
+  arrowArray.offset = 0;
+  arrowArray.n_buffers = 0;
+  arrowArray.n_children = 0;
+  arrowArray.children = nullptr;
+  arrowArray.dictionary = nullptr;
+  holder->markActive(arrowArray);
+  arrowArray.private_data = holder.release();
+}
+
+void exportToReusableArrowArray(
+    const VectorPtr& vector,
+    ArrowArray& arrowArray,
+    memory::MemoryPool* pool,
+    const ArrowOptions& options) {
+  BOLT_CHECK_NOT_NULL(arrowArray.private_data);
+  if (vector->encoding() == VectorEncoding::Simple::LAZY) {
+    exportToReusableArrowArray(
+        BaseVector::loadedVectorShared(vector), arrowArray, pool, options);
+    return;
+  }
+  auto* holder = static_cast<BoltToArrowBridgeHolder*>(arrowArray.private_data);
+  BOLT_CHECK(holder->reusable());
+  BOLT_CHECK(holder->ownsReleaseState());
+  try {
+    if (vector->encoding() == VectorEncoding::Simple::CONSTANT &&
+        options.flattenConstant && vector->valueVector() != nullptr &&
+        !vector->wrappedVector()->isFlatEncoding()) {
+      auto copiedVector = BaseVector::copy(*vector);
+      exportToArrowImpl(
+          *copiedVector,
+          Selection(vector->size()),
+          options,
+          arrowArray,
+          pool,
+          true);
+      return;
+    }
+    exportToArrowImpl(
+        *vector, Selection(vector->size()), options, arrowArray, pool, true);
+  } catch (...) {
+    holder->resetReusableArray(arrowArray);
+    throw;
+  }
+}
+
+void releaseReusableArrowArray(ArrowArray& arrowArray) {
+  auto* holder = static_cast<BoltToArrowBridgeHolder*>(arrowArray.private_data);
+  BOLT_CHECK(holder == nullptr || holder->reusable());
+  BOLT_CHECK(holder == nullptr || holder->ownsReleaseState());
+  if (arrowArray.release != nullptr) {
+    arrowArray.release(&arrowArray);
+  }
+  if (holder != nullptr) {
+    holder->releaseResources();
+    delete holder;
+  }
+  arrowArray.private_data = nullptr;
+  arrowArray.release = nullptr;
+}
+
+} // namespace
 
 void exportToArrow(
     const VectorPtr& vec,
@@ -3124,5 +3489,360 @@ VectorPtr importFromArrowAsOwner(
     memory::MemoryPool* pool) {
   return importFromArrowImplWithMeasure(
       options, arrowSchema, arrowArray, pool, false);
+}
+
+namespace {
+
+struct SchemaSignature {
+  uint64_t hash{1469598103934665603ULL};
+  uint32_t nodes{0};
+  uint32_t fields{0};
+
+  bool operator==(const SchemaSignature& other) const {
+    return hash == other.hash && nodes == other.nodes && fields == other.fields;
+  }
+};
+
+void mixSignature(SchemaSignature& signature, uint64_t value) {
+  signature.hash ^= value;
+  signature.hash *= 1099511628211ULL;
+}
+
+void mixBytes(SchemaSignature& signature, const char* data, size_t size) {
+  for (size_t i = 0; i < size; ++i) {
+    mixSignature(signature, static_cast<uint8_t>(data[i]));
+  }
+  mixSignature(signature, size);
+}
+
+void mixStringView(SchemaSignature& signature, std::string_view value) {
+  mixBytes(signature, value.data(), value.size());
+}
+
+void mixEncodingSignature(
+    const BaseVector& vector,
+    SchemaSignature& signature) {
+  ++signature.nodes;
+  mixSignature(signature, static_cast<uint64_t>(vector.encoding()));
+
+  switch (vector.encoding()) {
+    case VectorEncoding::Simple::ROW: {
+      const auto& rows = *vector.asUnchecked<RowVector>();
+      for (size_t i = 0; i < rows.childrenSize(); ++i) {
+        mixEncodingSignature(*rows.childAt(i)->loadedVector(), signature);
+      }
+      break;
+    }
+    case VectorEncoding::Simple::VARIANT: {
+      const auto& variant = *vector.asUnchecked<VariantVector>();
+      for (size_t i = 0; i < variant.childrenSize(); ++i) {
+        mixEncodingSignature(*variant.childAt(i)->loadedVector(), signature);
+      }
+      break;
+    }
+    case VectorEncoding::Simple::ARRAY: {
+      const auto& arrays = *vector.asUnchecked<ArrayVector>();
+      mixEncodingSignature(*arrays.elements()->loadedVector(), signature);
+      break;
+    }
+    case VectorEncoding::Simple::MAP: {
+      const auto& maps = *vector.asUnchecked<MapVector>();
+      mixEncodingSignature(*maps.mapKeys()->loadedVector(), signature);
+      mixEncodingSignature(*maps.mapValues()->loadedVector(), signature);
+      break;
+    }
+    case VectorEncoding::Simple::DICTIONARY:
+    case VectorEncoding::Simple::CONSTANT:
+      if (vector.valueVector() != nullptr) {
+        mixEncodingSignature(*vector.valueVector()->loadedVector(), signature);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+SchemaSignature makeSchemaSignature(
+    const VectorPtr& vector,
+    const ArrowOptions& options,
+    const std::vector<std::string>& fieldNames) {
+  SchemaSignature signature;
+  mixSignature(signature, static_cast<uint64_t>(vector->type()->kind()));
+  mixSignature(signature, vector->type()->size());
+  mixSignature(signature, options.flattenDictionary ? 1 : 0);
+  mixSignature(signature, options.flattenConstant ? 1 : 0);
+  mixSignature(signature, static_cast<uint64_t>(options.timestampUnit));
+  mixSignature(signature, options.timestampTimeZone.has_value() ? 1 : 0);
+  if (options.timestampTimeZone.has_value()) {
+    mixStringView(signature, *options.timestampTimeZone);
+  }
+  mixSignature(signature, options.exportToView ? 1 : 0);
+  mixSignature(signature, options.useLargeString ? 1 : 0);
+  mixSignature(signature, options.stringViewCopyValues ? 1 : 0);
+  mixSignature(signature, options.exportToArrowIPC ? 1 : 0);
+  for (const auto& fieldName : fieldNames) {
+    ++signature.fields;
+    mixStringView(signature, fieldName);
+  }
+  mixEncodingSignature(*vector, signature);
+  return signature;
+}
+
+class ArraySlot {
+ public:
+  ArraySlot() {
+    initializeReusableArrowArray(array_);
+  }
+
+  ArraySlot(const ArraySlot&) = delete;
+  ArraySlot& operator=(const ArraySlot&) = delete;
+
+  ~ArraySlot() {
+    releaseReusableArrowArray(array_);
+  }
+
+  bool tryExport(
+      const VectorPtr& vector,
+      memory::MemoryPool* pool,
+      const ArrowOptions& options) {
+    // The consumer's array release callback returns this lease. The source
+    // ArrowArray may already look released after ownership is moved.
+    bool expected = false;
+    if (!inUse_.compare_exchange_strong(
+            expected,
+            true,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+      return false;
+    }
+
+    try {
+      exportToReusableArrowArray(vector, array_, pool, options);
+      return true;
+    } catch (...) {
+      releaseReusableArrowArray(array_);
+      initializeReusableArrowArray(array_);
+      inUse_.store(false, std::memory_order_release);
+      throw;
+    }
+  }
+
+  ArrowArray& array() {
+    return array_;
+  }
+
+  void release() {
+    if (array_.release != nullptr) {
+      array_.release(&array_);
+    }
+    inUse_.store(false, std::memory_order_release);
+  }
+
+ private:
+  ArrowArray array_{};
+  std::atomic_bool inUse_{false};
+};
+
+struct CachedSchema {
+  CachedSchema() = default;
+  CachedSchema(const CachedSchema&) = delete;
+  CachedSchema& operator=(const CachedSchema&) = delete;
+
+  ~CachedSchema() {
+    if (schema.release != nullptr) {
+      schema.release(&schema);
+    }
+  }
+
+  ArrowSchema schema{};
+  TypePtr type;
+  // ArrowSchema::name points into these strings.
+  std::vector<std::string> fieldNames;
+};
+
+class SchemaCache {
+ public:
+  std::pair<std::shared_ptr<CachedSchema>, bool> get(
+      const VectorPtr& vector,
+      const ArrowOptions& options,
+      const std::vector<std::string>& fieldNames,
+      memory::MemoryPool* pool) {
+    const auto signature = makeSchemaSignature(vector, options, fieldNames);
+    std::lock_guard<std::mutex> lock(mutex_);
+    // The signature covers encoding and options; equivalent() validates the
+    // logical type and protects against hash collisions.
+    if (schema_ != nullptr && signature_.has_value() &&
+        *signature_ == signature &&
+        schema_->type->equivalent(*vector->type())) {
+      return {schema_, false};
+    }
+
+    auto schema = std::make_shared<CachedSchema>();
+    schema->type = vector->type();
+    schema->fieldNames = fieldNames;
+    try {
+      bytedance::bolt::exportToArrow(
+          vector, schema->schema, options, schema->fieldNames, pool);
+    } catch (...) {
+      if (schema->schema.release != nullptr) {
+        schema->schema.release(&schema->schema);
+      }
+      throw;
+    }
+
+    schema_ = std::move(schema);
+    signature_ = signature;
+    return {schema_, true};
+  }
+
+ private:
+  std::mutex mutex_;
+  std::shared_ptr<CachedSchema> schema_;
+  std::optional<SchemaSignature> signature_;
+};
+
+struct ExportHolder {
+  std::shared_ptr<ArraySlot> slot;
+  std::unique_ptr<ArrowArray> fallbackArray;
+  std::shared_ptr<CachedSchema> schema;
+  // Schema and array may be released independently and on different threads.
+  // Keep shared state until both release callbacks have run.
+  std::atomic_uint8_t releaseCount{0};
+
+  ArrowArray& sourceArray() {
+    return slot != nullptr ? slot->array() : *fallbackArray;
+  }
+
+  void releaseArray() {
+    if (slot != nullptr) {
+      slot->release();
+      slot.reset();
+      return;
+    }
+    if (fallbackArray != nullptr && fallbackArray->release != nullptr) {
+      fallbackArray->release(fallbackArray.get());
+    }
+    fallbackArray.reset();
+  }
+};
+
+void releaseArrowArrayBatchView(ArrowArray* array) {
+  if (array == nullptr || array->release == nullptr) {
+    return;
+  }
+  auto* holder = static_cast<ExportHolder*>(array->private_data);
+  array->release = nullptr;
+  array->private_data = nullptr;
+  if (holder != nullptr) {
+    holder->releaseArray();
+    if (holder->releaseCount.fetch_add(1) == 1) {
+      delete holder;
+    }
+  }
+}
+
+void releaseArrowSchemaBatchView(ArrowSchema* schema) {
+  if (schema == nullptr || schema->release == nullptr) {
+    return;
+  }
+  auto* holder = static_cast<ExportHolder*>(schema->private_data);
+  schema->release = nullptr;
+  schema->private_data = nullptr;
+  if (holder != nullptr && holder->releaseCount.fetch_add(1) == 1) {
+    delete holder;
+  }
+}
+
+} // namespace
+
+class ReusableArrowBatchPool::Impl {
+ public:
+  explicit Impl(size_t numSlots) {
+    slots_.reserve(numSlots);
+    for (size_t i = 0; i < numSlots; ++i) {
+      slots_.push_back(std::make_shared<ArraySlot>());
+    }
+  }
+
+  size_t size() const {
+    return slots_.size();
+  }
+
+  bool exportToArrow(
+      const VectorPtr& vector,
+      memory::MemoryPool* pool,
+      const ArrowOptions& options,
+      ArrowSchema* schema,
+      ArrowArray* array,
+      const std::vector<std::string>& fieldNames) {
+    BOLT_CHECK_NOT_NULL(schema);
+    BOLT_CHECK_NOT_NULL(array);
+    BOLT_CHECK_NULL(schema->release);
+    BOLT_CHECK_NULL(array->release);
+
+    auto loadedVector = vector->encoding() == VectorEncoding::Simple::LAZY
+        ? BaseVector::loadedVectorShared(vector)
+        : vector;
+    auto holder = std::make_unique<ExportHolder>();
+    for (auto& slot : slots_) {
+      if (slot->tryExport(loadedVector, pool, options)) {
+        holder->slot = slot;
+        break;
+      }
+    }
+    if (holder->slot == nullptr) {
+      holder->fallbackArray = std::make_unique<ArrowArray>();
+      bytedance::bolt::exportToArrow(
+          loadedVector, *holder->fallbackArray, pool, options);
+    }
+
+    bool schemaExported = false;
+    try {
+      std::tie(holder->schema, schemaExported) =
+          schemaCache_.get(loadedVector, options, fieldNames, pool);
+    } catch (...) {
+      holder->releaseArray();
+      throw;
+    }
+
+    auto* rawHolder = holder.release();
+    *schema = rawHolder->schema->schema;
+    schema->release = releaseArrowSchemaBatchView;
+    schema->private_data = rawHolder;
+
+    *array = rawHolder->sourceArray();
+    array->release = releaseArrowArrayBatchView;
+    array->private_data = rawHolder;
+    return schemaExported;
+  }
+
+ private:
+  std::vector<std::shared_ptr<ArraySlot>> slots_;
+  SchemaCache schemaCache_;
+};
+
+ReusableArrowBatchPool::ReusableArrowBatchPool(size_t numSlots)
+    : impl_(std::make_unique<Impl>(numSlots)) {}
+
+ReusableArrowBatchPool::ReusableArrowBatchPool(
+    ReusableArrowBatchPool&& other) noexcept = default;
+
+ReusableArrowBatchPool& ReusableArrowBatchPool::operator=(
+    ReusableArrowBatchPool&& other) noexcept = default;
+
+ReusableArrowBatchPool::~ReusableArrowBatchPool() = default;
+
+size_t ReusableArrowBatchPool::size() const {
+  return impl_->size();
+}
+
+bool ReusableArrowBatchPool::exportToArrow(
+    const VectorPtr& vector,
+    memory::MemoryPool* pool,
+    const ArrowOptions& options,
+    ArrowSchema* schema,
+    ArrowArray* array,
+    const std::vector<std::string>& fieldNames) {
+  return impl_->exportToArrow(vector, pool, options, schema, array, fieldNames);
 }
 } // namespace bytedance::bolt

--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -3835,8 +3835,6 @@ class ReusableArrowBatchPool::Impl {
       const std::vector<std::string>& fieldNames) {
     BOLT_CHECK_NOT_NULL(schema);
     BOLT_CHECK_NOT_NULL(array);
-    BOLT_CHECK_NULL(schema->release);
-    BOLT_CHECK_NULL(array->release);
 
     auto loadedVector = vector->encoding() == VectorEncoding::Simple::LAZY
         ? BaseVector::loadedVectorShared(vector)

--- a/bolt/vector/arrow/Bridge.h
+++ b/bolt/vector/arrow/Bridge.h
@@ -110,6 +110,12 @@ class ReusableArrowBatchPool {
   /// Exports into caller-owned Arrow C Data Interface structs. Returns true if
   /// the schema was rebuilt, and false if a cached schema was reused. The
   /// caller releases schema and array through their release callbacks.
+  ///
+  /// This pool is not thread-safe. Export and release all Arrow structures
+  /// produced by a pool, including any moved child arrays, using external
+  /// synchronization. The pool must outlive all Arrow structures exported from
+  /// it. The supplied MemoryPool must outlive the ReusableArrowBatchPool
+  /// because reusable slots may retain small scratch buffers between exports.
   bool exportToArrow(
       const VectorPtr& vector,
       memory::MemoryPool* pool,

--- a/bolt/vector/arrow/Bridge.h
+++ b/bolt/vector/arrow/Bridge.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <cstddef>
+#include <memory>
 #include "bolt/common/memory/Memory.h"
 #include "bolt/vector/BaseVector.h"
 
@@ -92,6 +94,34 @@ void exportToArrow(
     ArrowArray& arrowArray,
     memory::MemoryPool* pool,
     const ArrowOptions& options);
+
+/// A bounded pool for exporting ArrowArray and ArrowSchema together.
+class ReusableArrowBatchPool {
+ public:
+  explicit ReusableArrowBatchPool(size_t numSlots);
+  ReusableArrowBatchPool(const ReusableArrowBatchPool&) = delete;
+  ReusableArrowBatchPool& operator=(const ReusableArrowBatchPool&) = delete;
+  ReusableArrowBatchPool(ReusableArrowBatchPool&& other) noexcept;
+  ReusableArrowBatchPool& operator=(ReusableArrowBatchPool&& other) noexcept;
+  ~ReusableArrowBatchPool();
+
+  size_t size() const;
+
+  /// Exports into caller-owned Arrow C Data Interface structs. Returns true if
+  /// the schema was rebuilt, and false if a cached schema was reused. The
+  /// caller releases schema and array through their release callbacks.
+  bool exportToArrow(
+      const VectorPtr& vector,
+      memory::MemoryPool* pool,
+      const ArrowOptions& options,
+      ArrowSchema* schema,
+      ArrowArray* array,
+      const std::vector<std::string>& fieldNames = {});
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
 
 /// Export the type of a Bolt vector to an ArrowSchema.
 ///

--- a/bolt/vector/arrow/benchmarks/ExportBoltToArrowBenchmark.cpp
+++ b/bolt/vector/arrow/benchmarks/ExportBoltToArrowBenchmark.cpp
@@ -32,6 +32,7 @@ using namespace bytedance::bolt;
 using namespace bytedance::bolt::test;
 
 static constexpr int32_t kRowsPerVector = 100'000;
+static constexpr vector_size_t kSmallBatchRows = 128;
 static constexpr vector_size_t kBatchRows = 8'192;
 static constexpr size_t kWideBatchColumns = 1'700;
 
@@ -116,9 +117,11 @@ VectorPtr varcharVecHalfNull;
 VectorPtr varchar2VecHalfNull;
 VectorPtr complexVecHalfNull;
 
+VectorPtr smallNarrowBatch;
 VectorPtr narrowBatch;
 VectorPtr nestedBatch;
 VectorPtr wideBatch;
+std::unique_ptr<ReusableArrowBatchPool> smallNarrowBatchPool;
 std::unique_ptr<ReusableArrowBatchPool> narrowBatchPool;
 std::unique_ptr<ReusableArrowBatchPool> nestedBatchPool;
 std::unique_ptr<ReusableArrowBatchPool> wideBatchPool;
@@ -171,14 +174,17 @@ void createVectors() {
       bigintVecHalfNull->slice(0, kBatchRows),
       varcharVecHalfNull->slice(0, kBatchRows),
   });
+  smallNarrowBatch = narrowBatch->slice(0, kSmallBatchRows);
   nestedBatch = complexVec->slice(0, kBatchRows);
   // Share data vectors so this case isolates per-column Arrow metadata costs.
   wideBatch = vectorMaker_.rowVector(std::vector<VectorPtr>(
       kWideBatchColumns, integerVec->slice(0, kBatchRows)));
 
+  smallNarrowBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
   narrowBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
   nestedBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
   wideBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
+  warmUpBatchPool(smallNarrowBatch, *smallNarrowBatchPool);
   warmUpBatchPool(narrowBatch, *narrowBatchPool);
   warmUpBatchPool(nestedBatch, *nestedBatchPool);
   warmUpBatchPool(wideBatch, *wideBatchPool);
@@ -204,6 +210,14 @@ BENCHMARK_NAMED_PARAM(
     utf8viewHalfNull,
     varchar2VecHalfNull,
     options);
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(runExportArrowBatch, narrow8x128, smallNarrowBatch);
+BENCHMARK_NAMED_PARAM(
+    runExportReusableArrowBatch,
+    narrow8x128,
+    smallNarrowBatch,
+    smallNarrowBatchPool.get());
 
 BENCHMARK_DRAW_LINE();
 BENCHMARK_NAMED_PARAM(runExportArrowBatch, narrow8x8192, narrowBatch);

--- a/bolt/vector/arrow/benchmarks/ExportBoltToArrowBenchmark.cpp
+++ b/bolt/vector/arrow/benchmarks/ExportBoltToArrowBenchmark.cpp
@@ -19,9 +19,8 @@
 #include <folly/init/Init.h>
 #include <string>
 
-#include "bolt/exec/tests/utils/Cursor.h"
-#include "bolt/exec/tests/utils/OperatorTestBase.h"
-#include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/vector/arrow/Abi.h"
+#include "bolt/vector/arrow/Bridge.h"
 #include "bolt/vector/fuzzer/VectorFuzzer.h"
 #include "bolt/vector/tests/utils/VectorMaker.h"
 
@@ -31,25 +30,58 @@ DEFINE_int64(
     "Seed for random input dataset generator");
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::test;
-using namespace bytedance::bolt::exec::test;
 
 static constexpr int32_t kRowsPerVector = 100'000;
+static constexpr vector_size_t kBatchRows = 8'192;
+static constexpr size_t kWideBatchColumns = 1'700;
 
 namespace {
 
 // Boiler plate structures required by vectorMaker.
 memory::MemoryManager memoryManager;
-std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
 std::shared_ptr<memory::MemoryPool> pool_{memoryManager.addLeafPool()};
-core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
-bytedance::bolt::test::VectorMaker vectorMaker_{execCtx_.pool()};
+bytedance::bolt::test::VectorMaker vectorMaker_{pool_.get()};
 
 void runExportToArrow(
-    uint32_t,
+    uint32_t iterations,
     VectorPtr vec,
     ArrowOptions options = ArrowOptions{}) {
-  ArrowArray arrowArray;
-  exportToArrow(vec, arrowArray, pool_.get(), options);
+  for (uint32_t i = 0; i < iterations; ++i) {
+    ArrowArray arrowArray{};
+    exportToArrow(vec, arrowArray, pool_.get(), options);
+    folly::doNotOptimizeAway(arrowArray.buffers);
+    arrowArray.release(&arrowArray);
+  }
+}
+
+void runExportArrowBatch(uint32_t iterations, const VectorPtr& vector) {
+  for (uint32_t i = 0; i < iterations; ++i) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    exportToArrow(vector, schema, ArrowOptions{}, {}, pool_.get());
+    exportToArrow(vector, array, pool_.get(), ArrowOptions{});
+    folly::doNotOptimizeAway(schema.format);
+    folly::doNotOptimizeAway(array.buffers);
+    array.release(&array);
+    schema.release(&schema);
+  }
+}
+
+void runExportReusableArrowBatch(
+    uint32_t iterations,
+    const VectorPtr& vector,
+    ReusableArrowBatchPool* batchPool) {
+  for (uint32_t i = 0; i < iterations; ++i) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    const auto schemaExported = batchPool->exportToArrow(
+        vector, pool_.get(), ArrowOptions{}, &schema, &array);
+    folly::doNotOptimizeAway(schemaExported);
+    folly::doNotOptimizeAway(schema.format);
+    folly::doNotOptimizeAway(array.buffers);
+    array.release(&array);
+    schema.release(&schema);
+  }
 }
 
 RowTypePtr complexType = ROW({
@@ -84,6 +116,23 @@ VectorPtr varcharVecHalfNull;
 VectorPtr varchar2VecHalfNull;
 VectorPtr complexVecHalfNull;
 
+VectorPtr narrowBatch;
+VectorPtr nestedBatch;
+VectorPtr wideBatch;
+std::unique_ptr<ReusableArrowBatchPool> narrowBatchPool;
+std::unique_ptr<ReusableArrowBatchPool> nestedBatchPool;
+std::unique_ptr<ReusableArrowBatchPool> wideBatchPool;
+
+void warmUpBatchPool(
+    const VectorPtr& vector,
+    ReusableArrowBatchPool& batchPool) {
+  ArrowSchema schema{};
+  ArrowArray array{};
+  batchPool.exportToArrow(vector, pool_.get(), ArrowOptions{}, &schema, &array);
+  array.release(&array);
+  schema.release(&schema);
+}
+
 void createVectors() {
   VectorFuzzer::Options opts;
   opts.vectorSize = kRowsPerVector;
@@ -111,6 +160,28 @@ void createVectors() {
   varcharVecHalfNull = fuzzer.fuzzFlat(VARCHAR());
   varchar2VecHalfNull = fuzzer.fuzzFlat(VARCHAR());
   complexVecHalfNull = fuzzer.fuzzFlat(complexType);
+
+  narrowBatch = vectorMaker_.rowVector({
+      integerVec->slice(0, kBatchRows),
+      bigintVec->slice(0, kBatchRows),
+      realVec->slice(0, kBatchRows),
+      doubleVec->slice(0, kBatchRows),
+      varcharVec->slice(0, kBatchRows),
+      integerVecHalfNull->slice(0, kBatchRows),
+      bigintVecHalfNull->slice(0, kBatchRows),
+      varcharVecHalfNull->slice(0, kBatchRows),
+  });
+  nestedBatch = complexVec->slice(0, kBatchRows);
+  // Share data vectors so this case isolates per-column Arrow metadata costs.
+  wideBatch = vectorMaker_.rowVector(std::vector<VectorPtr>(
+      kWideBatchColumns, integerVec->slice(0, kBatchRows)));
+
+  narrowBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
+  nestedBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
+  wideBatchPool = std::make_unique<ReusableArrowBatchPool>(1);
+  warmUpBatchPool(narrowBatch, *narrowBatchPool);
+  warmUpBatchPool(nestedBatch, *nestedBatchPool);
+  warmUpBatchPool(wideBatch, *wideBatchPool);
 }
 
 BENCHMARK_NAMED_PARAM(runExportToArrow, integer, integerVec);
@@ -133,6 +204,30 @@ BENCHMARK_NAMED_PARAM(
     utf8viewHalfNull,
     varchar2VecHalfNull,
     options);
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(runExportArrowBatch, narrow8x8192, narrowBatch);
+BENCHMARK_NAMED_PARAM(
+    runExportReusableArrowBatch,
+    narrow8x8192,
+    narrowBatch,
+    narrowBatchPool.get());
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(runExportArrowBatch, nested4x8192, nestedBatch);
+BENCHMARK_NAMED_PARAM(
+    runExportReusableArrowBatch,
+    nested4x8192,
+    nestedBatch,
+    nestedBatchPool.get());
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(runExportArrowBatch, wide1700x8192, wideBatch);
+BENCHMARK_NAMED_PARAM(
+    runExportReusableArrowBatch,
+    wide1700x8192,
+    wideBatch,
+    wideBatchPool.get());
 
 } // namespace
 

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -811,6 +811,22 @@ TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolRecoversFromFailure) {
   schema.release(&schema);
 }
 
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolOverwritesOutputs) {
+  auto vector = vectorMaker_.flatVector<int64_t>({1, 2, 3});
+  ReusableArrowBatchPool batchPool(1);
+
+  ArrowSchema schema;
+  schema.release = mockSchemaRelease;
+  ArrowArray array;
+  array.release = mockArrayRelease;
+
+  EXPECT_TRUE(
+      batchPool.exportToArrow(vector, pool_.get(), options_, &schema, &array));
+  validateArray<int64_t>({1, 2, 3}, array);
+  array.release(&array);
+  schema.release(&schema);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolChangesShape) {
   auto flatVector = vectorMaker_.flatVector<int64_t>({1, 2, 3});
   auto arrayVector =

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -720,6 +720,271 @@ TEST_F(ArrowBridgeArrayExportTest, rowVectorEmpty) {
   arrowArray.release(&arrowArray);
 }
 
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolOffsets) {
+  constexpr vector_size_t kBatchSize = 8192;
+  auto vector = vectorMaker_.arrayVector<int64_t>(
+      kBatchSize, [](auto) { return 1; }, [](auto row) { return row; });
+  ReusableArrowBatchPool batchPool(1);
+
+  ArrowSchema firstSchema{};
+  ArrowArray firstArray{};
+  EXPECT_TRUE(batchPool.exportToArrow(
+      vector, pool_.get(), options_, &firstSchema, &firstArray));
+  ASSERT_NE(nullptr, firstArray.buffers);
+  const auto* firstOffsets = firstArray.buffers[1];
+  firstArray.release(&firstArray);
+  firstSchema.release(&firstSchema);
+  auto allocationBlocker =
+      AlignedBuffer::allocate<vector_size_t>(kBatchSize + 1, pool_.get());
+
+  ArrowSchema secondSchema{};
+  ArrowArray secondArray{};
+  EXPECT_FALSE(batchPool.exportToArrow(
+      vector, pool_.get(), options_, &secondSchema, &secondArray));
+  EXPECT_EQ(firstOffsets, secondArray.buffers[1]);
+  EXPECT_EQ(kBatchSize, secondArray.length);
+  EXPECT_EQ(kBatchSize, secondArray.children[0]->length);
+  secondArray.release(&secondArray);
+  secondSchema.release(&secondSchema);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolDropsLargeOffsets) {
+  constexpr vector_size_t kBatchSize = 8193;
+  auto vector = vectorMaker_.arrayVector<int64_t>(
+      kBatchSize, [](auto) { return 1; }, [](auto row) { return row; });
+  auto rootPool = memory::memoryManager()->addRootPool();
+  auto scratchPool = rootPool->addLeafChild("arrow_scratch");
+  ReusableArrowBatchPool batchPool(1);
+  const auto baselineBytes = scratchPool->currentBytes();
+
+  ArrowSchema schema{};
+  ArrowArray array{};
+  EXPECT_TRUE(batchPool.exportToArrow(
+      vector, scratchPool.get(), options_, &schema, &array));
+  EXPECT_GT(scratchPool->currentBytes(), baselineBytes);
+
+  array.release(&array);
+  schema.release(&schema);
+  EXPECT_EQ(baselineBytes, scratchPool->currentBytes());
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolNestedConstant) {
+  constexpr vector_size_t kBatchSize = 10;
+  auto arrayVector = vectorMaker_.arrayVector<int32_t>(
+      kBatchSize, [](auto) { return 10; }, [](auto row) { return row; });
+  auto constantVector = std::make_shared<ConstantVector<ComplexType>>(
+      pool_.get(), kBatchSize, 4, arrayVector);
+  auto nestedConstant =
+      BaseVector::wrapInConstant(kBatchSize, 0, constantVector);
+  ArrowOptions options{.flattenConstant = true};
+
+  ReusableArrowBatchPool batchPool(1);
+  ArrowSchema schema{};
+  ArrowArray array{};
+  EXPECT_TRUE(batchPool.exportToArrow(
+      nestedConstant, pool_.get(), options, &schema, &array));
+  EXPECT_OK_AND_ASSIGN(auto type, arrow::ImportType(&schema));
+  EXPECT_OK_AND_ASSIGN(auto imported, arrow::ImportArray(&array, type));
+  ASSERT_OK(imported->ValidateFull());
+  EXPECT_EQ(kBatchSize, imported->length());
+  EXPECT_EQ(arrow::Type::LIST, imported->type_id());
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolRecoversFromFailure) {
+  auto unsupported = vectorMaker_.sequenceVector<int64_t>({1, 1, 2, 2, 2, 3});
+  ReusableArrowBatchPool batchPool(1);
+
+  ArrowSchema failedSchema{};
+  ArrowArray failedArray{};
+  EXPECT_THROW(
+      batchPool.exportToArrow(
+          unsupported, pool_.get(), options_, &failedSchema, &failedArray),
+      BoltException);
+
+  auto vector = vectorMaker_.flatVector<int64_t>({4, 5, 6});
+  ArrowSchema schema{};
+  ArrowArray array{};
+  EXPECT_TRUE(
+      batchPool.exportToArrow(vector, pool_.get(), options_, &schema, &array));
+  validateArray<int64_t>({4, 5, 6}, array);
+  array.release(&array);
+  schema.release(&schema);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolChangesShape) {
+  auto flatVector = vectorMaker_.flatVector<int64_t>({1, 2, 3});
+  auto arrayVector =
+      vectorMaker_.arrayVector<int64_t>({{1, 2}, {3}, {4, 5, 6}});
+  auto rowVector = vectorMaker_.rowVector(
+      {flatVector, vectorMaker_.flatVector<std::string>({"a", "b", "c"})});
+  auto dictionaryVector = BaseVector::wrapInDictionary(
+      nullptr, makeBuffer<vector_size_t>({2, 0, 1}), 3, flatVector);
+  auto constantVector =
+      BaseVector::createConstant(BIGINT(), variant(int64_t{7}), 3, pool_.get());
+
+  ReusableArrowBatchPool batchPool(1);
+  for (const auto& vector : {
+           VectorPtr(arrayVector),
+           VectorPtr(flatVector),
+           VectorPtr(rowVector),
+           dictionaryVector,
+           constantVector,
+           VectorPtr(arrayVector),
+       }) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    EXPECT_TRUE(batchPool.exportToArrow(
+        vector, pool_.get(), options_, &schema, &array));
+    EXPECT_OK_AND_ASSIGN(auto type, arrow::ImportType(&schema));
+    EXPECT_OK_AND_ASSIGN(auto imported, arrow::ImportArray(&array, type));
+    ASSERT_OK(imported->ValidateFull());
+  }
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPool) {
+  ReusableArrowBatchPool batchPool(2);
+  EXPECT_EQ(2, batchPool.size());
+  auto vector = vectorMaker_.flatVector<int64_t>({1, 2, 3});
+
+  ArrowSchema firstSchema{};
+  ArrowArray firstArray{};
+  EXPECT_TRUE(batchPool.exportToArrow(
+      vector, pool_.get(), options_, &firstSchema, &firstArray));
+  EXPECT_OK_AND_ASSIGN(auto firstType, arrow::ImportType(&firstSchema));
+  EXPECT_OK_AND_ASSIGN(
+      auto firstImported, arrow::ImportArray(&firstArray, firstType));
+
+  ArrowSchema secondSchema{};
+  ArrowArray secondArray{};
+  EXPECT_FALSE(batchPool.exportToArrow(
+      vector, pool_.get(), options_, &secondSchema, &secondArray));
+  EXPECT_OK_AND_ASSIGN(auto secondType, arrow::ImportType(&secondSchema));
+  EXPECT_OK_AND_ASSIGN(
+      auto secondImported, arrow::ImportArray(&secondArray, secondType));
+
+  ArrowSchema fallbackSchema{};
+  ArrowArray fallbackArray{};
+  EXPECT_FALSE(batchPool.exportToArrow(
+      vector, pool_.get(), options_, &fallbackSchema, &fallbackArray));
+  EXPECT_OK_AND_ASSIGN(auto fallbackType, arrow::ImportType(&fallbackSchema));
+  EXPECT_OK_AND_ASSIGN(
+      auto fallbackImported, arrow::ImportArray(&fallbackArray, fallbackType));
+
+  ASSERT_OK(firstImported->ValidateFull());
+  ASSERT_OK(secondImported->ValidateFull());
+  ASSERT_OK(fallbackImported->ValidateFull());
+  firstImported.reset();
+
+  ArrowSchema reusedSchema{};
+  ArrowArray reusedArray{};
+  EXPECT_FALSE(batchPool.exportToArrow(
+      vector, pool_.get(), options_, &reusedSchema, &reusedArray));
+  EXPECT_OK_AND_ASSIGN(auto reusedType, arrow::ImportType(&reusedSchema));
+  EXPECT_OK_AND_ASSIGN(
+      auto reusedImported, arrow::ImportArray(&reusedArray, reusedType));
+  ASSERT_OK(reusedImported->ValidateFull());
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolSchemaCache) {
+  ReusableArrowBatchPool batchPool(1);
+  auto vector =
+      vectorMaker_.rowVector({vectorMaker_.flatVector<int64_t>({1, 2, 3})});
+
+  auto exportAndRelease = [&](const VectorPtr& input,
+                              const ArrowOptions& options,
+                              const std::vector<std::string>& fieldNames) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    const bool rebuilt = batchPool.exportToArrow(
+        input, pool_.get(), options, &schema, &array, fieldNames);
+    EXPECT_STREQ(fieldNames[0].c_str(), schema.children[0]->name);
+    array.release(&array);
+    schema.release(&schema);
+    return rebuilt;
+  };
+
+  EXPECT_TRUE(exportAndRelease(vector, options_, {"first"}));
+  EXPECT_FALSE(exportAndRelease(vector, options_, {"first"}));
+
+  auto equivalentVector =
+      vectorMaker_.rowVector({vectorMaker_.flatVector<int64_t>({4, 5, 6})});
+  ASSERT_NE(vector->type().get(), equivalentVector->type().get());
+  ASSERT_TRUE(vector->type()->equivalent(*equivalentVector->type()));
+  EXPECT_FALSE(exportAndRelease(equivalentVector, options_, {"first"}));
+
+  auto differentVector =
+      vectorMaker_.rowVector({vectorMaker_.flatVector<int32_t>({1, 2, 3})});
+  EXPECT_TRUE(exportAndRelease(differentVector, options_, {"first"}));
+  EXPECT_TRUE(exportAndRelease(vector, options_, {"second"}));
+
+  auto ipcOptions = options_;
+  ipcOptions.exportToArrowIPC = true;
+  EXPECT_TRUE(exportAndRelease(vector, ipcOptions, {"second"}));
+}
+
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    reusableArrowBatchPoolSchemaCacheInvalidation) {
+  ReusableArrowBatchPool batchPool(1);
+  auto flatVector = vectorMaker_.flatVector<int64_t>({10, 20, 30});
+  auto dictionaryVector = BaseVector::wrapInDictionary(
+      nullptr, makeBuffer<vector_size_t>({2, 0, 1}), 3, flatVector);
+
+  auto exportAndRelease = [&](const VectorPtr& input,
+                              const ArrowOptions& options) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    const bool rebuilt =
+        batchPool.exportToArrow(input, pool_.get(), options, &schema, &array);
+    const bool hasDictionary = schema.dictionary != nullptr;
+    array.release(&array);
+    schema.release(&schema);
+    return std::pair{rebuilt, hasDictionary};
+  };
+
+  EXPECT_EQ(
+      std::make_pair(true, false), exportAndRelease(flatVector, options_));
+  EXPECT_EQ(
+      std::make_pair(false, false), exportAndRelease(flatVector, options_));
+  EXPECT_EQ(
+      std::make_pair(true, true), exportAndRelease(dictionaryVector, options_));
+  EXPECT_EQ(
+      std::make_pair(false, true),
+      exportAndRelease(dictionaryVector, options_));
+
+  auto flattenOptions = options_;
+  flattenOptions.flattenDictionary = true;
+  EXPECT_EQ(
+      std::make_pair(true, false),
+      exportAndRelease(dictionaryVector, flattenOptions));
+  EXPECT_EQ(
+      std::make_pair(true, false), exportAndRelease(flatVector, options_));
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolZeroSlots) {
+  ReusableArrowBatchPool batchPool(0);
+  EXPECT_EQ(0, batchPool.size());
+  auto firstVector = vectorMaker_.flatVector<int64_t>({1, 2, 3});
+  auto secondVector = vectorMaker_.flatVector<int64_t>({4, 5, 6});
+
+  ArrowSchema firstSchema{};
+  ArrowArray firstArray{};
+  EXPECT_TRUE(batchPool.exportToArrow(
+      firstVector, pool_.get(), options_, &firstSchema, &firstArray));
+
+  ArrowSchema secondSchema{};
+  ArrowArray secondArray{};
+  EXPECT_FALSE(batchPool.exportToArrow(
+      secondVector, pool_.get(), options_, &secondSchema, &secondArray));
+
+  validateArray<int64_t>({1, 2, 3}, firstArray);
+  validateArray<int64_t>({4, 5, 6}, secondArray);
+  firstArray.release(&firstArray);
+  firstSchema.release(&firstSchema);
+  secondArray.release(&secondArray);
+  secondSchema.release(&secondSchema);
+}
+
 std::shared_ptr<arrow::Array> toArrow(
     const VectorPtr& vec,
     const ArrowOptions& options,

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -885,6 +885,44 @@ TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPool) {
   ASSERT_OK(reusedImported->ValidateFull());
 }
 
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolMovedChildLease) {
+  ReusableArrowBatchPool batchPool(1);
+  auto vector = vectorMaker_.rowVector({
+      vectorMaker_.flatVector<int64_t>({1, 2, 3}),
+      vectorMaker_.flatVector<int64_t>({4, 5, 6}),
+  });
+
+  ArrowSchema schema{};
+  ArrowArray array{};
+  EXPECT_TRUE(
+      batchPool.exportToArrow(vector, pool_.get(), options_, &schema, &array));
+  const auto* rootBuffers = array.buffers;
+
+  ArrowArray movedChild = *array.children[0];
+  array.children[0]->release = nullptr;
+  array.children[0]->private_data = nullptr;
+  array.release(&array);
+
+  ArrowSchema secondSchema{};
+  ArrowArray secondArray{};
+  batchPool.exportToArrow(
+      vector, pool_.get(), options_, &secondSchema, &secondArray);
+
+  EXPECT_NE(rootBuffers, secondArray.buffers)
+      << "the reusable slot must stay leased while a moved child is active";
+  ASSERT_NE(nullptr, movedChild.buffers);
+  EXPECT_NE(nullptr, movedChild.buffers[1])
+      << "parent release must not drop a moved child's buffers";
+  if (movedChild.buffers[1] != nullptr) {
+    validateArray<int64_t>({1, 2, 3}, movedChild);
+  }
+
+  secondArray.release(&secondArray);
+  secondSchema.release(&secondSchema);
+  schema.release(&schema);
+  movedChild.release(&movedChild);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolSchemaCache) {
   ReusableArrowBatchPool batchPool(1);
   auto vector =
@@ -920,6 +958,31 @@ TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolSchemaCache) {
   auto ipcOptions = options_;
   ipcOptions.exportToArrowIPC = true;
   EXPECT_TRUE(exportAndRelease(vector, ipcOptions, {"second"}));
+}
+
+TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolSchemaCacheRowNames) {
+  ReusableArrowBatchPool batchPool(1);
+  auto firstVector = vectorMaker_.rowVector(
+      {"first"}, {vectorMaker_.flatVector<int64_t>({1, 2, 3})});
+  auto secondVector = vectorMaker_.rowVector(
+      {"second"}, {vectorMaker_.flatVector<int64_t>({4, 5, 6})});
+  ASSERT_TRUE(firstVector->type()->equivalent(*secondVector->type()));
+  ASSERT_FALSE(*firstVector->type() == *secondVector->type());
+
+  auto exportAndRelease = [&](const VectorPtr& input,
+                              const char* expectedName) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    const bool rebuilt =
+        batchPool.exportToArrow(input, pool_.get(), options_, &schema, &array);
+    EXPECT_STREQ(expectedName, schema.children[0]->name);
+    array.release(&array);
+    schema.release(&schema);
+    return rebuilt;
+  };
+
+  EXPECT_TRUE(exportAndRelease(firstVector, "first"));
+  EXPECT_TRUE(exportAndRelease(secondVector, "second"));
 }
 
 TEST_F(


### PR DESCRIPTION
### What problem does this PR solve?

Repeated Arrow C Data Interface exports rebuild the ArrowArray holder tree,
offset buffers, and ArrowSchema for every batch. This creates avoidable
allocation and release overhead for callers that repeatedly export compatible
Bolt vectors.

Issue Number: N/A

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (optimization)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no logic changes)
- [ ] Build/CI or Infrastructure changes
- [ ] Documentation only

### Description

Add `ReusableArrowBatchPool`, a bounded pool for exporting `ArrowArray` and
`ArrowSchema` together.

- Reuse Arrow array holder trees through a flat release registry, avoiding
  recursive release work between batches.
- Reuse offsets scratch buffers while capping retained scratch memory at 32
  KiB, plus the trailing Arrow offset.
- Cache exported schemas and invalidate the cache when the vector type,
  encoding shape, field names, or relevant Arrow options change.
- Lease each pool slot until the consumer invokes the Arrow release callback.
- Fall back to the regular export path when all slots are leased or the pool
  has zero slots.
- Keep the low-level reusable-array lifecycle internal to `Bridge.cpp`; the
  public API continues to use standard `ArrowArray` and `ArrowSchema` structs.

Tests cover offsets reuse and eviction, nested and constant vectors, export
failure recovery, vector shape changes, concurrent slot leases, fallback
exports, schema cache hits and invalidation, and zero-slot behavior.

The Arrow export microbenchmark now compares full schema and array export plus
consumer release for regular and reusable paths. It also fixes the existing
array-only cases to honor Folly iteration counts and release exported arrays.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Release build, pinned to CPU 0.
    Seven paired rounds per case, alternating regular/reusable execution order.
    Each process measured the selected case for at least 500 ms.

    Case                         Regular median   Reusable median   Speedup
    8 columns x 128 rows              6.753 us          3.586 us      1.88x
    8 columns x 8192 rows            299.01 us         293.76 us      1.02x
    Nested 4 columns x 8192 rows     274.96 us         259.82 us      1.06x
    1700 columns x 8192 rows           1.283 ms         425.58 us      3.01x

    Exact paired sign-flip test on per-round log ratios:
    - 128-row follow-up: -46.94%, paired p=0.015625
    - 8192-row 8-column:  -1.90%, Holm p=0.0469, below 3% effect threshold
    - 8192-row nested:     -5.63%, Holm p=0.0469
    - 8192-row 1700-col:  -66.64%, Holm p=0.0469
    ```

    The 128-row case was measured as a separate seven-round follow-up. The
    three original 8192-row cases were corrected together using Holm's method.
    The 1700-column case shares child data vectors to isolate the per-column
    Arrow metadata allocation, traversal, and release costs targeted by this
    change.
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

The reusable path is opt-in. Existing callers continue to use the unchanged
export path, and pool exhaustion falls back to that path.

### Release Note

```text
Release Note:
- Added a bounded Arrow batch export pool that reuses array metadata, offsets
  scratch buffers, and schemas across compatible exports.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
