### PR TITLE
fix: make from_json STRUCT field name matching case-sensitive

### DIFF
--- a/bolt/functions/sparksql/specialforms/FromJson.cpp
+++ b/bolt/functions/sparksql/specialforms/FromJson.cpp
@@ -29,7 +29,6 @@
  */
 
 #include "bolt/functions/sparksql/specialforms/FromJson.h"
-#include "bolt/functions/lib/string/StringCore.h"
 
 #include <limits>
 #include <stdexcept>
@@ -223,13 +222,7 @@ struct ExtractJsonTypeImpl {
       if (type == simdjson::ondemand::json_type::object) {
         SIMDJSON_ASSIGN_OR_RAISE(auto object, value.get_object());
 
-        const auto& names = rowType.names();
-        bool allFieldsAreAscii =
-            std::all_of(names.begin(), names.end(), [](const auto& name) {
-              return functions::stringCore::isAscii(name.data(), name.size());
-            });
-
-        auto fieldIndices = makeFieldIndicesMap(rowType, allFieldsAreAscii);
+        auto fieldIndices = makeFieldIndicesMap(rowType);
 
         std::string key;
         for (const auto& fieldResult : object) {
@@ -240,11 +233,6 @@ struct ExtractJsonTypeImpl {
           if (!field.value().is_null()) {
             SIMDJSON_ASSIGN_OR_RAISE(key, field.unescaped_key(true));
 
-            if (allFieldsAreAscii) {
-              folly::toLowerAscii(key);
-            } else {
-              boost::algorithm::to_lower(key);
-            }
             auto it = fieldIndices.find(key);
             if (it != fieldIndices.end() && it->second >= 0) {
               const auto index = it->second;
@@ -354,21 +342,14 @@ struct ExtractJsonTypeImpl {
     return simdjson::SUCCESS;
   }
 
-  // Creates a map of lower case field names to their indices in the row type.
+  // Creates a map of field names to their indices in the row type.
+  // Field name matching is case-sensitive to match Spark's default behavior.
   static folly::F14FastMap<std::string, int32_t> makeFieldIndicesMap(
-      const RowType& rowType,
-      bool allFieldsAreAscii) {
+      const RowType& rowType) {
     folly::F14FastMap<std::string, int32_t> fieldIndices;
     const auto size = rowType.size();
     for (auto i = 0; i < size; ++i) {
-      std::string key = rowType.nameOf(i);
-      if (allFieldsAreAscii) {
-        folly::toLowerAscii(key);
-      } else {
-        boost::algorithm::to_lower(key);
-      }
-
-      fieldIndices[key] = i;
+      fieldIndices[rowType.nameOf(i)] = i;
     }
 
     return fieldIndices;

--- a/bolt/functions/sparksql/tests/FromJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/FromJsonTest.cpp
@@ -283,5 +283,38 @@ TEST_F(FromJsonTest, scalarRootDocumentDoesNotThrow) {
   testFromJson(scalarInput, expectedRow);
 }
 
+TEST_F(FromJsonTest, structFieldNameCaseSensitive) {
+  auto expectedLabels = makeNullableFlatVector<StringView>(
+      {"unknown", std::nullopt, "hello", std::nullopt, "ok"});
+  auto expectedValues = makeNullableFlatVector<StringView>(
+      {"0", std::nullopt, "world", "0", std::nullopt});
+  auto input = makeFlatVector<std::string>({
+      R"({"Label":"unknown","Value":"0"})",
+      R"({"label":"unknown","value":"0"})",
+      R"({"Label":"hello","Value":"world"})",
+      R"({"label":"bad","Value":"0"})",
+      R"({"Label":"ok","value":"1"})",
+  });
+  testFromJson(
+      input,
+      makeRowVector({"Label", "Value"}, {expectedLabels, expectedValues}));
+}
+
+TEST_F(FromJsonTest, structFieldNameCaseSensitiveDedup) {
+  auto input = makeFlatVector<std::string>({
+      R"({"Label":"unknown","Value":"0"})",
+      R"({"label":"unknown","value":"0"})",
+      R"({"label":"lower","Value":"0"})",
+      R"({"Label":"upper","value":"0"})",
+  });
+  auto expectedLabel = makeNullableFlatVector<StringView>(
+      {"unknown", std::nullopt, std::nullopt, "upper"});
+  auto expectedValue = makeNullableFlatVector<StringView>(
+      {"0", std::nullopt, "0", std::nullopt});
+  testFromJson(
+      input,
+      makeRowVector({"Label", "Value"}, {expectedLabel, expectedValue}));
+}
+
 } // namespace
 } // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?
Bolt's `from_json` implementation lowercases both JSON object keys and STRUCT field names before matching, resulting in case-insensitive field resolution. This diverges from standard Spark behavior, which is case-sensitive (using Jackson + JSON RFC 7159 semantics).

As a result, JSON keys like `{"label":"x","value":"y"}` incorrectly match a STRUCT schema declaring `Label` / `Value`, producing non-null rows where Spark returns NULL, causing row count inflation after dedup/join.

Issue Number: close #N/A

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

**Root cause**
In `bolt/functions/sparksql/specialforms/FromJson.cpp`, the STRUCT (ROW) JSON parser:
1. Lowercased every STRUCT field name when building the field→index lookup map (`makeFieldIndicesMap`).
2. Lowercased every incoming JSON object key before looking it up.

These two combined made field matching case-insensitive.

**Fix**
1. `makeFieldIndicesMap`: keep STRUCT field names as-is (no lowercasing).
2. JSON object key lookup: keep the key as-is (no lowercasing).
3. Remove the now-unused `StringCore.h` include (`isAscii` check + `toLowerAscii`/`boost::to_lower` are no longer needed for ROW dispatch).

Behavior now matches vanilla Spark's Jackson parser: only exact key/field-name case matches produce values; mismatches become NULL.

**Test coverage added**
- `FromJsonTest.structFieldNameCaseSensitive` – validates that only exact-case `Label`/`Value` keys match the schema; lower-case keys yield null values (including the mixed-key case: `label`+`Value`, `Label`+`value`).
- `FromJsonTest.structFieldNameCaseSensitiveDedup` – validates that tuples with case-mismatched keys correctly collapse to nulls (reproduces the dedup-inflation scenario from the bug).

### Performance Impact
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

Note: The change removes two `to_lower` calls per JSON object field + one `isAscii` pass per STRUCT parse. Pure-ASCII workloads are marginally cheaper; non-ASCII ones skip the heavier `boost::to_lower` altogether. Net effect is neutral-to-positive.

### Release Note

Release Note:

```text
Release Note:
- Fixed `from_json` STRUCT field name matching to be case-sensitive, aligning with Spark's default Jackson-based parser. Previously JSON keys like `{"label":"x"}` would incorrectly match a schema field `Label` (capitalized), leading to extra non-null rows and inflated row counts after dedup/join.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

All 21 tests in `FromJsonTest` pass (including 2 new case-sensitivity tests); all 5 `FromToJsonRoundTripTest` tests continue to pass.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
