### PR TITLE
fix: correct Spark numeric-to-timestamp cast guard

### DIFF
--- a/bolt/expression/CastExpr-inl.h
+++ b/bolt/expression/CastExpr-inl.h
@@ -669,7 +669,7 @@ void CastExpr::applyCastPrimitives(
     }
   };
 
-#ifndef SPARK_COMPATIABLE
+#ifndef SPARK_COMPATIBLE
   if constexpr (
       (FromKind == TypeKind::INTEGER || FromKind == TypeKind::BIGINT ||
        FromKind == TypeKind::REAL || FromKind == TypeKind::DOUBLE ||

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -892,6 +892,23 @@ TEST_F(CastExprTest, dateToTimestamp) {
       TIMESTAMP());
 }
 
+TEST_F(CastExprTest, numericToTimestampSemantics) {
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kThrowExceptionWhenCastIntToTimestamp, "true"},
+  });
+
+  auto input = makeRowVector({makeFlatVector<int32_t>({1})});
+#ifdef SPARK_COMPATIBLE
+  auto result =
+      evaluate<SimpleVector<Timestamp>>("cast(c0 as timestamp)", input);
+  EXPECT_EQ(result->valueAt(0), Timestamp(1, 0));
+#else
+  BOLT_ASSERT_THROW(
+      evaluate("cast(c0 as timestamp)", input),
+      "unsupported type conversion from INTEGER to TIMESTAMP");
+#endif
+}
+
 TEST_F(CastExprTest, timestampToDate) {
   setTimezone("");
   std::vector<std::optional<Timestamp>> inputTimestamps = {


### PR DESCRIPTION
### What problem does this PR solve?

`SPARK_COMPATIABLE` is misspelled in the numeric-to-timestamp cast guard. Since no build defines that spelling, Spark builds execute the Presto-only validation when `throw_exception_when_cast_int_to_timestamp` is enabled.

Issue Number: N/A

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Correct the guard to `SPARK_COMPATIBLE`. Presto keeps the existing validation, while Spark uses its numeric-to-timestamp conversion behavior.

Add a regression test covering both build modes.

### Performance Impact

- [x] **No Impact**: This only corrects a compile-time guard and adds no work to the runtime path.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixed numeric-to-timestamp casts in Spark-compatible builds when strict integer-to-timestamp validation is enabled.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
