### PR TITLE
fix: make from_json struct field name matching case-sensitive

### DIFF
--- a/bolt/functions/sparksql/specialforms/FromJson.cpp
+++ b/bolt/functions/sparksql/specialforms/FromJson.cpp
@@ -29,7 +29,6 @@
  */
 
 #include "bolt/functions/sparksql/specialforms/FromJson.h"
-#include "bolt/functions/lib/string/StringCore.h"
 
 #include <limits>
 #include <stdexcept>
@@ -223,13 +222,7 @@ struct ExtractJsonTypeImpl {
       if (type == simdjson::ondemand::json_type::object) {
         SIMDJSON_ASSIGN_OR_RAISE(auto object, value.get_object());
 
-        const auto& names = rowType.names();
-        bool allFieldsAreAscii =
-            std::all_of(names.begin(), names.end(), [](const auto& name) {
-              return functions::stringCore::isAscii(name.data(), name.size());
-            });
-
-        auto fieldIndices = makeFieldIndicesMap(rowType, allFieldsAreAscii);
+        auto fieldIndices = makeFieldIndicesMap(rowType);
 
         std::string key;
         for (const auto& fieldResult : object) {
@@ -240,11 +233,6 @@ struct ExtractJsonTypeImpl {
           if (!field.value().is_null()) {
             SIMDJSON_ASSIGN_OR_RAISE(key, field.unescaped_key(true));
 
-            if (allFieldsAreAscii) {
-              folly::toLowerAscii(key);
-            } else {
-              boost::algorithm::to_lower(key);
-            }
             auto it = fieldIndices.find(key);
             if (it != fieldIndices.end() && it->second >= 0) {
               const auto index = it->second;
@@ -354,21 +342,16 @@ struct ExtractJsonTypeImpl {
     return simdjson::SUCCESS;
   }
 
-  // Creates a map of lower case field names to their indices in the row type.
+  // Creates a map of field names to their indices in the row type.
+  // Matching is case-sensitive, like Spark's JacksonParser, which resolves a
+  // JSON key with StructType.getFieldIndex. That lookup is exact regardless of
+  // spark.sql.caseSensitive, and has not changed between Spark 3.2 and 4.0.
   static folly::F14FastMap<std::string, int32_t> makeFieldIndicesMap(
-      const RowType& rowType,
-      bool allFieldsAreAscii) {
+      const RowType& rowType) {
     folly::F14FastMap<std::string, int32_t> fieldIndices;
     const auto size = rowType.size();
     for (auto i = 0; i < size; ++i) {
-      std::string key = rowType.nameOf(i);
-      if (allFieldsAreAscii) {
-        folly::toLowerAscii(key);
-      } else {
-        boost::algorithm::to_lower(key);
-      }
-
-      fieldIndices[key] = i;
+      fieldIndices[rowType.nameOf(i)] = i;
     }
 
     return fieldIndices;

--- a/bolt/functions/sparksql/tests/FromJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/FromJsonTest.cpp
@@ -283,5 +283,71 @@ TEST_F(FromJsonTest, scalarRootDocumentDoesNotThrow) {
   testFromJson(scalarInput, expectedRow);
 }
 
+TEST_F(FromJsonTest, structFieldNameCaseSensitive) {
+  auto expectedLabels = makeNullableFlatVector<StringView>(
+      {"unknown", std::nullopt, "hello", std::nullopt, "ok"});
+  auto expectedValues = makeNullableFlatVector<StringView>(
+      {"0", std::nullopt, "world", "0", std::nullopt});
+  auto input = makeFlatVector<std::string>({
+      R"({"Label":"unknown","Value":"0"})",
+      R"({"label":"unknown","value":"0"})",
+      R"({"Label":"hello","Value":"world"})",
+      R"({"label":"bad","Value":"0"})",
+      R"({"Label":"ok","value":"1"})",
+  });
+  testFromJson(
+      input,
+      makeRowVector({"Label", "Value"}, {expectedLabels, expectedValues}));
+}
+
+TEST_F(FromJsonTest, structFieldNameCaseSensitiveDedup) {
+  auto input = makeFlatVector<std::string>({
+      R"({"Label":"unknown","Value":"0"})",
+      R"({"label":"unknown","value":"0"})",
+      R"({"label":"lower","Value":"0"})",
+      R"({"Label":"upper","value":"0"})",
+  });
+  auto expectedLabel = makeNullableFlatVector<StringView>(
+      {"unknown", std::nullopt, std::nullopt, "upper"});
+  auto expectedValue = makeNullableFlatVector<StringView>(
+      {"0", std::nullopt, "0", std::nullopt});
+  testFromJson(
+      input, makeRowVector({"Label", "Value"}, {expectedLabel, expectedValue}));
+}
+
+TEST_F(FromJsonTest, structFieldNameLowerCaseSchema) {
+  // The shape that reaches Bolt in production: the schema field names are lower
+  // case, but the JSON keys in the data are not constrained by that.
+  auto expectedLabel = makeNullableFlatVector<StringView>(
+      {"yes", std::nullopt, std::nullopt, "no"});
+  auto expectedValue = makeNullableFlatVector<StringView>(
+      {"1", std::nullopt, "0", std::nullopt});
+  auto input = makeFlatVector<std::string>({
+      R"({"label":"yes","value":"1"})",
+      R"({"Label":"yes","Value":"1"})",
+      R"({"Label":"no","value":"0"})",
+      R"({"label":"no","Value":"0"})",
+  });
+  testFromJson(
+      input, makeRowVector({"label", "value"}, {expectedLabel, expectedValue}));
+}
+
+TEST_F(FromJsonTest, structFieldNameNonAsciiIsExact) {
+  // A non-ASCII field name used to switch the matcher onto a Unicode-aware
+  // lower-casing path, which folded the ASCII names in the same row as well.
+  // Every name is now matched exactly.
+  auto expectedTag =
+      makeNullableFlatVector<StringView>({"a", "b", std::nullopt});
+  auto expectedValue =
+      makeNullableFlatVector<StringView>({"1", std::nullopt, "3"});
+  auto input = makeFlatVector<std::string>({
+      R"({"标签":"a","Value":"1"})",
+      R"({"标签":"b","value":"2"})",
+      R"({"标记":"c","Value":"3"})",
+  });
+  testFromJson(
+      input, makeRowVector({"标签", "Value"}, {expectedTag, expectedValue}));
+}
+
 } // namespace
 } // namespace bytedance::bolt::functions::sparksql::test


### PR DESCRIPTION
### What problem does this PR solve?

`from_json` lowercased both the STRUCT field names and the JSON object keys before
matching them, which made the match case-insensitive. Spark matches them exactly.

```sql
SELECT from_json(txt, 'STRUCT<label: STRING, value: STRING>') FROM t
```

| `txt` | Bolt (before) | Spark |
| --- | --- | --- |
| `{"label":"yes","value":"1"}` | `Row(label='yes', value='1')` | `Row(label='yes', value='1')` |
| `{"Label":"yes","Value":"1"}` | `Row(label='yes', value='1')` ❌ | `Row(label=null, value=null)` |
| `{"Label":"no","value":"0"}` | `Row(label='no', value='0')` ❌ | `Row(label=null, value='0')` |
| `{"label":"no","Value":"0"}` | `Row(label='no', value='0')` ❌ | `Row(label='no', value=null)` |

Three rows out of four are wrong, and the failure is silent.

Issue Number: close #xxx

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

`ExtractJsonTypeImpl` lowercased the row type's field names when building
`makeFieldIndicesMap()`, and lowercased every JSON key again before looking it up.
Both conversions are removed, so the lookup is now an exact match. The
`allFieldsAreAscii` probe and the `StringCore.h` include went with them — they only
existed to pick between `folly::toLowerAscii` and `boost::algorithm::to_lower`.

**Why exact matching is right.** Spark's `JacksonParser.convertObject` resolves each
JSON key with `schema.getFieldIndex(parser.currentName)`, and `StructType.getFieldIndex`
is a plain `nameToIndex` lookup. Measured on pyspark **3.2.4 / 3.3.4 / 3.5.5 / 4.0.1**,
with `spark.sql.caseSensitive` set to both `true` and `false` — all eight runs return
the same thing on the four inputs above. The matching is exact regardless of the
config and has not changed across those versions.

Note the third and fourth rows: the field whose case matches is populated while the
other is null, so this is a per-field exact match, not an all-or-nothing record match.

**A non-ASCII field name used to change the behaviour of the whole row.** When any
field name was non-ASCII the code switched to `boost::algorithm::to_lower`, which also
folded the ASCII names in that same row. Now every name is matched exactly regardless
of what the other names look like — `structFieldNameNonAsciiIsExact` covers this.

### Companion change on the Gluten side

Gluten lowercases struct field names when `spark.sql.caseSensitive` is false, so a
schema written as `STRUCT<Label: STRING, Value: STRING>` reaches the native side as
`ROW<label:VARCHAR,value:VARCHAR>` — the case is gone before Bolt ever sees it.
Gluten therefore stops offloading `from_json` when the schema carries an uppercase
field name, the same guard `to_json` already uses.

The two changes are complementary, not alternatives:

- the Gluten guard covers the **schema**;
- this PR covers the **JSON keys in the data**, which the schema does not constrain —
  the table above uses an all-lowercase schema and is still wrong without this PR.

They can be merged in either order. With only this PR merged, schemas with uppercase
field names keep the pre-existing behaviour until the Gluten guard lands.

### Performance Impact

- [x] **Positive Impact**: two `to_lower` conversions per field and per JSON key are
      removed from the parse loop, along with the `isAscii` scan over all field names
      per row. No benchmark was run — the change only deletes work from the hot path.

### Release Note

```text
Release Note:
- Fixed `from_json` matching JSON keys against STRUCT field names case-insensitively;
  it is now an exact match, consistent with Spark.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Four tests in `FromJsonTest`:

- `structFieldNameCaseSensitive` / `structFieldNameCaseSensitiveDedup` — mixed spellings
  against an uppercase schema.
- `structFieldNameLowerCaseSchema` — an all-lowercase schema against mixed-case JSON
  keys. This is the shape that actually reaches Bolt once the Gluten guard is in place,
  and its expectations were taken from a real Spark run.
- `structFieldNameNonAsciiIsExact` — a non-ASCII field name no longer folds the ASCII
  names beside it.

### Breaking Changes

- [x] No

Queries whose results change were producing results that did not match Spark.
