### PR TITLE
build: fix gersemi and license pre-commit hooks

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,0 +1,17 @@
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+line_length: 100
+indent: 2
+list_expansion: favour-expansion

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
     - id: gersemi
       name: Format CMake files
-      args: ["--no-warn-about-unknown-commands"]
+      args: ["-i", "--no-warn-about-unknown-commands"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -85,7 +85,7 @@ repos:
         require_serial: true
       - id: license-header-check
         name: Check for license headers
-        entry: go run -C .github/license_check check_license.go
+        entry: go run -C .github/license_check .
         language: golang
         pass_filenames: true
         require_serial: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,7 @@ if(POLICY CMP0177)
   set(CMAKE_POLICY_WARNING_CMP0177 OFF)
 endif()
 
-set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS
-    ON
-    CACHE BOOL "Suppress developer warnings"
-)
+set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS ON CACHE BOOL "Suppress developer warnings")
 
 # Sets new behavior for CMP0135, which controls how timestamps are extracted when using
 # ExternalProject_Add(): https://cmake.org/cmake/help/latest/policy/CMP0135.html
@@ -83,10 +80,16 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(OS_LINUX 1)
-  add_definitions(-D OS_LINUX)
+  add_definitions(
+    -D
+    OS_LINUX
+  )
 elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(OS_MACOSX 1)
-  add_definitions(-D OS_MACOSX)
+  add_definitions(
+    -D
+    OS_MACOSX
+  )
 endif()
 
 # Only use compiler-rt when building with Clang on Linux for ARM/AArch64
@@ -95,8 +98,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND OS_LINUX AND (ARCH_AARCH64 OR ARCH
   add_link_options(-rtlib=compiler-rt)
 endif()
 
-list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
-     "${PROJECT_SOURCE_DIR}/CMake/third-party"
+list(
+  PREPEND CMAKE_MODULE_PATH
+  "${PROJECT_SOURCE_DIR}/CMake"
+  "${PROJECT_SOURCE_DIR}/CMake/third-party"
 )
 
 # Include our ThirdPartyToolchain dependencies macros include(ResolveDependency)
@@ -105,11 +110,15 @@ list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Add all options below
-option(BOLT_BUILD_TESTING
-       "Enable Bolt tests. This will enable all other build options automatically." OFF
+option(
+  BOLT_BUILD_TESTING
+  "Enable Bolt tests. This will enable all other build options automatically."
+  OFF
 )
-option(BOLT_BUILD_MINIMAL
-       "Build a minimal set of components only. This will override other build options." OFF
+option(
+  BOLT_BUILD_MINIMAL
+  "Build a minimal set of components only. This will override other build options."
+  OFF
 )
 option(BOLT_BUILD_TESTING_WITH_COVERAGE "Enable Bolt tests with coverage statistics." OFF)
 # option() always creates a BOOL variable so we have to use a normal cache variable with STRING type
@@ -121,8 +130,10 @@ option(BOLT_BUILD_TESTING_WITH_COVERAGE "Enable Bolt tests with coverage statist
 #   ${BOLT_DEPENDENCY_SOURCE_DEFAULT} CACHE STRING "Default source for all dependencies with source
 #   builds enabled: AUTO SYSTEM BUNDLED." )
 
-option(BOLT_ENABLE_ADDRESS_SANITIZER "Enable Address Sanitizer to check for memory related errors"
-       OFF
+option(
+  BOLT_ENABLE_ADDRESS_SANITIZER
+  "Enable Address Sanitizer to check for memory related errors"
+  OFF
 )
 option(BOLT_ENABLE_EXEC "Build exec." ON)
 option(BOLT_ENABLE_AGGREGATES "Build aggregates." ON)
@@ -137,8 +148,10 @@ option(BOLT_ENABLE_COLOCATE_FUNCTIONS "Enable colocate function support" OFF)
 option(ALLOW_REMOTE_COLOCATE_REGISTER "Enable remote colocate function register" OFF)
 option(BOLT_ENABLE_EXPRESSION "Build expression." ON)
 option(BOLT_ENABLE_PARSE "Build parser used for unit tests." OFF)
-option(BOLT_ENABLE_EXAMPLES
-       "Build examples. This will enable BOLT_ENABLE_EXPRESSION automatically." OFF
+option(
+  BOLT_ENABLE_EXAMPLES
+  "Build examples. This will enable BOLT_ENABLE_EXPRESSION automatically."
+  OFF
 )
 option(BOLT_ENABLE_SUBSTRAIT "Build Substrait-to-Bolt converter." OFF)
 option(BOLT_ENABLE_S3 "Build S3 Connector" OFF)
@@ -153,16 +166,22 @@ option(BOLT_ENABLE_TXT "Enable TXT read support" OFF)
 option(BOLT_ENABLE_ARROW "Enable Arrow support" OFF)
 option(BOLT_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
 option(BOLT_ENABLE_CCACHE "Use ccache if installed." ON)
-option(BOLT_ENABLE_FILE_PREFIX_MAP
-       "Hide absolute source and build paths embedded by the compiler." ON
+option(
+  BOLT_ENABLE_FILE_PREFIX_MAP
+  "Hide absolute source and build paths embedded by the compiler."
+  ON
 )
-set(BOLT_MAPPED_SOURCE_PREFIX
-    "."
-    CACHE STRING "Path used instead of the absolute Bolt source directory."
+set(
+  BOLT_MAPPED_SOURCE_PREFIX
+  "."
+  CACHE STRING
+  "Path used instead of the absolute Bolt source directory."
 )
-set(BOLT_MAPPED_BINARY_PREFIX
-    "./_build"
-    CACHE STRING "Path used instead of the absolute Bolt build directory."
+set(
+  BOLT_MAPPED_BINARY_PREFIX
+  "./_build"
+  CACHE STRING
+  "Path used instead of the absolute Bolt build directory."
 )
 
 option(BOLT_BUILD_TEST_UTILS "Builds Bolt test utilities" OFF)
@@ -170,8 +189,10 @@ option(BOLT_BUILD_PYTHON_PACKAGE "Builds Bolt Python bindings" OFF)
 
 # make buildPartitionBounds_ a vector int64 instead of int32 to avoid integer overflow when the
 # hashtable has billions of records
-option(BOLT_ENABLE_INT64_BUILD_PARTITION_BOUND
-       "Avoid integer overflow when the hashtable has billions of records" OFF
+option(
+  BOLT_ENABLE_INT64_BUILD_PARTITION_BOUND
+  "Avoid integer overflow when the hashtable has billions of records"
+  OFF
 )
 
 option(BOLT_ENABLE_SPARK_COMPATIBLE "Enable spark compatible setting" OFF)
@@ -186,11 +207,17 @@ option(BOLT_BUILD_BENCHMARKS "Builds Bolt benchmarks" OFF)
 option(BOLT_BUILD_BENCHMARKS_BASIC "Enable Bolt basic benchmarks." OFF)
 
 if(BOLT_ENABLE_SPARK_COMPATIBLE)
-  set(SPARK_VERSION
-      "3.5"
-      CACHE STRING "Spark major.minor version"
+  set(SPARK_VERSION "3.5" CACHE STRING "Spark major.minor version")
+  set_property(
+    CACHE
+      SPARK_VERSION
+    PROPERTY
+      STRINGS
+        "3.2"
+        "3.3"
+        "3.4"
+        "3.5"
   )
-  set_property(CACHE SPARK_VERSION PROPERTY STRINGS "3.2" "3.3" "3.4" "3.5")
   message("Build with SPARK_VERSION ${SPARK_VERSION}")
   string(REPLACE "." "_" SPARK_VERSION_ENUM ${SPARK_VERSION})
   set(BOLT_SPARK_VERSION "SPARK_${SPARK_VERSION_ENUM}")
@@ -282,7 +309,7 @@ if(${BOLT_BUILD_BENCHMARKS})
   set(BOLT_CODEGEN_SUPPORT OFF)
 endif()
 
-if (${BOLT_ENABLE_TEST_UTILS})
+if(${BOLT_ENABLE_TEST_UTILS})
   set(BOLT_ENABLE_PARSE ON)
 endif()
 
@@ -290,7 +317,11 @@ endif()
 if(BOLT_BUILD_TESTING_WITH_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-  add_compile_options(-fprofile-arcs -ftest-coverage -DGTEST_USE_OWN_TR1_TUPLE=0)
+  add_compile_options(
+    -fprofile-arcs
+    -ftest-coverage
+    -DGTEST_USE_OWN_TR1_TUPLE=0
+  )
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
   if(NOT OS_MACOSX)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
@@ -335,11 +366,7 @@ if(${BOLT_BUILD_PYTHON_PACKAGE})
   set(BOLT_ENABLE_HDFS ON)
 endif()
 
-if(BOLT_ENABLE_CCACHE
-   AND NOT CMAKE_C_COMPILER_LAUNCHER
-   AND NOT CMAKE_CXX_COMPILER_LAUNCHER
-)
-
+if(BOLT_ENABLE_CCACHE AND NOT CMAKE_C_COMPILER_LAUNCHER AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
   find_program(CCACHE_FOUND ccache)
 
   if(CCACHE_FOUND)
@@ -354,8 +381,14 @@ endif()
 if(${BOLT_FORCE_COLORED_OUTPUT})
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-fdiagnostics-color=always)
-  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL
-                                                        "AppleClang"
+  elseif(
+    "${CMAKE_CXX_COMPILER_ID}"
+      STREQUAL
+      "Clang"
+    OR
+      "${CMAKE_CXX_COMPILER_ID}"
+        STREQUAL
+        "AppleClang"
   )
     add_compile_options(-fcolor-diagnostics)
   endif()
@@ -363,7 +396,11 @@ endif()
 
 # At the moment we prefer static linking but by default cmake looks for shared libs first. This will
 # still fallback to shared libs when static ones are not found
-list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 a)
+list(
+  INSERT CMAKE_FIND_LIBRARY_SUFFIXES
+  0
+  a
+)
 if(BOLT_ENABLE_S3)
   # Set AWS_ROOT_DIR if you have a custom install location of AWS SDK CPP.
   if(AWSSDK_ROOT_DIR)
@@ -435,7 +472,10 @@ endif()
 # DeveloperTools/TwoLevelNamespaces.html Enables -flat_namespace so type_info can be deudplicated
 # across .so boundaries
 if(APPLE)
-  add_link_options("-Wl,-flat_namespace,-no_warn_duplicate_libraries" "-Wl,-export_dynamic")
+  add_link_options(
+    "-Wl,-flat_namespace,-no_warn_duplicate_libraries"
+    "-Wl,-export_dynamic"
+  )
 elseif(UNIX)
   add_link_options("-Wl,--export-dynamic")
 else()
@@ -454,37 +494,35 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 if(BOLT_ENABLE_FILE_PREFIX_MAP)
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    set(BOLT_FILE_PREFIX_MAP_OPTIONS
-        "-ffile-prefix-map=${CMAKE_BINARY_DIR}=${BOLT_MAPPED_BINARY_PREFIX}"
-        "-ffile-prefix-map=${CMAKE_SOURCE_DIR}=${BOLT_MAPPED_SOURCE_PREFIX}"
+    set(
+      BOLT_FILE_PREFIX_MAP_OPTIONS
+      "-ffile-prefix-map=${CMAKE_BINARY_DIR}=${BOLT_MAPPED_BINARY_PREFIX}"
+      "-ffile-prefix-map=${CMAKE_SOURCE_DIR}=${BOLT_MAPPED_SOURCE_PREFIX}"
     )
 
     # GCC's -ffile-prefix-map covers all individual -f*-prefix-map options.
     # Clang uses a separate option for coverage metadata.
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       list(
-        APPEND
-        BOLT_FILE_PREFIX_MAP_OPTIONS
+        APPEND BOLT_FILE_PREFIX_MAP_OPTIONS
         "-fcoverage-prefix-map=${CMAKE_BINARY_DIR}=${BOLT_MAPPED_BINARY_PREFIX}"
         "-fcoverage-prefix-map=${CMAKE_SOURCE_DIR}=${BOLT_MAPPED_SOURCE_PREFIX}"
       )
     endif()
 
     foreach(BOLT_FILE_PREFIX_MAP_OPTION IN LISTS BOLT_FILE_PREFIX_MAP_OPTIONS)
-      add_compile_options(
-        "$<$<COMPILE_LANGUAGE:C,CXX>:${BOLT_FILE_PREFIX_MAP_OPTION}>"
-      )
+      add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:${BOLT_FILE_PREFIX_MAP_OPTION}>")
     endforeach()
     message(
       STATUS
-        "Mapping Bolt source path to '${BOLT_MAPPED_SOURCE_PREFIX}' "
-        "and build path to '${BOLT_MAPPED_BINARY_PREFIX}'"
+      "Mapping Bolt source path to '${BOLT_MAPPED_SOURCE_PREFIX}' "
+      "and build path to '${BOLT_MAPPED_BINARY_PREFIX}'"
     )
   else()
     message(
       WARNING
-        "BOLT_ENABLE_FILE_PREFIX_MAP is enabled, but "
-        "${CMAKE_CXX_COMPILER_ID} does not support the configured path mapping"
+      "BOLT_ENABLE_FILE_PREFIX_MAP is enabled, but "
+      "${CMAKE_CXX_COMPILER_ID} does not support the configured path mapping"
     )
   endif()
 endif()
@@ -509,30 +547,45 @@ endif()
 # Under Ninja, we are able to designate certain targets large enough to require restricted
 # parallelism.
 if("${MAX_HIGH_MEM_JOBS}")
-  set_property(GLOBAL PROPERTY JOB_POOLS "high_memory_pool=${MAX_HIGH_MEM_JOBS}")
+  set_property(
+    GLOBAL
+    PROPERTY
+      JOB_POOLS
+        "high_memory_pool=${MAX_HIGH_MEM_JOBS}"
+  )
 else()
-  set_property(GLOBAL PROPERTY JOB_POOLS high_memory_pool=1000)
+  set_property(
+    GLOBAL
+    PROPERTY
+      JOB_POOLS
+        high_memory_pool=1000
+  )
 endif()
 
-set(MAX_LINK_JOBS
-    4
-    CACHE STRING ""
-)
+set(MAX_LINK_JOBS 4 CACHE STRING "")
 if("${MAX_LINK_JOBS}")
-  set_property(GLOBAL APPEND PROPERTY JOB_POOLS "link_job_pool=${MAX_LINK_JOBS}")
+  set_property(
+    GLOBAL
+    APPEND
+    PROPERTY
+      JOB_POOLS
+        "link_job_pool=${MAX_LINK_JOBS}"
+  )
   set(CMAKE_JOB_POOL_LINK link_job_pool)
 endif()
 
 if("${ENABLE_ALL_WARNINGS}")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(KNOWN_COMPILER_SPECIFIC_WARNINGS
-        "-Wno-range-loop-analysis \
+    set(
+      KNOWN_COMPILER_SPECIFIC_WARNINGS
+      "-Wno-range-loop-analysis \
          -Wno-mismatched-tags \
          -Wno-nullability-completeness"
     )
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(KNOWN_COMPILER_SPECIFIC_WARNINGS
-        "-Wno-implicit-fallthrough \
+    set(
+      KNOWN_COMPILER_SPECIFIC_WARNINGS
+      "-Wno-implicit-fallthrough \
          -Wno-empty-body \
          -Wno-class-memaccess \
          -Wno-comment \
@@ -550,8 +603,9 @@ if("${ENABLE_ALL_WARNINGS}")
     )
   endif()
 
-  set(KNOWN_WARNINGS
-      "-Wno-unused \
+  set(
+    KNOWN_WARNINGS
+    "-Wno-unused \
        -Wno-unused-parameter \
        -Wno-sign-compare \
        -Wno-ignored-qualifiers \
@@ -626,9 +680,19 @@ if(KERNEL_SUPPORTS_IO_URING)
 endif()
 
 if(DEFINED FOLLY_BENCHMARK_STATIC_LIB)
-  set(FOLLY_BENCHMARK ${FOLLY_BENCHMARK_STATIC_LIB} GTest::gtest GTest::gtest_main)
+  set(
+    FOLLY_BENCHMARK
+    ${FOLLY_BENCHMARK_STATIC_LIB}
+    GTest::gtest
+    GTest::gtest_main
+  )
 else()
-  set(FOLLY_BENCHMARK Folly::follybenchmark GTest::gtest GTest::gtest_main)
+  set(
+    FOLLY_BENCHMARK
+    Folly::follybenchmark
+    GTest::gtest
+    GTest::gtest_main
+  )
 endif()
 
 find_package(Protobuf CONFIG REQUIRED)
@@ -665,7 +729,6 @@ find_package(xxHash CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(roaring REQUIRED)
 
-
 include_directories(${CMAKE_SOURCE_DIR})
 include_directories(${CMAKE_SOURCE_DIR}/bolt)
 include_directories(${CMAKE_BINARY_DIR}/gen_cpp)
@@ -689,19 +752,22 @@ function(bolt_add_sharded_gtest TEST_TARGET NUM_SHARDS)
   math(EXPR LAST_SHARD "${NUM_SHARDS} - 1")
   foreach(SHARD_INDEX RANGE ${LAST_SHARD})
     set(TEST_NAME "${TEST_TARGET}_shard_${SHARD_INDEX}")
-    add_test(
-      NAME ${TEST_NAME}
-      COMMAND ${TEST_TARGET}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_TARGET} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_tests_properties(
       ${TEST_NAME}
-      PROPERTIES COST 1
-                 ENVIRONMENT
-                 "GTEST_TOTAL_SHARDS=${NUM_SHARDS};GTEST_SHARD_INDEX=${SHARD_INDEX}"
+      PROPERTIES
+        COST
+          1
+        ENVIRONMENT
+          "GTEST_TOTAL_SHARDS=${NUM_SHARDS};GTEST_SHARD_INDEX=${SHARD_INDEX}"
     )
     if(ARGC GREATER 2)
-      set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT ${ARGV2})
+      set_tests_properties(
+        ${TEST_NAME}
+        PROPERTIES
+          TIMEOUT
+            ${ARGV2}
+      )
     endif()
   endforeach()
 endfunction()
@@ -714,41 +780,37 @@ endif()
 # It would be better to only expose public headers Currently, just expose all the headers
 install(
   DIRECTORY
-  "${CMAKE_SOURCE_DIR}/bolt" # source directory
+    "${CMAKE_SOURCE_DIR}/bolt" # source directory
   DESTINATION
-  "include" # target directory
+    "include" # target directory
   FILES_MATCHING # install only matched files
   # PATTERN "test" EXCLUDE
+  PATTERN "benchmarks"
+    EXCLUDE
+  PATTERN "benchmark"
+    EXCLUDE
   PATTERN
-  "benchmarks"
-  EXCLUDE
+    "*.h" # select header files
   PATTERN
-  "benchmark"
-  EXCLUDE
-  PATTERN
-  "*.h" # select header files
-  PATTERN
-  "*.hpp" # select header files
+    "*.hpp" # select header files
 )
 
 if(${BOLT_ENABLE_SUBSTRAIT})
   install(
     DIRECTORY
-    "${CMAKE_BINARY_DIR}/gen_cpp/bolt" # source directory
+      "${CMAKE_BINARY_DIR}/gen_cpp/bolt" # source directory
     DESTINATION
-    "include" # target directory
+      "include" # target directory
     FILES_MATCHING # install only matched files
     # PATTERN "test" EXCLUDE
+    PATTERN "benchmarks"
+      EXCLUDE
+    PATTERN "benchmark"
+      EXCLUDE
     PATTERN
-    "benchmarks"
-    EXCLUDE
+      "*.h" # select header files
     PATTERN
-    "benchmark"
-    EXCLUDE
-    PATTERN
-    "*.h" # select header files
-    PATTERN
-    "*.hpp" # select header files
+      "*.hpp" # select header files
   )
 endif()
 
@@ -818,19 +880,12 @@ function(specialize_template output_var template_file)
     set(output_file "${output_dir}/${CLASS_NAME}_${SAFE_TYPE}.cpp")
 
     configure_file("${template_file}" "${output_file}.in" @ONLY)
-    file(
-      GENERATE
-      OUTPUT "${output_file}"
-      INPUT "${output_file}.in"
-    )
+    file(GENERATE OUTPUT "${output_file}" INPUT "${output_file}.in")
 
     list(APPEND generated_files "${output_file}")
   endforeach()
 
-  set(${output_var}
-      ${generated_files}
-      PARENT_SCOPE
-  )
+  set(${output_var} ${generated_files} PARENT_SCOPE)
 endfunction()
 
 add_subdirectory(bolt)

--- a/bolt/CMakeLists.txt
+++ b/bolt/CMakeLists.txt
@@ -25,7 +25,6 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-
 set(BOLT_BASE_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_EXECUTION_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_FUNCTIONS_OBJECT_TARGETS "" CACHE INTERNAL "")
@@ -36,7 +35,13 @@ set(BOLT_EXTENSIONS_OBJECT_TARGETS "" CACHE INTERNAL "")
 set(BOLT_TESTUTILS_OBJECT_TARGETS "" CACHE INTERNAL "")
 
 function(bolt_add_library target_name)
-  set(options OBJECT STATIC SHARED INTERFACE)
+  set(
+    options
+    OBJECT
+    STATIC
+    SHARED
+    INTERFACE
+  )
   set(oneValueArgs)
   set(multiValueArgs)
   cmake_parse_arguments(BOLT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -47,7 +52,10 @@ function(bolt_add_library target_name)
   list(REMOVE_ITEM ARGN INTERFACE)
 
   if(BOLT_STATIC OR BOLT_SHARED)
-    message(FATAL_ERROR "Do NOT specify shared/static type, it will be decided automatically by conan")
+    message(
+      FATAL_ERROR
+      "Do NOT specify shared/static type, it will be decided automatically by conan"
+    )
   endif()
 
   # Get current directory relative path
@@ -60,44 +68,71 @@ function(bolt_add_library target_name)
 
   # these are test utils are scattered in different directories
   # TODO: Move these targets to bolt_testutils subdirectory, and adjust the header files accordingly.
-  set(TESTUTIL_PATH_LIST
-      "common/file/tests"
-      "vector/fuzzer"
-      "vector/tests/utils"
-      "expression/tests"
-      "expression/fuzzer"
-      "parse"
-      "dwio/common/tests/utils"
-      "dwio/common/fuzzer"
-      "dwio/parquet/arrow/tests"
-      "tpch/gen/dbgen"
-      "tpch/gen"
-      "functions/lib/aggregates/tests/utils"
-      "functions/lib/window/tests"
-      "functions/prestosql/tests/utils"
-      "connectors/fuzzer"
-      "connectors/tpch"
-      "cudf/tests"
-      "exec/fuzzer"
-      "exec/tests/utils"
-      "exec/prefixsort/tests/utils"
-      "duckdb/conversion")
+  set(
+    TESTUTIL_PATH_LIST
+    "common/file/tests"
+    "vector/fuzzer"
+    "vector/tests/utils"
+    "expression/tests"
+    "expression/fuzzer"
+    "parse"
+    "dwio/common/tests/utils"
+    "dwio/common/fuzzer"
+    "dwio/parquet/arrow/tests"
+    "tpch/gen/dbgen"
+    "tpch/gen"
+    "functions/lib/aggregates/tests/utils"
+    "functions/lib/window/tests"
+    "functions/prestosql/tests/utils"
+    "connectors/fuzzer"
+    "connectors/tpch"
+    "cudf/tests"
+    "exec/fuzzer"
+    "exec/tests/utils"
+    "exec/prefixsort/tests/utils"
+    "duckdb/conversion"
+  )
 
-  set(BASE_COMP_LIST "buffer" "core" "type" "common" "vector" "row" "serializers" "version")
+  set(
+    BASE_COMP_LIST
+    "buffer"
+    "core"
+    "type"
+    "common"
+    "vector"
+    "row"
+    "serializers"
+    "version"
+  )
 
-  set(EXECUTION_COMP_LIST "exec" "jit" "expression")
+  set(
+    EXECUTION_COMP_LIST
+    "exec"
+    "jit"
+    "expression"
+  )
 
   set(FUNCTIONS_COMP_LIST "functions")
 
-  set(IO_COMP_LIST "connectors" "dwio" "external")
+  set(
+    IO_COMP_LIST
+    "connectors"
+    "dwio"
+    "external"
+  )
 
   set(SUBSTRAIT_COMP_LIST "substrait")
 
   set(SHUFFLE_COMP_LIST "shuffle")
 
-  set(EXTENSIONS_COMP_LIST "torch" "cudf" "python")
+  set(
+    EXTENSIONS_COMP_LIST
+    "torch"
+    "cudf"
+    "python"
+  )
 
-  if (BOLT_INTERFACE)
+  if(BOLT_INTERFACE)
     add_library(${target_name} INTERFACE ${ARGN})
     return()
   endif()
@@ -112,7 +147,6 @@ function(bolt_add_library target_name)
     set(BOLT_TESTUTILS_OBJECT_TARGETS ${BOLT_TESTUTILS_OBJECT_TARGETS} CACHE INTERNAL "")
     return()
   endif()
-
 
   if(FIRST_LEVEL_DIR IN_LIST BASE_COMP_LIST)
     list(APPEND BOLT_BASE_OBJECT_TARGETS $<TARGET_OBJECTS:${target_name}>)
@@ -236,42 +270,48 @@ if(${BOLT_BUILD_PYTHON_PACKAGE})
   add_subdirectory(python)
 endif()
 
-add_library(bolt_engine
+add_library(
+  bolt_engine
   ${BOLT_FUNCTIONS_OBJECT_TARGETS}
   ${BOLT_EXECUTION_OBJECT_TARGETS}
   ${BOLT_BASE_OBJECT_TARGETS}
   ${BOLT_IO_OBJECT_TARGETS}
   ${BOLT_SUBSTRAIT_OBJECT_TARGETS}
   ${BOLT_SHUFFLE_OBJECT_TARGETS}
-  ${BOLT_EXTENSIONS_OBJECT_TARGETS})
+  ${BOLT_EXTENSIONS_OBJECT_TARGETS}
+)
 
-target_link_libraries(bolt_engine PUBLIC
-                                  $<$<CONFIG:Debug>:bolt_debug_util>
-                                  arrow::arrow
-                                  $<$<BOOL:${ENABLE_BOLT_JIT}>:llvm-core::llvm-core>
-                                  Folly::folly
-                                  gflags::gflags
-                                  gfx::timsort
-                                  date::date
-                                  re2::re2
-                                  ryu::ryu
-                                  fmt::fmt
-                                  thrift::thrift
-                                  simdjson::simdjson
-                                  sonic-cpp::sonic-cpp
-                                  xxHash::xxhash
-                                  cityhash::cityhash
-                                  utf8proc::utf8proc
-                                  icu::icu
-                                  date::date
-                                  roaring::roaring
-                                  Boost::boost
-                                  Boost::url
-                                  $<$<BOOL:${BOLT_BUILD_TEST_UTILS}>:cpr::cpr>
-                                  $<$<BOOL:${BOLT_ENABLE_SPARK_COMPATIBLE}>:celeborn-cpp-client::celeborn-cpp-client>
-                                  $<$<BOOL:${BOLT_ENABLE_S3}>:aws-sdk-cpp::aws-sdk-cpp>
-                                  $<$<BOOL:${BOLT_ENABLE_GCS}>:google-cloud-cpp::storage>
-                                  $<$<BOOL:${BOLT_ENABLE_ABFS}>:Azure::azure-storage-blobs Azure::azure-storage-files-datalake Azure::azure-identity>
+target_link_libraries(
+  bolt_engine
+  PUBLIC
+    $<$<CONFIG:Debug>:bolt_debug_util>
+    arrow::arrow
+    $<$<BOOL:${ENABLE_BOLT_JIT}>:llvm-core::llvm-core>
+    Folly::folly
+    gflags::gflags
+    gfx::timsort
+    date::date
+    re2::re2
+    ryu::ryu
+    fmt::fmt
+    thrift::thrift
+    simdjson::simdjson
+    sonic-cpp::sonic-cpp
+    xxHash::xxhash
+    cityhash::cityhash
+    utf8proc::utf8proc
+    icu::icu
+    date::date
+    roaring::roaring
+    Boost::boost
+    Boost::url
+    $<$<BOOL:${BOLT_BUILD_TEST_UTILS}>:cpr::cpr>
+    $<$<BOOL:${BOLT_ENABLE_SPARK_COMPATIBLE}>:celeborn-cpp-client::celeborn-cpp-client>
+    $<$<BOOL:${BOLT_ENABLE_S3}>:aws-sdk-cpp::aws-sdk-cpp>
+    $<$<BOOL:${BOLT_ENABLE_GCS}>:google-cloud-cpp::storage>
+    $<$<BOOL:${BOLT_ENABLE_ABFS}>:Azure::azure-storage-blobs
+    Azure::azure-storage-files-datalake
+    Azure::azure-identity>
 )
 
 if(${BOLT_ENABLE_TORCH})
@@ -287,18 +327,27 @@ endif()
 if(${BOLT_ENABLE_CUDF})
   target_link_libraries(bolt_engine PUBLIC cudf::cudf)
   target_compile_definitions(
-    bolt_engine PUBLIC BOLT_HAS_CUDF=1 LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+    bolt_engine
+    PUBLIC
+      BOLT_HAS_CUDF=1
+      LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
   )
 endif()
 
 if(${BOLT_BUILD_TEST_UTILS})
-  add_library(bolt_testutils ${BOLT_TESTUTILS_OBJECT_TARGETS} common/testutil/BoltTestFlags.cpp)
-  target_link_libraries(bolt_testutils PUBLIC
-                                  bolt_engine
-                                  $<$<CONFIG:Debug>:bolt_debug_util>
-                                  duckdb::duckdb
-                                  gflags::gflags
-                                  GTest::gtest
+  add_library(
+    bolt_testutils
+    ${BOLT_TESTUTILS_OBJECT_TARGETS}
+    common/testutil/BoltTestFlags.cpp
+  )
+  target_link_libraries(
+    bolt_testutils
+    PUBLIC
+      bolt_engine
+      $<$<CONFIG:Debug>:bolt_debug_util>
+      duckdb::duckdb
+      gflags::gflags
+      GTest::gtest
   )
   target_include_directories(bolt_testutils PUBLIC ${CMAKE_BINARY_DIR})
 endif()
@@ -309,8 +358,12 @@ if(${BOLT_BUILD_TEST_UTILS})
 endif()
 
 install(
-  TARGETS ${BOLT_INSTALL_TARGETS}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+  TARGETS
+    ${BOLT_INSTALL_TARGETS}
+  ARCHIVE
+    DESTINATION lib
+  LIBRARY
+    DESTINATION lib
+  RUNTIME
+    DESTINATION bin
 )

--- a/bolt/benchmarks/CMakeLists.txt
+++ b/bolt/benchmarks/CMakeLists.txt
@@ -28,10 +28,11 @@
 add_subdirectory(basic)
 add_subdirectory(unstable)
 
-set(BOLT_BENCHMARK_DEPS
-    bolt_testutils
-    ${FOLLY_BENCHMARK}
-    GTest::gtest
+set(
+  BOLT_BENCHMARK_DEPS
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
+  GTest::gtest
 )
 
 add_library(bolt_benchmark_builder OBJECT ExpressionBenchmarkBuilder.cpp)
@@ -44,9 +45,10 @@ endif()
 
 add_library(bolt_query_benchmark OBJECT QueryBenchmarkBase.cpp)
 target_link_libraries(
-  bolt_query_benchmark PRIVATE
-  bolt_benchmark_builder
-  bolt_testutils
-  Folly::follybenchmark
-  fmt::fmt
+  bolt_query_benchmark
+  PRIVATE
+    bolt_benchmark_builder
+    bolt_testutils
+    Folly::follybenchmark
+    fmt::fmt
 )

--- a/bolt/benchmarks/basic/CMakeLists.txt
+++ b/bolt/benchmarks/basic/CMakeLists.txt
@@ -25,12 +25,13 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(BOLT_BENCHMARK_DEPS
-    bolt_vector_fuzzer
-    bolt_benchmark_builder
-    bolt_testutils
-    ${FOLLY_BENCHMARK}
-    GTest::gtest
+set(
+  BOLT_BENCHMARK_DEPS
+  bolt_vector_fuzzer
+  bolt_benchmark_builder
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
+  GTest::gtest
 )
 
 add_executable(bolt_benchmark_basic_simple_arithmetic SimpleArithmetic.cpp)
@@ -50,49 +51,77 @@ target_link_libraries(bolt_benchmark_basic_selectivity_vector ${BOLT_BENCHMARK_D
 
 add_executable(bolt_benchmark_basic_vector_compare VectorCompare.cpp)
 target_link_libraries(
-  bolt_benchmark_basic_vector_compare ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib
+  bolt_benchmark_basic_vector_compare
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_vector_test_lib
 )
 
 add_executable(bolt_benchmark_basic_vector_slice VectorSlice.cpp)
-target_link_libraries(bolt_benchmark_basic_vector_slice ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib)
+target_link_libraries(
+  bolt_benchmark_basic_vector_slice
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_vector_test_lib
+)
 
 add_executable(bolt_benchmark_feature_normalization FeatureNormalization.cpp)
 target_link_libraries(
-  bolt_benchmark_feature_normalization ${BOLT_BENCHMARK_DEPS} bolt_functions_prestosql
+  bolt_benchmark_feature_normalization
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_functions_prestosql
 )
 
 add_executable(bolt_benchmark_basic_preproc Preproc.cpp)
 target_link_libraries(
-  bolt_benchmark_basic_preproc ${BOLT_BENCHMARK_DEPS} bolt_functions_prestosql bolt_vector_test_lib
+  bolt_benchmark_basic_preproc
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_functions_prestosql
+  bolt_vector_test_lib
 )
 
 add_executable(bolt_like_tpch_benchmark LikeTpchBenchmark.cpp)
 target_link_libraries(
-  bolt_like_tpch_benchmark ${BOLT_BENCHMARK_DEPS} bolt_functions_lib bolt_tpch_gen
+  bolt_like_tpch_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_functions_lib
+  bolt_tpch_gen
   bolt_vector_test_lib
 )
 
 add_executable(bolt_like_benchmark LikeBenchmark.cpp)
 target_link_libraries(
-  bolt_like_benchmark ${BOLT_BENCHMARK_DEPS} bolt_functions_lib bolt_functions_prestosql
+  bolt_like_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_functions_lib
+  bolt_functions_prestosql
   bolt_vector_test_lib
 )
 
 add_executable(bolt_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
 target_link_libraries(
-  bolt_benchmark_basic_vector_fuzzer ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib
+  bolt_benchmark_basic_vector_fuzzer
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_vector_test_lib
 )
 
 add_executable(bolt_cast_benchmark CastBenchmark.cpp)
-target_link_libraries(bolt_cast_benchmark ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib)
+target_link_libraries(
+  bolt_cast_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_vector_test_lib
+)
 
 add_executable(bolt_benchmark_expr_flat_no_nulls ExprFlatNoNullsBenchmark.cpp)
 target_link_libraries(
-  bolt_benchmark_expr_flat_no_nulls ${BOLT_BENCHMARK_DEPS} bolt_functions_prestosql
+  bolt_benchmark_expr_flat_no_nulls
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_functions_prestosql
 )
 
 add_executable(bolt_format_datetime_benchmark FormatDateTimeBenchmark.cpp)
 target_link_libraries(
-  bolt_format_datetime_benchmark ${BOLT_BENCHMARK_DEPS} bolt_vector_test_lib bolt_functions_spark
+  bolt_format_datetime_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_vector_test_lib
+  bolt_functions_spark
   bolt_functions_prestosql
 )

--- a/bolt/benchmarks/paimon/CMakeLists.txt
+++ b/bolt/benchmarks/paimon/CMakeLists.txt
@@ -38,7 +38,8 @@ target_link_libraries(
   $<TARGET_NAME_IF_EXISTS:bolt_test_util_gperf>
   Folly::folly
   ${FOLLY_BENCHMARK}
-  fmt::fmt)
+  fmt::fmt
+)
 
 add_executable(bolt_paimon_benchmark PaimonBenchmarkMain.cpp)
 

--- a/bolt/benchmarks/tpch/CMakeLists.txt
+++ b/bolt/benchmarks/tpch/CMakeLists.txt
@@ -25,7 +25,7 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_library(bolt_tpch_benchmark_lib  OBJECT TpchBenchmark.cpp)
+add_library(bolt_tpch_benchmark_lib OBJECT TpchBenchmark.cpp)
 
 target_link_libraries(
   bolt_tpch_benchmark_lib
@@ -39,10 +39,12 @@ target_link_libraries(
 
 add_executable(bolt_tpch_benchmark TpchBenchmarkMain.cpp)
 
-target_link_libraries(bolt_tpch_benchmark PRIVATE
-  bolt_tpch_benchmark_lib
-  bolt_query_benchmark
-  bolt_testutils
-  $<TARGET_NAME_IF_EXISTS:bolt_test_util_gperf>
-  ${FOLLY_BENCHMARK}
+target_link_libraries(
+  bolt_tpch_benchmark
+  PRIVATE
+    bolt_tpch_benchmark_lib
+    bolt_query_benchmark
+    bolt_testutils
+    $<TARGET_NAME_IF_EXISTS:bolt_test_util_gperf>
+    ${FOLLY_BENCHMARK}
 )

--- a/bolt/benchmarks/unstable/CMakeLists.txt
+++ b/bolt/benchmarks/unstable/CMakeLists.txt
@@ -25,10 +25,11 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(BOLT_BENCHMARK_DEPS
-    bolt_vector_fuzzer
-    bolt_testutils
-    ${FOLLY_BENCHMARK}
+set(
+  BOLT_BENCHMARK_DEPS
+  bolt_vector_fuzzer
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
 )
 
 add_executable(bolt_memory_alloc_benchmark MemoryAllocationBenchmark.cpp)
@@ -36,12 +37,28 @@ add_executable(bolt_memory_alloc_contiguous_benchmark AllocateContiguousBenchmar
 add_executable(bolt_memory_realloc_benchmark ReallocateBenchmark.cpp)
 add_executable(bolt_memory_realloc_contiguous_benchmark ReallocateContiguousBenchmark.cpp)
 
-target_link_libraries(bolt_memory_alloc_benchmark ${BOLT_BENCHMARK_DEPS} bolt_memory pthread)
 target_link_libraries(
-  bolt_memory_alloc_contiguous_benchmark ${BOLT_BENCHMARK_DEPS} bolt_memory pthread
+  bolt_memory_alloc_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_memory
+  pthread
 )
-target_link_libraries(bolt_memory_realloc_benchmark ${BOLT_BENCHMARK_DEPS} bolt_memory pthread)
+target_link_libraries(
+  bolt_memory_alloc_contiguous_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_memory
+  pthread
+)
+target_link_libraries(
+  bolt_memory_realloc_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_memory
+  pthread
+)
 
 target_link_libraries(
-  bolt_memory_realloc_contiguous_benchmark ${BOLT_BENCHMARK_DEPS} bolt_memory pthread
+  bolt_memory_realloc_contiguous_benchmark
+  ${BOLT_BENCHMARK_DEPS}
+  bolt_memory
+  pthread
 )

--- a/bolt/buffer/CMakeLists.txt
+++ b/bolt/buffer/CMakeLists.txt
@@ -27,7 +27,12 @@
 
 bolt_add_library(bolt_buffer Buffer.cpp StringViewBufferHolder.cpp)
 
-target_link_libraries(bolt_buffer bolt_memory bolt_common_base Folly::folly)
+target_link_libraries(
+  bolt_buffer
+  bolt_memory
+  bolt_common_base
+  Folly::folly
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)
@@ -38,7 +43,7 @@ endif()
 target_sources(
   bolt_buffer
   PUBLIC
-  FILE_SET HEADERS
-           BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-           FILES Buffer.h StringViewBufferHolder.h
+    FILE_SET HEADERS
+      BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+      FILES Buffer.h StringViewBufferHolder.h
 )

--- a/bolt/buffer/tests/CMakeLists.txt
+++ b/bolt/buffer/tests/CMakeLists.txt
@@ -25,14 +25,19 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_buffer_test BufferTest.cpp StringViewBufferHolderTest.cpp)
+add_executable(
+  bolt_buffer_test
+  BufferTest.cpp
+  StringViewBufferHolderTest.cpp
+)
 
 add_test(bolt_buffer_test bolt_buffer_test)
 
 target_link_libraries(
   bolt_buffer_test
-  PRIVATE bolt_testutils
-          GTest::gtest
-          GTest::gtest_main
-          GTest::gmock_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock_main
 )

--- a/bolt/common/base/CMakeLists.txt
+++ b/bolt/common/base/CMakeLists.txt
@@ -27,8 +27,14 @@
 
 bolt_add_library(bolt_exception BoltException.cpp Exceptions.cpp Exceptions.h)
 target_link_libraries(
-  bolt_exception PUBLIC bolt_common_flags bolt_process Folly::folly fmt::fmt gflags::gflags
-                        glog::glog
+  bolt_exception
+  PUBLIC
+    bolt_common_flags
+    bolt_process
+    Folly::folly
+    fmt::fmt
+    gflags::gflags
+    glog::glog
 )
 
 bolt_add_library(
@@ -55,18 +61,20 @@ find_package(OpenSSL REQUIRED)
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)
 target_link_libraries(
   bolt_common_base
-  PUBLIC bolt_exception
-         Folly::folly
-         fmt::fmt
-         xsimd::xsimd
-         cityhash::cityhash
-         xxHash::xxhash
-         ryu::ryu
-         date::date
-         openssl::openssl
-  PRIVATE bolt_common_compression
-          bolt_process
-          glog::glog
+  PUBLIC
+    bolt_exception
+    Folly::folly
+    fmt::fmt
+    xsimd::xsimd
+    cityhash::cityhash
+    xxHash::xxhash
+    ryu::ryu
+    date::date
+    openssl::openssl
+  PRIVATE
+    bolt_common_compression
+    bolt_process
+    glog::glog
 )
 
 if(${BOLT_BUILD_TESTING})
@@ -92,6 +100,9 @@ target_link_libraries(
 bolt_add_library(bolt_status Status.cpp)
 target_link_libraries(
   bolt_status
-  PUBLIC fmt::fmt Folly::folly
-  PRIVATE glog::glog
+  PUBLIC
+    fmt::fmt
+    Folly::folly
+  PRIVATE
+    glog::glog
 )

--- a/bolt/common/base/benchmarks/CMakeLists.txt
+++ b/bolt/common/base/benchmarks/CMakeLists.txt
@@ -29,6 +29,10 @@ add_executable(bolt_common_base_benchmarks BitUtilBenchmark.cpp)
 
 target_link_libraries(
   bolt_common_base_benchmarks
-  PUBLIC ${FOLLY_BENCHMARK}
-  PRIVATE bolt_testutils Folly::folly bolt_process
+  PUBLIC
+    ${FOLLY_BENCHMARK}
+  PRIVATE
+    bolt_testutils
+    Folly::folly
+    bolt_process
 )

--- a/bolt/common/base/tests/CMakeLists.txt
+++ b/bolt/common/base/tests/CMakeLists.txt
@@ -25,7 +25,6 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-
 add_executable(
   bolt_base_test
   AsyncSourceTest.cpp
@@ -53,18 +52,20 @@ add_test(bolt_base_test bolt_base_test)
 
 target_link_libraries(
   bolt_base_test
-  PRIVATE bolt_testutils
-          bolt_common_base
-          GTest::gtest
-          GTest::gmock
-          GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    bolt_common_base
+    GTest::gtest
+    GTest::gmock
+    GTest::gtest_main
 )
 
 add_executable(bolt_memcpy_meter MemcpyTest.cpp)
 target_link_libraries(
-  bolt_memcpy_meter PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
-  pthread
+  bolt_memcpy_meter
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    pthread
 )

--- a/bolt/common/caching/CMakeLists.txt
+++ b/bolt/common/caching/CMakeLists.txt
@@ -39,14 +39,16 @@ bolt_add_library(
 
 target_link_libraries(
   bolt_caching
-  PUBLIC bolt_common_base
-         bolt_exception
-         bolt_file
-         bolt_memory
-         Folly::folly
-         fmt::fmt
-         gflags::gflags
-  PRIVATE bolt_time
+  PUBLIC
+    bolt_common_base
+    bolt_exception
+    bolt_file
+    bolt_memory
+    Folly::folly
+    fmt::fmt
+    gflags::gflags
+  PRIVATE
+    bolt_time
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/common/caching/tests/CMakeLists.txt
+++ b/bolt/common/caching/tests/CMakeLists.txt
@@ -25,7 +25,8 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_cache_test
+add_executable(
+  bolt_cache_test
   AsyncDataCacheTest.cpp
   CacheTTLControllerTest.cpp
   SsdFileTest.cpp
@@ -39,7 +40,8 @@ add_test(bolt_cache_test bolt_cache_test)
 
 target_link_libraries(
   bolt_cache_test
-  PRIVATE bolt_testutils
-          GTest::gtest
-          GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/compression/CMakeLists.txt
+++ b/bolt/common/compression/CMakeLists.txt
@@ -30,8 +30,4 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 bolt_add_library(bolt_common_compression Compression.cpp LzoDecompressor.cpp)
-target_link_libraries(
-  bolt_common_compression
-  PUBLIC Folly::folly
-  PRIVATE bolt_exception
-)
+target_link_libraries(bolt_common_compression PUBLIC Folly::folly PRIVATE bolt_exception)

--- a/bolt/common/compression/tests/CMakeLists.txt
+++ b/bolt/common/compression/tests/CMakeLists.txt
@@ -29,5 +29,8 @@ add_executable(bolt_common_compression_test CompressionTest.cpp)
 add_test(bolt_common_compression_test bolt_common_compression_test)
 target_link_libraries(
   bolt_common_compression_test
-  PRIVATE bolt_testutils GTest::gtest GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/config/CMakeLists.txt
+++ b/bolt/common/config/CMakeLists.txt
@@ -32,6 +32,9 @@ endif()
 bolt_add_library(bolt_common_config Config.cpp)
 target_link_libraries(
   bolt_common_config
-  PUBLIC bolt_common_base bolt_exception
-  PRIVATE re2::re2
+  PUBLIC
+    bolt_common_base
+    bolt_exception
+  PRIVATE
+    re2::re2
 )

--- a/bolt/common/config/tests/CMakeLists.txt
+++ b/bolt/common/config/tests/CMakeLists.txt
@@ -29,5 +29,8 @@ add_executable(bolt_config_test ConfigTest.cpp)
 add_test(bolt_config_test bolt_config_test)
 target_link_libraries(
   bolt_config_test
-  PRIVATE bolt_testutils GTest::gtest GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/encode/CMakeLists.txt
+++ b/bolt/common/encode/CMakeLists.txt
@@ -30,4 +30,9 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 bolt_add_library(bolt_encode Base64.cpp)
-target_link_libraries(bolt_encode PUBLIC Folly::folly bolt_exception)
+target_link_libraries(
+  bolt_encode
+  PUBLIC
+    Folly::folly
+    bolt_exception
+)

--- a/bolt/common/encode/tests/CMakeLists.txt
+++ b/bolt/common/encode/tests/CMakeLists.txt
@@ -25,9 +25,17 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_common_coding_test Base64Test.cpp CodingTest.cpp ZigZagTest.cpp)
+add_executable(
+  bolt_common_coding_test
+  Base64Test.cpp
+  CodingTest.cpp
+  ZigZagTest.cpp
+)
 add_test(bolt_common_coding_test bolt_common_coding_test)
 target_link_libraries(
-  bolt_common_coding_test PRIVATE bolt_testutils GTest::gtest
-                                  GTest::gtest_main
+  bolt_common_coding_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/file/CMakeLists.txt
+++ b/bolt/common/file/CMakeLists.txt
@@ -35,14 +35,27 @@ if(KERNEL_SUPPORTS_IO_URING)
   find_package(liburing REQUIRED)
   target_link_libraries(
     bolt_file
-    PUBLIC bolt_exception Folly::folly liburing::liburing
-    PRIVATE bolt_buffer bolt_common_base fmt::fmt glog::glog
+    PUBLIC
+      bolt_exception
+      Folly::folly
+      liburing::liburing
+    PRIVATE
+      bolt_buffer
+      bolt_common_base
+      fmt::fmt
+      glog::glog
   )
 else()
   target_link_libraries(
     bolt_file
-    PUBLIC bolt_exception Folly::folly
-    PRIVATE bolt_buffer bolt_common_base fmt::fmt glog::glog
+    PUBLIC
+      bolt_exception
+      Folly::folly
+    PRIVATE
+      bolt_buffer
+      bolt_common_base
+      fmt::fmt
+      glog::glog
   )
 endif()
 

--- a/bolt/common/file/benchmark/CMakeLists.txt
+++ b/bolt/common/file/benchmark/CMakeLists.txt
@@ -28,9 +28,19 @@
 add_library(bolt_read_benchmark_lib ReadBenchmark.cpp)
 
 target_link_libraries(
-  bolt_read_benchmark_lib PUBLIC bolt_file bolt_time Folly::folly gflags::gflags
+  bolt_read_benchmark_lib
+  PUBLIC
+    bolt_file
+    bolt_time
+    Folly::folly
+    gflags::gflags
 )
 
 add_executable(bolt_read_benchmark ReadBenchmarkMain.cpp)
 
-target_link_libraries(bolt_read_benchmark PRIVATE bolt_read_benchmark_lib bolt_testutils)
+target_link_libraries(
+  bolt_read_benchmark
+  PRIVATE
+    bolt_read_benchmark_lib
+    bolt_testutils
+)

--- a/bolt/common/file/tests/CMakeLists.txt
+++ b/bolt/common/file/tests/CMakeLists.txt
@@ -29,23 +29,36 @@ bolt_add_library(bolt_file_test_utils TestUtils.cpp)
 target_link_libraries(bolt_file_test_utils PUBLIC bolt_file)
 
 if(${BOLT_BUILD_TESTING})
-  add_executable(bolt_file_test FileInputStreamTest.cpp FileTest.cpp UtilsTest.cpp)
+  add_executable(
+    bolt_file_test
+    FileInputStreamTest.cpp
+    FileTest.cpp
+    UtilsTest.cpp
+  )
   add_test(bolt_file_test bolt_file_test)
   target_link_libraries(
     bolt_file_test
-    PRIVATE bolt_testutils
-            GTest::gmock
-            GTest::gtest
-            GTest::gtest_main
+    PRIVATE
+      bolt_testutils
+      GTest::gmock
+      GTest::gtest
+      GTest::gtest_main
   )
 
   if(KERNEL_SUPPORTS_IO_URING)
-    add_executable(bolt_async_file_test AsyncFileTest.cpp UtilsTest.cpp)
+    add_executable(
+      bolt_async_file_test
+      AsyncFileTest.cpp
+      UtilsTest.cpp
+    )
     add_test(bolt_async_file_test bolt_async_file_test)
     target_link_libraries(
-      bolt_async_file_test PRIVATE bolt_testutils
-                                  GTest::gmock
-                                  GTest::gtest GTest::gtest_main
+      bolt_async_file_test
+      PRIVATE
+        bolt_testutils
+        GTest::gmock
+        GTest::gtest
+        GTest::gtest_main
     )
   endif()
 endif()

--- a/bolt/common/hyperloglog/CMakeLists.txt
+++ b/bolt/common/hyperloglog/CMakeLists.txt
@@ -31,8 +31,4 @@ endif()
 
 bolt_add_library(bolt_common_hyperloglog BiasCorrection.cpp DenseHll.cpp SparseHll.cpp)
 
-target_link_libraries(
-  bolt_common_hyperloglog
-  PUBLIC bolt_memory
-  PRIVATE bolt_exception
-)
+target_link_libraries(bolt_common_hyperloglog PUBLIC bolt_memory PRIVATE bolt_exception)

--- a/bolt/common/hyperloglog/tests/CMakeLists.txt
+++ b/bolt/common/hyperloglog/tests/CMakeLists.txt
@@ -25,12 +25,18 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
+add_executable(
+  bolt_common_hyperloglog_test
+  DenseHllTest.cpp
+  SparseHllTest.cpp
+)
 
 add_test(NAME bolt_common_hyperloglog_test COMMAND bolt_common_hyperloglog_test)
 
 target_link_libraries(
-  bolt_common_hyperloglog_test PRIVATE bolt_testutils
-                                       GTest::gtest
-                                       GTest::gtest_main
+  bolt_common_hyperloglog_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/io/CMakeLists.txt
+++ b/bolt/common/io/CMakeLists.txt
@@ -27,4 +27,8 @@
 
 bolt_add_library(bolt_common_io IoStatistics.cpp)
 
-target_link_libraries(bolt_common_io Folly::folly glog::glog)
+target_link_libraries(
+  bolt_common_io
+  Folly::folly
+  glog::glog
+)

--- a/bolt/common/memory/CMakeLists.txt
+++ b/bolt/common/memory/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT APPLE)
   include_directories(${JEMALLOC_INCLUDE_DIRS})
 endif()
 
-if (BOLT_BUILD_TEST_UTILS)
+if(BOLT_BUILD_TEST_UTILS)
   find_package(GTest CONFIG REQUIRED)
 endif()
 
@@ -75,16 +75,18 @@ find_package(Arrow CONFIG REQUIRED)
 
 target_link_libraries(
   bolt_memory
-  PUBLIC bolt_common_base
-         bolt_common_config
-         bolt_exception
-         bolt_common_flags
-         bolt_time
-         bolt_type_base
-         Folly::folly
-         fmt::fmt
-         gflags::gflags
-         glog::glog
-         arrow::arrow
-  PRIVATE re2::re2
+  PUBLIC
+    bolt_common_base
+    bolt_common_config
+    bolt_exception
+    bolt_common_flags
+    bolt_time
+    bolt_type_base
+    Folly::folly
+    fmt::fmt
+    gflags::gflags
+    glog::glog
+    arrow::arrow
+  PRIVATE
+    re2::re2
 )

--- a/bolt/common/memory/tests/CMakeLists.txt
+++ b/bolt/common/memory/tests/CMakeLists.txt
@@ -54,24 +54,32 @@ endif()
 
 target_link_libraries(
   bolt_memory_test
-  PRIVATE bolt_testutils
-          GTest::gmock
-          GTest::gtest
-          GTest::gtest_main
-          $<$<NOT:$<PLATFORM_ID:Darwin>>:jemalloc::jemalloc>
-          pthread
-          dl
+  PRIVATE
+    bolt_testutils
+    GTest::gmock
+    GTest::gtest
+    GTest::gtest_main
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:jemalloc::jemalloc>
+    pthread
+    dl
 )
 
-gtest_add_tests(bolt_memory_test "" AUTO)
+gtest_add_tests(
+  bolt_memory_test
+  ""
+  AUTO
+)
 
 add_executable(bolt_fragmentation_benchmark FragmentationBenchmark.cpp)
 
 target_link_libraries(
   bolt_fragmentation_benchmark
-  PRIVATE bolt_testutils
-          $<$<NOT:$<PLATFORM_ID:Darwin>>:jemalloc::jemalloc>
-          gflags::gflags glog::glog dl
+  PRIVATE
+    bolt_testutils
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:jemalloc::jemalloc>
+    gflags::gflags
+    glog::glog
+    dl
 )
 
 add_executable(bolt_concurrent_allocation_benchmark ConcurrentAllocationBenchmark.cpp)

--- a/bolt/common/process/CMakeLists.txt
+++ b/bolt/common/process/CMakeLists.txt
@@ -32,8 +32,13 @@ bolt_add_library(
 
 target_link_libraries(
   bolt_process
-  PUBLIC bolt_common_flags Folly::folly
-  PRIVATE fmt::fmt gflags::gflags glog::glog
+  PUBLIC
+    bolt_common_flags
+    Folly::folly
+  PRIVATE
+    fmt::fmt
+    gflags::gflags
+    glog::glog
 )
 
 find_package(libbacktrace REQUIRED CONFIG)

--- a/bolt/common/process/tests/CMakeLists.txt
+++ b/bolt/common/process/tests/CMakeLists.txt
@@ -25,14 +25,20 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_process_test ExceptionTraceTest.cpp TraceContextTest.cpp)
+add_executable(
+  bolt_process_test
+  ExceptionTraceTest.cpp
+  TraceContextTest.cpp
+)
 
 add_test(bolt_process_test bolt_process_test)
 
 target_link_libraries(
-  bolt_process_test PRIVATE
-                    bolt_testutils
-                    GTest::gtest GTest::gtest_main
+  bolt_process_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_executable(bolt_crash_report_test CrashReportTest.cpp)
@@ -40,7 +46,8 @@ add_executable(bolt_crash_report_test CrashReportTest.cpp)
 add_test(bolt_crash_report_test bolt_crash_report_test)
 
 target_link_libraries(
-  bolt_crash_report_test PRIVATE
-                         bolt_process_crash_report
-                         GTest::gtest
+  bolt_crash_report_test
+  PRIVATE
+    bolt_process_crash_report
+    GTest::gtest
 )

--- a/bolt/common/serialization/CMakeLists.txt
+++ b/bolt/common/serialization/CMakeLists.txt
@@ -27,7 +27,13 @@
 
 bolt_add_library(bolt_serialization DeserializationRegistry.cpp)
 
-target_link_libraries(bolt_serialization PUBLIC bolt_exception Folly::folly glog::glog)
+target_link_libraries(
+  bolt_serialization
+  PUBLIC
+    bolt_exception
+    Folly::folly
+    glog::glog
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/common/serialization/tests/CMakeLists.txt
+++ b/bolt/common/serialization/tests/CMakeLists.txt
@@ -25,12 +25,17 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_serialization_test SerializableTest.cpp TestRegistry.cpp)
+add_executable(
+  bolt_serialization_test
+  SerializableTest.cpp
+  TestRegistry.cpp
+)
 add_test(bolt_serialization_test bolt_serialization_test)
 
 target_link_libraries(
   bolt_serialization_test
-  PRIVATE bolt_testutils
-          GTest::gtest
-          GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/testutil/CMakeLists.txt
+++ b/bolt/common/testutil/CMakeLists.txt
@@ -25,7 +25,12 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_library(bolt_debug_util OBJECT ScopedTestTime.cpp TestValue.cpp)
+  add_library(
+    bolt_debug_util
+    OBJECT
+    ScopedTestTime.cpp
+    TestValue.cpp
+  )
   target_link_libraries(bolt_debug_util PUBLIC bolt_exception)
 
   if(${BOLT_BUILD_TESTING})

--- a/bolt/common/testutil/tests/CMakeLists.txt
+++ b/bolt/common/testutil/tests/CMakeLists.txt
@@ -25,11 +25,21 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_test_util_test TestScopedTestTime.cpp TestValueTest.cpp)
-gtest_add_tests(bolt_test_util_test "" AUTO)
+add_executable(
+  bolt_test_util_test
+  TestScopedTestTime.cpp
+  TestValueTest.cpp
+)
+gtest_add_tests(
+  bolt_test_util_test
+  ""
+  AUTO
+)
 
 target_link_libraries(
-  bolt_test_util_test PRIVATE bolt_testutils
-                              GTest::gtest
-                              GTest::gtest_main
+  bolt_test_util_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/common/time/CMakeLists.txt
+++ b/bolt/common/time/CMakeLists.txt
@@ -30,8 +30,10 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 bolt_add_library(bolt_time CpuWallTimer.cpp Timer.cpp)
-target_link_libraries(bolt_time
-      PRIVATE
-        Folly::folly
-        fmt::fmt
-        $<$<CONFIG:Debug>:bolt_debug_util>)
+target_link_libraries(
+  bolt_time
+  PRIVATE
+    Folly::folly
+    fmt::fmt
+    $<$<CONFIG:Debug>:bolt_debug_util>
+)

--- a/bolt/common/time/tests/CMakeLists.txt
+++ b/bolt/common/time/tests/CMakeLists.txt
@@ -30,8 +30,15 @@ include(GoogleTest)
 add_executable(bolt_time_test CpuWallTimerTest.cpp)
 
 target_link_libraries(
-  bolt_time_test PRIVATE bolt_testutils
-                         GTest::gtest GTest::gtest_main
+  bolt_time_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
-gtest_add_tests(bolt_time_test "" AUTO)
+gtest_add_tests(
+  bolt_time_test
+  ""
+  AUTO
+)

--- a/bolt/common/token/CMakeLists.txt
+++ b/bolt/common/token/CMakeLists.txt
@@ -15,4 +15,8 @@
 
 bolt_add_library(bolt_token_extractor ITokenExtractor.cpp)
 
-target_link_libraries(bolt_token_extractor xxHash::xxhash Folly::folly)
+target_link_libraries(
+  bolt_token_extractor
+  xxHash::xxhash
+  Folly::folly
+)

--- a/bolt/connectors/CMakeLists.txt
+++ b/bolt/connectors/CMakeLists.txt
@@ -27,7 +27,11 @@
 
 bolt_add_library(bolt_connector Connector.cpp ConnectorObjectFactory.cpp)
 
-target_link_libraries(bolt_connector bolt_common_config bolt_vector)
+target_link_libraries(
+  bolt_connector
+  bolt_common_config
+  bolt_vector
+)
 
 add_subdirectory(fuzzer)
 

--- a/bolt/connectors/arrow/CMakeLists.txt
+++ b/bolt/connectors/arrow/CMakeLists.txt
@@ -20,7 +20,8 @@ target_link_libraries(bolt_arrow_connector bolt_connector)
 # Force export this library
 add_custom_target(
   dummy_arrow_connector_target
-  DEPENDS bolt_arrow_connector
+  DEPENDS
+    bolt_arrow_connector
   COMMENT "Exporting arrow connector library"
 )
 

--- a/bolt/connectors/fuzzer/CMakeLists.txt
+++ b/bolt/connectors/fuzzer/CMakeLists.txt
@@ -27,7 +27,11 @@
 
 bolt_add_library(bolt_fuzzer_connector OBJECT FuzzerConnector.cpp)
 
-target_link_libraries(bolt_fuzzer_connector bolt_connector bolt_vector_fuzzer)
+target_link_libraries(
+  bolt_fuzzer_connector
+  bolt_connector
+  bolt_vector_fuzzer
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/connectors/hive/CMakeLists.txt
+++ b/bolt/connectors/hive/CMakeLists.txt
@@ -58,14 +58,26 @@ bolt_add_library(
 
 set(ENABLED_DWIO_FORMATS "")
 if(BOLT_ENABLE_ORC)
-  list(APPEND ENABLED_DWIO_FORMATS bolt_dwio_orc_reader bolt_dwio_orc_writer)
+  list(
+    APPEND ENABLED_DWIO_FORMATS
+    bolt_dwio_orc_reader
+    bolt_dwio_orc_writer
+  )
 endif()
 if(BOLT_ENABLE_PARQUET)
-  list(APPEND ENABLED_DWIO_FORMATS bolt_dwio_parquet_reader bolt_dwio_parquet_writer)
+  list(
+    APPEND ENABLED_DWIO_FORMATS
+    bolt_dwio_parquet_reader
+    bolt_dwio_parquet_writer
+  )
 endif()
 
 if(BOLT_ENABLE_TXT)
-  list(APPEND ENABLED_DWIO_FORMATS bolt_dwio_txt_reader bolt_dwio_txt_writer)
+  list(
+    APPEND ENABLED_DWIO_FORMATS
+    bolt_dwio_txt_reader
+    bolt_dwio_txt_writer
+  )
 endif()
 
 set(ENABLED_FILESYSTEMS "")
@@ -77,25 +89,30 @@ list(APPEND ENABLED_FILESYSTEMS "bolt_abfs")
 
 target_link_libraries(
   bolt_hive_connector
-  PUBLIC bolt_common_io
-         bolt_connector
-         bolt_dwio_catalog_fbhive
-         bolt_dwio_dwrf_reader
-         bolt_dwio_dwrf_writer
-         bolt_dwio_orc_reader
-         bolt_dwio_parquet_reader
-         bolt_dwio_parquet_writer
-         ${ENABLED_FILESYSTEMS}
-         ${ENABLED_DWIO_FORMATS}
-         bolt_dwio_paimon_deletion_vector_reader
-         bolt_file
-         bolt_hive_partition_function
-         arrow::arrow
+  PUBLIC
+    bolt_common_io
+    bolt_connector
+    bolt_dwio_catalog_fbhive
+    bolt_dwio_dwrf_reader
+    bolt_dwio_dwrf_writer
+    bolt_dwio_orc_reader
+    bolt_dwio_parquet_reader
+    bolt_dwio_parquet_writer
+    ${ENABLED_FILESYSTEMS}
+    ${ENABLED_DWIO_FORMATS}
+    bolt_dwio_paimon_deletion_vector_reader
+    bolt_file
+    bolt_hive_partition_function
+    arrow::arrow
 )
 
 bolt_add_library(bolt_hive_partition_function HivePartitionFunction.cpp)
 
-target_link_libraries(bolt_hive_partition_function bolt_core bolt_exec)
+target_link_libraries(
+  bolt_hive_partition_function
+  bolt_core
+  bolt_exec
+)
 
 add_subdirectory(storage_adapters)
 

--- a/bolt/connectors/hive/storage_adapters/abfs/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/abfs/CMakeLists.txt
@@ -30,7 +30,9 @@
 bolt_add_library(bolt_abfs RegisterAbfsFileSystem.cpp)
 
 if(BOLT_ENABLE_ABFS)
-  target_sources(bolt_abfs PRIVATE
+  target_sources(
+    bolt_abfs
+    PRIVATE
       AbfsFileSystem.cpp
       AbfsPath.cpp
       AbfsReadFile.cpp
@@ -38,20 +40,22 @@ if(BOLT_ENABLE_ABFS)
       AbfsWriteFile.cpp
       AzureClientProviderFactories.cpp
       AzureClientProviderImpl.cpp
-      DynamicSasTokenClientProvider.cpp)
+      DynamicSasTokenClientProvider.cpp
+  )
 
   target_link_libraries(
     bolt_abfs
-    PUBLIC bolt_file
-           bolt_core
-           bolt_hive_config
-           bolt_dwio_common_exception
-           Azure::azure-storage-files-datalake
-           Azure::azure-storage-blobs
-           Azure::azure-identity
-           Folly::folly
-           glog::glog
-           fmt::fmt
+    PUBLIC
+      bolt_file
+      bolt_core
+      bolt_hive_config
+      bolt_dwio_common_exception
+      Azure::azure-storage-files-datalake
+      Azure::azure-storage-blobs
+      Azure::azure-identity
+      Folly::folly
+      glog::glog
+      fmt::fmt
   )
 
   if(${BOLT_BUILD_TESTING})

--- a/bolt/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
@@ -26,7 +26,11 @@ add_executable(
 add_test(bolt_abfs_test bolt_abfs_test)
 target_link_libraries(
   bolt_abfs_test
-  PRIVATE bolt_abfs bolt_testutils GTest::gtest GTest::gtest_main
+  PRIVATE
+    bolt_abfs
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 target_compile_options(bolt_abfs_test PRIVATE -Wno-deprecated-declarations)

--- a/bolt/connectors/hive/storage_adapters/gcs/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/gcs/CMakeLists.txt
@@ -30,8 +30,21 @@
 bolt_add_library(bolt_gcs RegisterGcsFileSystem.cpp)
 
 if(BOLT_ENABLE_GCS)
-  target_sources(bolt_gcs PRIVATE GcsFileSystem.cpp GcsUtil.cpp GcsWriteFile.cpp GcsReadFile.cpp)
-  target_link_libraries(bolt_gcs bolt_dwio_common bolt_exception Folly::folly google-cloud-cpp::storage)
+  target_sources(
+    bolt_gcs
+    PRIVATE
+      GcsFileSystem.cpp
+      GcsUtil.cpp
+      GcsWriteFile.cpp
+      GcsReadFile.cpp
+  )
+  target_link_libraries(
+    bolt_gcs
+    bolt_dwio_common
+    bolt_exception
+    Folly::folly
+    google-cloud-cpp::storage
+  )
 
   if(${BOLT_BUILD_TESTING})
     add_subdirectory(tests)

--- a/bolt/connectors/hive/storage_adapters/gcs/examples/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/gcs/examples/CMakeLists.txt
@@ -26,7 +26,4 @@
 # --------------------------------------------------------------------------
 
 add_executable(bolt_gcsfile_example GcsFileSystemExample.cpp)
-target_link_libraries(
-  bolt_gcsfile_example
-  bolt_testutils
-)
+target_link_libraries(bolt_gcsfile_example bolt_testutils)

--- a/bolt/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
@@ -25,7 +25,11 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_gcs_file_test GcsFileSystemTest.cpp GcsUtilTest.cpp)
+add_executable(
+  bolt_gcs_file_test
+  GcsFileSystemTest.cpp
+  GcsUtilTest.cpp
+)
 add_test(bolt_gcs_file_test bolt_gcsfile_test)
 target_link_libraries(
   bolt_gcs_file_test

--- a/bolt/connectors/hive/storage_adapters/hdfs/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/hdfs/CMakeLists.txt
@@ -26,15 +26,30 @@
 # --------------------------------------------------------------------------
 
 bolt_add_library(bolt_hdfs RegisterHdfsFileSystem.cpp)
-target_link_libraries(bolt_hdfs Folly::folly bolt_dwio_common xsimd::xsimd date::date)
+target_link_libraries(
+  bolt_hdfs
+  Folly::folly
+  bolt_dwio_common
+  xsimd::xsimd
+  date::date
+)
 
 if(BOLT_USE_ARROW_HDFS)
   target_sources(
-    bolt_hdfs PRIVATE HdfsFileSystem.cpp HdfsReadFile.cpp HdfsWriteFile.cpp StorageException.cpp
+    bolt_hdfs
+    PRIVATE
+      HdfsFileSystem.cpp
+      HdfsReadFile.cpp
+      HdfsWriteFile.cpp
+      StorageException.cpp
   )
 
   find_package(Arrow CONFIG REQUIRED)
-  target_link_libraries(bolt_hdfs bolt_external_hdfs arrow::arrow)
+  target_link_libraries(
+    bolt_hdfs
+    bolt_external_hdfs
+    arrow::arrow
+  )
 
   if(${BOLT_BUILD_TESTING})
     add_subdirectory(tests)

--- a/bolt/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
@@ -26,8 +26,11 @@
 # --------------------------------------------------------------------------
 
 add_executable(
-  bolt_hdfs_file_test HdfsFileSystemTest.cpp HdfsMiniCluster.cpp HdfsUtilTest.cpp
-                      InsertIntoHdfsTest.cpp
+  bolt_hdfs_file_test
+  HdfsFileSystemTest.cpp
+  HdfsMiniCluster.cpp
+  HdfsUtilTest.cpp
+  InsertIntoHdfsTest.cpp
 )
 
 add_test(bolt_hdfs_file_test bolt_hdfs_file_test)

--- a/bolt/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
@@ -30,11 +30,23 @@
 bolt_add_library(bolt_s3fs RegisterS3FileSystem.cpp)
 if(BOLT_ENABLE_S3)
   target_sources(
-    bolt_s3fs PRIVATE S3FileSystem.cpp S3Util.cpp S3Config.cpp S3WriteFile.cpp S3ReadFile.cpp
+    bolt_s3fs
+    PRIVATE
+      S3FileSystem.cpp
+      S3Util.cpp
+      S3Config.cpp
+      S3WriteFile.cpp
+      S3ReadFile.cpp
   )
 
   target_include_directories(bolt_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
-  target_link_libraries(bolt_s3fs bolt_dwio_common Folly::folly ${AWSSDK_LIBRARIES} xsimd::xsimd)
+  target_link_libraries(
+    bolt_s3fs
+    bolt_dwio_common
+    Folly::folly
+    ${AWSSDK_LIBRARIES}
+    xsimd::xsimd
+  )
 
   if(${BOLT_BUILD_TESTING})
     add_subdirectory(tests)

--- a/bolt/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/bolt/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -28,10 +28,17 @@
 add_executable(bolt_s3config_test S3ConfigTest.cpp)
 add_test(bolt_s3config_test bolt_s3config_test)
 target_link_libraries(
-  bolt_s3config_test bolt_testutils GTest::gtest GTest::gtest_main
+  bolt_s3config_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
 )
 
-add_executable(bolt_s3file_test S3FileSystemTest.cpp S3UtilTest.cpp)
+add_executable(
+  bolt_s3file_test
+  S3FileSystemTest.cpp
+  S3UtilTest.cpp
+)
 add_test(bolt_s3file_test bolt_s3file_test)
 target_link_libraries(
   bolt_s3file_test
@@ -52,7 +59,10 @@ target_link_libraries(
 add_executable(bolt_s3finalize_test S3FileSystemFinalizeTest.cpp)
 add_test(bolt_s3finalize_test bolt_s3finalize_test)
 target_link_libraries(
-  bolt_s3finalize_test bolt_testutils GTest::gtest GTest::gtest_main
+  bolt_s3finalize_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
 )
 
 add_executable(bolt_s3insert_test S3InsertTest.cpp)
@@ -67,7 +77,8 @@ target_link_libraries(
 add_executable(bolt_s3read_test S3ReadTest.cpp)
 add_test(
   NAME bolt_s3read_test
-  COMMAND bolt_s3read_test
+  COMMAND
+    bolt_s3read_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(
@@ -80,7 +91,10 @@ target_link_libraries(
 add_executable(bolt_s3metrics_test S3FileSystemMetricsTest.cpp)
 add_test(bolt_s3metrics_test bolt_s3metrics_test)
 target_link_libraries(
-  bolt_s3metrics_test bolt_testutils GTest::gtest GTest::gtest_main
+  bolt_s3metrics_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
 )
 
 add_executable(bolt_s3multiendpoints_test S3MultipleEndpointsTest.cpp)

--- a/bolt/connectors/paimon/CMakeLists.txt
+++ b/bolt/connectors/paimon/CMakeLists.txt
@@ -30,21 +30,22 @@ endif()
 
 target_link_libraries(
   bolt_connector_paimon
-  PUBLIC bolt_common_io
-         bolt_connector
-         $<$<BOOL:${BOLT_ENABLE_HDFS}>:bolt_hdfs>
-         bolt_dwio_parquet_reader
-         bolt_dwio_parquet_writer
-         bolt_file
-         bolt_dwio_common
-         bolt_type
-         bolt_vector
-         arrow::arrow
-         Paimon::core
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,Paimon::format_avro>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,Paimon::fs_local>
-    PRIVATE
-        Paimon::libavrocpp
+  PUBLIC
+    bolt_common_io
+    bolt_connector
+    $<$<BOOL:${BOLT_ENABLE_HDFS}>:bolt_hdfs>
+    bolt_dwio_parquet_reader
+    bolt_dwio_parquet_writer
+    bolt_file
+    bolt_dwio_common
+    bolt_type
+    bolt_vector
+    arrow::arrow
+    Paimon::core
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,Paimon::format_avro>
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,Paimon::fs_local>
+  PRIVATE
+    Paimon::libavrocpp
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/connectors/paimon/benchmark/CMakeLists.txt
+++ b/bolt/connectors/paimon/benchmark/CMakeLists.txt
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(
-    bolt_paimon_connector_benchmark
-    PaimonBenchmark.cpp
-)
+add_executable(bolt_paimon_connector_benchmark PaimonBenchmark.cpp)
 
 target_link_libraries(
-    bolt_paimon_connector_benchmark
-    PRIVATE
+  bolt_paimon_connector_benchmark
+  PRIVATE
     bolt_connector_paimon
     bolt_hive_connector
     bolt_exec_test_lib

--- a/bolt/connectors/paimon/tests/CMakeLists.txt
+++ b/bolt/connectors/paimon/tests/CMakeLists.txt
@@ -15,14 +15,11 @@
 # Ensure paimon Python package is available for tests that use it.
 # Only runs during cmake configuration; skips if already installed.
 
-find_package(
-        Python3
-        REQUIRED
-        COMPONENTS Interpreter
-)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 execute_process(
-  COMMAND ${Python3_EXECUTABLE} -c "import pypaimon"
+  COMMAND
+    ${Python3_EXECUTABLE} -c "import pypaimon"
   RESULT_VARIABLE _paimon_check_result
   ERROR_QUIET
   OUTPUT_QUIET
@@ -30,42 +27,53 @@ execute_process(
 if(NOT _paimon_check_result EQUAL 0)
   message(STATUS "Installing paimon Python package for integration tests...")
   execute_process(
-    COMMAND ${Python3_EXECUTABLE} -m pip install
+    COMMAND
+      ${Python3_EXECUTABLE} -m pip install
       "git+https://github.com/apache/paimon@release-1.4.1-rc2#subdirectory=paimon-python"
     RESULT_VARIABLE _paimon_install_result
     OUTPUT_VARIABLE _paimon_install_output
     ERROR_VARIABLE _paimon_install_error
   )
   if(NOT _paimon_install_result EQUAL 0)
-    message(WARNING "Failed to install paimon Python package: ${_paimon_install_error}. Please install at least version 1.4.1")
+    message(
+      WARNING
+      "Failed to install paimon Python package: ${_paimon_install_error}. Please install at least version 1.4.1"
+    )
   else()
     message(STATUS "paimon Python package installed successfully")
   endif()
 endif()
 
-set(PAIMON_CONNECTOR_TEST_SOURCES
-    PaimonConnectorTest.cpp
-    PaimonConfigTest.cpp
-    PaimonFilterPushdownTest.cpp
-    PaimonFilterTranslatorTest.cpp
-    PaimonParquetReaderTest.cpp)
+set(
+  PAIMON_CONNECTOR_TEST_SOURCES
+  PaimonConnectorTest.cpp
+  PaimonConfigTest.cpp
+  PaimonFilterPushdownTest.cpp
+  PaimonFilterTranslatorTest.cpp
+  PaimonParquetReaderTest.cpp
+)
 
 if(BOLT_ENABLE_HDFS)
-  list(APPEND PAIMON_CONNECTOR_TEST_SOURCES
-      PaimonHdfsFileSystemTest.cpp
-      HdfsContainerMiniCluster.cpp)
+  list(
+    APPEND PAIMON_CONNECTOR_TEST_SOURCES
+    PaimonHdfsFileSystemTest.cpp
+    HdfsContainerMiniCluster.cpp
+  )
 endif()
 
 add_executable(bolt_paimon_connector_test ${PAIMON_CONNECTOR_TEST_SOURCES})
 
 add_test(bolt_paimon_connector_test bolt_paimon_connector_test)
-set_tests_properties(bolt_paimon_connector_test PROPERTIES
-  ENVIRONMENT
-    "PAIMON_TEST_SCRIPT_DIR=${CMAKE_CURRENT_SOURCE_DIR};PAIMON_TEST_PYTHON=${Python3_EXECUTABLE}"
+set_tests_properties(
+  bolt_paimon_connector_test
+  PROPERTIES
+    ENVIRONMENT
+      "PAIMON_TEST_SCRIPT_DIR=${CMAKE_CURRENT_SOURCE_DIR};PAIMON_TEST_PYTHON=${Python3_EXECUTABLE}"
 )
 
-target_link_libraries(bolt_paimon_connector_test
-    PUBLIC
+target_link_libraries(
+  bolt_paimon_connector_test
+  PUBLIC
     bolt_connector_paimon
     bolt_testutils
     bolt_engine
@@ -83,7 +91,7 @@ target_link_libraries(bolt_paimon_connector_test
     glog::glog
     gflags::gflags
     Folly::folly
-    PRIVATE
+  PRIVATE
     $<LINK_LIBRARY:WHOLE_ARCHIVE,paimon_avro_file_format>
     $<LINK_LIBRARY:WHOLE_ARCHIVE,paimon_local_file_system>
     Paimon::tbb

--- a/bolt/connectors/tpch/CMakeLists.txt
+++ b/bolt/connectors/tpch/CMakeLists.txt
@@ -27,7 +27,12 @@
 
 bolt_add_library(bolt_tpch_connector TpchConnector.cpp)
 
-target_link_libraries(bolt_tpch_connector bolt_connector bolt_tpch_gen fmt::fmt)
+target_link_libraries(
+  bolt_tpch_connector
+  bolt_connector
+  bolt_tpch_gen
+  fmt::fmt
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/connectors/tpch/tests/CMakeLists.txt
+++ b/bolt/connectors/tpch/tests/CMakeLists.txt
@@ -40,5 +40,7 @@ target_link_libraries(
 add_executable(bolt_tpch_speed_test SpeedTest.cpp)
 
 target_link_libraries(
-  bolt_tpch_speed_test bolt_tpch_connector bolt_testutils
+  bolt_tpch_speed_test
+  bolt_tpch_connector
+  bolt_testutils
 )

--- a/bolt/core/CMakeLists.txt
+++ b/bolt/core/CMakeLists.txt
@@ -30,7 +30,11 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 bolt_add_library(bolt_config Config.cpp Context.cpp)
-target_link_libraries(bolt_config bolt_exception Folly::folly)
+target_link_libraries(
+  bolt_config
+  bolt_exception
+  Folly::folly
+)
 
 bolt_add_library(
   bolt_core Expressions.cpp PlanFragment.cpp PlanNode.cpp QueryConfig.cpp QueryCtx.cpp
@@ -39,20 +43,22 @@ bolt_add_library(
 
 target_link_libraries(
   bolt_core
-  PUBLIC bolt_arrow_bridge
-         bolt_caching
-         bolt_config
-         bolt_common_config
-         bolt_connector
-         bolt_exception
-         bolt_expression_functions
-         bolt_memory
-         bolt_type_base
-         bolt_vector
-         Boost::headers
-         Folly::folly
-         fmt::fmt
-  PRIVATE bolt_encode
+  PUBLIC
+    bolt_arrow_bridge
+    bolt_caching
+    bolt_config
+    bolt_common_config
+    bolt_connector
+    bolt_exception
+    bolt_expression_functions
+    bolt_memory
+    bolt_type_base
+    bolt_vector
+    Boost::headers
+    Folly::folly
+    fmt::fmt
+  PRIVATE
+    bolt_encode
 )
 
 if(${BOLT_ENABLE_TORCH})
@@ -70,5 +76,10 @@ endif()
 if(${BOLT_ENABLE_CUDF})
   target_compile_definitions(bolt_core PRIVATE BOLT_HAS_CUDF=1)
   target_include_directories(bolt_core SYSTEM PRIVATE ${cudf_INCLUDE_DIRS})
-  target_link_libraries(bolt_core PRIVATE bolt_cudf_exec cudf::cudf)
+  target_link_libraries(
+    bolt_core
+    PRIVATE
+      bolt_cudf_exec
+      cudf::cudf
+  )
 endif()

--- a/bolt/core/tests/CMakeLists.txt
+++ b/bolt/core/tests/CMakeLists.txt
@@ -40,7 +40,8 @@ add_test(bolt_core_test bolt_core_test)
 
 target_link_libraries(
   bolt_core_test
-  PRIVATE bolt_testutils
-          GTest::gtest
-          GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/cudf/benchmarks/CMakeLists.txt
+++ b/bolt/cudf/benchmarks/CMakeLists.txt
@@ -16,18 +16,31 @@
 add_executable(bolt_cudf_benchmark Main.cpp)
 
 target_link_libraries(
-  bolt_cudf_benchmark PRIVATE bolt_tpch_gen bolt_testutils ${FOLLY_BENCHMARK}
+  bolt_cudf_benchmark
+  PRIVATE
+    bolt_tpch_gen
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
 )
 
 # This linker option eliminates the following warning. /usr/bin/ld: warning: XXX.o: missing
 # .note.GNU-stack section implies executable stack /usr/bin/ld: NOTE: This behaviour is deprecated
 # and will be removed in a future version of the linker
-target_link_options(bolt_cudf_benchmark PRIVATE -z execstack)
-
-add_test(NAME bolt_cudf_orderby_benchmark_test COMMAND bolt_cudf_benchmark -scaleFactor 1 -opType
-                                                       orderby
+target_link_options(
+  bolt_cudf_benchmark
+  PRIVATE
+    -z
+    execstack
 )
 
-add_test(NAME bolt_cudf_aggregation_benchmark_test COMMAND bolt_cudf_benchmark -scaleFactor 1
-                                                           -opType aggregation
+add_test(
+  NAME bolt_cudf_orderby_benchmark_test
+  COMMAND
+    bolt_cudf_benchmark -scaleFactor 1 -opType orderby
+)
+
+add_test(
+  NAME bolt_cudf_aggregation_benchmark_test
+  COMMAND
+    bolt_cudf_benchmark -scaleFactor 1 -opType aggregation
 )

--- a/bolt/cudf/exec/CMakeLists.txt
+++ b/bolt/cudf/exec/CMakeLists.txt
@@ -18,7 +18,10 @@ bolt_add_library(bolt_cudf_exec HashAggregation.cpp InterOp.cpp OrderBy.cpp)
 target_include_directories(bolt_cudf_exec PRIVATE ${cudf_INCLUDE_DIRS})
 
 target_link_libraries(
-  bolt_cudf_exec PRIVATE arrow::arrow cudf::cudf
+  bolt_cudf_exec
+  PRIVATE
+    arrow::arrow
+    cudf::cudf
 )
 
 # The LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE macro enables the experimental
@@ -27,8 +30,17 @@ target_link_libraries(
 #
 # References: - RMM Fix: https://github.com/rapidsai/rmm/pull/1852 - libcudacxx Docs:
 # https://nvidia.github.io/cccl/libcudacxx/extended_api/memory_resource.html
-target_compile_options(bolt_cudf_exec PRIVATE -Wno-missing-field-initializers -fcoroutines)
+target_compile_options(
+  bolt_cudf_exec
+  PRIVATE
+    -Wno-missing-field-initializers
+    -fcoroutines
+)
 
 target_compile_definitions(
-  bolt_cudf_exec PUBLIC LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE PRIVATE BOLT_HAS_CUDF=1
+  bolt_cudf_exec
+  PUBLIC
+    LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+  PRIVATE
+    BOLT_HAS_CUDF=1
 )

--- a/bolt/cudf/tests/CMakeLists.txt
+++ b/bolt/cudf/tests/CMakeLists.txt
@@ -17,11 +17,7 @@ bolt_add_library(bolt_cudf_test_util CudfResource.cpp)
 
 target_include_directories(bolt_cudf_test_util PRIVATE ${cudf_INCLUDE_DIRS})
 
-target_link_libraries(
-  bolt_cudf_test_util
-  PUBLIC cudf::cudf
-  PRIVATE bolt_exception
-)
+target_link_libraries(bolt_cudf_test_util PUBLIC cudf::cudf PRIVATE bolt_exception)
 
 # The LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE macro enables the experimental
 # <cuda/memory_resource> header, a feature used by RMM and libcudf. This definition is necessary to
@@ -30,5 +26,8 @@ target_link_libraries(
 # References: - RMM Fix: https://github.com/rapidsai/rmm/pull/1852 - libcudacxx Docs:
 # https://nvidia.github.io/cccl/libcudacxx/extended_api/memory_resource.html
 target_compile_definitions(
-  bolt_cudf_test_util PUBLIC LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE BOLT_HAS_CUDF=1
+  bolt_cudf_test_util
+  PUBLIC
+    LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+    BOLT_HAS_CUDF=1
 )

--- a/bolt/duckdb/conversion/CMakeLists.txt
+++ b/bolt/duckdb/conversion/CMakeLists.txt
@@ -27,12 +27,20 @@
 
 bolt_add_library(bolt_duckdb_conversion DuckConversion.cpp)
 
-target_link_libraries(bolt_duckdb_conversion bolt_core bolt_vector duckdb::duckdb)
+target_link_libraries(
+  bolt_duckdb_conversion
+  bolt_core
+  bolt_vector
+  duckdb::duckdb
+)
 
 bolt_add_library(bolt_duckdb_parser DuckParser.cpp)
 
 target_link_libraries(
-  bolt_duckdb_parser bolt_duckdb_conversion bolt_parse_expression duckdb::duckdb
+  bolt_duckdb_parser
+  bolt_duckdb_conversion
+  bolt_parse_expression
+  duckdb::duckdb
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/duckdb/conversion/tests/CMakeLists.txt
+++ b/bolt/duckdb/conversion/tests/CMakeLists.txt
@@ -25,7 +25,11 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_duckdb_conversion_test DuckConversionTest.cpp DuckParserTest.cpp)
+add_executable(
+  bolt_duckdb_conversion_test
+  DuckConversionTest.cpp
+  DuckParserTest.cpp
+)
 
 add_test(bolt_duckdb_conversion_test bolt_duckdb_conversion_test)
 

--- a/bolt/dwio/CMakeLists.txt
+++ b/bolt/dwio/CMakeLists.txt
@@ -28,20 +28,21 @@
 bolt_add_library(bolt_link_libs INTERFACE)
 target_link_libraries(
   bolt_link_libs
-  INTERFACE bolt_caching
-            bolt_dwio_catalog_fbhive
-            bolt_dwio_common
-            bolt_dwio_common_exception
-            bolt_encode
-            bolt_exception
-            bolt_memory
-            bolt_process
-            bolt_serialization
-            bolt_type
-            bolt_type_fbhive
-            bolt_vector
-            Folly::folly
-            fmt::fmt
+  INTERFACE
+    bolt_caching
+    bolt_dwio_catalog_fbhive
+    bolt_dwio_common
+    bolt_dwio_common_exception
+    bolt_encode
+    bolt_exception
+    bolt_memory
+    bolt_process
+    bolt_serialization
+    bolt_type
+    bolt_type_fbhive
+    bolt_vector
+    Folly::folly
+    fmt::fmt
 )
 
 add_subdirectory(common)

--- a/bolt/dwio/catalog/fbhive/CMakeLists.txt
+++ b/bolt/dwio/catalog/fbhive/CMakeLists.txt
@@ -27,7 +27,10 @@
 
 bolt_add_library(bolt_dwio_catalog_fbhive FileUtils.cpp)
 target_link_libraries(
-  bolt_dwio_catalog_fbhive bolt_dwio_common_exception ${FMT} Folly::folly
+  bolt_dwio_catalog_fbhive
+  bolt_dwio_common_exception
+  ${FMT}
+  Folly::folly
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/dwio/catalog/fbhive/test/CMakeLists.txt
+++ b/bolt/dwio/catalog/fbhive/test/CMakeLists.txt
@@ -28,6 +28,9 @@
 add_executable(file_utils_test FileUtilsTests.cpp)
 add_test(file_utils_test file_utils_test)
 target_link_libraries(
-  file_utils_test bolt_testutils GTest::gtest
-  GTest::gtest_main GTest::gmock
+  file_utils_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
 )

--- a/bolt/dwio/common/exception/CMakeLists.txt
+++ b/bolt/dwio/common/exception/CMakeLists.txt
@@ -28,5 +28,8 @@
 bolt_add_library(bolt_dwio_common_exception Exception.cpp Exceptions.cpp)
 
 target_link_libraries(
-  bolt_dwio_common_exception bolt_exception Folly::folly glog::glog
+  bolt_dwio_common_exception
+  bolt_exception
+  Folly::folly
+  glog::glog
 )

--- a/bolt/dwio/common/tests/CMakeLists.txt
+++ b/bolt/dwio/common/tests/CMakeLists.txt
@@ -75,17 +75,16 @@ target_link_libraries(
 )
 
 add_library(bolt_e2e_filter_test_base OBJECT E2EFilterTestBase.cpp)
-target_link_libraries(
-  bolt_e2e_filter_test_base
-  bolt_testutils
-)
+target_link_libraries(bolt_e2e_filter_test_base bolt_testutils)
 
 if(BOLT_ENABLE_ARROW AND BOLT_BUILD_BENCHMARKS)
   add_subdirectory(Lemire/FastPFor)
   add_executable(bolt_dwio_common_bitpack_decoder_benchmark BitPackDecoderBenchmark.cpp)
 
   target_compile_options(
-    bolt_dwio_common_bitpack_decoder_benchmark PRIVATE -Wno-deprecated-declarations
+    bolt_dwio_common_bitpack_decoder_benchmark
+    PRIVATE
+      -Wno-deprecated-declarations
   )
 
   target_link_libraries(

--- a/bolt/dwio/dwrf/proto/CMakeLists.txt
+++ b/bolt/dwio/dwrf/proto/CMakeLists.txt
@@ -27,19 +27,34 @@
 
 # Set up Proto file( GLOB PROTO_FILES RELATIVE ${PROJECT_SOURCE_DIR}
 # ${CMAKE_CURRENT_SOURCE_DIR}/*.proto)
-set(PROTO_FILES ${CMAKE_CURRENT_SOURCE_DIR}/dwrf_schema.proto
-                ${CMAKE_CURRENT_SOURCE_DIR}/orc_schema.proto
+set(
+  PROTO_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/dwrf_schema.proto
+  ${CMAKE_CURRENT_SOURCE_DIR}/orc_schema.proto
 )
 
 set(PROTO_SRCS)
 set(PROTO_HDRS)
 foreach(proto ${PROTO_FILES})
-  protobuf_generate_cpp(BOLT_PROTO_SRCS BOLT_PROTO_HDRS ${proto})
+  protobuf_generate_cpp(
+    BOLT_PROTO_SRCS
+    BOLT_PROTO_HDRS
+    ${proto}
+  )
   list(APPEND PROTO_SRCS ${BOLT_PROTO_SRCS})
   list(APPEND PROTO_HDRS ${BOLT_PROTO_HDRS})
 endforeach()
-set(PROTO_OUTPUT_FILES ${PROTO_HDRS} ${PROTO_SRCS})
-set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
+set(
+  PROTO_OUTPUT_FILES
+  ${PROTO_HDRS}
+  ${PROTO_SRCS}
+)
+set_source_files_properties(
+  ${PROTO_OUTPUT_FILES}
+  PROPERTIES
+    GENERATED
+      TRUE
+)
 
 # add_custom_command( OUTPUT ${PROTO_OUTPUT_FILES} COMMAND ${Protobuf_PROTOC_EXECUTABLE}
 # --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path ${Protobuf_INCLUDE_DIRS} --cpp_out
@@ -51,17 +66,19 @@ bolt_add_library(bolt_dwio_dwrf_proto ${PROTO_SRCS} ${PROTO_HDRS})
 target_link_libraries(bolt_dwio_dwrf_proto protobuf::libprotobuf)
 target_include_directories(bolt_dwio_dwrf_proto PUBLIC ${CMAKE_BINARY_DIR})
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dwrf_schema.pb.h
-        ${CMAKE_CURRENT_BINARY_DIR}/orc_schema.pb.h DESTINATION "include/bolt/dwio/dwrf/proto/"
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/dwrf_schema.pb.h
+    ${CMAKE_CURRENT_BINARY_DIR}/orc_schema.pb.h
+  DESTINATION "include/bolt/dwio/dwrf/proto/"
 )
 
 install(
-  TARGETS bolt_dwio_dwrf_proto
-          # PUBLIC_HEADER DESTINATION include/bolt/dwio/dwrf/proto/
-          ARCHIVE
-          DESTINATION
-          ${CMAKE_INSTALL_LIBDIR}
-          LIBRARY
-          DESTINATION
-          ${CMAKE_INSTALL_LIBDIR}
+  TARGETS
+    bolt_dwio_dwrf_proto
+  # PUBLIC_HEADER DESTINATION include/bolt/dwio/dwrf/proto/
+  ARCHIVE
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/bolt/dwio/dwrf/reader/CMakeLists.txt
+++ b/bolt/dwio/dwrf/reader/CMakeLists.txt
@@ -59,11 +59,10 @@ target_link_libraries(
 )
 
 install(
-  TARGETS bolt_dwio_dwrf_reader
-          ARCHIVE
-          DESTINATION
-          ${CMAKE_INSTALL_LIBDIR}
-          LIBRARY
-          DESTINATION
-          ${CMAKE_INSTALL_LIBDIR}
+  TARGETS
+    bolt_dwio_dwrf_reader
+  ARCHIVE
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/bolt/dwio/dwrf/test/CMakeLists.txt
+++ b/bolt/dwio/dwrf/test/CMakeLists.txt
@@ -30,18 +30,18 @@ add_subdirectory(utils)
 # find_package(lzo CONFIG REQUIRED)
 find_package(zstd CONFIG REQUIRED)
 
-
-set(TEST_LINK_LIBS
-    bolt_dwio_common_test_utils
-    bolt_dwio_dwrf_proto
-    bolt_dwio_dwrf_reader
-    bolt_dwio_dwrf_writer
-    bolt_testutils
-    gflags::gflags
-    GTest::gtest
-    GTest::gtest_main
-    GTest::gmock
-    glog::glog
+set(
+  TEST_LINK_LIBS
+  bolt_dwio_common_test_utils
+  bolt_dwio_dwrf_proto
+  bolt_dwio_dwrf_reader
+  bolt_dwio_dwrf_writer
+  bolt_testutils
+  gflags::gflags
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+  glog::glog
 )
 
 include_directories("${CMAKE_BINARY_DIR}")
@@ -50,14 +50,20 @@ add_executable(bolt_dwio_dwrf_buffered_output_stream_test TestBufferedOutputStre
 add_test(bolt_dwio_dwrf_buffered_output_stream_test bolt_dwio_dwrf_buffered_output_stream_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_buffered_output_stream_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_buffered_output_stream_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_column_statistics_test TestColumnStatistics.cpp)
 add_test(bolt_dwio_dwrf_column_statistics_test bolt_dwio_dwrf_column_statistics_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_column_statistics_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_column_statistics_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_compression_test CompressionTest.cpp)
@@ -77,7 +83,8 @@ target_link_libraries(
 add_executable(bolt_dwio_dwrf_decompression_test TestDecompression.cpp)
 add_test(
   NAME bolt_dwio_dwrf_decompression_test
-  COMMAND bolt_dwio_dwrf_decompression_test
+  COMMAND
+    bolt_dwio_dwrf_decompression_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -134,43 +141,61 @@ target_link_libraries(
 )
 
 add_executable(
-  bolt_dwio_dwrf_dictionary_encoder_test TestIntegerDictionaryEncoder.cpp
-                                         TestStringDictionaryEncoder.cpp
+  bolt_dwio_dwrf_dictionary_encoder_test
+  TestIntegerDictionaryEncoder.cpp
+  TestStringDictionaryEncoder.cpp
 )
 add_test(bolt_dwio_dwrf_dictionary_encoder_test bolt_dwio_dwrf_dictionary_encoder_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_dictionary_encoder_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_dictionary_encoder_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_encoding_selector_test TestEncodingSelector.cpp)
 add_test(bolt_dwio_dwrf_encoding_selector_test bolt_dwio_dwrf_encoding_selector_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_encoding_selector_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_encoding_selector_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_index_builder_test IndexBuilderTests.cpp)
 add_test(bolt_dwio_dwrf_index_builder_test bolt_dwio_dwrf_index_builder_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_index_builder_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_index_builder_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_dictionary_encoding_utils_test TestDictionaryEncodingUtils.cpp)
-add_test(bolt_dwio_dwrf_dictionary_encoding_utils_test
-         bolt_dwio_dwrf_dictionary_encoding_utils_test
+add_test(
+  bolt_dwio_dwrf_dictionary_encoding_utils_test
+  bolt_dwio_dwrf_dictionary_encoding_utils_test
 )
 
 target_link_libraries(
-  bolt_dwio_dwrf_dictionary_encoding_utils_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_dictionary_encoding_utils_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_checksum_test ChecksumTests.cpp)
 add_test(bolt_dwio_dwrf_checksum_test bolt_dwio_dwrf_checksum_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_checksum_test bolt_link_libs Folly::folly Boost::headers ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_checksum_test
+  bolt_link_libs
+  Folly::folly
+  Boost::headers
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_writer_test WriterTest.cpp)
@@ -215,13 +240,21 @@ target_link_libraries(
 add_executable(bolt_dwio_dwrf_writer_sink_test WriterSinkTest.cpp)
 add_test(bolt_dwio_dwrf_writer_sink_test bolt_dwio_dwrf_writer_sink_test)
 
-target_link_libraries(bolt_dwio_dwrf_writer_sink_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  bolt_dwio_dwrf_writer_sink_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
+)
 
 add_executable(bolt_dwio_dwrf_data_buffer_holder_test DataBufferHolderTests.cpp)
 add_test(bolt_dwio_dwrf_data_buffer_holder_test bolt_dwio_dwrf_data_buffer_holder_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_data_buffer_holder_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_data_buffer_holder_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_layout_planner_test LayoutPlannerTests.cpp)
@@ -240,12 +273,22 @@ target_link_libraries(
 add_executable(bolt_dwio_dwrf_decryption_test DecryptionTests.cpp)
 add_test(bolt_dwio_dwrf_decryption_test bolt_dwio_dwrf_decryption_test)
 
-target_link_libraries(bolt_dwio_dwrf_decryption_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  bolt_dwio_dwrf_decryption_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
+)
 
 add_executable(bolt_dwio_dwrf_encryption_test EncryptionTests.cpp)
 add_test(bolt_dwio_dwrf_encryption_test bolt_dwio_dwrf_encryption_test)
 
-target_link_libraries(bolt_dwio_dwrf_encryption_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  bolt_dwio_dwrf_encryption_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
+)
 
 add_executable(bolt_dwio_dwrf_stripe_reader_base_test StripeReaderBaseTests.cpp)
 add_test(bolt_dwio_dwrf_stripe_reader_base_test bolt_dwio_dwrf_stripe_reader_base_test)
@@ -277,71 +320,112 @@ target_link_libraries(
 add_executable(bolt_dwio_dwrf_config_test ConfigTests.cpp)
 add_test(bolt_dwio_dwrf_config_test bolt_dwio_dwrf_config_test)
 
-target_link_libraries(bolt_dwio_dwrf_config_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  bolt_dwio_dwrf_config_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
+)
 
 add_executable(bolt_dwio_dwrf_ratio_checker_test RatioTrackerTest.cpp)
 add_test(bolt_dwio_dwrf_ratio_checker_test bolt_dwio_dwrf_ratio_checker_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_ratio_checker_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_ratio_checker_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_flush_policy_test FlushPolicyTest.cpp)
 add_test(bolt_dwio_dwrf_flush_policy_test bolt_dwio_dwrf_flush_policy_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_flush_policy_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_flush_policy_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_byte_rle_test TestByteRle.cpp)
 add_test(bolt_dwio_dwrf_byte_rle_test bolt_dwio_dwrf_byte_rle_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_byte_rle_test bolt_link_libs fmt::fmt Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_byte_rle_test
+  bolt_link_libs
+  fmt::fmt
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_byte_rle_encoder_test TestByteRLEEncoder.cpp)
 add_test(bolt_dwio_dwrf_byte_rle_encoder_test bolt_dwio_dwrf_byte_rle_encoder_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_byte_rle_encoder_test bolt_link_libs fmt::fmt Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_byte_rle_encoder_test
+  bolt_link_libs
+  fmt::fmt
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_int_encoder_test TestIntEncoder.cpp)
 add_test(bolt_dwio_dwrf_int_encoder_test bolt_dwio_dwrf_int_encoder_test)
 
-target_link_libraries(bolt_dwio_dwrf_int_encoder_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  bolt_dwio_dwrf_int_encoder_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
+)
 
 add_executable(bolt_dwio_dwrf_rle_test TestRle.cpp)
 add_test(bolt_dwio_dwrf_rle_test bolt_dwio_dwrf_rle_test)
 
-target_link_libraries(bolt_dwio_dwrf_rle_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS})
+target_link_libraries(
+  bolt_dwio_dwrf_rle_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
+)
 
 add_executable(bolt_dwio_dwrf_int_direct_test TestIntDirect.cpp)
 add_test(bolt_dwio_dwrf_int_direct_test bolt_dwio_dwrf_int_direct_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_int_direct_test bolt_link_libs fmt::fmt Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_int_direct_test
+  bolt_link_libs
+  fmt::fmt
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_rlev1_encoder_test TestRLEv1Encoder.cpp)
 add_test(bolt_dwio_dwrf_rlev1_encoder_test bolt_dwio_dwrf_rlev1_encoder_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_rlev1_encoder_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_rlev1_encoder_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_column_reader_test TestColumnReader.cpp)
 add_test(bolt_dwio_dwrf_column_reader_test bolt_dwio_dwrf_column_reader_test)
 
 target_link_libraries(
-  bolt_dwio_dwrf_column_reader_test bolt_link_libs Folly::folly fmt::fmt ${TEST_LINK_LIBS}
+  bolt_dwio_dwrf_column_reader_test
+  bolt_link_libs
+  Folly::folly
+  fmt::fmt
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_dwrf_reader_test ReaderTest.cpp)
 add_test(
   NAME bolt_dwio_dwrf_reader_test
-  COMMAND bolt_dwio_dwrf_reader_test
+  COMMAND
+    bolt_dwio_dwrf_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -358,13 +442,12 @@ target_link_libraries(
   ${TEST_LINK_LIBS}
 )
 
-add_executable(dwrf_selective_string_dict_reader_test
-  SelectiveStringDictionaryColumnReaderTest.cpp
-)
+add_executable(dwrf_selective_string_dict_reader_test SelectiveStringDictionaryColumnReaderTest.cpp)
 
 add_test(
   NAME dwrf_selective_string_dict_reader_test
-  COMMAND dwrf_selective_string_dict_reader_test
+  COMMAND
+    dwrf_selective_string_dict_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -400,7 +483,10 @@ add_executable(bolt_dwrf_statistics_builder_utils_test TestStatisticsBuilderUtil
 add_test(bolt_dwrf_statistics_builder_utils_test bolt_dwrf_statistics_builder_utils_test)
 
 target_link_libraries(
-  bolt_dwrf_statistics_builder_utils_test bolt_link_libs Folly::folly ${TEST_LINK_LIBS}
+  bolt_dwrf_statistics_builder_utils_test
+  bolt_link_libs
+  Folly::folly
+  ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwrf_column_writer_test ColumnWriterTest.cpp)
@@ -541,7 +627,11 @@ target_link_libraries(
   ${FOLLY_BENCHMARK}
 )
 
-add_executable(bolt_dwio_cache_test CacheInputTest.cpp DirectBufferedInputTest.cpp)
+add_executable(
+  bolt_dwio_cache_test
+  CacheInputTest.cpp
+  DirectBufferedInputTest.cpp
+)
 
 add_test(bolt_dwio_cache_test bolt_dwio_cache_test)
 

--- a/bolt/dwio/dwrf/utils/CMakeLists.txt
+++ b/bolt/dwio/dwrf/utils/CMakeLists.txt
@@ -33,4 +33,9 @@ bolt_add_library(bolt_dwio_dwrf_utils BitIterator.h ProtoUtils.cpp)
 
 add_dependencies(bolt_dwio_dwrf_utils bolt_dwio_dwrf_proto)
 
-target_link_libraries(bolt_dwio_dwrf_utils bolt_dwio_dwrf_proto bolt_type bolt_memory)
+target_link_libraries(
+  bolt_dwio_dwrf_utils
+  bolt_dwio_dwrf_proto
+  bolt_type
+  bolt_memory
+)

--- a/bolt/dwio/dwrf/utils/test/CMakeLists.txt
+++ b/bolt/dwio/dwrf/utils/test/CMakeLists.txt
@@ -26,7 +26,10 @@
 # --------------------------------------------------------------------------
 
 add_executable(
-  bolt_dwio_dwrf_utils_test BitIteratorTests.cpp BufferedWriterTest.cpp ProtoUtilsTests.cpp
+  bolt_dwio_dwrf_utils_test
+  BitIteratorTests.cpp
+  BufferedWriterTest.cpp
+  ProtoUtilsTests.cpp
 )
 
 add_test(bolt_dwio_dwrf_utils_test bolt_dwio_dwrf_utils_test)

--- a/bolt/dwio/orc/test/CMakeLists.txt
+++ b/bolt/dwio/orc/test/CMakeLists.txt
@@ -25,10 +25,15 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_dwio_orc_test OrcReaderTest.cpp OrcWriterTest.cpp)
+add_executable(
+  bolt_dwio_orc_test
+  OrcReaderTest.cpp
+  OrcWriterTest.cpp
+)
 add_test(
   NAME bolt_dwio_orc_test
-  COMMAND bolt_dwio_orc_test
+  COMMAND
+    bolt_dwio_orc_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -45,7 +50,8 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINAR
 add_executable(bolt_dwio_orc_tpch_test OrcTpchTest.cpp)
 add_test(
   NAME bolt_dwio_orc_tpch_test
-  COMMAND bolt_dwio_orc_tpch_test
+  COMMAND
+    bolt_dwio_orc_tpch_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(

--- a/bolt/dwio/orc/writer/CMakeLists.txt
+++ b/bolt/dwio/orc/writer/CMakeLists.txt
@@ -16,7 +16,13 @@
 if(BOLT_ENABLE_ORC)
   find_package(Arrow CONFIG REQUIRED)
   bolt_add_library(bolt_dwio_orc_writer OrcWriter.cpp RegisterOrcWriter.cpp)
-  target_link_libraries(bolt_dwio_orc_writer bolt_dwio_common bolt_arrow_bridge arrow::arrow ${FMT})
+  target_link_libraries(
+    bolt_dwio_orc_writer
+    bolt_dwio_common
+    bolt_arrow_bridge
+    arrow::arrow
+    ${FMT}
+  )
 else()
   bolt_add_library(bolt_dwio_orc_writer RegisterOrcWriter.cpp)
   # No additional dependencies

--- a/bolt/dwio/paimon/deletionvectors/CMakeLists.txt
+++ b/bolt/dwio/paimon/deletionvectors/CMakeLists.txt
@@ -18,7 +18,10 @@ bolt_add_library(bolt_dwio_paimon_deletion_vector_reader DeletionFileReader.cpp 
 find_package(roaring REQUIRED)
 
 target_link_libraries(
-  bolt_dwio_paimon_deletion_vector_reader bolt_process bolt_link_libs roaring::roaring
+  bolt_dwio_paimon_deletion_vector_reader
+  bolt_process
+  bolt_link_libs
+  roaring::roaring
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/dwio/paimon/deletionvectors/tests/CMakeLists.txt
+++ b/bolt/dwio/paimon/deletionvectors/tests/CMakeLists.txt
@@ -15,14 +15,19 @@
 
 set(PAIMON_DELETION_TESTS DeleteionVectorTest.cpp)
 if(BOLT_ENABLE_PARQUET)
-  set(PAIMON_DELETION_TESTS ${PAIMON_DELETION_TESTS} DeletionFileReaderTest.cpp)
+  set(
+    PAIMON_DELETION_TESTS
+    ${PAIMON_DELETION_TESTS}
+    DeletionFileReaderTest.cpp
+  )
 endif()
 
 add_executable(bolt_paimon_deletion_vector_reader_test ${PAIMON_DELETION_TESTS})
 
 add_test(
   NAME bolt_paimon_deletion_vector_reader_test
-  COMMAND bolt_paimon_deletion_vector_reader_test
+  COMMAND
+    bolt_paimon_deletion_vector_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/bolt/dwio/paimon/reader/tests/CMakeLists.txt
+++ b/bolt/dwio/paimon/reader/tests/CMakeLists.txt
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(bolt_dwio_paimon_test
-               PaimonReaderDeduplicateTest.cpp
-               PaimonReaderAggregateTest.cpp
-               PaimonReaderPartialUpdateTest.cpp
-               PaimonReaderMetadataFieldTest.cpp
-               PaimonTestUtils.cpp)
+add_executable(
+  bolt_dwio_paimon_test
+  PaimonReaderDeduplicateTest.cpp
+  PaimonReaderAggregateTest.cpp
+  PaimonReaderPartialUpdateTest.cpp
+  PaimonReaderMetadataFieldTest.cpp
+  PaimonTestUtils.cpp
+)
 
 add_test(bolt_dwio_paimon_test bolt_dwio_paimon_test)
 

--- a/bolt/dwio/parquet/CMakeLists.txt
+++ b/bolt/dwio/parquet/CMakeLists.txt
@@ -41,6 +41,10 @@ bolt_add_library(bolt_dwio_parquet_reader RegisterParquetReader.cpp)
 bolt_add_library(bolt_dwio_parquet_writer RegisterParquetWriter.cpp)
 
 if(BOLT_ENABLE_PARQUET)
-  target_link_libraries(bolt_dwio_parquet_reader bolt_dwio_native_parquet_reader xsimd::xsimd)
+  target_link_libraries(
+    bolt_dwio_parquet_reader
+    bolt_dwio_native_parquet_reader
+    xsimd::xsimd
+  )
   target_link_libraries(bolt_dwio_parquet_writer bolt_dwio_arrow_parquet_writer)
 endif()

--- a/bolt/dwio/parquet/arrow/generated/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/generated/CMakeLists.txt
@@ -27,4 +27,8 @@
 
 bolt_add_library(bolt_dwio_parquet_arrow_thrift_lib parquet_types.cpp)
 
-target_link_libraries(bolt_dwio_parquet_arrow_thrift_lib arrow::arrow Boost::headers)
+target_link_libraries(
+  bolt_dwio_parquet_arrow_thrift_lib
+  arrow::arrow
+  Boost::headers
+)

--- a/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
@@ -59,8 +59,9 @@ add_executable(
 )
 target_link_libraries(
   bolt_dwio_parquet_level_conversion_benchmark
-  PRIVATE arrow::arrow
-  ${FOLLY_BENCHMARK}
+  PRIVATE
+    arrow::arrow
+    ${FOLLY_BENCHMARK}
 )
 
 bolt_add_library(
@@ -75,6 +76,9 @@ bolt_add_library(
 )
 
 target_link_libraries(
-  bolt_dwio_parquet_arrow_test_lib bolt_dwio_parquet_arrow_lib arrow::arrow GTest::gtest
+  bolt_dwio_parquet_arrow_test_lib
+  bolt_dwio_parquet_arrow_lib
+  arrow::arrow
+  GTest::gtest
   GTest::gtest_main
 )

--- a/bolt/dwio/parquet/encryption/CMakeLists.txt
+++ b/bolt/dwio/parquet/encryption/CMakeLists.txt
@@ -16,7 +16,8 @@
 bolt_add_library(
   bolt_dwio_parquet_encryption
         EncryptionInternal.cpp
-        InternalFileDecryptor.cpp)
+        InternalFileDecryptor.cpp
+)
 
 find_package(Arrow CONFIG REQUIRED)
 

--- a/bolt/dwio/parquet/fuzzer/CMakeLists.txt
+++ b/bolt/dwio/parquet/fuzzer/CMakeLists.txt
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(bolt_parquet_fuzzer_test ParquetFuzzerRunner.cpp ParquetFuzzerTest.cpp)
+add_executable(
+  bolt_parquet_fuzzer_test
+  ParquetFuzzerRunner.cpp
+  ParquetFuzzerTest.cpp
+)
 
-target_link_libraries(bolt_parquet_fuzzer_test bolt_fuzzer_flags bolt_testutils)
+target_link_libraries(
+  bolt_parquet_fuzzer_test
+  bolt_fuzzer_flags
+  bolt_testutils
+)

--- a/bolt/dwio/parquet/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/reader/CMakeLists.txt
@@ -70,7 +70,12 @@ if(${BOLT_BUILD_TESTING})
   add_library(bolt_dwio_native_parquet_reader_cli OBJECT ParquetReaderCli.cpp)
 
   target_link_libraries(
-    bolt_dwio_native_parquet_reader_cli bolt_dwio_parquet_reader bolt_dwio_parquet_arrow_lib
-    bolt_dwio_native_parquet_reader bolt_dwio_common bolt_hdfs GTest::gtest
+    bolt_dwio_native_parquet_reader_cli
+    bolt_dwio_parquet_reader
+    bolt_dwio_parquet_arrow_lib
+    bolt_dwio_native_parquet_reader
+    bolt_dwio_common
+    bolt_hdfs
+    GTest::gtest
   )
 endif()

--- a/bolt/dwio/parquet/tests/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/CMakeLists.txt
@@ -25,14 +25,15 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(TEST_LINK_LIBS
-    bolt_testutils
-    bolt_temp_path
-    GTest::gtest
-    GTest::gtest_main
-    GTest::gmock
-    gflags::gflags
-    ${GLOG}
+set(
+  TEST_LINK_LIBS
+  bolt_testutils
+  bolt_temp_path
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+  gflags::gflags
+  ${GLOG}
 )
 
 add_subdirectory(reader)
@@ -43,7 +44,8 @@ add_subdirectory(encryption)
 add_executable(bolt_dwio_parquet_tpch_test ParquetTpchTest.cpp)
 add_test(
   NAME bolt_dwio_parquet_tpch_test
-  COMMAND bolt_dwio_parquet_tpch_test
+  COMMAND
+    bolt_dwio_parquet_tpch_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(

--- a/bolt/dwio/parquet/tests/encryption/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/encryption/CMakeLists.txt
@@ -16,12 +16,15 @@
 add_executable(
   bolt_dwio_parquet_encryption_test
   AesDecryptorTest.cpp
-  InternalFileDecryptorTest.cpp)
+  InternalFileDecryptorTest.cpp
+)
 
 add_test(
   NAME bolt_dwio_parquet_encryption_test
-  COMMAND bolt_dwio_parquet_encryption_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  COMMAND
+    bolt_dwio_parquet_encryption_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 target_link_libraries(
   bolt_dwio_parquet_encryption_test
@@ -29,4 +32,5 @@ target_link_libraries(
   #bolt_dwio_parquet_arrow_lib
   bolt_testutils
   GTest::gtest
-  GTest::gtest_main)
+  GTest::gtest_main
+)

--- a/bolt/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/reader/CMakeLists.txt
@@ -28,7 +28,8 @@
 # find_package(lzo CONFIG REQUIRED)
 find_package(Arrow CONFIG REQUIRED)
 
-add_executable(bolt_dwio_parquet_reader_test
+add_executable(
+  bolt_dwio_parquet_reader_test
   ParquetReaderTest.cpp
   ParquetPageReaderTest.cpp
   NestedStructureDecoderTest.cpp
@@ -36,17 +37,20 @@ add_executable(bolt_dwio_parquet_reader_test
 
 add_test(
   NAME bolt_dwio_parquet_reader_test
-  COMMAND bolt_dwio_parquet_reader_test
+  COMMAND
+    bolt_dwio_parquet_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(
-  bolt_dwio_parquet_reader_test PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  bolt_dwio_parquet_reader_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
-add_executable(bolt_parquet_filter_test
+add_executable(
+  bolt_parquet_filter_test
   E2EFilterTest.cpp
   ParquetDictionaryFilterTest.cpp
   ParquetRowGroupFilterTest.cpp
@@ -62,62 +66,72 @@ target_link_libraries(
 add_executable(bolt_dwio_parquet_reader_benchmark ParquetReaderBenchmark.cpp)
 target_link_libraries(
   bolt_dwio_parquet_reader_benchmark
-  PRIVATE bolt_testutils
-  ${FOLLY_BENCHMARK}
+  PRIVATE
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
 )
 
-add_executable(bolt_dwio_parquet_page_reader_preload_benchmark ParquetPageReaderPreloadBenchmark.cpp)
+add_executable(
+  bolt_dwio_parquet_page_reader_preload_benchmark
+  ParquetPageReaderPreloadBenchmark.cpp
+)
 target_link_libraries(
   bolt_dwio_parquet_page_reader_preload_benchmark
-  PRIVATE bolt_testutils
-  ${FOLLY_BENCHMARK}
+  PRIVATE
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
 )
 
 add_executable(bolt_dwio_parquet_structure_decoder_benchmark NestedStructureDecoderBenchmark.cpp)
 target_link_libraries(
-  bolt_dwio_parquet_structure_decoder_benchmark PRIVATE
-  bolt_testutils
-  ${FOLLY_BENCHMARK}
+  bolt_dwio_parquet_structure_decoder_benchmark
+  PRIVATE
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
 )
 
 add_executable(bolt_dwio_parquet_table_scan_test ParquetTableScanTest.cpp)
 add_test(
   NAME bolt_dwio_parquet_table_scan_test
-  COMMAND bolt_dwio_parquet_table_scan_test
+  COMMAND
+    bolt_dwio_parquet_table_scan_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(
-  bolt_dwio_parquet_table_scan_test PRIVATE
-  bolt_testutils
-  ${TEST_LINK_LIBS}
+  bolt_dwio_parquet_table_scan_test
+  PRIVATE
+    bolt_testutils
+    ${TEST_LINK_LIBS}
 )
 
 add_executable(bolt_dwio_parquet_cli_test ParquetReaderCliTest.cpp)
 
 add_test(
   NAME bolt_dwio_parquet_cli_test
-  COMMAND bolt_dwio_parquet_cli_test
+  COMMAND
+    bolt_dwio_parquet_cli_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(
-  bolt_dwio_parquet_cli_test PRIVATE
-  bolt_dwio_native_parquet_reader_cli
-  bolt_testutils
+  bolt_dwio_parquet_cli_test
+  PRIVATE
+    bolt_dwio_native_parquet_reader_cli
+    bolt_testutils
 )
 
 if(${BOLT_ENABLE_ARROW})
-
   add_executable(bolt_dwio_parquet_rlebp_decoder_test RleBpDecoderTest.cpp)
   add_test(
     NAME bolt_dwio_parquet_rlebp_decoder_test
-    COMMAND bolt_dwio_parquet_rlebp_decoder_test
+    COMMAND
+      bolt_dwio_parquet_rlebp_decoder_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
   target_link_libraries(
-    bolt_dwio_parquet_rlebp_decoder_test PRIVATE
-    bolt_testutils
-    ${TEST_LINK_LIBS}
+    bolt_dwio_parquet_rlebp_decoder_test
+    PRIVATE
+      bolt_testutils
+      ${TEST_LINK_LIBS}
   )
-
 endif()

--- a/bolt/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/writer/CMakeLists.txt
@@ -25,14 +25,16 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_parquet_writer_sink_test
+add_executable(
+  bolt_parquet_writer_sink_test
   SinkTests.cpp
   ParquetWriterTest.cpp
 )
 
 add_test(
   NAME bolt_parquet_writer_sink_test
-  COMMAND bolt_parquet_writer_sink_test
+  COMMAND
+    bolt_parquet_writer_sink_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/bolt/dwio/parquet/thrift/CMakeLists.txt
+++ b/bolt/dwio/parquet/thrift/CMakeLists.txt
@@ -45,16 +45,22 @@ set(GENERATED_CPP_FILE "${GENERATED_DIR}/parquet_types.cpp")
 message(STATUS "Running Thrift compiler for ${THRIFT_FILE}")
 
 add_custom_command(
-  OUTPUT ${GENERATED_H_FILE} ${GENERATED_CPP_FILE}
-  COMMAND ${THRIFT_COMPILER} --gen cpp -out ${GENERATED_DIR} ${THRIFT_FILE}
-  DEPENDS ${THRIFT_FILE}
+  OUTPUT
+    ${GENERATED_H_FILE}
+    ${GENERATED_CPP_FILE}
+  COMMAND
+    ${THRIFT_COMPILER} --gen cpp -out ${GENERATED_DIR} ${THRIFT_FILE}
+  DEPENDS
+    ${THRIFT_FILE}
   COMMENT "Generating Thrift files from ${THRIFT_FILE}"
   VERBATIM
 )
 
 add_custom_target(
   generate_parquet_thrift
-  DEPENDS ${GENERATED_H_FILE} ${GENERATED_CPP_FILE}
+  DEPENDS
+    ${GENERATED_H_FILE}
+    ${GENERATED_CPP_FILE}
   COMMENT "Generating Parquet Thrift files"
 )
 
@@ -62,4 +68,10 @@ bolt_add_library(bolt_dwio_parquet_thrift ${GENERATED_CPP_FILE})
 add_dependencies(bolt_dwio_parquet_thrift generate_parquet_thrift)
 target_include_directories(bolt_dwio_parquet_thrift PUBLIC ${GENERATED_DIR})
 
-target_link_libraries(bolt_dwio_parquet_thrift arrow::arrow thrift::thrift fmt::fmt Boost::headers)
+target_link_libraries(
+  bolt_dwio_parquet_thrift
+  arrow::arrow
+  thrift::thrift
+  fmt::fmt
+  Boost::headers
+)

--- a/bolt/dwio/txt/tests/CMakeLists.txt
+++ b/bolt/dwio/txt/tests/CMakeLists.txt
@@ -13,16 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(TXT_TEST_LINK_LIBS
-    bolt_dwio_common_test_utils
-    bolt_vector_test_lib
-    bolt_exec_test_lib
-    bolt_temp_path
-    GTest::gtest
-    GTest::gtest_main
-    GTest::gmock
-    gflags::gflags
-    ${GLOG}
+set(
+  TXT_TEST_LINK_LIBS
+  bolt_dwio_common_test_utils
+  bolt_vector_test_lib
+  bolt_exec_test_lib
+  bolt_temp_path
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+  gflags::gflags
+  ${GLOG}
 )
 
 add_subdirectory(reader)

--- a/bolt/dwio/txt/tests/reader/CMakeLists.txt
+++ b/bolt/dwio/txt/tests/reader/CMakeLists.txt
@@ -18,9 +18,14 @@ find_package(Arrow CONFIG REQUIRED)
 add_executable(bolt_dwio_txt_reader_test TxtReaderTest.cpp)
 add_test(
   NAME bolt_dwio_txt_reader_test
-  COMMAND bolt_dwio_txt_reader_test
+  COMMAND
+    bolt_dwio_txt_reader_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(
-  bolt_dwio_txt_reader_test bolt_dwio_txt_reader bolt_link_libs ${TXT_TEST_LINK_LIBS} bolt_testutils
+  bolt_dwio_txt_reader_test
+  bolt_dwio_txt_reader
+  bolt_link_libs
+  ${TXT_TEST_LINK_LIBS}
+  bolt_testutils
 )

--- a/bolt/dwio/txt/tests/writer/CMakeLists.txt
+++ b/bolt/dwio/txt/tests/writer/CMakeLists.txt
@@ -18,14 +18,15 @@ find_package(Arrow CONFIG REQUIRED)
 add_executable(bolt_dwio_txt_writer_test TxtWriterTest.cpp)
 add_test(
   NAME bolt_dwio_txt_writer_test
-  COMMAND bolt_dwio_txt_writer_test
+  COMMAND
+    bolt_dwio_txt_writer_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(
   bolt_dwio_txt_writer_test
-PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
-  GTest::gmock
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
 )

--- a/bolt/dwio/txt/writer/CMakeLists.txt
+++ b/bolt/dwio/txt/writer/CMakeLists.txt
@@ -16,7 +16,13 @@
 if(BOLT_ENABLE_TXT)
   find_package(Arrow CONFIG REQUIRED)
   bolt_add_library(bolt_dwio_txt_writer RegisterTxtWriter.cpp TxtWriter.cpp)
-  target_link_libraries(bolt_dwio_txt_writer bolt_dwio_common bolt_arrow_bridge arrow::arrow ${FMT})
+  target_link_libraries(
+    bolt_dwio_txt_writer
+    bolt_dwio_common
+    bolt_arrow_bridge
+    arrow::arrow
+    ${FMT}
+  )
 else()
   bolt_add_library(bolt_dwio_txt_writer RegisterTxtWriter.cpp)
   # No additional dependencies

--- a/bolt/examples/CMakeLists.txt
+++ b/bolt/examples/CMakeLists.txt
@@ -29,22 +29,15 @@ add_executable(bolt_example_simple_functions SimpleFunctions.cpp)
 
 find_package(simdjson CONFIG REQUIRED)
 find_package(sonic-cpp CONFIG REQUIRED)
-target_link_libraries(
-  bolt_example_simple_functions
-  bolt_testutils
-)
+target_link_libraries(bolt_example_simple_functions bolt_testutils)
 
 add_executable(bolt_example_expression_eval ExpressionEval.cpp)
 
-target_link_libraries(
-  bolt_example_expression_eval bolt_testutils
-)
+target_link_libraries(bolt_example_expression_eval bolt_testutils)
 
 add_executable(bolt_example_opaque_type OpaqueType.cpp)
 
-target_link_libraries(
-  bolt_example_opaque_type bolt_testutils
-)
+target_link_libraries(bolt_example_opaque_type bolt_testutils)
 
 # This is disabled temporarily until we figure out why g++ is crashing linking it on linux builds.
 
@@ -55,10 +48,7 @@ target_link_libraries(
 
 add_executable(bolt_example_scan_orc ScanOrc.cpp)
 
-target_link_libraries(
-  bolt_example_scan_orc
-  bolt_testutils
-)
+target_link_libraries(bolt_example_scan_orc bolt_testutils)
 
 add_executable(bolt_example_vector_reader_writer VectorReaderWriter.cpp)
 
@@ -66,7 +56,4 @@ target_link_libraries(bolt_example_vector_reader_writer bolt_testutils)
 
 add_executable(bolt_example_operator_extensibility OperatorExtensibility.cpp)
 
-target_link_libraries(
-  bolt_example_operator_extensibility
-  bolt_testutils
-)
+target_link_libraries(bolt_example_operator_extensibility bolt_testutils)

--- a/bolt/exec/CMakeLists.txt
+++ b/bolt/exec/CMakeLists.txt
@@ -122,7 +122,12 @@ bolt_add_library(
   WindowPartition.cpp
 )
 
-set_target_properties(bolt_exec PROPERTIES ENABLE_EXPORTS ON)
+set_target_properties(
+  bolt_exec
+  PROPERTIES
+    ENABLE_EXPORTS
+      ON
+)
 
 if(${ENABLE_BOLT_JIT})
   find_package(LLVM REQUIRED CONFIG)
@@ -163,7 +168,11 @@ endif()
 if(${BOLT_ENABLE_CUDF})
   target_compile_definitions(bolt_exec PRIVATE BOLT_HAS_CUDF=1)
   target_include_directories(bolt_exec SYSTEM PRIVATE ${cudf_INCLUDE_DIRS})
-  target_link_libraries(bolt_exec bolt_cudf_exec cudf::cudf)
+  target_link_libraries(
+    bolt_exec
+    bolt_cudf_exec
+    cudf::cudf
+  )
 endif()
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/exec/benchmarks/CMakeLists.txt
+++ b/bolt/exec/benchmarks/CMakeLists.txt
@@ -28,7 +28,8 @@
 add_executable(bolt_exec_vector_hasher_benchmark VectorHasherBenchmark.cpp)
 
 target_link_libraries(
-  bolt_exec_vector_hasher_benchmark PRIVATE
+  bolt_exec_vector_hasher_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -37,7 +38,8 @@ target_link_libraries(
 add_executable(bolt_filter_project_benchmark FilterProjectBenchmark.cpp)
 
 target_link_libraries(
-  bolt_filter_project_benchmark PRIVATE
+  bolt_filter_project_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -46,7 +48,8 @@ target_link_libraries(
 add_executable(bolt_exchange_benchmark ExchangeBenchmark.cpp)
 
 target_link_libraries(
-  bolt_exchange_benchmark PRIVATE
+  bolt_exchange_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -55,7 +58,8 @@ target_link_libraries(
 add_executable(bolt_merge_benchmark MergeBenchmark.cpp)
 
 target_link_libraries(
-  bolt_merge_benchmark PRIVATE
+  bolt_merge_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -64,7 +68,8 @@ target_link_libraries(
 add_executable(bolt_hash_benchmark HashTableBenchmark.cpp)
 
 target_link_libraries(
-  bolt_hash_benchmark PRIVATE
+  bolt_hash_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -74,7 +79,8 @@ add_executable(bolt_sort_random_data_benchmark SortRandomDataBenchmark.cpp)
 
 add_executable(bolt_sort_window_benchmark SortWindowBenchmark.cpp)
 target_link_libraries(
-  bolt_sort_random_data_benchmark PRIVATE
+  bolt_sort_random_data_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -83,14 +89,16 @@ target_link_libraries(
 add_executable(bolt_hash_join_prepare_join_table_benchmark HashJoinPrepareJoinTableBenchmark.cpp)
 
 target_link_libraries(
-  bolt_hash_join_prepare_join_table_benchmark PRIVATE
+  bolt_hash_join_prepare_join_table_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
 )
 
 target_link_libraries(
-  bolt_sort_window_benchmark PRIVATE
+  bolt_sort_window_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -102,7 +110,8 @@ if(${BOLT_ENABLE_PARQUET})
   find_package(Arrow CONFIG REQUIRED)
 
   target_link_libraries(
-    bolt_sort_benchmark PRIVATE
+    bolt_sort_benchmark
+    PRIVATE
       bolt_testutils
       ${FOLLY_BENCHMARK}
       GTest::gtest_main
@@ -111,14 +120,16 @@ endif()
 
 add_executable(bolt_gather_copy_benchmark GatherCopyBenchmark.cpp)
 target_link_libraries(
-  bolt_gather_copy_benchmark bolt_testutils
-    ${FOLLY_BENCHMARK}
-    GTest::gtest_main
+  bolt_gather_copy_benchmark
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
+  GTest::gtest_main
 )
 
 add_executable(rowEqVectors_benchmark RowEqVectorsBenchmark.cpp)
 target_link_libraries(
-  rowEqVectors_benchmark PRIVATE
+  rowEqVectors_benchmark
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main
@@ -126,7 +137,8 @@ target_link_libraries(
 
 add_executable(hash_vectors_bench HashVectorsBenchmark.cpp)
 target_link_libraries(
-  hash_vectors_bench PRIVATE
+  hash_vectors_bench
+  PRIVATE
     bolt_testutils
     ${FOLLY_BENCHMARK}
     GTest::gtest_main

--- a/bolt/exec/fuzzer/CMakeLists.txt
+++ b/bolt/exec/fuzzer/CMakeLists.txt
@@ -28,7 +28,12 @@
 bolt_add_library(bolt_fuzzer_util DuckQueryRunner.cpp PrestoQueryRunner.cpp)
 
 target_link_libraries(
-  bolt_fuzzer_util bolt_core bolt_exec_test_lib cpr::cpr bolt_type_parser Folly::folly
+  bolt_fuzzer_util
+  bolt_core
+  bolt_exec_test_lib
+  cpr::cpr
+  bolt_type_parser
+  Folly::folly
 )
 
 add_library(bolt_fuzzer_flags STATIC FuzzerFlags.cpp)

--- a/bolt/exec/prefixsort/benchmarks/CMakeLists.txt
+++ b/bolt/exec/prefixsort/benchmarks/CMakeLists.txt
@@ -27,7 +27,8 @@
 
 add_executable(bolt_prefix_sort_algorithm_benchmark PrefixSortAlgorithmBenchmark.cpp)
 target_link_libraries(
-  bolt_prefix_sort_algorithm_benchmark PRIVATE
-  bolt_testutils
-  ${FOLLY_BENCHMARK}
+  bolt_prefix_sort_algorithm_benchmark
+  PRIVATE
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
 )

--- a/bolt/exec/prefixsort/tests/CMakeLists.txt
+++ b/bolt/exec/prefixsort/tests/CMakeLists.txt
@@ -33,11 +33,17 @@ add_executable(bolt_exec_prefixsort_test PrefixSortAlgorithmTest.cpp)
 
 add_test(
   NAME bolt_exec_prefixsort_test
-  COMMAND bolt_exec_prefixsort_test
+  COMMAND
+    bolt_exec_prefixsort_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-set_tests_properties(bolt_exec_prefixsort_test PROPERTIES TIMEOUT 3000)
+set_tests_properties(
+  bolt_exec_prefixsort_test
+  PROPERTIES
+    TIMEOUT
+      3000
+)
 
 target_link_libraries(
   bolt_exec_prefixsort_test

--- a/bolt/exec/tests/CMakeLists.txt
+++ b/bolt/exec/tests/CMakeLists.txt
@@ -29,20 +29,24 @@ add_subdirectory(utils)
 
 add_executable(
   aggregate_companion_functions_test
-  AggregateCompanionAdapterTest.cpp AggregateCompanionSignaturesTest.cpp DummyAggregateFunction.cpp
+  AggregateCompanionAdapterTest.cpp
+  AggregateCompanionSignaturesTest.cpp
+  DummyAggregateFunction.cpp
 )
 
 add_test(
   NAME aggregate_companion_functions_test
-  COMMAND aggregate_companion_functions_test
+  COMMAND
+    aggregate_companion_functions_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(
-  aggregate_companion_functions_test PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  aggregate_companion_functions_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_executable(
@@ -102,31 +106,68 @@ add_executable(
   WindowTest.cpp
 )
 
-add_executable(row_based_spill_test RowBasedCompareTest.cpp RowToColumnVectorTest.cpp)
+add_executable(
+  row_based_spill_test
+  RowBasedCompareTest.cpp
+  RowToColumnVectorTest.cpp
+)
 if(KERNEL_SUPPORTS_IO_URING)
   add_executable(iouring_spill_test AsyncSpillerTest.cpp)
 endif()
 
-add_executable(bolt_exec_aggregation_test AggregationTest.cpp Main.cpp)
-
-add_executable(bolt_exec_spiller_test Main.cpp SpillerTest.cpp)
-
 add_executable(
-  bolt_exec_multifragment_window_test Main.cpp MultiFragmentTest.cpp SpillableWindowTest.cpp
+  bolt_exec_aggregation_test
+  AggregationTest.cpp
+  Main.cpp
 )
 
 add_executable(
-  bolt_exec_hash_join_test HashBitRangeTest.cpp HashJoinBridgeTest.cpp HashJoinTest.cpp
-                           HashPartitionFunctionTest.cpp HashTableTest.cpp Main.cpp
+  bolt_exec_spiller_test
+  Main.cpp
+  SpillerTest.cpp
 )
 
-add_executable(bolt_exec_merge_join_test Main.cpp MergeJoinTest.cpp NestedLoopJoinTest.cpp)
+add_executable(
+  bolt_exec_multifragment_window_test
+  Main.cpp
+  MultiFragmentTest.cpp
+  SpillableWindowTest.cpp
+)
 
-add_executable(bolt_exec_scan_test Main.cpp TableScanTest.cpp)
+add_executable(
+  bolt_exec_hash_join_test
+  HashBitRangeTest.cpp
+  HashJoinBridgeTest.cpp
+  HashJoinTest.cpp
+  HashPartitionFunctionTest.cpp
+  HashTableTest.cpp
+  Main.cpp
+)
 
-add_executable(bolt_exec_unested_test Main.cpp UnnestTest.cpp)
+add_executable(
+  bolt_exec_merge_join_test
+  Main.cpp
+  MergeJoinTest.cpp
+  NestedLoopJoinTest.cpp
+)
 
-add_executable(bolt_exec_table_writer_test Main.cpp TableWriteTest.cpp)
+add_executable(
+  bolt_exec_scan_test
+  Main.cpp
+  TableScanTest.cpp
+)
+
+add_executable(
+  bolt_exec_unested_test
+  Main.cpp
+  UnnestTest.cpp
+)
+
+add_executable(
+  bolt_exec_table_writer_test
+  Main.cpp
+  TableWriteTest.cpp
+)
 
 add_executable(
   bolt_exec_infra_test
@@ -143,54 +184,80 @@ add_executable(
   TreeOfLosersTest.cpp
 )
 
-add_test(
-  NAME bolt_exec_test
-  COMMAND bolt_exec_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+add_test(NAME bolt_exec_test COMMAND bolt_exec_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(
+  bolt_exec_test
+  PROPERTIES
+    COST
+      1
+    TIMEOUT
+      3000
 )
-set_tests_properties(bolt_exec_test PROPERTIES COST 1 TIMEOUT 3000)
 
 add_test(
   NAME row_based_spill_test
-  COMMAND row_based_spill_test
+  COMMAND
+    row_based_spill_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 if(KERNEL_SUPPORTS_IO_URING)
   add_test(
     NAME iouring_spill_test
-    COMMAND iouring_spill_test
+    COMMAND
+      iouring_spill_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
-  set_tests_properties(iouring_spill_test PROPERTIES COST 1)
+  set_tests_properties(
+    iouring_spill_test
+    PROPERTIES
+      COST
+        1
+  )
 endif()
 
 add_test(
   NAME bolt_exec_infra_test
-  COMMAND bolt_exec_infra_test
+  COMMAND
+    bolt_exec_infra_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_test(
   NAME bolt_exec_aggregation_test
-  COMMAND bolt_exec_aggregation_test
+  COMMAND
+    bolt_exec_aggregation_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_test(
   NAME bolt_exec_spiller_test
-  COMMAND bolt_exec_spiller_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-set_tests_properties(bolt_exec_spiller_test PROPERTIES COST 1 TIMEOUT 3000)
-
-add_test(
-  NAME bolt_exec_multifragment_window_test
-  COMMAND bolt_exec_multifragment_window_test
+  COMMAND
+    bolt_exec_spiller_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 set_tests_properties(
-  bolt_exec_multifragment_window_test PROPERTIES COST 1 TIMEOUT 3000
+  bolt_exec_spiller_test
+  PROPERTIES
+    COST
+      1
+    TIMEOUT
+      3000
+)
+
+add_test(
+  NAME bolt_exec_multifragment_window_test
+  COMMAND
+    bolt_exec_multifragment_window_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(
+  bolt_exec_multifragment_window_test
+  PROPERTIES
+    COST
+      1
+    TIMEOUT
+      3000
 )
 
 bolt_add_sharded_gtest(bolt_exec_hash_join_test 5)
@@ -199,58 +266,107 @@ bolt_add_sharded_gtest(bolt_exec_scan_test 4)
 
 add_test(
   NAME bolt_exec_merge_join_test
-  COMMAND bolt_exec_merge_join_test
+  COMMAND
+    bolt_exec_merge_join_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_test(
   NAME bolt_exec_unested_test
-  COMMAND bolt_exec_unested_test
+  COMMAND
+    bolt_exec_unested_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_test(
   NAME bolt_exec_table_writer_test
-  COMMAND bolt_exec_table_writer_test
+  COMMAND
+    bolt_exec_table_writer_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-set(BOLT_EXEC_TEST_DEPENDENCIES
-    bolt_testutils
-    GTest::gtest
-    GTest::gtest_main
-    GTest::gmock
+set(
+  BOLT_EXEC_TEST_DEPENDENCIES
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
 )
-
-target_link_libraries(bolt_exec_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
 
 target_link_libraries(
-  bolt_exec_infra_test bolt_presto_serializer bolt_fuzzer_util ${BOLT_EXEC_TEST_DEPENDENCIES}
+  bolt_exec_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
 )
-
-target_link_libraries(row_based_spill_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
-
-target_link_libraries(bolt_exec_aggregation_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
-
-target_link_libraries(bolt_exec_spiller_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
 
 target_link_libraries(
-  bolt_exec_multifragment_window_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES}
+  bolt_exec_infra_test
+  bolt_presto_serializer
+  bolt_fuzzer_util
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
 )
 
-target_link_libraries(bolt_exec_hash_join_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+target_link_libraries(
+  row_based_spill_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
+
+target_link_libraries(
+  bolt_exec_aggregation_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
+
+target_link_libraries(
+  bolt_exec_spiller_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
+
+target_link_libraries(
+  bolt_exec_multifragment_window_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
+
+target_link_libraries(
+  bolt_exec_hash_join_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
 
 if(KERNEL_SUPPORTS_IO_URING)
-  target_link_libraries(iouring_spill_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+  target_link_libraries(
+    iouring_spill_test
+    bolt_aggregates
+    ${BOLT_EXEC_TEST_DEPENDENCIES}
+  )
 endif()
 
-target_link_libraries(bolt_exec_scan_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+target_link_libraries(
+  bolt_exec_scan_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
 
-target_link_libraries(bolt_exec_merge_join_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+target_link_libraries(
+  bolt_exec_merge_join_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
 
-target_link_libraries(bolt_exec_unested_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+target_link_libraries(
+  bolt_exec_unested_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
 
-target_link_libraries(bolt_exec_table_writer_test bolt_aggregates ${BOLT_EXEC_TEST_DEPENDENCIES})
+target_link_libraries(
+  bolt_exec_table_writer_test
+  bolt_aggregates
+  ${BOLT_EXEC_TEST_DEPENDENCIES}
+)
 
 add_executable(bolt_in_10_min_demo BoltIn10MinDemo.cpp)
 
@@ -274,10 +390,12 @@ target_link_libraries(
 
 add_executable(bolt_join_fuzzer_test JoinFuzzerTest.cpp)
 
-target_link_libraries(bolt_join_fuzzer_test PRIVATE
-  bolt_join_fuzzer
-  bolt_testutils
-  GTest::gtest
+target_link_libraries(
+  bolt_join_fuzzer_test
+  PRIVATE
+    bolt_join_fuzzer
+    bolt_testutils
+    GTest::gtest
 )
 
 add_executable(bolt_exchange_fuzzer_test ExchangeFuzzer.cpp)
@@ -323,22 +441,33 @@ target_link_libraries(
   GTest::gtest
 )
 
-add_library(bolt_simple_aggregate SimpleArrayAggAggregate.cpp SimpleAverageAggregate.cpp)
-
-target_link_libraries(
-  bolt_simple_aggregate PUBLIC bolt_testutils
+add_library(
+  bolt_simple_aggregate
+  SimpleArrayAggAggregate.cpp
+  SimpleAverageAggregate.cpp
 )
 
-add_executable(bolt_simple_aggregate_test Main.cpp SimpleAggregateAdapterTest.cpp)
+target_link_libraries(bolt_simple_aggregate PUBLIC bolt_testutils)
+
+add_executable(
+  bolt_simple_aggregate_test
+  Main.cpp
+  SimpleAggregateAdapterTest.cpp
+)
 
 target_link_libraries(
-  bolt_simple_aggregate_test bolt_simple_aggregate bolt_exec bolt_functions_aggregates_test_lib
+  bolt_simple_aggregate_test
+  bolt_simple_aggregate
+  bolt_exec
+  bolt_functions_aggregates_test_lib
   bolt_testutils
   GTest::gtest
 )
 
 add_library(
-  bolt_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp SpillerBenchmarkBase.cpp
+  bolt_spiller_join_benchmark_base
+  JoinSpillInputBenchmarkBase.cpp
+  SpillerBenchmarkBase.cpp
 )
 target_link_libraries(
   bolt_spiller_join_benchmark_base
@@ -348,13 +477,16 @@ target_link_libraries(
 
 add_executable(bolt_spiller_join_benchmark SpillerJoinInputBenchmarkTest.cpp)
 target_link_libraries(
-  bolt_spiller_join_benchmark PUBLIC
-  bolt_spiller_join_benchmark_base
-  bolt_testutils
+  bolt_spiller_join_benchmark
+  PUBLIC
+    bolt_spiller_join_benchmark_base
+    bolt_testutils
 )
 
 add_library(
-  bolt_spiller_aggregate_benchmark_base AggregateSpillBenchmarkBase.cpp SpillerBenchmarkBase.cpp
+  bolt_spiller_aggregate_benchmark_base
+  AggregateSpillBenchmarkBase.cpp
+  SpillerBenchmarkBase.cpp
 )
 target_link_libraries(
   bolt_spiller_aggregate_benchmark_base
@@ -364,21 +496,25 @@ target_link_libraries(
 
 add_executable(bolt_spiller_aggregate_benchmark SpillerAggregateBenchmarkTest.cpp)
 target_link_libraries(
-  bolt_spiller_aggregate_benchmark bolt_exec bolt_exec_test_lib
+  bolt_spiller_aggregate_benchmark
+  bolt_exec
+  bolt_exec_test_lib
   bolt_spiller_aggregate_benchmark_base
 )
 
 add_executable(cpr_http_client_test CprHttpClientTest.cpp)
 add_test(
   NAME cpr_http_client_test
-  COMMAND cpr_http_client_test
+  COMMAND
+    cpr_http_client_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(
-  cpr_http_client_test PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  cpr_http_client_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/bolt/exec/tests/utils/CMakeLists.txt
+++ b/bolt/exec/tests/utils/CMakeLists.txt
@@ -84,5 +84,9 @@ endif()
 if(${BOLT_ENABLE_CUDF})
   target_compile_definitions(bolt_exec_test_lib PRIVATE BOLT_HAS_CUDF=1)
   target_include_directories(bolt_exec_test_lib SYSTEM PRIVATE ${cudf_INCLUDE_DIRS})
-  target_link_libraries(bolt_exec_test_lib bolt_cudf_exec bolt_cudf_test_util)
+  target_link_libraries(
+    bolt_exec_test_lib
+    bolt_cudf_exec
+    bolt_cudf_test_util
+  )
 endif()

--- a/bolt/expression/CMakeLists.txt
+++ b/bolt/expression/CMakeLists.txt
@@ -27,14 +27,21 @@
 
 bolt_add_library(bolt_type_signature TypeSignature.cpp)
 
-target_link_libraries(bolt_type_signature bolt_common_base Boost::headers)
+target_link_libraries(
+  bolt_type_signature
+  bolt_common_base
+  Boost::headers
+)
 
 bolt_add_library(
   bolt_expression_functions FunctionSignature.cpp ReverseSignatureBinder.cpp SignatureBinder.cpp
 )
 
 target_link_libraries(
-  bolt_expression_functions bolt_common_base bolt_type_calculation bolt_type_signature
+  bolt_expression_functions
+  bolt_common_base
+  bolt_type_calculation
+  bolt_type_signature
   bolt_signature_parser
 )
 

--- a/bolt/expression/benchmarks/CMakeLists.txt
+++ b/bolt/expression/benchmarks/CMakeLists.txt
@@ -25,37 +25,56 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(BENCHMARK_DEPENDENCIES bolt_functions_test_lib bolt_exec bolt_exec_test_lib gflags::gflags
-                           Folly::folly ${FOLLY_BENCHMARK}
+set(
+  BENCHMARK_DEPENDENCIES
+  bolt_functions_test_lib
+  bolt_exec
+  bolt_exec_test_lib
+  gflags::gflags
+  Folly::folly
+  ${FOLLY_BENCHMARK}
 )
 
 add_executable(bolt_benchmark_call_null_free_no_nulls CallNullFreeBenchmark.cpp)
 target_link_libraries(bolt_benchmark_call_null_free_no_nulls ${BENCHMARK_DEPENDENCIES})
 target_compile_definitions(
-  bolt_benchmark_call_null_free_no_nulls PUBLIC WITH_NULL_ARRAYS=false WITH_NULL_ELEMENTS=false
+  bolt_benchmark_call_null_free_no_nulls
+  PUBLIC
+    WITH_NULL_ARRAYS=false
+    WITH_NULL_ELEMENTS=false
 )
 
 add_executable(bolt_benchmark_call_null_free_null_arrays CallNullFreeBenchmark.cpp)
 target_link_libraries(bolt_benchmark_call_null_free_null_arrays ${BENCHMARK_DEPENDENCIES})
 target_compile_definitions(
-  bolt_benchmark_call_null_free_null_arrays PUBLIC WITH_NULL_ARRAYS=true WITH_NULL_ELEMENTS=false
+  bolt_benchmark_call_null_free_null_arrays
+  PUBLIC
+    WITH_NULL_ARRAYS=true
+    WITH_NULL_ELEMENTS=false
 )
 
 add_executable(bolt_benchmark_call_null_free_null_elements CallNullFreeBenchmark.cpp)
 target_link_libraries(bolt_benchmark_call_null_free_null_elements ${BENCHMARK_DEPENDENCIES})
 target_compile_definitions(
-  bolt_benchmark_call_null_free_null_elements PUBLIC WITH_NULL_ARRAYS=false WITH_NULL_ELEMENTS=true
+  bolt_benchmark_call_null_free_null_elements
+  PUBLIC
+    WITH_NULL_ARRAYS=false
+    WITH_NULL_ELEMENTS=true
 )
 
 add_executable(
-  bolt_benchmark_call_null_free_null_arrays_and_null_elements CallNullFreeBenchmark.cpp
+  bolt_benchmark_call_null_free_null_arrays_and_null_elements
+  CallNullFreeBenchmark.cpp
 )
 target_link_libraries(
-  bolt_benchmark_call_null_free_null_arrays_and_null_elements ${BENCHMARK_DEPENDENCIES}
+  bolt_benchmark_call_null_free_null_arrays_and_null_elements
+  ${BENCHMARK_DEPENDENCIES}
 )
 target_compile_definitions(
-  bolt_benchmark_call_null_free_null_arrays_and_null_elements PUBLIC WITH_NULL_ARRAYS=true
-                                                                     WITH_NULL_ELEMENTS=true
+  bolt_benchmark_call_null_free_null_arrays_and_null_elements
+  PUBLIC
+    WITH_NULL_ARRAYS=true
+    WITH_NULL_ELEMENTS=true
 )
 
 add_executable(bolt_benchmark_variadic VariadicBenchmark.cpp)

--- a/bolt/expression/fuzzer/CMakeLists.txt
+++ b/bolt/expression/fuzzer/CMakeLists.txt
@@ -27,11 +27,20 @@
 
 bolt_add_library(bolt_expression_test_utility ArgumentTypeFuzzer.cpp FuzzerToolkit.cpp)
 
-target_link_libraries(bolt_expression_test_utility bolt_type bolt_expression_functions GTest::gtest)
+target_link_libraries(
+  bolt_expression_test_utility
+  bolt_type
+  bolt_expression_functions
+  GTest::gtest
+)
 
 add_library(
-  bolt_expression_fuzzer STATIC ArgumentTypeFuzzer.cpp ExpressionFuzzer.cpp ExpressionFuzzerVerifier.cpp
-                         FuzzerRunner.cpp
+  bolt_expression_fuzzer
+  STATIC
+  ArgumentTypeFuzzer.cpp
+  ExpressionFuzzer.cpp
+  ExpressionFuzzerVerifier.cpp
+  FuzzerRunner.cpp
 )
 
 target_link_libraries(
@@ -48,21 +57,23 @@ target_link_libraries(
 add_executable(bolt_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 
 target_link_libraries(
-  bolt_expression_fuzzer_test PRIVATE
-  bolt_expression_fuzzer
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  bolt_expression_fuzzer_test
+  PRIVATE
+    bolt_expression_fuzzer
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_executable(spark_expression_fuzzer_test SparkExpressionFuzzerTest.cpp)
 
 target_link_libraries(
-  spark_expression_fuzzer_test PRIVATE
-  bolt_expression_fuzzer
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  spark_expression_fuzzer_test
+  PRIVATE
+    bolt_expression_fuzzer
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 find_package(Arrow CONFIG REQUIRED)

--- a/bolt/expression/fuzzer/tests/CMakeLists.txt
+++ b/bolt/expression/fuzzer/tests/CMakeLists.txt
@@ -26,7 +26,9 @@
 # --------------------------------------------------------------------------
 
 add_executable(
-  bolt_expression_fuzzer_unit_test ArgumentTypeFuzzerTest.cpp ExpressionFuzzerUnitTest.cpp
+  bolt_expression_fuzzer_unit_test
+  ArgumentTypeFuzzerTest.cpp
+  ExpressionFuzzerUnitTest.cpp
 )
 
 target_link_libraries(

--- a/bolt/expression/signature_parser/CMakeLists.txt
+++ b/bolt/expression/signature_parser/CMakeLists.txt
@@ -30,17 +30,24 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 bison_target(
-  SignatureParser SignatureParser.yy ${CMAKE_CURRENT_BINARY_DIR}/SignatureParser.yy.cc
+  SignatureParser
+  SignatureParser.yy
+  ${CMAKE_CURRENT_BINARY_DIR}/SignatureParser.yy.cc
   DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/SignatureParser.yy.h
   COMPILE_FLAGS "-Werror -Wno-deprecated"
 )
 
 flex_target(
-  SignatureParserScanner SignatureParser.ll ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp
+  SignatureParserScanner
+  SignatureParser.ll
+  ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp
   COMPILE_FLAGS "-Cf --prefix=boltsp"
 )
 
-add_flex_bison_dependency(SignatureParserScanner SignatureParser)
+add_flex_bison_dependency(
+  SignatureParserScanner
+  SignatureParser
+)
 
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${FLEX_INCLUDE_DIRS})
@@ -48,4 +55,8 @@ bolt_add_library(
   bolt_signature_parser ${BISON_SignatureParser_OUTPUTS} ${FLEX_SignatureParserScanner_OUTPUTS}
                         ParseUtil.cpp
 )
-target_link_libraries(bolt_signature_parser bolt_common_base bolt_type_base)
+target_link_libraries(
+  bolt_signature_parser
+  bolt_common_base
+  bolt_type_base
+)

--- a/bolt/expression/signature_parser/tests/CMakeLists.txt
+++ b/bolt/expression/signature_parser/tests/CMakeLists.txt
@@ -31,7 +31,9 @@ add_test(NAME bolt_signature_parser_test COMMAND bolt_signature_parser_test)
 
 target_link_libraries(
   bolt_signature_parser_test
-  PRIVATE bolt_testutils
-          GTest::gtest
-          GTest::gtest_main GTest::gmock
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
 )

--- a/bolt/expression/tests/CMakeLists.txt
+++ b/bolt/expression/tests/CMakeLists.txt
@@ -65,12 +65,14 @@ add_executable(
 
 add_test(
   NAME bolt_expression_test
-  COMMAND bolt_expression_test
+  COMMAND
+    bolt_expression_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(
-  bolt_expression_test PRIVATE
+  bolt_expression_test
+  PRIVATE
     bolt_testutils
     GTest::gtest
     GTest::gtest_main
@@ -80,32 +82,43 @@ target_link_libraries(
 bolt_add_library(bolt_expression_verifier ExpressionVerifier.cpp)
 
 target_link_libraries(
-  bolt_expression_verifier bolt_vector_test_lib bolt_vector_fuzzer bolt_type
+  bolt_expression_verifier
+  bolt_vector_test_lib
+  bolt_vector_fuzzer
+  bolt_type
   bolt_expression_test_utility
 )
 
 bolt_add_library(bolt_expression_runner ExpressionRunner.cpp)
 target_link_libraries(
-  bolt_expression_runner bolt_expression_verifier bolt_functions_prestosql bolt_parse_parser
+  bolt_expression_runner
+  bolt_expression_verifier
+  bolt_functions_prestosql
+  bolt_parse_parser
   GTest::gtest
 )
 
 add_executable(bolt_expression_runner_test ExpressionRunnerTest.cpp)
 target_link_libraries(
-  bolt_expression_runner_test  PRIVATE
+  bolt_expression_runner_test
+  PRIVATE
+    bolt_expression_runner
+    bolt_exec_test_lib
+    bolt_function_registry
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+)
+
+add_executable(spark_expression_runner_test SparkExpressionRunnerTest.cpp)
+target_link_libraries(
+  spark_expression_runner_test
   bolt_expression_runner
   bolt_exec_test_lib
   bolt_function_registry
   bolt_testutils
   GTest::gtest
   GTest::gtest_main
-)
-
-add_executable(spark_expression_runner_test SparkExpressionRunnerTest.cpp)
-target_link_libraries(
-  spark_expression_runner_test bolt_expression_runner bolt_exec_test_lib bolt_function_registry
-  bolt_testutils
-  GTest::gtest GTest::gtest_main
 )
 
 add_executable(bolt_expression_verifier_unit_test ExpressionVerifierUnitTest.cpp)

--- a/bolt/expression/type_calculation/CMakeLists.txt
+++ b/bolt/expression/type_calculation/CMakeLists.txt
@@ -29,16 +29,23 @@
 # BISON_EXECUTABLE BISON_VERSION )
 
 bison_target(
-  TypeCalculationParser TypeCalculation.yy ${CMAKE_CURRENT_BINARY_DIR}/TypeCalculation.yy.cc
+  TypeCalculationParser
+  TypeCalculation.yy
+  ${CMAKE_CURRENT_BINARY_DIR}/TypeCalculation.yy.cc
   DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/TypeCalculation.yy.h
 )
 
 flex_target(
-  TypeCalculationScanner TypeCalculation.ll ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp
+  TypeCalculationScanner
+  TypeCalculation.ll
+  ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp
   COMPILE_FLAGS "-Cf --prefix=bolttc"
 )
 
-add_flex_bison_dependency(TypeCalculationScanner TypeCalculationParser)
+add_flex_bison_dependency(
+  TypeCalculationScanner
+  TypeCalculationParser
+)
 
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${FLEX_INCLUDE_DIRS})

--- a/bolt/functions/CMakeLists.txt
+++ b/bolt/functions/CMakeLists.txt
@@ -28,7 +28,13 @@
 bolt_add_library(bolt_function_registry FunctionRegistry.cpp)
 bolt_add_library(bolt_coverage_util CoverageUtil.cpp)
 
-target_link_libraries(bolt_function_registry bolt_expression bolt_type bolt_core bolt_exception)
+target_link_libraries(
+  bolt_function_registry
+  bolt_expression
+  bolt_type
+  bolt_core
+  bolt_exception
+)
 target_link_libraries(bolt_coverage_util bolt_function_registry)
 add_subdirectory(lib)
 if(${BOLT_ENABLE_PRESTO_FUNCTIONS})

--- a/bolt/functions/flinksql/CMakeLists.txt
+++ b/bolt/functions/flinksql/CMakeLists.txt
@@ -36,7 +36,13 @@ target_link_libraries(
   simdjson::simdjson
 )
 
-set_property(TARGET bolt_functions_flink_impl PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_functions_flink_impl
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/functions/flinksql/registration/CMakeLists.txt
+++ b/bolt/functions/flinksql/registration/CMakeLists.txt
@@ -23,6 +23,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(bolt_functions_flink PRIVATE -Wno-deprecated-declarations)
 endif()
 
-target_link_libraries(bolt_functions_flink bolt_functions_flink_impl simdjson::simdjson)
+target_link_libraries(
+  bolt_functions_flink
+  bolt_functions_flink_impl
+  simdjson::simdjson
+)
 
-set_property(TARGET bolt_functions_flink PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_functions_flink
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)

--- a/bolt/functions/flinksql/tests/CMakeLists.txt
+++ b/bolt/functions/flinksql/tests/CMakeLists.txt
@@ -27,7 +27,8 @@ add_executable(
 
 add_test(
   NAME bolt_functions_flink_test
-  COMMAND bolt_functions_flink_test
+  COMMAND
+    bolt_functions_flink_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/bolt/functions/lib/CMakeLists.txt
+++ b/bolt/functions/lib/CMakeLists.txt
@@ -31,23 +31,36 @@ target_link_libraries(bolt_is_null_functions bolt_expression)
 
 bolt_add_library(bolt_functions_util LambdaFunctionUtil.cpp RowsTranslationUtil.cpp)
 
-target_link_libraries(bolt_functions_util bolt_vector bolt_common_base)
+target_link_libraries(
+  bolt_functions_util
+  bolt_vector
+  bolt_common_base
+)
 
 find_package(simdjson CONFIG REQUIRED)
 
-set(GK_TYPES
-    "int8_t"
-    "int16_t"
-    "int32_t"
-    "int64_t"
-    "int128_t"
-    "float"
-    "double"
-    "Timestamp"
+set(
+  GK_TYPES
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "int128_t"
+  "float"
+  "double"
+  "Timestamp"
 )
 specialize_template(GK_GENERATED_FILES GreenwaldKhanna.cpp.in ${GK_TYPES})
 
-set(KLL_TYPES "int8_t" "int16_t" "int32_t" "int64_t" "float" "double")
+set(
+  KLL_TYPES
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "float"
+  "double"
+)
 specialize_template(KLL_GENERATED_FILES KllSketch.cpp.in ${KLL_TYPES})
 
 bolt_add_library(

--- a/bolt/functions/lib/aggregates/CMakeLists.txt
+++ b/bolt/functions/lib/aggregates/CMakeLists.txt
@@ -38,7 +38,10 @@ bolt_add_library(
 )
 
 target_link_libraries(
-  bolt_functions_aggregates bolt_exec bolt_presto_serializer Folly::folly
+  bolt_functions_aggregates
+  bolt_exec
+  bolt_presto_serializer
+  Folly::folly
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/functions/lib/aggregates/tests/utils/CMakeLists.txt
+++ b/bolt/functions/lib/aggregates/tests/utils/CMakeLists.txt
@@ -27,4 +27,8 @@
 
 bolt_add_library(bolt_functions_aggregates_test_lib AggregationTestBase.cpp)
 
-target_link_libraries(bolt_functions_aggregates_test_lib bolt_exec_test_lib bolt_vector_test_lib)
+target_link_libraries(
+  bolt_functions_aggregates_test_lib
+  bolt_exec_test_lib
+  bolt_vector_test_lib
+)

--- a/bolt/functions/lib/string/CMakeLists.txt
+++ b/bolt/functions/lib/string/CMakeLists.txt
@@ -28,8 +28,14 @@
 bolt_add_library(bolt_functions_string INTERFACE)
 
 target_link_libraries(
-  bolt_functions_string INTERFACE bolt_exception xxHash::xxhash utf8proc::utf8proc
-                                  Folly::folly ${ICU_LIBRARIES} re2::re2
+  bolt_functions_string
+  INTERFACE
+    bolt_exception
+    xxHash::xxhash
+    utf8proc::utf8proc
+    Folly::folly
+    ${ICU_LIBRARIES}
+    re2::re2
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/functions/lib/tests/CMakeLists.txt
+++ b/bolt/functions/lib/tests/CMakeLists.txt
@@ -45,7 +45,8 @@ add_executable(
 
 add_test(
   NAME bolt_functions_lib_test
-  COMMAND bolt_functions_lib_test
+  COMMAND
+    bolt_functions_lib_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/bolt/functions/lib/window/CMakeLists.txt
+++ b/bolt/functions/lib/window/CMakeLists.txt
@@ -27,7 +27,12 @@
 
 bolt_add_library(bolt_functions_window NthValue.cpp Ntile.cpp Rank.cpp RowNumber.cpp)
 
-target_link_libraries(bolt_functions_window bolt_buffer bolt_exec Folly::folly)
+target_link_libraries(
+  bolt_functions_window
+  bolt_buffer
+  bolt_exec
+  Folly::folly
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/functions/lib/window/tests/CMakeLists.txt
+++ b/bolt/functions/lib/window/tests/CMakeLists.txt
@@ -28,6 +28,10 @@
 bolt_add_library(bolt_functions_window_test_lib WindowTestBase.cpp)
 
 target_link_libraries(
-  bolt_functions_window_test_lib bolt_exec_test_lib bolt_vector_fuzzer bolt_vector_test_lib
-  gflags::gflags GTest::gtest
+  bolt_functions_window_test_lib
+  bolt_exec_test_lib
+  bolt_vector_fuzzer
+  bolt_vector_test_lib
+  gflags::gflags
+  GTest::gtest
 )

--- a/bolt/functions/prestosql/CMakeLists.txt
+++ b/bolt/functions/prestosql/CMakeLists.txt
@@ -95,7 +95,13 @@ target_link_libraries(
   Folly::folly
 )
 
-set_property(TARGET bolt_functions_prestosql_impl PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_functions_prestosql_impl
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)
 
 if(${BOLT_ENABLE_AGGREGATES})
   add_subdirectory(aggregates)

--- a/bolt/functions/prestosql/aggregates/CMakeLists.txt
+++ b/bolt/functions/prestosql/aggregates/CMakeLists.txt
@@ -25,21 +25,30 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(APAGG_TYPES "int8_t" "int16_t" "int32_t" "int64_t" "float" "double")
+set(
+  APAGG_TYPES
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "float"
+  "double"
+)
 specialize_template(APAGG_GENERATED_FILES ApproxPercentileAggregate.cpp.in ${APAGG_TYPES})
 
-set(MIN_MAX_BY_VALUE_TYPES
-    "bool"
-    "int8_t"
-    "int16_t"
-    "int32_t"
-    "int64_t"
-    "int128_t"
-    "float"
-    "double"
-    "StringView"
-    "Timestamp"
-    "ComplexType"
+set(
+  MIN_MAX_BY_VALUE_TYPES
+  "bool"
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "int128_t"
+  "float"
+  "double"
+  "StringView"
+  "Timestamp"
+  "ComplexType"
 )
 set(MIN_MAX_BY_NARG_VALUE_TYPES ${MIN_MAX_BY_VALUE_TYPES})
 list(REMOVE_ITEM MIN_MAX_BY_NARG_VALUE_TYPES "int128_t")

--- a/bolt/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/bolt/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -25,49 +25,50 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(AGGREGATES_TEST_SRC
-    AggregationFunctionRegTest.cpp
-    ApproxDistinctTest.cpp
-    ApproxMostFrequentTest.cpp
-    ApproxPercentileTest.cpp
-    ArbitraryTest.cpp
-    ArrayAggTest.cpp
-    ArrayAdditionAggregateTest.cpp
-    ArrayCountAggregateTest.cpp
-    AverageAggregationTest.cpp
-    BitwiseAggregationTest.cpp
-    BoolAndOrTest.cpp
-    CentralMomentsAggregationTest.cpp
-    ChecksumAggregateTest.cpp
-    CountAggregationTest.cpp
-    CountDistinctTest.cpp
-    CountIfAggregationTest.cpp
-    CovarianceAggregationTest.cpp
-    EntropyAggregationTest.cpp
-    GeometricMeanTest.cpp
-    HistogramTest.cpp
-    Main.cpp
-    MapAccumulatorTest.cpp
-    MapSumAggregateTest.cpp
-    MinMaxByAggregationTest.cpp
-    MinMaxTest.cpp
-    MultiMapAggTest.cpp
-    PrestoHasherTest.cpp
-    SetAggTest.cpp
-    SetUnionTest.cpp
-    SumTest.cpp
-    MapAggTest.cpp
-    MapUnionAggregationTest.cpp
-    MapUnionSumTest.cpp
-    ReduceAggTest.cpp
-    VarianceAggregationTest.cpp
-    MaxSizeForStatsTest.cpp
-    SumDataSizeForStatsTest.cpp
-    MapUnionAvgTest.cpp
-    MapUnionCountTest.cpp
-    MapUnionMinMaxTest.cpp
-    AggregationLazyInputTest.cpp
-    BitDaysOrAggregationTest.cpp
+set(
+  AGGREGATES_TEST_SRC
+  AggregationFunctionRegTest.cpp
+  ApproxDistinctTest.cpp
+  ApproxMostFrequentTest.cpp
+  ApproxPercentileTest.cpp
+  ArbitraryTest.cpp
+  ArrayAggTest.cpp
+  ArrayAdditionAggregateTest.cpp
+  ArrayCountAggregateTest.cpp
+  AverageAggregationTest.cpp
+  BitwiseAggregationTest.cpp
+  BoolAndOrTest.cpp
+  CentralMomentsAggregationTest.cpp
+  ChecksumAggregateTest.cpp
+  CountAggregationTest.cpp
+  CountDistinctTest.cpp
+  CountIfAggregationTest.cpp
+  CovarianceAggregationTest.cpp
+  EntropyAggregationTest.cpp
+  GeometricMeanTest.cpp
+  HistogramTest.cpp
+  Main.cpp
+  MapAccumulatorTest.cpp
+  MapSumAggregateTest.cpp
+  MinMaxByAggregationTest.cpp
+  MinMaxTest.cpp
+  MultiMapAggTest.cpp
+  PrestoHasherTest.cpp
+  SetAggTest.cpp
+  SetUnionTest.cpp
+  SumTest.cpp
+  MapAggTest.cpp
+  MapUnionAggregationTest.cpp
+  MapUnionSumTest.cpp
+  ReduceAggTest.cpp
+  VarianceAggregationTest.cpp
+  MaxSizeForStatsTest.cpp
+  SumDataSizeForStatsTest.cpp
+  MapUnionAvgTest.cpp
+  MapUnionCountTest.cpp
+  MapUnionMinMaxTest.cpp
+  AggregationLazyInputTest.cpp
+  BitDaysOrAggregationTest.cpp
 )
 
 if(NOT BOLT_ENABLE_SPARK_COMPATIBLE)
@@ -78,26 +79,27 @@ add_executable(bolt_aggregates_test ${AGGREGATES_TEST_SRC})
 
 bolt_add_sharded_gtest(bolt_aggregates_test 6)
 
-set(BOLT_AGGREGATES_TEST_DEPENDENCIES
-    bolt_aggregates
-    bolt_core
-    bolt_dwio_common_test_utils
-    bolt_exec
-    bolt_exec_test_lib
-    bolt_file
-    bolt_functions_aggregates
-    bolt_functions_aggregates_test_lib
-    bolt_functions_test_lib
-    bolt_functions_prestosql
-    bolt_functions_lib
-    bolt_hive_connector
-    bolt_simple_aggregate
-    bolt_type
-    bolt_vector_fuzzer
-    bolt_testutils
-    gflags::gflags
-    GTest::gtest
-    GTest::gtest_main
+set(
+  BOLT_AGGREGATES_TEST_DEPENDENCIES
+  bolt_aggregates
+  bolt_core
+  bolt_dwio_common_test_utils
+  bolt_exec
+  bolt_exec_test_lib
+  bolt_file
+  bolt_functions_aggregates
+  bolt_functions_aggregates_test_lib
+  bolt_functions_test_lib
+  bolt_functions_prestosql
+  bolt_functions_lib
+  bolt_hive_connector
+  bolt_simple_aggregate
+  bolt_type
+  bolt_vector_fuzzer
+  bolt_testutils
+  gflags::gflags
+  GTest::gtest
+  GTest::gtest_main
 )
 
 target_link_libraries(bolt_aggregates_test ${BOLT_AGGREGATES_TEST_DEPENDENCIES})

--- a/bolt/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/bolt/functions/prestosql/benchmarks/CMakeLists.txt
@@ -25,19 +25,22 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(BENCHMARK_DEPENDENCIES_NO_FUNC
-    bolt_functions_test_lib
-    bolt_exec
-    bolt_exec_test_lib
-    gflags::gflags
-    Folly::folly
-    ${FOLLY_BENCHMARK}
-    bolt_benchmark_builder
+set(
+  BENCHMARK_DEPENDENCIES_NO_FUNC
+  bolt_functions_test_lib
+  bolt_exec
+  bolt_exec_test_lib
+  gflags::gflags
+  Folly::folly
+  ${FOLLY_BENCHMARK}
+  bolt_benchmark_builder
 )
 
-set(BENCHMARK_DEPENDENCIES
+set(
+  BENCHMARK_DEPENDENCIES
   bolt_functions_prestosql
-  bolt_functions_lib bolt_vector_fuzzer
+  bolt_functions_lib
+  bolt_vector_fuzzer
   ${BENCHMARK_DEPENDENCIES_NO_FUNC}
   bolt_testutils
 )
@@ -63,7 +66,8 @@ add_executable(
   StringAsciiUTFFunctionBenchmarks.cpp
 )
 target_link_libraries(
-  bolt_functions_prestosql_benchmarks_string_ascii_utf_functions ${BENCHMARK_DEPENDENCIES}
+  bolt_functions_prestosql_benchmarks_string_ascii_utf_functions
+  ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_not NotBenchmark.cpp)
@@ -89,119 +93,150 @@ target_link_libraries(bolt_functions_benchmarks_compare ${BENCHMARK_DEPENDENCIES
 
 add_executable(bolt_benchmark_array_writer_with_nulls ArrayWriterBenchmark.cpp)
 target_compile_definitions(bolt_benchmark_array_writer_with_nulls PUBLIC WITH_NULLS=true)
-target_link_libraries(bolt_benchmark_array_writer_with_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_benchmark_array_writer_with_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_benchmark_array_writer_no_nulls ArrayWriterBenchmark.cpp)
-target_link_libraries(bolt_benchmark_array_writer_no_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_benchmark_array_writer_no_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 target_compile_definitions(bolt_benchmark_array_writer_no_nulls PUBLIC WITH_NULLS=false)
 
 add_executable(bolt_benchmark_nested_array_writer_no_nulls NestedArrayWriterBenchmark.cpp)
-target_link_libraries(bolt_benchmark_nested_array_writer_no_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_benchmark_nested_array_writer_no_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 target_compile_definitions(bolt_benchmark_nested_array_writer_no_nulls PUBLIC WITH_NULLS=false)
 
 add_executable(bolt_benchmark_nested_array_writer_with_nulls NestedArrayWriterBenchmark.cpp)
 target_compile_definitions(bolt_benchmark_nested_array_writer_with_nulls PUBLIC WITH_NULLS=true)
 target_link_libraries(
-  bolt_benchmark_nested_array_writer_with_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+  bolt_benchmark_nested_array_writer_with_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
-
 
 add_executable(bolt_benchmark_map_writer_with_nulls MapWriterBenchmarks.cpp)
 target_compile_definitions(bolt_benchmark_map_writer_with_nulls PUBLIC WITH_NULLS=true)
-target_link_libraries(bolt_benchmark_map_writer_with_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_benchmark_map_writer_with_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_benchmark_map_writer_no_nulls MapWriterBenchmarks.cpp)
-target_link_libraries(bolt_benchmark_map_writer_no_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_benchmark_map_writer_no_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 target_compile_definitions(bolt_benchmark_map_writer_no_nulls PUBLIC WITH_NULLS=false)
 
 add_executable(bolt_functions_benchmarks_row_writer_no_nulls RowWriterBenchmark.cpp)
 target_link_libraries(
-  bolt_functions_benchmarks_row_writer_no_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+  bolt_functions_benchmarks_row_writer_no_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_benchmarks_string_writer_no_nulls StringWriterBenchmark.cpp)
 target_link_libraries(
-  bolt_functions_benchmarks_string_writer_no_nulls PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+  bolt_functions_benchmarks_string_writer_no_nulls
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_zip ZipBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_zip PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_zip
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_row Row.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_row PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_row
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_comparisons ComparisonsBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_comparisons PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_comparisons
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_concat ConcatBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_concat PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_concat
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_zip_with ZipWithBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_zip_with PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_zip_with
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_map_zip_with MapZipWithBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_map_zip_with PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_map_zip_with
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_cardinality CardinalityBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_cardinality PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_cardinality
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_benchmarks_simdjson_function_with_expr JsonExprBenchmark.cpp)
 target_link_libraries(
-  bolt_functions_benchmarks_simdjson_function_with_expr PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+  bolt_functions_benchmarks_simdjson_function_with_expr
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_map_subscript MapSubscriptCachingBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_map_subscript PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_map_subscript
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )
 
 add_executable(bolt_functions_prestosql_benchmarks_generic GenericBenchmark.cpp)
-target_link_libraries(bolt_functions_prestosql_benchmarks_generic PRIVATE
-  ${BENCHMARK_DEPENDENCIES_NO_FUNC}
-  ${BENCHMARK_DEPENDENCIES}
+target_link_libraries(
+  bolt_functions_prestosql_benchmarks_generic
+  PRIVATE
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC}
+    ${BENCHMARK_DEPENDENCIES}
 )

--- a/bolt/functions/prestosql/coverage/CMakeLists.txt
+++ b/bolt/functions/prestosql/coverage/CMakeLists.txt
@@ -28,10 +28,12 @@
 add_executable(bolt_prestosql_coverage Coverage.cpp)
 
 target_link_libraries(
-  bolt_prestosql_coverage PRIVATE
-  bolt_functions_prestosql
-  bolt_function_registry
-  bolt_aggregates
-  bolt_window bolt_coverage_util
-  bolt_testutils
+  bolt_prestosql_coverage
+  PRIVATE
+    bolt_functions_prestosql
+    bolt_function_registry
+    bolt_aggregates
+    bolt_window
+    bolt_coverage_util
+    bolt_testutils
 )

--- a/bolt/functions/prestosql/json/tests/CMakeLists.txt
+++ b/bolt/functions/prestosql/json/tests/CMakeLists.txt
@@ -26,8 +26,10 @@
 # --------------------------------------------------------------------------
 
 add_executable(
-  bolt_functions_json_test JsonExtractorTest.cpp JsonPathTokenizerTest.cpp
-                           SIMDJsonExtractorTest.cpp
+  bolt_functions_json_test
+  JsonExtractorTest.cpp
+  JsonPathTokenizerTest.cpp
+  SIMDJsonExtractorTest.cpp
 )
 
 add_test(bolt_functions_json_test bolt_functions_json_test)

--- a/bolt/functions/prestosql/registration/CMakeLists.txt
+++ b/bolt/functions/prestosql/registration/CMakeLists.txt
@@ -77,4 +77,10 @@ target_link_libraries(
   Boost::url
 )
 
-set_property(TARGET bolt_functions_prestosql PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_functions_prestosql
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)

--- a/bolt/functions/prestosql/tests/CMakeLists.txt
+++ b/bolt/functions/prestosql/tests/CMakeLists.txt
@@ -118,12 +118,13 @@ add_executable(
 add_test(bolt_functions_test bolt_functions_test)
 
 target_link_libraries(
-  bolt_functions_test PRIVATE
-  bolt_functions_test_lib
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
-  GTest::gmock
+  bolt_functions_test
+  PRIVATE
+    bolt_functions_test_lib
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
 )
 
 add_executable(bolt_functions_simple_test SimpleComparisonMatcherTest.cpp)
@@ -131,8 +132,9 @@ add_executable(bolt_functions_simple_test SimpleComparisonMatcherTest.cpp)
 add_test(bolt_functions_simple_test bolt_functions_simple_test)
 
 target_link_libraries(
-  bolt_functions_simple_test  PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  bolt_functions_simple_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/functions/prestosql/tests/utils/CMakeLists.txt
+++ b/bolt/functions/prestosql/tests/utils/CMakeLists.txt
@@ -28,5 +28,9 @@
 bolt_add_library(bolt_functions_test_lib FunctionBaseTest.cpp)
 
 target_link_libraries(
-  bolt_functions_test_lib bolt_exec bolt_exec_test_lib bolt_vector_test_lib bolt_parse_parser
+  bolt_functions_test_lib
+  bolt_exec
+  bolt_exec_test_lib
+  bolt_vector_test_lib
+  bolt_parse_parser
 )

--- a/bolt/functions/prestosql/types/CMakeLists.txt
+++ b/bolt/functions/prestosql/types/CMakeLists.txt
@@ -30,7 +30,12 @@ bolt_add_library(bolt_presto_types HyperLogLogType.cpp JsonType.cpp TimestampWit
 find_package(ryu CONFIG REQUIRED)
 
 target_link_libraries(
-  bolt_presto_types bolt_memory bolt_expression bolt_functions_util bolt_functions_json ryu::ryu
+  bolt_presto_types
+  bolt_memory
+  bolt_expression
+  bolt_functions_util
+  bolt_functions_json
+  ryu::ryu
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/functions/prestosql/types/tests/CMakeLists.txt
+++ b/bolt/functions/prestosql/types/tests/CMakeLists.txt
@@ -26,8 +26,11 @@
 # --------------------------------------------------------------------------
 
 add_executable(
-  bolt_presto_types_test HyperLogLogTypeTest.cpp JsonTypeTest.cpp TimestampWithTimeZoneTypeTest.cpp
-                         TypeTestBase.cpp
+  bolt_presto_types_test
+  HyperLogLogTypeTest.cpp
+  JsonTypeTest.cpp
+  TimestampWithTimeZoneTypeTest.cpp
+  TypeTestBase.cpp
 )
 
 add_test(bolt_presto_types_test bolt_presto_types_test)

--- a/bolt/functions/prestosql/window/CMakeLists.txt
+++ b/bolt/functions/prestosql/window/CMakeLists.txt
@@ -32,5 +32,9 @@ endif()
 bolt_add_library(bolt_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp WindowFunctionsRegistration.cpp)
 
 target_link_libraries(
-  bolt_window bolt_buffer bolt_exec bolt_functions_window Folly::folly
+  bolt_window
+  bolt_buffer
+  bolt_exec
+  bolt_functions_window
+  Folly::folly
 )

--- a/bolt/functions/prestosql/window/tests/CMakeLists.txt
+++ b/bolt/functions/prestosql/window/tests/CMakeLists.txt
@@ -25,16 +25,18 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(CMAKE_WINDOW_TEST_LINK_LIBRARIES
-    bolt_testutils
-    gflags::gflags
-    GTest::gtest
-    GTest::gtest_main
+set(
+  CMAKE_WINDOW_TEST_LINK_LIBRARIES
+  bolt_testutils
+  gflags::gflags
+  GTest::gtest
+  GTest::gtest_main
 )
 
 set(CMAKE_WINDOW_TEST_MAIN_FILES Main.cpp)
 
-add_executable(bolt_windows_test
+add_executable(
+  bolt_windows_test
   ${CMAKE_WINDOW_TEST_MAIN_FILES}
   NtileTest.cpp
   RankTest.cpp
@@ -43,10 +45,6 @@ add_executable(bolt_windows_test
   AggregateWindowTest.cpp
 )
 
-add_test(
-  NAME bolt_windows_test
-  COMMAND bolt_windows_test
-  WORKING_DIRECTORY .
-)
+add_test(NAME bolt_windows_test COMMAND bolt_windows_test WORKING_DIRECTORY .)
 
 target_link_libraries(bolt_windows_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})

--- a/bolt/functions/remote/client/CMakeLists.txt
+++ b/bolt/functions/remote/client/CMakeLists.txt
@@ -27,13 +27,21 @@
 
 bolt_add_library(bolt_functions_remote_thrift_client ThriftClient.cpp)
 target_link_libraries(
-  bolt_functions_remote_thrift_client PUBLIC bolt_remote_function_thrift FBThrift::thriftcpp2
+  bolt_functions_remote_thrift_client
+  PUBLIC
+    bolt_remote_function_thrift
+    FBThrift::thriftcpp2
 )
 
 bolt_add_library(bolt_functions_remote Remote.cpp)
 target_link_libraries(
-  bolt_functions_remote PUBLIC bolt_expression bolt_functions_remote_thrift_client
-                               bolt_functions_remote_get_serde bolt_type_fbhive Folly::folly
+  bolt_functions_remote
+  PUBLIC
+    bolt_expression
+    bolt_functions_remote_thrift_client
+    bolt_functions_remote_get_serde
+    bolt_type_fbhive
+    Folly::folly
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/functions/remote/if/CMakeLists.txt
+++ b/bolt/functions/remote/if/CMakeLists.txt
@@ -35,5 +35,8 @@ target_compile_options(bolt_remote_function_thrift PRIVATE -Wno-deprecated-decla
 
 bolt_add_library(bolt_functions_remote_get_serde GetSerde.cpp)
 target_link_libraries(
-  bolt_functions_remote_get_serde PUBLIC bolt_remote_function_thrift bolt_presto_serializer
+  bolt_functions_remote_get_serde
+  PUBLIC
+    bolt_remote_function_thrift
+    bolt_presto_serializer
 )

--- a/bolt/functions/remote/server/CMakeLists.txt
+++ b/bolt/functions/remote/server/CMakeLists.txt
@@ -28,12 +28,18 @@
 bolt_add_library(bolt_functions_remote_server RemoteFunctionService.cpp)
 
 target_link_libraries(
-  bolt_functions_remote_server PUBLIC bolt_remote_function_thrift bolt_functions_remote_get_serde
-                                      bolt_type_fbhive bolt_memory
+  bolt_functions_remote_server
+  PUBLIC
+    bolt_remote_function_thrift
+    bolt_functions_remote_get_serde
+    bolt_type_fbhive
+    bolt_memory
 )
 
 add_executable(bolt_functions_remote_server_main RemoteFunctionServiceMain.cpp)
 
 target_link_libraries(
-  bolt_functions_remote_server_main bolt_functions_remote_server bolt_functions_prestosql
+  bolt_functions_remote_server_main
+  bolt_functions_remote_server
+  bolt_functions_prestosql
 )

--- a/bolt/functions/sketches/CMakeLists.txt
+++ b/bolt/functions/sketches/CMakeLists.txt
@@ -42,10 +42,22 @@ bolt_add_library(
 )
 
 target_include_directories(
-  bolt_sketch_aggregates PRIVATE ${FOLLY_INCLUDE_DIRS} ${DataSketches_INCLUDE_DIRS}
+  bolt_sketch_aggregates
+  PRIVATE
+    ${FOLLY_INCLUDE_DIRS}
+    ${DataSketches_INCLUDE_DIRS}
 )
 target_link_libraries(
-  bolt_sketch_aggregates bolt_exec DataSketches::DataSketches Folly::folly
+  bolt_sketch_aggregates
+  bolt_exec
+  DataSketches::DataSketches
+  Folly::folly
 )
 
-set_property(TARGET bolt_sketch_aggregates PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_sketch_aggregates
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)

--- a/bolt/functions/sketches/tests/CMakeLists.txt
+++ b/bolt/functions/sketches/tests/CMakeLists.txt
@@ -38,7 +38,8 @@ add_executable(
 
 add_test(
   NAME bolt_sketches_aggregates_test
-  COMMAND bolt_sketches_aggregates_test
+  COMMAND
+    bolt_sketches_aggregates_test
   WORKING_DIRECTORY .
 )
 

--- a/bolt/functions/sparksql/CMakeLists.txt
+++ b/bolt/functions/sparksql/CMakeLists.txt
@@ -71,7 +71,13 @@ target_link_libraries(
   simdjson::simdjson
 )
 
-set_property(TARGET bolt_functions_spark_impl PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_functions_spark_impl
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)
 
 # directory for generated version.h
 include_directories("${CMAKE_BINARY_DIR}/gen_cpp")

--- a/bolt/functions/sparksql/aggregates/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/CMakeLists.txt
@@ -25,44 +25,47 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(PAAGG_TYPES
-    "int8_t"
-    "int16_t"
-    "int32_t"
-    "int64_t"
-    "int128_t"
-    "float"
-    "double"
-    "Timestamp"
+set(
+  PAAGG_TYPES
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "int128_t"
+  "float"
+  "double"
+  "Timestamp"
 )
 specialize_template(PAAGG_GENERATED_FILES PercentileApproxAggregate.cpp.in ${PAAGG_TYPES})
 
-set(PERCENTILE_TYPES
-    "TypeKind::TINYINT"
-    "TypeKind::SMALLINT"
-    "TypeKind::INTEGER"
-    "TypeKind::BIGINT"
-    "TypeKind::HUGEINT"
-    "TypeKind::REAL"
-    "TypeKind::DOUBLE"
-    "TypeKind::VARCHAR"
+set(
+  PERCENTILE_TYPES
+  "TypeKind::TINYINT"
+  "TypeKind::SMALLINT"
+  "TypeKind::INTEGER"
+  "TypeKind::BIGINT"
+  "TypeKind::HUGEINT"
+  "TypeKind::REAL"
+  "TypeKind::DOUBLE"
+  "TypeKind::VARCHAR"
 )
 specialize_template(
   PERCENTILE_GENERATED_FILES PercentileAggregate.cpp.in ${PERCENTILE_TYPES}
 )
 
-set(MIN_MAX_BY_TYPES
-    "bool"
-    "int8_t"
-    "int16_t"
-    "int32_t"
-    "int64_t"
-    "int128_t"
-    "float"
-    "double"
-    "StringView"
-    "Timestamp"
-    "ComplexType"
+set(
+  MIN_MAX_BY_TYPES
+  "bool"
+  "int8_t"
+  "int16_t"
+  "int32_t"
+  "int64_t"
+  "int128_t"
+  "float"
+  "double"
+  "StringView"
+  "Timestamp"
+  "ComplexType"
 )
 specialize_template(
   MIN_MAX_BY_GENERATED_FILES MinMaxByAggregate.cpp.in ${MIN_MAX_BY_TYPES}
@@ -93,7 +96,11 @@ bolt_add_library(
 )
 
 target_link_libraries(
-  bolt_functions_spark_aggregates bolt_exec bolt_expression_functions bolt_aggregates bolt_vector
+  bolt_functions_spark_aggregates
+  bolt_exec
+  bolt_expression_functions
+  bolt_aggregates
+  bolt_vector
   fmt::fmt
 )
 

--- a/bolt/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/bolt/functions/sparksql/benchmarks/CMakeLists.txt
@@ -25,78 +25,86 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(BOLT_BENCHMARK_DEPS
-    bolt_vector_fuzzer
-    bolt_testutils
-    ${FOLLY_BENCHMARK}
-    GTest::gtest
+set(
+  BOLT_BENCHMARK_DEPS
+  bolt_vector_fuzzer
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
+  GTest::gtest
 )
 add_executable(bolt_sparksql_benchmarks_in In.cpp)
 
 target_link_libraries(
-  bolt_sparksql_benchmarks_in PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_in
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(bolt_sparksql_benchmarks_compare CompareBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_compare PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_compare
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(bolt_sparksql_benchmarks_simd_compare SIMDCompareBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_simd_compare PRIVATE
-  bolt_benchmark_builder
-  ${FOLLY_BENCHMARK})
+  bolt_sparksql_benchmarks_simd_compare
+  PRIVATE
+    bolt_benchmark_builder
+    ${FOLLY_BENCHMARK}
+)
 
 add_executable(bolt_sparksql_benchmarks_regex RegexBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_regex PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_regex
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 add_executable(bolt_sparksql_benchmarks_split Split.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_split PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_split
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(bolt_sparksql_benchmarks_hash HiveHashBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_hash PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_hash
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(bolt_sparksql_benchmarks_map MapBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_map PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_map
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(bolt_sparksql_benchmarks_get_funcs FunctionBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_get_funcs PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_get_funcs
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(bolt_sparksql_benchmarks_unix_timestamp UnixTimestampBenchmark.cpp)
 target_link_libraries(
-  bolt_sparksql_benchmarks_unix_timestamp PRIVATE
-  bolt_benchmark_builder
-  ${BOLT_BENCHMARK_DEPS}
+  bolt_sparksql_benchmarks_unix_timestamp
+  PRIVATE
+    bolt_benchmark_builder
+    ${BOLT_BENCHMARK_DEPS}
 )
 
-add_executable(
-  bolt_collect_list_aggregate_bm
-  CollectListAggregateBenchmark.cpp
-)
+add_executable(bolt_collect_list_aggregate_bm CollectListAggregateBenchmark.cpp)
 
 target_link_libraries(
   bolt_collect_list_aggregate_bm

--- a/bolt/functions/sparksql/coverage/CMakeLists.txt
+++ b/bolt/functions/sparksql/coverage/CMakeLists.txt
@@ -28,10 +28,11 @@
 add_executable(bolt_sparksql_coverage Coverage.cpp)
 
 target_link_libraries(
-  bolt_sparksql_coverage PRIVATE
-  # bolt_functions_spark bolt_function_registry
-  # bolt_functions_spark_aggregates
-  # bolt_functions_spark_window
-  bolt_coverage_util
-  bolt_testutils
+  bolt_sparksql_coverage
+  PRIVATE
+    # bolt_functions_spark bolt_function_registry
+    # bolt_functions_spark_aggregates
+    # bolt_functions_spark_window
+    bolt_coverage_util
+    bolt_testutils
 )

--- a/bolt/functions/sparksql/registration/CMakeLists.txt
+++ b/bolt/functions/sparksql/registration/CMakeLists.txt
@@ -60,7 +60,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 target_link_libraries(
-  bolt_functions_spark bolt_functions_spark_impl bolt_is_null_functions simdjson::simdjson
+  bolt_functions_spark
+  bolt_functions_spark_impl
+  bolt_is_null_functions
+  simdjson::simdjson
 )
 
-set_property(TARGET bolt_functions_spark PROPERTY JOB_POOL_COMPILE high_memory_pool)
+set_property(
+  TARGET
+    bolt_functions_spark
+  PROPERTY
+    JOB_POOL_COMPILE
+      high_memory_pool
+)

--- a/bolt/functions/sparksql/specialforms/CMakeLists.txt
+++ b/bolt/functions/sparksql/specialforms/CMakeLists.txt
@@ -40,6 +40,10 @@ bolt_add_library(
 
 find_package(sonic-cpp CONFIG REQUIRED)
 target_link_libraries(
-  bolt_functions_spark_specialforms fmt::fmt bolt_functions_json bolt_expression simdjson::simdjson
+  bolt_functions_spark_specialforms
+  fmt::fmt
+  bolt_functions_json
+  bolt_expression
+  simdjson::simdjson
   sonic-cpp::sonic-cpp
 )

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -110,7 +110,8 @@ add_executable(
 
 add_test(
   NAME bolt_functions_spark_test
-  COMMAND bolt_functions_spark_test
+  COMMAND
+    bolt_functions_spark_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/bolt/functions/sparksql/window/CMakeLists.txt
+++ b/bolt/functions/sparksql/window/CMakeLists.txt
@@ -28,7 +28,10 @@
 bolt_add_library(bolt_functions_spark_window WindowFunctionsRegistration.cpp)
 
 target_link_libraries(
-  bolt_functions_spark_window bolt_buffer bolt_exec bolt_functions_window
+  bolt_functions_spark_window
+  bolt_buffer
+  bolt_exec
+  bolt_functions_window
   Folly::folly
 )
 

--- a/bolt/functions/sparksql/window/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/window/tests/CMakeLists.txt
@@ -25,20 +25,21 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(CMAKE_WINDOW_TEST_LINK_LIBRARIES
-    bolt_testutils
-    GTest::gtest
-    GTest::gtest_main
+set(
+  CMAKE_WINDOW_TEST_LINK_LIBRARIES
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
 )
 
 set(CMAKE_WINDOW_TEST_MAIN_FILES Main.cpp)
 
-add_executable(bolt_spark_windows_test ${CMAKE_WINDOW_TEST_MAIN_FILES} SparkWindowTest.cpp)
-
-add_test(
-  NAME bolt_spark_windows_test
-  COMMAND bolt_spark_windows_test
-  WORKING_DIRECTORY .
+add_executable(
+  bolt_spark_windows_test
+  ${CMAKE_WINDOW_TEST_MAIN_FILES}
+  SparkWindowTest.cpp
 )
+
+add_test(NAME bolt_spark_windows_test COMMAND bolt_spark_windows_test WORKING_DIRECTORY .)
 
 target_link_libraries(bolt_spark_windows_test PRIVATE ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})

--- a/bolt/functions/tests/CMakeLists.txt
+++ b/bolt/functions/tests/CMakeLists.txt
@@ -30,5 +30,9 @@ add_executable(bolt_function_registry_test FunctionRegistryTest.cpp)
 add_test(NAME bolt_function_registry_test COMMAND bolt_function_registry_test)
 
 target_link_libraries(
-  bolt_function_registry_test bolt_testutils GTest::gmock GTest::gtest GTest::gtest_main
+  bolt_function_registry_test
+  bolt_testutils
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main
 )

--- a/bolt/jit/CMakeLists.txt
+++ b/bolt/jit/CMakeLists.txt
@@ -20,10 +20,19 @@ bolt_add_library(
                  RowContainer/RowEqVectorsCodeGenerator.cpp
 )
 
-target_link_libraries(bolt_thrustjit PUBLIC llvm-core::llvm-core date::date fmt::fmt Folly::folly)
+target_link_libraries(
+  bolt_thrustjit
+  PUBLIC
+    llvm-core::llvm-core
+    date::date
+    fmt::fmt
+    Folly::folly
+)
 
 target_compile_options(
-  bolt_thrustjit PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-Werror=return-type>
+  bolt_thrustjit
+  PRIVATE
+    $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-Werror=return-type>
 )
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/jit/tests/CMakeLists.txt
+++ b/bolt/jit/tests/CMakeLists.txt
@@ -14,22 +14,22 @@
 # limitations under the License.
 
 if(${ENABLE_BOLT_JIT})
-
-  add_executable(bolt_thrustjit_test
+  add_executable(
+    bolt_thrustjit_test
     RowContainerIRTest.cpp
     ThrustJITv2Test.cpp
   )
   target_link_libraries(
-    bolt_thrustjit_test PRIVATE
-    bolt_testutils
-    bolt_engine
-    GTest::gtest GTest::gtest_main
+    bolt_thrustjit_test
+    PRIVATE
+      bolt_testutils
+      bolt_engine
+      GTest::gtest
+      GTest::gtest_main
   )
   add_test(bolt_thrustjit_test bolt_thrustjit_test)
 
-  add_executable(bolt_row_row_cmp_test
-    RowEqRowIRTest.cpp
-  )
+  add_executable(bolt_row_row_cmp_test RowEqRowIRTest.cpp)
   target_link_libraries(
     bolt_row_row_cmp_test
     bolt_testutils
@@ -39,9 +39,7 @@ if(${ENABLE_BOLT_JIT})
   )
   bolt_add_sharded_gtest(bolt_row_row_cmp_test 3)
 
-  add_executable(bolt_row_vec_cmp_test
-    RowEqVectorsIRTest.cpp
-  )
+  add_executable(bolt_row_vec_cmp_test RowEqVectorsIRTest.cpp)
   target_link_libraries(
     bolt_row_vec_cmp_test
     bolt_testutils
@@ -58,7 +56,8 @@ if(${ENABLE_BOLT_EXPR_JIT})
   find_package(ThrustVector REQUIRED)
   add_test(
     NAME bolt_expr_jit_test
-    COMMAND bolt_expr_jit_test
+    COMMAND
+      bolt_expr_jit_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
@@ -90,5 +89,4 @@ if(${ENABLE_BOLT_EXPR_JIT})
     glog::glog
     ${FMT}
   )
-
 endif() # ENABLE_BOLT_EXPR_JIT

--- a/bolt/parse/CMakeLists.txt
+++ b/bolt/parse/CMakeLists.txt
@@ -37,7 +37,12 @@ target_link_libraries(
 )
 
 bolt_add_library(bolt_parse_parser ExpressionsParser.cpp QueryPlanner.cpp)
-target_link_libraries(bolt_parse_parser bolt_parse_expression bolt_type bolt_duckdb_parser)
+target_link_libraries(
+  bolt_parse_parser
+  bolt_parse_expression
+  bolt_type
+  bolt_duckdb_parser
+)
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)
 endif()

--- a/bolt/parse/tests/CMakeLists.txt
+++ b/bolt/parse/tests/CMakeLists.txt
@@ -30,8 +30,9 @@ add_executable(bolt_parse_test QueryPlannerTest.cpp)
 add_test(bolt_parse_test bolt_parse_test)
 
 target_link_libraries(
-  bolt_parse_test PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  bolt_parse_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/python/CMakeLists.txt
+++ b/bolt/python/CMakeLists.txt
@@ -32,19 +32,20 @@ bolt_add_library(
 
 target_include_directories(
   bolt_python
-  PRIVATE ${pybind11_INCLUDE_DIRS}
-          ${fmt_INCLUDE_DIRS}
-          ${glog_INCLUDE_DIRS} # transitive include
-          ${gflags_INCLUDE_DIRS} # transitive include
-          ${folly_INCLUDE_DIRS} # transitive include
-          ${Boost_INCLUDE_DIRS} # transitive include
-          ${double-conversion_INCLUDE_DIRS} # transitive include
-          ${xsimd_INCLUDE_DIRS} # transitive include
-          ${Libevent_INCLUDE_DIRS} # transitive include
-          ${ryu_INCLUDE_DIRS} # transitive include
-          ${gfx-timsort_INCLUDE_DIRS} # transitive include
-          ${xxHash_INCLUDE_DIRS} # transitive include
-          ${date_INCLUDE_DIRS} # transitive include
+  PRIVATE
+    ${pybind11_INCLUDE_DIRS}
+    ${fmt_INCLUDE_DIRS}
+    ${glog_INCLUDE_DIRS} # transitive include
+    ${gflags_INCLUDE_DIRS} # transitive include
+    ${folly_INCLUDE_DIRS} # transitive include
+    ${Boost_INCLUDE_DIRS} # transitive include
+    ${double-conversion_INCLUDE_DIRS} # transitive include
+    ${xsimd_INCLUDE_DIRS} # transitive include
+    ${Libevent_INCLUDE_DIRS} # transitive include
+    ${ryu_INCLUDE_DIRS} # transitive include
+    ${gfx-timsort_INCLUDE_DIRS} # transitive include
+    ${xxHash_INCLUDE_DIRS} # transitive include
+    ${date_INCLUDE_DIRS} # transitive include
 )
 
 target_compile_options(bolt_python PRIVATE -fvisibility=hidden)
@@ -54,5 +55,11 @@ if(${ENABLE_BOLT_JIT})
 endif()
 
 # icu is needed as a result of a transitive include calling a function from icu library.
-target_link_libraries(bolt_python PRIVATE pybind11::pybind11 icu::icu folly::folly)
+target_link_libraries(
+  bolt_python
+  PRIVATE
+    pybind11::pybind11
+    icu::icu
+    folly::folly
+)
 target_compile_definitions(bolt_python PRIVATE ${glog_DEFINITIONS})

--- a/bolt/row/CMakeLists.txt
+++ b/bolt/row/CMakeLists.txt
@@ -33,7 +33,8 @@ bolt_add_library(
   dense/DenseRowGeneralEncode.cpp
   dense/DenseRowGeneralDecode.cpp
   dense/DenseRowScalarEncode.cpp
-  dense/DenseRowScalarDecode.cpp)
+  dense/DenseRowScalarDecode.cpp
+)
 
 target_link_libraries(bolt_row_fast PUBLIC bolt_vector)
 

--- a/bolt/row/tests/CMakeLists.txt
+++ b/bolt/row/tests/CMakeLists.txt
@@ -25,16 +25,21 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_row_test CompactRowTest.cpp UnsafeRowTest.cpp
-                             DenseRowTest.cpp)
+add_executable(
+  bolt_row_test
+  CompactRowTest.cpp
+  UnsafeRowTest.cpp
+  DenseRowTest.cpp
+)
 
 add_test(bolt_row_test bolt_row_test)
 
 target_link_libraries(
   bolt_row_test
-  PRIVATE bolt_row_fast
-          bolt_testutils
-          Folly::folly
-          GTest::gtest
-          GTest::gtest_main
+  PRIVATE
+    bolt_row_fast
+    bolt_testutils
+    Folly::folly
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/serializers/CMakeLists.txt
+++ b/bolt/serializers/CMakeLists.txt
@@ -34,14 +34,14 @@ bolt_add_library(
 )
 
 target_link_libraries(
-    bolt_presto_serializer
-    bolt_vector
-    bolt_row_fast
-    utf8proc::utf8proc
+  bolt_presto_serializer
+  bolt_vector
+  bolt_row_fast
+  utf8proc::utf8proc
 )
 
 if(${BOLT_BUILD_TESTING})
-    add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()
 
 if(${BOLT_BUILD_BENCHMARKS})

--- a/bolt/serializers/benchmarks/CMakeLists.txt
+++ b/bolt/serializers/benchmarks/CMakeLists.txt
@@ -30,4 +30,5 @@ target_link_libraries(
   bolt_row_serializer_benchmark
   bolt_engine
   bolt_vector_fuzzer
-  ${FOLLY_BENCHMARK})
+  ${FOLLY_BENCHMARK}
+)

--- a/bolt/serializers/tests/CMakeLists.txt
+++ b/bolt/serializers/tests/CMakeLists.txt
@@ -26,30 +26,32 @@
 # --------------------------------------------------------------------------
 
 add_executable(
-    bolt_serializer_test
-    PrestoOutputStreamListenerTest.cpp
-    PrestoSerializerTest.cpp
-    UnsafeRowSerializerTest.cpp
-    CompactRowSerializerTest.cpp
-    ArrowSerializerTest.cpp
+  bolt_serializer_test
+  PrestoOutputStreamListenerTest.cpp
+  PrestoSerializerTest.cpp
+  UnsafeRowSerializerTest.cpp
+  CompactRowSerializerTest.cpp
+  ArrowSerializerTest.cpp
 )
 
 add_test(bolt_serializer_test bolt_serializer_test)
 
 target_link_libraries(
   bolt_serializer_test
-  PRIVATE bolt_testutils
-          GTest::gtest
-          GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_executable(bolt_serializer_benchmark SerializerBenchmark.cpp)
 
 target_link_libraries(
   bolt_serializer_benchmark
-  PRIVATE   bolt_testutils
-            GTest::gtest
-            GTest::gtest_main
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_executable(bolt_arrowserde_test ArrowSerializerTest.cpp)
@@ -57,20 +59,22 @@ add_executable(bolt_arrowserde_test ArrowSerializerTest.cpp)
 add_test(bolt_arrowserde_test bolt_arrowserde_test)
 
 target_link_libraries(
-    bolt_arrowserde_test
-    PRIVATE bolt_presto_serializer
-            bolt_testutils
-            GTest::gtest
-            GTest::gtest_main
+  bolt_arrowserde_test
+  PRIVATE
+    bolt_presto_serializer
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_executable(bolt_arrowserde_benchmark ArrowSerializerBenchmark.cpp)
 
 target_link_libraries(
-    bolt_arrowserde_benchmark
-    PRIVATE bolt_testutils
-            GTest::gtest
-            GTest::gtest_main
-            gflags::gflags
-            glog::glog
+  bolt_arrowserde_benchmark
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog
 )

--- a/bolt/shuffle/sparksql/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/CMakeLists.txt
@@ -67,8 +67,14 @@ bolt_add_library(
 find_package(celeborn-cpp-client CONFIG REQUIRED)
 
 target_link_libraries(
-  bolt_shuffle_spark_impl PUBLIC arrow::arrow ryu::ryu bolt_vector bolt_core bolt_exec
-                                 celeborn-cpp-client::celeborn-cpp-client
+  bolt_shuffle_spark_impl
+  PUBLIC
+    arrow::arrow
+    ryu::ryu
+    bolt_vector
+    bolt_core
+    bolt_exec
+    celeborn-cpp-client::celeborn-cpp-client
 )
 
 if(ENABLE_QAT)
@@ -76,16 +82,27 @@ if(ENABLE_QAT)
   include(BuildQATZstd)
   target_sources(bolt_shuffle_spark_impl PRIVATE compression/qat/QatCodec.cpp)
   target_include_directories(
-    bolt_shuffle_spark_impl PUBLIC ${QATZIP_INCLUDE_DIR} ${QATZSTD_INCLUDE_DIR}
+    bolt_shuffle_spark_impl
+    PUBLIC
+      ${QATZIP_INCLUDE_DIR}
+      ${QATZSTD_INCLUDE_DIR}
   )
-  target_link_libraries(bolt_shuffle_spark_impl PUBLIC qatzip::qatzip qatzstd::qatzstd)
+  target_link_libraries(
+    bolt_shuffle_spark_impl
+    PUBLIC
+      qatzip::qatzip
+      qatzstd::qatzstd
+  )
 endif()
 
 if(ENABLE_IAA)
   include(BuildQpl)
   target_include_directories(bolt_shuffle_spark_impl PUBLIC ${QPL_INCLUDE_DIR})
   target_sources(
-    bolt_shuffle_spark_impl PRIVATE compression/qpl/qpl_job_pool.cpp compression/qpl/qpl_codec.cpp
+    bolt_shuffle_spark_impl
+    PRIVATE
+      compression/qpl/qpl_job_pool.cpp
+      compression/qpl/qpl_codec.cpp
   )
   target_link_libraries(bolt_shuffle_spark_impl PUBLIC qpl::qpl)
 endif()

--- a/bolt/shuffle/sparksql/benchmarks/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/benchmarks/CMakeLists.txt
@@ -15,23 +15,23 @@
 add_executable(bolt_codec_benchmark CodecBenchmark.cpp)
 
 target_link_libraries(
-    bolt_codec_benchmark
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        Folly::folly
-        ${FOLLY_BENCHMARK}
-        glog::glog
+  bolt_codec_benchmark
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    glog::glog
 )
 
 add_executable(bolt_block_payload_benchmark BlockPayloadBenchmark.cpp)
 
 target_link_libraries(
-    bolt_block_payload_benchmark
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        Folly::folly
-        ${FOLLY_BENCHMARK}
-        glog::glog
+  bolt_block_payload_benchmark
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    glog::glog
 )

--- a/bolt/shuffle/sparksql/tests/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/tests/CMakeLists.txt
@@ -17,200 +17,172 @@ add_executable(bolt_shuffle_spark_celeborn_test CelebornClientTest.cpp)
 add_test(bolt_shuffle_spark_celeborn_test bolt_shuffle_spark_celeborn_test)
 
 target_link_libraries(
-    bolt_shuffle_spark_celeborn_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        glog::glog
-        GTest::gtest
-        GTest::gtest_main
+  bolt_shuffle_spark_celeborn_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    glog::glog
+    GTest::gtest
+    GTest::gtest_main
 )
 
 add_test(
-    NAME bolt_shuffle_spark_celeborn_e2e_test
-    COMMAND
-        bolt_shuffle_spark_celeborn_test
-        --gtest_filter=CelebornE2ESmokeTest.nativeClientPushAndReadBack
+  NAME bolt_shuffle_spark_celeborn_e2e_test
+  COMMAND
+    bolt_shuffle_spark_celeborn_test --gtest_filter=CelebornE2ESmokeTest.nativeClientPushAndReadBack
 )
 set_tests_properties(
-    bolt_shuffle_spark_celeborn_e2e_test
-    PROPERTIES
-        LABELS "celeborn_e2e"
+  bolt_shuffle_spark_celeborn_e2e_test
+  PROPERTIES
+    LABELS
+      "celeborn_e2e"
 )
 
 add_executable(
-    bolt_shuffle_spark_matrix_test
-    ShuffleTestBase.cpp
-    ShuffleMatrixTest.cpp
+  bolt_shuffle_spark_matrix_test
+  ShuffleTestBase.cpp
+  ShuffleMatrixTest.cpp
 )
 
 target_link_libraries(
-    bolt_shuffle_spark_matrix_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        bolt_vector_fuzzer
-        GTest::gtest_main
-        GTest::gmock
+  bolt_shuffle_spark_matrix_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    bolt_vector_fuzzer
+    GTest::gtest_main
+    GTest::gmock
+)
+
+# Add test
+add_test(NAME bolt_shuffle_spark_matrix_test COMMAND bolt_shuffle_spark_matrix_test)
+
+add_executable(
+  bolt_shuffle_spark_large_partition_test
+  ShuffleTestBase.cpp
+  ShuffleLargePartitionTest.cpp
+)
+
+target_link_libraries(
+  bolt_shuffle_spark_large_partition_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_vector_fuzzer
+    bolt_testutils
+    GTest::gtest_main
+    GTest::gmock
 )
 
 # Add test
 add_test(
-    NAME bolt_shuffle_spark_matrix_test
-    COMMAND bolt_shuffle_spark_matrix_test
-)
-
-add_executable(
+  NAME bolt_shuffle_spark_large_partition_test
+  COMMAND
     bolt_shuffle_spark_large_partition_test
-    ShuffleTestBase.cpp
-    ShuffleLargePartitionTest.cpp
+)
+
+add_executable(
+  bolt_shuffle_spark_memory_test
+  ShuffleTestBase.cpp
+  ShuffleMemoryTest.cpp
 )
 
 target_link_libraries(
-    bolt_shuffle_spark_large_partition_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_vector_fuzzer
-        bolt_testutils
-        GTest::gtest_main
-        GTest::gmock
+  bolt_shuffle_spark_memory_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_vector_fuzzer
+    bolt_testutils
+    GTest::gtest_main
+    GTest::gmock
 )
 
 # Add test
-add_test(
-    NAME bolt_shuffle_spark_large_partition_test
-    COMMAND bolt_shuffle_spark_large_partition_test
-)
+add_test(NAME bolt_shuffle_spark_memory_test COMMAND bolt_shuffle_spark_memory_test)
 
 add_executable(
-    bolt_shuffle_spark_memory_test
-    ShuffleTestBase.cpp
-    ShuffleMemoryTest.cpp
+  bolt_shuffle_spark_misc_test
+  ShuffleTestBase.cpp
+  ShuffleMiscTest.cpp
 )
 
 target_link_libraries(
-    bolt_shuffle_spark_memory_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_vector_fuzzer
-        bolt_testutils
-        GTest::gtest_main
-        GTest::gmock
+  bolt_shuffle_spark_misc_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_vector_fuzzer
+    bolt_testutils
+    GTest::gtest_main
+    GTest::gmock
 )
 
 # Add test
-add_test(
-    NAME bolt_shuffle_spark_memory_test
-    COMMAND bolt_shuffle_spark_memory_test
-)
+add_test(NAME bolt_shuffle_spark_misc_test COMMAND bolt_shuffle_spark_misc_test)
 
-add_executable(
-    bolt_shuffle_spark_misc_test
-    ShuffleTestBase.cpp
-    ShuffleMiscTest.cpp
-)
+add_executable(bolt_shuffle_codec_test CodecTest.cpp)
 
 target_link_libraries(
-    bolt_shuffle_spark_misc_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_vector_fuzzer
-        bolt_testutils
-        GTest::gtest_main
-        GTest::gmock
+  bolt_shuffle_codec_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    GTest::gtest_main
+    GTest::gmock
 )
 
-# Add test
-add_test(
-    NAME bolt_shuffle_spark_misc_test
-    COMMAND bolt_shuffle_spark_misc_test
-)
+add_test(NAME bolt_shuffle_codec_test COMMAND bolt_shuffle_codec_test)
 
-add_executable(
-    bolt_shuffle_codec_test
-    CodecTest.cpp
-)
+add_executable(bolt_shuffle_adaptive_zstd_codec_test AdaptiveParallelZstdCodecTest.cpp)
 
 target_link_libraries(
-    bolt_shuffle_codec_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        GTest::gtest_main
-        GTest::gmock
+  bolt_shuffle_adaptive_zstd_codec_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    GTest::gtest_main
+    GTest::gmock
 )
 
-add_test(
-    NAME bolt_shuffle_codec_test
-    COMMAND bolt_shuffle_codec_test
-)
-
-add_executable(
-    bolt_shuffle_adaptive_zstd_codec_test
-    AdaptiveParallelZstdCodecTest.cpp
-)
-
-target_link_libraries(
-    bolt_shuffle_adaptive_zstd_codec_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        GTest::gtest_main
-        GTest::gmock
-)
-
-add_test(
-    NAME bolt_shuffle_adaptive_zstd_codec_test
-    COMMAND bolt_shuffle_adaptive_zstd_codec_test
-)
+add_test(NAME bolt_shuffle_adaptive_zstd_codec_test COMMAND bolt_shuffle_adaptive_zstd_codec_test)
 
 add_executable(bolt_shuffle_reader_test BoltShuffleReaderTest.cpp)
 
 target_link_libraries(
-    bolt_shuffle_reader_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        GTest::gtest
-        GTest::gmock
+  bolt_shuffle_reader_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    GTest::gtest
+    GTest::gmock
 )
 
-add_test(
-    NAME bolt_shuffle_reader_test
-    COMMAND bolt_shuffle_reader_test
-)
+add_test(NAME bolt_shuffle_reader_test COMMAND bolt_shuffle_reader_test)
 
 add_executable(bolt_shuffle_payload_test PayloadTest.cpp)
 
 target_link_libraries(
-    bolt_shuffle_payload_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        GTest::gtest
+  bolt_shuffle_payload_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    GTest::gtest
 )
 
-add_test(
-    NAME bolt_shuffle_payload_test
-    COMMAND bolt_shuffle_payload_test
-)
+add_test(NAME bolt_shuffle_payload_test COMMAND bolt_shuffle_payload_test)
 
-add_executable(
-    bolt_shuffle_local_partition_writer_test
-    LocalPartitionWriterTest.cpp
-)
+add_executable(bolt_shuffle_local_partition_writer_test LocalPartitionWriterTest.cpp)
 
 target_link_libraries(
-    bolt_shuffle_local_partition_writer_test
-    PRIVATE
-        bolt_shuffle_spark_impl
-        bolt_testutils
-        GTest::gtest
-        GTest::gtest_main
-        GTest::gmock
+  bolt_shuffle_local_partition_writer_test
+  PRIVATE
+    bolt_shuffle_spark_impl
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
 )
 
 add_test(
-    NAME bolt_shuffle_local_partition_writer_test
-    COMMAND bolt_shuffle_local_partition_writer_test
+  NAME bolt_shuffle_local_partition_writer_test
+  COMMAND
+    bolt_shuffle_local_partition_writer_test
 )

--- a/bolt/substrait/CMakeLists.txt
+++ b/bolt/substrait/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 message(
   STATUS
-    "Found Protobuf compiler: ${Protobuf_PROTOC_EXECUTABLE} (found version ${Protobuf_VERSION})"
+  "Found Protobuf compiler: ${Protobuf_PROTOC_EXECUTABLE} (found version ${Protobuf_VERSION})"
 )
 
 message(STATUS "Proto directory path: ${CMAKE_CURRENT_SOURCE_DIR}/proto")
@@ -43,8 +43,11 @@ set(PROTO_OUTPUT_DIR "${CMAKE_BINARY_DIR}/gen_cpp")
 file(MAKE_DIRECTORY ${PROTO_OUTPUT_DIR})
 
 # Glob all the .proto files
-file(GLOB PROTO_FILES ${SUBSTRAIT_PROTO_DIRECTORY}/*.proto
-     ${SUBSTRAIT_PROTO_DIRECTORY}/extensions/*.proto ${SUBSTRAIT_PROTO_DIRECTORY}/bolt/*.proto
+file(
+  GLOB PROTO_FILES
+  ${SUBSTRAIT_PROTO_DIRECTORY}/*.proto
+  ${SUBSTRAIT_PROTO_DIRECTORY}/extensions/*.proto
+  ${SUBSTRAIT_PROTO_DIRECTORY}/bolt/*.proto
 )
 
 set(PROTO_SRCS "")
@@ -62,43 +65,64 @@ foreach(proto ${PROTO_FILES})
   message(STATUS "Compiling proto file: ${proto}")
   # Generate commands for each .proto file
   add_custom_command(
-    OUTPUT ${PROTO_SRC} ${PROTO_HDR}
-    COMMAND ${Protobuf_PROTOC_EXECUTABLE} ARGS --proto_path=${PROJECT_SOURCE_DIR}/
-            --cpp_out=${PROTO_OUTPUT_DIR} ${proto}
-    DEPENDS ${proto}
+    OUTPUT
+      ${PROTO_SRC}
+      ${PROTO_HDR}
+    COMMAND
+      ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS
+      --proto_path=${PROJECT_SOURCE_DIR}/ --cpp_out=${PROTO_OUTPUT_DIR} ${proto}
+    DEPENDS
+      ${proto}
     COMMENT "Running proto compiler for ${proto}"
     VERBATIM
   )
 endforeach()
 
-set(PROTO_OUTPUT_FILES ${PROTO_HDRS} ${PROTO_SRCS})
-set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
+set(
+  PROTO_OUTPUT_FILES
+  ${PROTO_HDRS}
+  ${PROTO_SRCS}
+)
+set_source_files_properties(
+  ${PROTO_OUTPUT_FILES}
+  PROPERTIES
+    GENERATED
+      TRUE
+)
 
 # Custom target to handle all the generated .pb.cc and .pb.h files
 add_custom_target(
-  substrait_proto ALL
-  DEPENDS ${PROTO_OUTPUT_FILES}
+  substrait_proto
+  ALL
+  DEPENDS
+    ${PROTO_OUTPUT_FILES}
   COMMENT "Generating substrait proto files"
 )
 add_dependencies(substrait_proto protobuf::libprotobuf)
 
-set(SRCS
-    ${PROTO_SRCS}
-    SubstraitParser.cpp
-    SubstraitToBoltExpr.cpp
-    SubstraitToBoltPlan.cpp
-    TypeUtils.cpp
-    SubstraitExtensionCollector.cpp
-    BoltToSubstraitExpr.cpp
-    BoltToSubstraitPlan.cpp
-    BoltToSubstraitType.cpp
-    BoltSubstraitSignature.cpp
-    VariantToVectorConverter.cpp
+set(
+  SRCS
+  ${PROTO_SRCS}
+  SubstraitParser.cpp
+  SubstraitToBoltExpr.cpp
+  SubstraitToBoltPlan.cpp
+  TypeUtils.cpp
+  SubstraitExtensionCollector.cpp
+  BoltToSubstraitExpr.cpp
+  BoltToSubstraitPlan.cpp
+  BoltToSubstraitType.cpp
+  BoltSubstraitSignature.cpp
+  VariantToVectorConverter.cpp
 )
 
 bolt_add_library(bolt_substrait_plan_converter ${SRCS})
 target_include_directories(bolt_substrait_plan_converter PUBLIC ${PROTO_OUTPUT_DIR}/)
-target_link_libraries(bolt_substrait_plan_converter bolt_connector bolt_dwio_dwrf_common)
+target_link_libraries(
+  bolt_substrait_plan_converter
+  bolt_connector
+  bolt_dwio_dwrf_common
+)
 
 if(${BOLT_ENABLE_TORCH})
   target_compile_definitions(bolt_substrait_plan_converter PRIVATE BOLT_HAS_TORCH=1)
@@ -109,7 +133,8 @@ endif()
 # Force export this library
 add_custom_target(
   dummy_substrait_target
-  DEPENDS bolt_substrait_plan_converter
+  DEPENDS
+    bolt_substrait_plan_converter
   COMMENT "Exporting substrait plan converter library"
 )
 

--- a/bolt/substrait/tests/CMakeLists.txt
+++ b/bolt/substrait/tests/CMakeLists.txt
@@ -41,7 +41,8 @@ add_dependencies(bolt_plan_conversion_test bolt_substrait_plan_converter)
 
 add_test(
   NAME bolt_plan_conversion_test
-  COMMAND bolt_plan_conversion_test
+  COMMAND
+    bolt_plan_conversion_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -55,5 +56,9 @@ target_link_libraries(
 if(${BOLT_ENABLE_TORCH})
   target_compile_definitions(bolt_plan_conversion_test PRIVATE BOLT_HAS_TORCH=1)
   target_include_directories(bolt_plan_conversion_test SYSTEM PRIVATE ${TORCH_INCLUDE_DIRS})
-  target_link_libraries(bolt_plan_conversion_test bolt_torch bolt_vector_fuzzer)
+  target_link_libraries(
+    bolt_plan_conversion_test
+    bolt_torch
+    bolt_vector_fuzzer
+  )
 endif()

--- a/bolt/tool/trace/CMakeLists.txt
+++ b/bolt/tool/trace/CMakeLists.txt
@@ -26,7 +26,8 @@
 # --------------------------------------------------------------------------
 
 add_library(
-  bolt_query_trace_replayer_base OBJECT
+  bolt_query_trace_replayer_base
+  OBJECT
   AggregationReplayer.cpp
   FilterProjectReplayer.cpp
   HashJoinReplayer.cpp
@@ -87,11 +88,13 @@ target_link_libraries(
 add_executable(bolt_query_replayer TraceReplayerMain.cpp)
 
 target_link_libraries(
-  bolt_query_replayer PRIVATE
-  bolt_query_trace_replayer_base
-  bolt_exec bolt_exec_test_lib
-  bolt_tpch_connector
-  bolt_testutils
+  bolt_query_replayer
+  PRIVATE
+    bolt_query_trace_replayer_base
+    bolt_exec
+    bolt_exec_test_lib
+    bolt_tpch_connector
+    bolt_testutils
 )
 
 add_library(bolt_trace_file_tool_base OBJECT TraceFileToolRunner.cpp)
@@ -110,9 +113,11 @@ target_link_libraries(
 
 add_executable(bolt_trace_file_tool TraceFileToolMain.cpp)
 
-target_link_libraries(bolt_trace_file_tool  PRIVATE
-  bolt_trace_file_tool_base
-  bolt_testutils
+target_link_libraries(
+  bolt_trace_file_tool
+  PRIVATE
+    bolt_trace_file_tool_base
+    bolt_testutils
 )
 
 add_subdirectory(tests)

--- a/bolt/tool/trace/tests/CMakeLists.txt
+++ b/bolt/tool/trace/tests/CMakeLists.txt
@@ -38,11 +38,17 @@ add_executable(
 
 add_test(
   NAME bolt_tool_trace_test
-  COMMAND bolt_tool_trace_test
+  COMMAND
+    bolt_tool_trace_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-set_tests_properties(bolt_tool_trace_test PROPERTIES TIMEOUT 3000)
+set_tests_properties(
+  bolt_tool_trace_test
+  PROPERTIES
+    TIMEOUT
+      3000
+)
 
 target_link_libraries(
   bolt_tool_trace_test

--- a/bolt/torch/CMakeLists.txt
+++ b/bolt/torch/CMakeLists.txt
@@ -17,19 +17,20 @@ bolt_add_library(bolt_torch Compatibility.cpp Operator.cpp PlanNode.cpp Tensor.c
 
 target_include_directories(
   bolt_torch
-  PRIVATE ${TORCH_INCLUDE_DIRS}
-          ${fmt_INCLUDE_DIRS}
-          ${glog_INCLUDE_DIRS} # transitive include
-          ${gflags_INCLUDE_DIRS} # transitive include
-          ${folly_INCLUDE_DIRS} # transitive include
-          ${Boost_INCLUDE_DIRS} # transitive include
-          ${double-conversion_INCLUDE_DIRS} # transitive include
-          ${xsimd_INCLUDE_DIRS} # transitive include
-          ${Libevent_INCLUDE_DIRS} # transitive include
-          ${ryu_INCLUDE_DIRS} # transitive include
-          ${gfx-timsort_INCLUDE_DIRS} # transitive include
-          ${xxHash_INCLUDE_DIRS} # transitive include
-          ${date_INCLUDE_DIRS} # transitive include
+  PRIVATE
+    ${TORCH_INCLUDE_DIRS}
+    ${fmt_INCLUDE_DIRS}
+    ${glog_INCLUDE_DIRS} # transitive include
+    ${gflags_INCLUDE_DIRS} # transitive include
+    ${folly_INCLUDE_DIRS} # transitive include
+    ${Boost_INCLUDE_DIRS} # transitive include
+    ${double-conversion_INCLUDE_DIRS} # transitive include
+    ${xsimd_INCLUDE_DIRS} # transitive include
+    ${Libevent_INCLUDE_DIRS} # transitive include
+    ${ryu_INCLUDE_DIRS} # transitive include
+    ${gfx-timsort_INCLUDE_DIRS} # transitive include
+    ${xxHash_INCLUDE_DIRS} # transitive include
+    ${date_INCLUDE_DIRS} # transitive include
 )
 
 if(${ENABLE_BOLT_JIT})
@@ -37,7 +38,13 @@ if(${ENABLE_BOLT_JIT})
 endif()
 
 # icu is needed as a result of a transitive include calling a function from icu library.
-target_link_libraries(bolt_torch PUBLIC ${TORCH_LIBRARIES} icu::icu folly::folly)
+target_link_libraries(
+  bolt_torch
+  PUBLIC
+    ${TORCH_LIBRARIES}
+    icu::icu
+    folly::folly
+)
 target_compile_definitions(bolt_torch PRIVATE ${glog_DEFINITIONS})
 
 if(${BOLT_BUILD_TESTING})

--- a/bolt/torch/tests/CMakeLists.txt
+++ b/bolt/torch/tests/CMakeLists.txt
@@ -14,12 +14,30 @@
 # limitations under the License.
 
 add_executable(
-  torch_test test_compatibility.cpp test_main.cpp test_operator.cpp test_plan_node.cpp utils.cpp
+  torch_test
+  test_compatibility.cpp
+  test_main.cpp
+  test_operator.cpp
+  test_plan_node.cpp
+  utils.cpp
 )
 target_link_libraries(
-  torch_test PRIVATE bolt_torch bolt_exec bolt_core bolt_exec_test_lib glog::glog GTest::gtest
+  torch_test
+  PRIVATE
+    bolt_torch
+    bolt_exec
+    bolt_core
+    bolt_exec_test_lib
+    glog::glog
+    GTest::gtest
 )
-target_include_directories(torch_test SYSTEM PRIVATE ${TORCH_INCLUDE_DIRS} ${GTest_INCLUDE_DIRS})
+target_include_directories(
+  torch_test
+  SYSTEM
+  PRIVATE
+    ${TORCH_INCLUDE_DIRS}
+    ${GTest_INCLUDE_DIRS}
+)
 target_compile_definitions(torch_test PRIVATE BOLT_HAS_TORCH=1)
 
 add_test(torch_test torch_test)

--- a/bolt/tpch/gen/CMakeLists.txt
+++ b/bolt/tpch/gen/CMakeLists.txt
@@ -31,7 +31,12 @@ bolt_add_library(bolt_tpch_gen DBGenIterator.cpp TpchGen.cpp)
 
 target_include_directories(bolt_tpch_gen PRIVATE dbgen/include)
 
-target_link_libraries(bolt_tpch_gen bolt_memory bolt_vector bolt_dbgen)
+target_link_libraries(
+  bolt_tpch_gen
+  bolt_memory
+  bolt_vector
+  bolt_dbgen
+)
 
 if(${BOLT_BUILD_TESTING})
   add_subdirectory(tests)

--- a/bolt/tpch/gen/dbgen/CMakeLists.txt
+++ b/bolt/tpch/gen/dbgen/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_policy(SET CMP0063 NEW)
 
-project(dbgen CXX C)
+project(
+  dbgen
+  CXX
+  C
+)
 
-add_definitions(-DDBNAME=dss -DMAC -DORACLE -DTPCH)
+add_definitions(
+  -DDBNAME=dss
+  -DMAC
+  -DORACLE
+  -DTPCH
+)
 
 bolt_add_library(
   bolt_dbgen

--- a/bolt/tpch/gen/tests/CMakeLists.txt
+++ b/bolt/tpch/gen/tests/CMakeLists.txt
@@ -30,8 +30,9 @@ add_executable(bolt_tpch_gen_test TpchGenTest.cpp)
 add_test(bolt_tpch_gen_test bolt_tpch_gen_test)
 
 target_link_libraries(
-  bolt_tpch_gen_test PRIVATE
-  bolt_testutils
-  GTest::gtest
-  GTest::gtest_main
+  bolt_tpch_gen_test
+  PRIVATE
+    bolt_testutils
+    GTest::gtest
+    GTest::gtest_main
 )

--- a/bolt/type/CMakeLists.txt
+++ b/bolt/type/CMakeLists.txt
@@ -40,7 +40,9 @@ find_package(ryu CONFIG REQUIRED)
 # Header-only interface library for type definitions
 bolt_add_library(bolt_type_headers INTERFACE)
 target_include_directories(
-  bolt_type_headers INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  bolt_type_headers
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
 # Implementation library for core type functionality
@@ -63,25 +65,33 @@ bolt_add_library(
 )
 
 target_include_directories(
-  bolt_type_base PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> ${xxHash_INCLUDE_DIR}
-                        ${ryu_INCLUDE_DIR} ${re2_INCLUDE_DIR} ${date_INCLUDE_DIR}
+  bolt_type_base
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    ${xxHash_INCLUDE_DIR}
+    ${ryu_INCLUDE_DIR}
+    ${re2_INCLUDE_DIR}
+    ${date_INCLUDE_DIR}
 )
 
 target_link_libraries(
   bolt_type_base
-  PUBLIC bolt_type_headers date::date
-  PRIVATE bolt_type_tz
-          bolt_common_base
-          bolt_encode
-          bolt_exception
-          bolt_serialization
-          bolt_status
-          bolt_token_extractor
-          Boost::headers
-          re2::re2
-          xxHash::xxhash
-          ryu::ryu
-          Folly::folly
+  PUBLIC
+    bolt_type_headers
+    date::date
+  PRIVATE
+    bolt_type_tz
+    bolt_common_base
+    bolt_encode
+    bolt_exception
+    bolt_serialization
+    bolt_status
+    bolt_token_extractor
+    Boost::headers
+    re2::re2
+    xxHash::xxhash
+    ryu::ryu
+    Folly::folly
 )
 
 # Main interface library that combines everything
@@ -89,21 +99,22 @@ bolt_add_library(bolt_type INTERFACE)
 
 target_link_libraries(
   bolt_type
-  INTERFACE bolt_type_headers
-            bolt_type_base
-            bolt_filter
-            bolt_vector
-            bolt_exec
-            bolt_type_tz
-            bolt_common_base
-            bolt_encode
-            bolt_exception
-            bolt_serialization
-            bolt_status
-            bolt_token_extractor
-            Boost::headers
-            re2::re2
-            xxHash::xxhash
-            ryu::ryu
-            Folly::folly
+  INTERFACE
+    bolt_type_headers
+    bolt_type_base
+    bolt_filter
+    bolt_vector
+    bolt_exec
+    bolt_type_tz
+    bolt_common_base
+    bolt_encode
+    bolt_exception
+    bolt_serialization
+    bolt_status
+    bolt_token_extractor
+    Boost::headers
+    re2::re2
+    xxHash::xxhash
+    ryu::ryu
+    Folly::folly
 )

--- a/bolt/type/fbhive/tests/CMakeLists.txt
+++ b/bolt/type/fbhive/tests/CMakeLists.txt
@@ -29,10 +29,15 @@ add_executable(bolt_type_fbhive_test HiveTypeParserTests.cpp)
 
 add_test(
   NAME bolt_type_fbhive_test
-  COMMAND bolt_type_fbhive_test
+  COMMAND
+    bolt_type_fbhive_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(
-  bolt_type_fbhive_test bolt_testutils GTest::gtest GTest::gtest_main GTest::gmock
+  bolt_type_fbhive_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
 )

--- a/bolt/type/filter/CMakeLists.txt
+++ b/bolt/type/filter/CMakeLists.txt
@@ -33,6 +33,13 @@ find_package(ryu CONFIG REQUIRED)
 
 target_link_libraries(
   bolt_filter
-  PUBLIC bolt_type_headers
-  PRIVATE bolt_common_base bolt_token_extractor bolt_exception re2::re2 xxHash::xxhash ryu::ryu
+  PUBLIC
+    bolt_type_headers
+  PRIVATE
+    bolt_common_base
+    bolt_token_extractor
+    bolt_exception
+    re2::re2
+    xxHash::xxhash
+    ryu::ryu
 )

--- a/bolt/type/parser/CMakeLists.txt
+++ b/bolt/type/parser/CMakeLists.txt
@@ -30,17 +30,24 @@ if(${BOLT_BUILD_TESTING})
 endif()
 
 bison_target(
-  TypeParser TypeParser.yy ${CMAKE_CURRENT_BINARY_DIR}/TypeParser.yy.cc
+  TypeParser
+  TypeParser.yy
+  ${CMAKE_CURRENT_BINARY_DIR}/TypeParser.yy.cc
   DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/TypeParser.yy.h
   COMPILE_FLAGS "-Werror -Wno-deprecated"
 )
 
 flex_target(
-  TypeParserScanner TypeParser.ll ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp
+  TypeParserScanner
+  TypeParser.ll
+  ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp
   COMPILE_FLAGS "-Cf --prefix=bolttp"
 )
 
-add_flex_bison_dependency(TypeParserScanner TypeParser)
+add_flex_bison_dependency(
+  TypeParserScanner
+  TypeParser
+)
 
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${FLEX_INCLUDE_DIRS})

--- a/bolt/type/parser/tests/CMakeLists.txt
+++ b/bolt/type/parser/tests/CMakeLists.txt
@@ -30,5 +30,9 @@ add_executable(bolt_type_parser_test TypeParserTest.cpp)
 add_test(NAME bolt_type_parser_test COMMAND bolt_type_parser_test)
 
 target_link_libraries(
-  bolt_type_parser_test bolt_testutils GTest::gtest GTest::gtest_main GTest::gmock
+  bolt_type_parser_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
 )

--- a/bolt/type/tests/CMakeLists.txt
+++ b/bolt/type/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(bolt_negated_values_filter_benchmark NegatedValuesFilterBenchmark
 
 target_link_libraries(
   bolt_negated_values_filter_benchmark
-   bolt_testutils
+  bolt_testutils
   ${FOLLY_BENCHMARK}
   GTest::gtest
   GTest::gtest_main

--- a/bolt/type/tz/CMakeLists.txt
+++ b/bolt/type/tz/CMakeLists.txt
@@ -30,11 +30,12 @@ if(${BOLT_BUILD_TESTING})
 endif()
 bolt_add_library(bolt_type_tz TimeZoneDatabase.cpp TimeZoneLinks.cpp TimeZoneMap.cpp TimeZoneMap.h TimeZoneNames.cpp)
 
-target_link_libraries(bolt_type_tz
-          PUBLIC
-            Folly::folly
-            date::date
-            fmt::fmt
-          PRIVATE
-            $<$<CONFIG:Debug>:bolt_debug_util>
+target_link_libraries(
+  bolt_type_tz
+  PUBLIC
+    Folly::folly
+    date::date
+    fmt::fmt
+  PRIVATE
+    $<$<CONFIG:Debug>:bolt_debug_util>
 )

--- a/bolt/type/tz/tests/CMakeLists.txt
+++ b/bolt/type/tz/tests/CMakeLists.txt
@@ -29,8 +29,10 @@ add_executable(bolt_type_tz_test TimeZoneMapTest.cpp)
 
 add_test(bolt_type_tz_test bolt_type_tz_test)
 
-target_link_libraries(bolt_type_tz_test
-                      bolt_testutils
-                      GTest::gtest
-                      GTest::gtest_main
-                      pthread)
+target_link_libraries(
+  bolt_type_tz_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
+  pthread
+)

--- a/bolt/vector/arrow/CMakeLists.txt
+++ b/bolt/vector/arrow/CMakeLists.txt
@@ -28,19 +28,19 @@
 bolt_add_library(bolt_arrow_bridge Bridge.cpp)
 
 target_link_libraries(
-    bolt_arrow_bridge
-    utf8proc::utf8proc
-    bolt_memory
-    bolt_type_base
-    bolt_buffer
-    bolt_exception
-    ${ICU_LIBRARIES}
+  bolt_arrow_bridge
+  utf8proc::utf8proc
+  bolt_memory
+  bolt_type_base
+  bolt_buffer
+  bolt_exception
+  ${ICU_LIBRARIES}
 )
 
 if(BOLT_BUILD_TESTING AND BOLT_ENABLE_ARROW)
-    add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()
 
 if(BOLT_BUILD_BENCHMARKS AND BOLT_ENABLE_ARROW)
-    add_subdirectory(benchmarks)
+  add_subdirectory(benchmarks)
 endif()

--- a/bolt/vector/arrow/benchmarks/CMakeLists.txt
+++ b/bolt/vector/arrow/benchmarks/CMakeLists.txt
@@ -13,36 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(BOLT_BENCHMARK_DEPS
-    bolt_vector_fuzzer
-    bolt_testutils
-    ${FOLLY_BENCHMARK}
-    GTest::gtest
+set(
+  BOLT_BENCHMARK_DEPS
+  bolt_vector_fuzzer
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
+  GTest::gtest
 )
 add_executable(export_bolt_arrow_bridge_benchmark ExportBoltToArrowBenchmark.cpp)
 target_link_libraries(
-  export_bolt_arrow_bridge_benchmark PRIVATE
-  bolt_arrow_bridge
-  ${BOLT_BENCHMARK_DEPS}
+  export_bolt_arrow_bridge_benchmark
+  PRIVATE
+    bolt_arrow_bridge
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(arrow_bolt_bridge_benchmark ArrowToBoltBenchmark.cpp)
 target_link_libraries(
-  arrow_bolt_bridge_benchmark PRIVATE
-  bolt_arrow_bridge
-  ${BOLT_BENCHMARK_DEPS}
+  arrow_bolt_bridge_benchmark
+  PRIVATE
+    bolt_arrow_bridge
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(arrow_bolt_array_bridge_benchmark ArrowToBoltArrayBenchmark.cpp)
 target_link_libraries(
-  arrow_bolt_array_bridge_benchmark PRIVATE
-  bolt_arrow_bridge
-  ${BOLT_BENCHMARK_DEPS}
+  arrow_bolt_array_bridge_benchmark
+  PRIVATE
+    bolt_arrow_bridge
+    ${BOLT_BENCHMARK_DEPS}
 )
 
 add_executable(import_arrow_bolt_bridge_benchmark ImportArrowToBoltBenchmark.cpp)
 target_link_libraries(
-  import_arrow_bolt_bridge_benchmark PRIVATE
-  bolt_arrow_bridge
-  ${BOLT_BENCHMARK_DEPS}
+  import_arrow_bolt_bridge_benchmark
+  PRIVATE
+    bolt_arrow_bridge
+    ${BOLT_BENCHMARK_DEPS}
 )

--- a/bolt/vector/arrow/tests/CMakeLists.txt
+++ b/bolt/vector/arrow/tests/CMakeLists.txt
@@ -25,7 +25,11 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-add_executable(bolt_arrow_bridge_test ArrowBridgeArrayTest.cpp ArrowBridgeSchemaTest.cpp)
+add_executable(
+  bolt_arrow_bridge_test
+  ArrowBridgeArrayTest.cpp
+  ArrowBridgeSchemaTest.cpp
+)
 
 add_test(bolt_arrow_bridge_test bolt_arrow_bridge_test)
 

--- a/bolt/vector/benchmarks/CMakeLists.txt
+++ b/bolt/vector/benchmarks/CMakeLists.txt
@@ -25,17 +25,16 @@
 # This modified file is released under the same license.
 # --------------------------------------------------------------------------
 
-set(BOLT_BENCHMARK_DEPS
-    bolt_vector_fuzzer
-    bolt_testutils
-    ${FOLLY_BENCHMARK}
-    GTest::gtest
+set(
+  BOLT_BENCHMARK_DEPS
+  bolt_vector_fuzzer
+  bolt_testutils
+  ${FOLLY_BENCHMARK}
+  GTest::gtest
 )
 add_executable(bolt_vector_hash_all_benchmark SimpleVectorHashAllBenchmark.cpp)
 
-target_link_libraries(
-  bolt_vector_hash_all_benchmark PRIVATE ${BOLT_BENCHMARK_DEPS}
-)
+target_link_libraries(bolt_vector_hash_all_benchmark PRIVATE ${BOLT_BENCHMARK_DEPS})
 # This is a workaround for the use of VectorTestUtils.h which include gtest.h
 target_link_libraries(bolt_vector_hash_all_benchmark PRIVATE ${BOLT_BENCHMARK_DEPS})
 
@@ -48,7 +47,4 @@ add_executable(copy_benchmark CopyBenchmark.cpp)
 target_link_libraries(copy_benchmark PRIVATE ${BOLT_BENCHMARK_DEPS})
 
 add_executable(copy_vectors_opt_bench CopyVecOptBenchmark.cpp)
-target_link_libraries(
-  copy_vectors_opt_bench
-  PRIVATE ${BOLT_BENCHMARK_DEPS}
-)
+target_link_libraries(copy_vectors_opt_bench PRIVATE ${BOLT_BENCHMARK_DEPS})

--- a/bolt/vector/fuzzer/CMakeLists.txt
+++ b/bolt/vector/fuzzer/CMakeLists.txt
@@ -27,7 +27,11 @@
 
 bolt_add_library(bolt_vector_fuzzer GeneratorSpec.cpp Utils.cpp VectorFuzzer.cpp)
 
-target_link_libraries(bolt_vector_fuzzer bolt_type bolt_vector)
+target_link_libraries(
+  bolt_vector_fuzzer
+  bolt_type
+  bolt_vector
+)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(bolt_vector_fuzzer PRIVATE -Wno-deprecated-declarations)
 endif()

--- a/bolt/vector/fuzzer/tests/CMakeLists.txt
+++ b/bolt/vector/fuzzer/tests/CMakeLists.txt
@@ -30,6 +30,9 @@ add_executable(bolt_vector_fuzzer_test VectorFuzzerTest.cpp)
 add_test(bolt_vector_fuzzer_test bolt_vector_fuzzer_test)
 
 target_link_libraries(
-  bolt_vector_fuzzer_test bolt_testutils GTest::gtest GTest::gtest_main
+  bolt_vector_fuzzer_test
+  bolt_testutils
+  GTest::gtest
+  GTest::gtest_main
   GTest::gmock
 )

--- a/bolt/vector/tests/utils/CMakeLists.txt
+++ b/bolt/vector/tests/utils/CMakeLists.txt
@@ -27,4 +27,10 @@
 
 bolt_add_library(bolt_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 
-target_link_libraries(bolt_vector_test_lib bolt_exec bolt_vector GTest::gtest GTest::gtest_main)
+target_link_libraries(
+  bolt_vector_test_lib
+  bolt_exec
+  bolt_vector
+  GTest::gtest
+  GTest::gtest_main
+)

--- a/bolt/version/CMakeLists.txt
+++ b/bolt/version/CMakeLists.txt
@@ -23,21 +23,25 @@ set(BOLT_MODIFIED_FILES "None")
 if(GIT_FOUND)
   set(FILE_TO_CHECK "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
   execute_process(
-    COMMAND git ls-files --error-unmatch ${FILE_TO_CHECK}
+    COMMAND
+      git ls-files --error-unmatch ${FILE_TO_CHECK}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE git_result
     OUTPUT_VARIABLE git_output
-    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
   if(git_result EQUAL 0)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      COMMAND
+        ${GIT_EXECUTABLE} rev-parse --short HEAD
       OUTPUT_VARIABLE SHORT_SHA
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+      COMMAND
+        ${GIT_EXECUTABLE} rev-parse HEAD
       OUTPUT_VARIABLE LONG_SHA
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
@@ -72,7 +76,8 @@ set(BOLT_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 
 # Check if there are uncommitted changes
 execute_process(
-  COMMAND ${GIT_EXECUTABLE} diff --quiet
+  COMMAND
+    ${GIT_EXECUTABLE} diff --quiet
   RESULT_VARIABLE GIT_DIFF_RESULT
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
@@ -82,13 +87,13 @@ if(NOT GIT_DIFF_RESULT EQUAL 0)
 
   # Get the list of modified files
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} diff --name-only
+    COMMAND
+      ${GIT_EXECUTABLE} diff --name-only
     OUTPUT_VARIABLE MODIFIED_FILES
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   string(REPLACE "\n" ", " MODIFIED_FILES_CLEANED "${MODIFIED_FILES}")
   set(BOLT_MODIFIED_FILES ${MODIFIED_FILES_CLEANED})
-
 endif()
 
 # Get template file's relative path (relative to source directory)
@@ -98,8 +103,5 @@ set(OUTPUT_DIR "${CMAKE_BINARY_DIR}/gen_cpp/${REL_PATH}")
 # Ensure output directory exists
 file(MAKE_DIRECTORY ${OUTPUT_DIR})
 # generate version.h
-configure_file(
-  "${CMAKE_SOURCE_DIR}/bolt/version/version.h.in" "${OUTPUT_DIR}/version.h"
-  @ONLY
-)
+configure_file("${CMAKE_SOURCE_DIR}/bolt/version/version.h.in" "${OUTPUT_DIR}/version.h" @ONLY)
 install(FILES "${OUTPUT_DIR}/version.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${REL_PATH}")

--- a/scripts/conan/recipes/celeborn-cpp-client/all/test_package/CMakeLists.txt
+++ b/scripts/conan/recipes/celeborn-cpp-client/all/test_package/CMakeLists.txt
@@ -19,4 +19,10 @@ find_package(celeborn-cpp-client REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE celeborn-cpp-client::celeborn-cpp-client)
 
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+set_property(
+  TARGET
+    ${PROJECT_NAME}
+  PROPERTY
+    CXX_STANDARD
+      17
+)

--- a/scripts/conan/recipes/cudf/all/test_package/CMakeLists.txt
+++ b/scripts/conan/recipes/cudf/all/test_package/CMakeLists.txt
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.30.4)
-project(test_package LANGUAGES CXX CUDA)
+project(
+  test_package
+  LANGUAGES
+    CXX
+    CUDA
+)
 
 find_package(cudf REQUIRED CONFIG)
 

--- a/scripts/conan/recipes/fizz/all/test_package/CMakeLists.txt
+++ b/scripts/conan/recipes/fizz/all/test_package/CMakeLists.txt
@@ -19,4 +19,10 @@ find_package(fizz REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE fizz::fizz)
 
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+set_property(
+  TARGET
+    ${PROJECT_NAME}
+  PROPERTY
+    CXX_STANDARD
+      17
+)

--- a/scripts/conan/recipes/sonic-cpp/all/test_v1_package/CMakeLists.txt
+++ b/scripts/conan/recipes/sonic-cpp/all/test_v1_package/CMakeLists.txt
@@ -19,5 +19,6 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 add_subdirectory(
-  ${CMAKE_CURRENT_SOURCE_DIR}/../test_package/ ${CMAKE_CURRENT_BINARY_DIR}/test_package/
+  ${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+  ${CMAKE_CURRENT_BINARY_DIR}/test_package/
 )

--- a/scripts/conan/recipes/wangle/all/test_package/CMakeLists.txt
+++ b/scripts/conan/recipes/wangle/all/test_package/CMakeLists.txt
@@ -19,4 +19,10 @@ find_package(wangle REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE wangle::wangle)
 
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+set_property(
+  TARGET
+    ${PROJECT_NAME}
+  PROPERTY
+    CXX_STANDARD
+      17
+)


### PR DESCRIPTION
### What problem does this PR solve?

Two pre-commit hooks do not handle their inputs correctly:

- The repository gersemi arguments replace the hook defaults and drop `-i`, so gersemi prints formatted CMake content without updating files while pre-commit reports success.
- The license hook runs a single Go source file directly. When `check_license.go` itself is part of a commit, the filename appended by pre-commit is interpreted as another Go source path after `-C`, and the hook fails before checking licenses.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Restore gersemi in-place formatting and define the project style in `.gersemirc` with two-space indentation, a 100-column line length, and fully expanded multiline argument groups. Format all tracked CMake files once so the repository is clean under the corrected hook.

Run the license checker as a Go package so filenames appended by pre-commit are always passed to the checker as program arguments, including when the checker source file itself is committed.

### Performance Impact

- [x] **No Impact**: These changes only affect pre-commit hooks and CMake formatting.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixed gersemi and license pre-commit hook behavior and normalized CMake formatting.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

### Validation

- `pre-commit run license-header-check --files .github/license_check/check_license.go`
- `SKIP=clang-tidy pre-commit run --all-files`
- `make release_with_test BOLT_CONAN_CONFIGURE_ONLY=1`
- `make release_spark BOLT_CONAN_CONFIGURE_ONLY=1`
