### PR TITLE
perf: SIMD implementation of isAscii for amd64 platform

### DIFF
--- a/bolt/functions/lib/string/StringCore.h
+++ b/bolt/functions/lib/string/StringCore.h
@@ -49,8 +49,10 @@
 #include <folly/Conv.h>
 #include <folly/Range.h>
 #include <folly/String.h>
+#include <folly/lang/Bits.h>
 
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/SimdUtil.h"
 #include "bolt/functions/lib/string/RegexUtils.h"
 #include "bolt/type/StringView.h"
 
@@ -86,27 +88,47 @@ static utf8proc_bool utf8proc_char_first_byte(const char* u_input);
 static utf8proc_int32_t utf8proc_codepoint_length(utf8proc_int32_t uc);
 
 FOLLY_ALWAYS_INLINE bool isAscii(const char* str, size_t length) {
-#if defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
   size_t i = 0;
+#if defined(__ARM_FEATURE_SVE) && defined(__aarch64__)
   const size_t sveVectorSize = svcntb();
   const svuint8_t v80 = svdup_u8(0x80);
-  while (i < length) {
-    svbool_t pgTail = svwhilelt_b8(i, length);
-    svuint8_t v = svld1_u8(pgTail, reinterpret_cast<const uint8_t*>(str) + i);
-    if (svptest_any(pgTail, svcmpge(pgTail, v, v80))) {
+  const svbool_t pg = svptrue_b8();
+  for (; i + sveVectorSize <= length; i += sveVectorSize) {
+    svuint8_t v = svld1_u8(pg, reinterpret_cast<const uint8_t*>(str) + i);
+    if (svptest_any(pg, svcmpge(pg, v, v80))) {
       return false;
     }
-    i += sveVectorSize;
   }
-  return true;
+#elif defined(__x86_64__) || defined(_M_X64)
+  const auto mask = xsimd::broadcast<uint8_t>(0x80);
+  for (; i + mask.size <= length; i += mask.size) {
+    const auto batch =
+        xsimd::load_unaligned(reinterpret_cast<const uint8_t*>(str) + i);
+#if XSIMD_WITH_AVX && !XSIMD_WITH_AVX512F && !XSIMD_WITH_AVX512CD && \
+    !XSIMD_WITH_AVX512DQ && !XSIMD_WITH_AVX512BW
+    // for avx, only one instruction
+    if (!_mm256_testz_si256(batch, mask)) {
 #else
-  for (auto i = 0; i < length; i++) {
+    // general impl for sse / avx512
+    if (xsimd::any(batch >= mask)) {
+#endif
+      return false;
+    }
+  }
+#endif
+  constexpr uint64_t kAsciiMask64 = 0x8080808080808080ULL;
+  for (; i + sizeof(uint64_t) <= length; i += sizeof(uint64_t)) {
+    const auto word = folly::loadUnaligned<uint64_t>(str + i);
+    if ((word & kAsciiMask64) != 0) {
+      return false;
+    }
+  }
+  for (; i < length; ++i) {
     if (str[i] & 0x80) {
       return false;
     }
   }
   return true;
-#endif
 }
 
 /// Perform reverse for ascii string input

--- a/bolt/functions/lib/string/tests/StringImplTest.cpp
+++ b/bolt/functions/lib/string/tests/StringImplTest.cpp
@@ -92,6 +92,29 @@ class StringImplTest : public testing::Test {
   }
 };
 
+TEST_F(StringImplTest, isAscii) {
+  constexpr size_t kSimdWidth = xsimd::batch<uint8_t>::size;
+  constexpr size_t kMaxLength = 2 * kSimdWidth + 1;
+  std::string input(kMaxLength + 1, 'a');
+
+  // Start at an unaligned address and cover lengths around the first two SIMD
+  // boundaries. Deriving the range from the native batch width covers SSE,
+  // AVX/AVX2, and AVX-512 builds.
+  const char* data = input.data() + 1;
+  for (size_t length = 0; length <= kMaxLength; ++length) {
+    EXPECT_TRUE(isAscii(data, length));
+
+    for (size_t nonAsciiPosition = 0; nonAsciiPosition < length;
+         ++nonAsciiPosition) {
+      input[nonAsciiPosition + 1] = static_cast<char>(0x80);
+      EXPECT_FALSE(isAscii(data, length))
+          << "length: " << length
+          << ", non-ASCII position: " << nonAsciiPosition;
+      input[nonAsciiPosition + 1] = 'a';
+    }
+  }
+}
+
 TEST_F(StringImplTest, upperAscii) {
   for (auto& testCase : getUpperAsciiTestData()) {
     auto input = StringView(std::get<0>(testCase));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
