### PR TITLE
build: narrow Spark compatibility rebuild scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md
+
+Guidance for coding agents working in the Bolt repository.
+
+## Overview
+
+Bolt is a C++ data-processing and query-execution library built with Conan and
+CMake. Read [CONTRIBUTING.md](CONTRIBUTING.md) and
+[doc/coding-style.md](doc/coding-style.md) before making changes. The rules
+below summarize constraints that are easy to violate during automated edits.
+
+## Branch Hygiene
+
+- Inspect the current branch, remotes, and working tree before editing.
+- Create a topic branch from an up-to-date `upstream/main`. Do not rebase,
+  force-push, delete branches, or rewrite existing user work unless explicitly
+  requested.
+- Preserve unrelated staged, unstaged, and untracked changes. Keep each branch
+  focused on one reviewable concern.
+
+## Build and Testing
+
+```bash
+make debug
+make release
+make unittest
+make unittest_release
+```
+
+Build outputs are under `_build/<BuildType>`. Reconfigure the build after
+adding source files, changing CMake targets, or changing build options. Run the
+smallest relevant test target while iterating, then validate every affected
+build mode before finishing.
+
+### Test targets
+
+- GoogleTest unit test targets must link `bolt_gtest_main`. It supplies the
+  standard test entry point and the public `bolt_testutils` dependency.
+- Do not define `main()` in individual GoogleTest files or compile another copy
+  of the test entry point.
+- Consume test utilities through `bolt_gtest_main` or `bolt_testutils`. Do not
+  collect or link the object libraries that implement `bolt_testutils`.
+- Select shared or static test linkage with `BOLT_TEST_LINKAGE`. Do not
+  hard-code an engine or testutils implementation target in an individual
+  test.
+
+## Build-Mode Configuration
+
+- Do not reintroduce a global `SPARK_COMPATIBLE` compile definition.
+- Keep build-mode-dependent behavior in the implementation files that need it.
+  Use the configured `kSparkCompatible` constant for C++ branches and CMake
+  source selection when a complete source file belongs to one mode.
+- Do not include build-mode configuration from public or widely included
+  headers unless a template definition must vary. Keep unavoidable template
+  logic in the narrowest internal or `-inl.h` header.
+- Preserve runtime behavior in both Presto and Spark modes. Verify that
+  switching modes does not rebuild unrelated translation units.
+
+## Command-Line Flags
+
+- A gflag used by more than one source file must have one owner. Put the only
+  `DECLARE_*` in the owner's header and the only `DEFINE_*` in its source file.
+  Consumers include the owner header and use `FLAGS_xxx`.
+- Keep a `DEFINE_*` local to a source file only when that file builds an
+  independent binary and the flag is used nowhere else. Both conditions are
+  required.
+- If a local flag gains a second consumer, move it to an owner header and
+  source file instead of adding declarations beside each consumer.
+- Use the existing shared owners when applicable:
+  - Production: `bolt/common/flags/BoltFlags.h` and `BoltFlags.cpp`.
+  - Tests: `bolt/common/testutil/BoltTestFlags.h` and `BoltTestFlags.cpp`.
+  - Fuzzers: `bolt/exec/fuzzer/FuzzerFlags.h` and `FuzzerFlags.cpp`.
+- Prefix new flag names by purpose: `bolt_` for production,
+  `bolt_testing_` for tests, `bolt_fuzzer_` for fuzzers, and
+  `bolt_benchmark_` for benchmarks.
+
+## Formatting
+
+```bash
+pre-commit run --files <paths>
+```
+
+Use the repository hooks for C++, CMake, Python, shell, license, and secret
+checks. Do not bypass a failing hook unless the user explicitly requests it and
+the skipped check has been validated separately.
+
+## Commit Messages
+
+- Each commit must be an atomic, independently applicable and testable unit of
+  work.
+- Write a concise English title using `type: subject`. Common types are
+  `feat`, `fix`, `docs`, `test`, `build`, `ci`, `perf`, and `refactor`.
+- Use the body to explain motivation, important design decisions, and notable
+  compatibility or performance effects. Do not repeat the diff line by line.
+- Do not add AI attribution, generated-by text, or an agent as a co-author.
+- Review the staged diff and run the relevant hooks and tests before committing.
+
+## Pull Requests
+
+- Push topic branches to the contributor fork and open PRs against the intended
+  upstream base. Do not push directly to the upstream repository.
+- Use [.github/pull_request_template.md](.github/pull_request_template.md) and
+  complete every applicable section: problem, change type, description,
+  performance impact, release note, validation, and breaking changes.
+- Keep the PR small and focused. Separate unrelated cleanup, formatting, or
+  infrastructure work into another PR.
+- Report only tests and benchmarks that were actually run. Include reproducible
+  commands, build options, failures, retries, and any remaining validation gap.
+- Use a draft PR while required validation is incomplete. Do not create, update,
+  mark ready, or merge a PR unless the user authorizes that external action.
+
+## PR Review
+
+- Treat review requests as read-only unless fixes are explicitly requested.
+- Review the complete branch diff against the stated base. Prioritize semantic
+  drift, correctness, compatibility, build scope, performance regressions,
+  duplicated logic, and unnecessary change volume.
+- Support findings with exact file and line references and verify suspected
+  failures when practical. Separate confirmed defects from risks and questions.
+- Do not post GitHub reviews or comments without explicit authorization.
+
+## Common Mistakes
+
+- Adding a custom GoogleTest `main()` or linking testutils object targets.
+- Duplicating `DEFINE_*` or scattering `DECLARE_*` across consumers.
+- Putting build-mode conditionals in high-fanout headers.
+- Expanding a focused change with unrelated cleanup or formatting churn.
+- Claiming a failure is caused by a change without reproducing or isolating it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ option(BOLT_BUILD_BENCHMARKS "Builds Bolt benchmarks" OFF)
 option(BOLT_BUILD_BENCHMARKS_BASIC "Enable Bolt basic benchmarks." OFF)
 
 if(BOLT_ENABLE_SPARK_COMPATIBLE)
+  set(BOLT_SPARK_COMPATIBLE_VALUE true)
   set(SPARK_VERSION "3.5" CACHE STRING "Spark major.minor version")
   set_property(
     CACHE
@@ -251,8 +252,17 @@ if(BOLT_ENABLE_SPARK_COMPATIBLE)
   string(REPLACE "." "_" SPARK_VERSION_ENUM ${SPARK_VERSION})
   set(BOLT_SPARK_VERSION "SPARK_${SPARK_VERSION_ENUM}")
 else()
+  set(BOLT_SPARK_COMPATIBLE_VALUE false)
   set(BOLT_SPARK_VERSION "UNDEFINED")
 endif()
+
+set(BOLT_GENERATED_BASE_INCLUDE_DIR "${CMAKE_BINARY_DIR}/gen_cpp/bolt/common/base")
+file(MAKE_DIRECTORY "${BOLT_GENERATED_BASE_INCLUDE_DIR}")
+configure_file(
+  "${CMAKE_SOURCE_DIR}/bolt/common/base/SparkCompatibility.h.in"
+  "${BOLT_GENERATED_BASE_INCLUDE_DIR}/SparkCompatibility.h"
+  @ONLY
+)
 
 # Enable address sanitizer, this needs to precede the addition of all targets to be enabled for all
 # subdirectories
@@ -696,11 +706,6 @@ if(BOLT_ENABLE_REMOTE_FUNCTIONS)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)
-endif()
-
-if(BOLT_ENABLE_SPARK_COMPATIBLE)
-  message("Enable spark compatible setting.")
-  add_definitions(-DSPARK_COMPATIBLE)
 endif()
 
 if(KERNEL_SUPPORTS_IO_URING)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,6 +296,19 @@ The Bolt project and all its contributors are governed by a [Code of Conduct.](h
 
 - **Location**: Place test files in the `tests` directory of the corresponding module, following existing naming and structure conventions.
 
+### Test Target Conventions
+
+- GoogleTest unit test targets must link `bolt_gtest_main`. It provides the
+  standard test entry point and the public `bolt_testutils` dependency.
+- Do not define `main()` in individual GoogleTest source files or compile a
+  second copy of the test entry point.
+- Consume test utilities through `bolt_gtest_main` or `bolt_testutils`. Do not
+  collect or link the object libraries that implement `bolt_testutils`
+  directly.
+- Select shared or static test linkage through `BOLT_TEST_LINKAGE`. Do not
+  hard-code a concrete engine or testutils implementation target in an
+  individual test.
+
 - **Execution**:
 
 

--- a/bolt/benchmarks/basic/CastBenchmark.cpp
+++ b/bolt/benchmarks/basic/CastBenchmark.cpp
@@ -169,8 +169,9 @@ void benchmarkAll(
       } else if (v.second == "short_decimal") {
         input = vectorMaker.flatVector<std::string>(vectorSize, [&](auto j) {
           char buf[32];
-          auto size =
-              DecimalUtil::convertToString<int64_t>(123456789 * j, 6, 32, buf);
+          auto size = DecimalUtil::convertToString<
+              DecimalUtil::DecimalStringFormat::kPlain>(
+              123456789 * j, 6, 32, buf);
           return std::string(buf, size);
         });
       } else if (v.second == "long_decimal") {
@@ -178,7 +179,8 @@ void benchmarkAll(
           char buf[128];
           auto v =
               bytedance::bolt::HugeInt::build(12345 * j, 56789 * j + 12345);
-          auto size = DecimalUtil::convertToString<int64_t>(v, 18, 128, buf);
+          auto size = DecimalUtil::convertToString<
+              DecimalUtil::DecimalStringFormat::kPlain>(v, 18, 128, buf);
           return std::string(buf, size);
         });
       } else {

--- a/bolt/common/base/CMakeLists.txt
+++ b/bolt/common/base/CMakeLists.txt
@@ -58,6 +58,12 @@ bolt_add_library(
 find_package(ryu CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)
 
+install(
+  FILES
+    "${BOLT_GENERATED_BASE_INCLUDE_DIR}/SparkCompatibility.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/bolt/common/base"
+)
+
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)
 target_link_libraries(
   bolt_common_base

--- a/bolt/common/base/SparkCompatibility.h.in
+++ b/bolt/common/base/SparkCompatibility.h.in
@@ -16,4 +16,9 @@
 
 #pragma once
 
-#include <glog/logging.h>
+namespace bytedance::bolt {
+
+/// True when Bolt is built with Spark-compatible behavior.
+inline constexpr bool kSparkCompatible = @BOLT_SPARK_COMPATIBLE_VALUE@;
+
+} // namespace bytedance::bolt

--- a/bolt/common/base/Uuid.cpp
+++ b/bolt/common/base/Uuid.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -59,13 +61,13 @@ void makeUuid(char* uuid, uint64_t seed) {
 
 void makeUuid(char* uuid, std::mt19937_64& rng) {
   auto next = [&rng]() {
-#ifdef SPARK_COMPATIBLE
-    uint64_t high = rng() << 32;
-    uint64_t low = rng() & 4294967295L;
-    return high | low;
-#else
-    return rng();
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      uint64_t high = rng() << 32;
+      uint64_t low = rng() & 4294967295L;
+      return high | low;
+    } else {
+      return rng();
+    }
   };
   makeUuid(uuid, next(), next());
 }

--- a/bolt/common/base/Uuid.cpp
+++ b/bolt/common/base/Uuid.cpp
@@ -61,13 +61,12 @@ void makeUuid(char* uuid, uint64_t seed) {
 
 void makeUuid(char* uuid, std::mt19937_64& rng) {
   auto next = [&rng]() {
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
-      uint64_t high = rng() << 32;
-      uint64_t low = rng() & 4294967295L;
-      return high | low;
-    } else {
+    if (!::bytedance::bolt::kSparkCompatible) {
       return rng();
     }
+    uint64_t high = rng() << 32;
+    uint64_t low = rng() & 4294967295L;
+    return high | low;
   };
   makeUuid(uuid, next(), next());
 }

--- a/bolt/connectors/hive/HiveConnectorUtil.cpp
+++ b/bolt/connectors/hive/HiveConnectorUtil.cpp
@@ -30,6 +30,7 @@
 
 #include "bolt/connectors/hive/HiveConnectorUtil.h"
 
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/connectors/hive/FileHandle.h"
 #include "bolt/connectors/hive/HiveConfig.h"
 #include "bolt/connectors/hive/HiveConnectorSplit.h"
@@ -43,6 +44,10 @@
 #include "bolt/type/TimestampConversion.h"
 
 namespace bytedance::bolt::connector::hive {
+
+bool shouldAdjustPartitionTimestampToTimezone() {
+  return !kSparkCompatible;
+}
 
 namespace {
 

--- a/bolt/connectors/hive/HiveConnectorUtil.h
+++ b/bolt/connectors/hive/HiveConnectorUtil.h
@@ -95,8 +95,12 @@ void configureRowReaderOptions(
 
 bool isHiveNull(const std::string& source);
 
+bool shouldAdjustPartitionTimestampToTimezone();
+
 template <TypeKind ToKind>
-bolt::variant convertFromString(const std::optional<std::string>& value) {
+bolt::variant convertFromString(
+    const std::optional<std::string>& value,
+    bool adjustTimestampToTimezone) {
   if (value.has_value()) {
     if constexpr (ToKind == TypeKind::VARCHAR) {
       return bolt::variant(value.value());
@@ -105,14 +109,24 @@ bolt::variant convertFromString(const std::optional<std::string>& value) {
       return bolt::variant::binary((value.value()));
     }
     auto result = bolt::util::Converter<ToKind>::cast(value.value(), nullptr);
-#ifndef SPARK_COMPATIBLE
     if constexpr (ToKind == TypeKind::TIMESTAMP) {
-      result.toGMT(Timestamp::defaultTimezone());
+      if (adjustTimestampToTimezone) {
+        result.toGMT(Timestamp::defaultTimezone());
+      }
     }
-#endif
     return bolt::variant(result);
   }
   return bolt::variant(ToKind);
+}
+
+template <TypeKind ToKind>
+bolt::variant convertFromString(const std::optional<std::string>& value) {
+  if constexpr (ToKind == TypeKind::TIMESTAMP) {
+    return convertFromString<ToKind>(
+        value, shouldAdjustPartitionTimestampToTimezone());
+  } else {
+    return convertFromString<ToKind>(value, false);
+  }
 }
 
 bool testFilters(

--- a/bolt/connectors/hive/PaimonMetadataColumn.cpp
+++ b/bolt/connectors/hive/PaimonMetadataColumn.cpp
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 #include "bolt/connectors/hive/PaimonMetadataColumn.h"
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/connectors/hive/HiveConnectorUtil.h"
 #include "bolt/type/Type.h"
 #include "bolt/vector/BaseVector.h"
 
 namespace bytedance::bolt::connector::paimon {
+namespace {
+
+template <TypeKind Kind>
+bolt::variant convertPartitionValueFromString(
+    const std::optional<std::string>& value) {
+  return hive::convertFromString<Kind>(
+      value, !::bytedance::bolt::kSparkCompatible);
+}
+
+} // namespace
 
 TypePtr MetadataColumnFilePath::type() const {
   return VARCHAR();
@@ -60,7 +71,7 @@ MetadataColumnPartition::MetadataColumnPartition(
 
     if (it != partitionKeys.end() && it->second.has_value()) {
       auto convertedValue = BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          hive::convertFromString, fieldType->kind(), it->second);
+          convertPartitionValueFromString, fieldType->kind(), it->second);
       childVectors.push_back(
           BaseVector::createConstant(fieldType, convertedValue, 1, pool));
     } else {

--- a/bolt/connectors/hive/SplitReader.cpp
+++ b/bolt/connectors/hive/SplitReader.cpp
@@ -31,6 +31,7 @@
 #include "bolt/connectors/hive/SplitReader.h"
 #include <cstdint>
 
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/common/caching/CacheTTLController.h"
 #include "bolt/common/testutil/TestValue.h"
 #include "bolt/connectors/hive/HiveConfig.h"
@@ -48,6 +49,12 @@
 namespace bytedance::bolt::connector::hive {
 
 namespace {
+template <TypeKind Kind>
+bolt::variant convertPartitionValueFromString(
+    const std::optional<std::string>& value) {
+  return convertFromString<Kind>(value, !::bytedance::bolt::kSparkCompatible);
+}
+
 template <TypeKind kind>
 VectorPtr newConstantFromString(
     const TypePtr& type,
@@ -735,7 +742,9 @@ void SplitReader::setPartitionValue(
         }
       } else {
         constValue = BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
-            convertFromString, it->second->dataType()->kind(), value);
+            convertPartitionValueFromString,
+            it->second->dataType()->kind(),
+            value);
       }
       setConstantValue(spec, it->second->dataType(), constValue);
     } catch (const std::exception& e) {

--- a/bolt/core/PlanNode.cpp
+++ b/bolt/core/PlanNode.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <folly/container/F14Set.h>
 
 #include "bolt/common/encode/Base64.h"
@@ -1780,11 +1782,11 @@ RowTypePtr getRowNumberOutputType(
   std::vector<TypePtr> types = inputType->children();
 
   names.push_back(rowNumberColumnName);
-#ifdef SPARK_COMPATIBLE
-  types.push_back(INTEGER());
-#else
-  types.push_back(BIGINT());
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    types.push_back(INTEGER());
+  } else {
+    types.push_back(BIGINT());
+  }
 
   return ROW(std::move(names), std::move(types));
 }

--- a/bolt/core/PlanNode.cpp
+++ b/bolt/core/PlanNode.cpp
@@ -1782,11 +1782,9 @@ RowTypePtr getRowNumberOutputType(
   std::vector<TypePtr> types = inputType->children();
 
   names.push_back(rowNumberColumnName);
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    types.push_back(INTEGER());
-  } else {
-    types.push_back(BIGINT());
-  }
+  types.push_back(
+      ::bytedance::bolt::kSparkCompatible ? TypePtr{INTEGER()}
+                                          : TypePtr{BIGINT()});
 
   return ROW(std::move(names), std::move(types));
 }

--- a/bolt/core/QueryConfig.cpp
+++ b/bolt/core/QueryConfig.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <re2/re2.h>
 
 #include "bolt/common/config/Config.h"
@@ -49,6 +51,12 @@ QueryConfig::QueryConfig(std::unordered_map<std::string, std::string>&& values)
   VLOG(1) << "Morsel-driven Bolt enabled: " << this->morselDrivenEnabled()
           << " (morselSize=" << this->morselSize()
           << ", queueSize=" << this->morselDrivenPrimedQueueSize() << ")";
+}
+
+uint64_t QueryConfig::maxSpillBytes() const {
+  static constexpr uint64_t kDefault =
+      ::bytedance::bolt::kSparkCompatible ? 0UL : 100UL << 30;
+  return get<uint64_t>(kMaxSpillBytes, kDefault);
 }
 
 void QueryConfig::testingOverrideConfigUnsafe(

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -899,14 +899,7 @@ class QueryConfig {
     return get<uint64_t>(kMaxSpillRunRows, kDefault);
   }
 
-  uint64_t maxSpillBytes() const {
-#ifdef SPARK_COMPATIBLE
-    static constexpr uint64_t kDefault = 0UL;
-#else
-    static constexpr uint64_t kDefault = 100UL << 30;
-#endif
-    return get<uint64_t>(kMaxSpillBytes, kDefault);
-  }
+  uint64_t maxSpillBytes() const;
 
   /// Returns the maximum number of bytes to buffer in PartitionedOutput
   /// operator to avoid creating tiny SerializedPages.

--- a/bolt/dwio/common/InputStream.cpp
+++ b/bolt/dwio/common/InputStream.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/dwio/common/InputStream.h"
 
 #include <fcntl.h>
@@ -74,6 +76,25 @@ ReadFileInputStream::ReadFileInputStream(
     IoStatistics* stats)
     : InputStream(readFile->getName(), metricsLog, stats),
       readFile_(std::move(readFile)) {}
+
+uint64_t ReadFileInputStream::getLength() const {
+  // file_size_ is populated by hdfsGetPathInfo for Spark, which involves an
+  // RPC with the HDFS namenode.
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    uint64_t readTime = 0;
+    uint64_t len = 0;
+    {
+      NanosecondTimer timer(&readTime);
+      len = readFile_->size();
+    }
+    if (stats_) {
+      stats_->incLoadFileMetaDataTimeNs(readTime);
+    }
+    return len;
+  } else {
+    return readFile_->size();
+  }
+}
 
 void ReadFileInputStream::read(
     void* buf,

--- a/bolt/dwio/common/InputStream.cpp
+++ b/bolt/dwio/common/InputStream.cpp
@@ -80,20 +80,19 @@ ReadFileInputStream::ReadFileInputStream(
 uint64_t ReadFileInputStream::getLength() const {
   // file_size_ is populated by hdfsGetPathInfo for Spark, which involves an
   // RPC with the HDFS namenode.
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    uint64_t readTime = 0;
-    uint64_t len = 0;
-    {
-      NanosecondTimer timer(&readTime);
-      len = readFile_->size();
-    }
-    if (stats_) {
-      stats_->incLoadFileMetaDataTimeNs(readTime);
-    }
-    return len;
-  } else {
+  if (!::bytedance::bolt::kSparkCompatible) {
     return readFile_->size();
   }
+  uint64_t readTime = 0;
+  uint64_t len = 0;
+  {
+    NanosecondTimer timer(&readTime);
+    len = readFile_->size();
+  }
+  if (stats_) {
+    stats_->incLoadFileMetaDataTimeNs(readTime);
+  }
+  return len;
 }
 
 void ReadFileInputStream::read(

--- a/bolt/dwio/common/InputStream.h
+++ b/bolt/dwio/common/InputStream.h
@@ -164,24 +164,7 @@ class ReadFileInputStream final : public InputStream {
 
   virtual ~ReadFileInputStream() {}
 
-  uint64_t getLength() const final override {
-    // file_size_ is populated by hdfsGetPathInfo for Spark
-    // which involves an RPC with hdfs namenode
-    uint64_t len = 0;
-#ifdef SPARK_COMPATIBLE
-    uint64_t readTime = 0;
-    {
-      NanosecondTimer timer(&readTime);
-      len = readFile_->size();
-    }
-    if (stats_) {
-      stats_->incLoadFileMetaDataTimeNs(readTime);
-    }
-#else
-    len = readFile_->size();
-#endif
-    return len;
-  }
+  uint64_t getLength() const final override;
 
   uint64_t getNaturalReadSize() const final override {
     return readFile_->getNaturalReadSize();

--- a/bolt/dwio/orc/test/OrcTpchTest.cpp
+++ b/bolt/dwio/orc/test/OrcTpchTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <vector>
 
 #include "bolt/common/file/FileSystems.h"
@@ -47,9 +49,9 @@ class OrcTpchTest : public testing::Test {
 
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
-#ifdef SPARK_COMPATIBLE
-    functions::sparksql::registerFunctions("");
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      functions::sparksql::registerFunctions("");
+    }
 
     parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();

--- a/bolt/dwio/orc/test/OrcTpchTest.cpp
+++ b/bolt/dwio/orc/test/OrcTpchTest.cpp
@@ -49,7 +49,7 @@ class OrcTpchTest : public testing::Test {
 
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       functions::sparksql::registerFunctions("");
     }
 

--- a/bolt/dwio/parquet/arrow/Encoding.cpp
+++ b/bolt/dwio/parquet/arrow/Encoding.cpp
@@ -137,13 +137,10 @@ class EncoderImpl : virtual public Encoder {
   template <typename SinkType>
   std::shared_ptr<::arrow::Buffer> FinishSink(SinkType& sink) {
     std::shared_ptr<Buffer> buffer;
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
-      // as customized ArrowMemoryPool can't resize 0, speciallly avoid
-      // shrinking to fit for length = 0, and the memory will be released soon
-      PARQUET_THROW_NOT_OK(sink.Finish(&buffer, sink.length() > 0));
-    } else {
-      PARQUET_THROW_NOT_OK(sink.Finish(&buffer));
-    }
+    // The customized Spark ArrowMemoryPool can't resize an empty buffer. The
+    // buffer is released immediately, so skip shrinking in that case.
+    PARQUET_THROW_NOT_OK(sink.Finish(
+        &buffer, !::bytedance::bolt::kSparkCompatible || sink.length() > 0));
     return buffer;
   }
 

--- a/bolt/dwio/parquet/arrow/Encoding.cpp
+++ b/bolt/dwio/parquet/arrow/Encoding.cpp
@@ -30,6 +30,8 @@
 
 // Adapted from Apache Arrow.
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/dwio/parquet/arrow/Encoding.h"
 
 #include <algorithm>
@@ -135,13 +137,13 @@ class EncoderImpl : virtual public Encoder {
   template <typename SinkType>
   std::shared_ptr<::arrow::Buffer> FinishSink(SinkType& sink) {
     std::shared_ptr<Buffer> buffer;
-#ifdef SPARK_COMPATIBLE
-    // as customized ArrowMemoryPool can't resize 0, speciallly avoid shrinking
-    // to fit for length = 0, and the memory will be released soon
-    PARQUET_THROW_NOT_OK(sink.Finish(&buffer, sink.length() > 0));
-#else
-    PARQUET_THROW_NOT_OK(sink.Finish(&buffer));
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      // as customized ArrowMemoryPool can't resize 0, speciallly avoid
+      // shrinking to fit for length = 0, and the memory will be released soon
+      PARQUET_THROW_NOT_OK(sink.Finish(&buffer, sink.length() > 0));
+    } else {
+      PARQUET_THROW_NOT_OK(sink.Finish(&buffer));
+    }
     return buffer;
   }
 

--- a/bolt/dwio/parquet/reader/IntegerColumnReader.h
+++ b/bolt/dwio/parquet/reader/IntegerColumnReader.h
@@ -84,37 +84,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
     return numValues;
   }
 
-  void getValues(const RowSet& rows, VectorPtr* result) override {
-    bool needConvertion = (castExprSet_ && castExprSet_->size() != 0);
-    auto& requestedType = needConvertion ? castSourceType_ : requestedType_;
-    auto& fileType = static_cast<const ParquetTypeWithId&>(*fileType_);
-    bool isUnsigned = false;
-    if (fileType.logicalType_.has_value() &&
-        fileType.logicalType_.value().__isset.INTEGER) {
-      isUnsigned = !fileType.logicalType_.value().INTEGER.isSigned;
-    }
-#ifdef SPARK_COMPATIBLE
-    if (!fileType.logicalType_.has_value() &&
-        fileType.convertedType_ == thrift::ConvertedType::UINT_64) {
-      // Legacy Parquet files may carry only the UINT_64 converted type. In
-      // particular, convertType accepts these files as DECIMAL(20, 0). Without
-      // this fallback, getIntValues() would use its HUGEINT path and interpret
-      // each 8-byte physical UINT64 as a 16-byte int128_t. Use the unsigned
-      // path to preserve the UINT64 bits and widen each value correctly.
-      isUnsigned = true;
-    }
-#endif
-
-    if (isUnsigned) {
-      getUnsignedIntValues(rows, requestedType, result);
-    } else {
-      getIntValues(rows, requestedType, result);
-    }
-
-    if (needConvertion) {
-      doCastEvaluate(result);
-    }
-  }
+  void getValues(const RowSet& rows, VectorPtr* result) override;
 
   void read(
       int64_t offset,

--- a/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -32,6 +32,8 @@
 // Created by Ying Su on 2/14/22.
 //
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/dwio/parquet/reader/ParquetColumnReader.h"
 
 #include "bolt/dwio/common/Options.h"
@@ -47,6 +49,38 @@
 #include "bolt/dwio/parquet/reader/VariantColumnReader.h"
 #include "bolt/dwio/parquet/thrift/codegen/parquet_types.h"
 namespace bytedance::bolt::parquet {
+
+void IntegerColumnReader::getValues(const RowSet& rows, VectorPtr* result) {
+  bool needConvertion = (castExprSet_ && castExprSet_->size() != 0);
+  auto& requestedType = needConvertion ? castSourceType_ : requestedType_;
+  auto& fileType = static_cast<const ParquetTypeWithId&>(*fileType_);
+  bool isUnsigned = false;
+  if (fileType.logicalType_.has_value() &&
+      fileType.logicalType_.value().__isset.INTEGER) {
+    isUnsigned = !fileType.logicalType_.value().INTEGER.isSigned;
+  }
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (!fileType.logicalType_.has_value() &&
+        fileType.convertedType_ == thrift::ConvertedType::UINT_64) {
+      // Legacy Parquet files may carry only the UINT_64 converted type. In
+      // particular, convertType accepts these files as DECIMAL(20, 0). Without
+      // this fallback, getIntValues() would use its HUGEINT path and interpret
+      // each 8-byte physical UINT64 as a 16-byte int128_t. Use the unsigned
+      // path to preserve the UINT64 bits and widen each value correctly.
+      isUnsigned = true;
+    }
+  }
+
+  if (isUnsigned) {
+    getUnsignedIntValues(rows, requestedType, result);
+  } else {
+    getIntValues(rows, requestedType, result);
+  }
+
+  if (needConvertion) {
+    doCastEvaluate(result);
+  }
+}
 
 /* type matching restriction, only allow following type convert
  * real -> real/double/varchar
@@ -93,14 +127,14 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
       fileType->childByName("value")->type()->isVarbinary() &&
       fileType->childByName("metadata")->type()->isVarbinary();
 
-#ifndef SPARK_COMPATIBLE
-  BOLT_CHECK(
-      canReadVariantStructAsVariant ||
-          matchType(fileType->type()->kind(), requestedType->type()->kind()),
-      "file schema type {} can not convert to ddl type {}",
-      mapTypeKindToName(fileType->type()->kind()),
-      mapTypeKindToName(requestedType->type()->kind()));
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    BOLT_CHECK(
+        canReadVariantStructAsVariant ||
+            matchType(fileType->type()->kind(), requestedType->type()->kind()),
+        "file schema type {} can not convert to ddl type {}",
+        mapTypeKindToName(fileType->type()->kind()),
+        mapTypeKindToName(requestedType->type()->kind()));
+  }
 
   switch (fileType->type()->kind()) {
     case TypeKind::INTEGER:
@@ -123,10 +157,8 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
             requestedType->type(), fileType, params, scanSpec);
       }
     case TypeKind::DOUBLE:
-      if (
-#ifdef SPARK_COMPATIBLE
-          requestedType->type()->kind() == TypeKind::BIGINT ||
-#endif
+      if ((::bytedance::bolt::kSparkCompatible &&
+           requestedType->type()->kind() == TypeKind::BIGINT) ||
           requestedType->type()->kind() == TypeKind::VARCHAR) {
         return std::make_unique<FloatingPointColumnReader<double, double>>(
             requestedType->type(), fileType, params, scanSpec, DOUBLE());

--- a/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -59,16 +59,15 @@ void IntegerColumnReader::getValues(const RowSet& rows, VectorPtr* result) {
       fileType.logicalType_.value().__isset.INTEGER) {
     isUnsigned = !fileType.logicalType_.value().INTEGER.isSigned;
   }
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    if (!fileType.logicalType_.has_value() &&
-        fileType.convertedType_ == thrift::ConvertedType::UINT_64) {
-      // Legacy Parquet files may carry only the UINT_64 converted type. In
-      // particular, convertType accepts these files as DECIMAL(20, 0). Without
-      // this fallback, getIntValues() would use its HUGEINT path and interpret
-      // each 8-byte physical UINT64 as a 16-byte int128_t. Use the unsigned
-      // path to preserve the UINT64 bits and widen each value correctly.
-      isUnsigned = true;
-    }
+  if (::bytedance::bolt::kSparkCompatible &&
+      !fileType.logicalType_.has_value() &&
+      fileType.convertedType_ == thrift::ConvertedType::UINT_64) {
+    // Legacy Parquet files may carry only the UINT_64 converted type. In
+    // particular, convertType accepts these files as DECIMAL(20, 0). Without
+    // this fallback, getIntValues() would use its HUGEINT path and interpret
+    // each 8-byte physical UINT64 as a 16-byte int128_t. Use the unsigned
+    // path to preserve the UINT64 bits and widen each value correctly.
+    isUnsigned = true;
   }
 
   if (isUnsigned) {
@@ -127,7 +126,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
       fileType->childByName("value")->type()->isVarbinary() &&
       fileType->childByName("metadata")->type()->isVarbinary();
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     BOLT_CHECK(
         canReadVariantStructAsVariant ||
             matchType(fileType->type()->kind(), requestedType->type()->kind()),

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -29,7 +29,8 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/dwio/parquet/reader/ParquetReader.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <parquet/metadata.h>
 #include <thrift/protocol/TCompactProtocol.h> //@manual
 #include <cstdint>
@@ -39,6 +40,7 @@
 #include "bolt/dwio/parquet/encryption/KmsClient.h"
 #include "bolt/dwio/parquet/reader/ParquetColumnReader.h"
 #include "bolt/dwio/parquet/reader/ParquetFooterCache.h"
+#include "bolt/dwio/parquet/reader/ParquetReader.h"
 #include "bolt/dwio/parquet/reader/SchemaHelper.h"
 #include "bolt/dwio/parquet/reader/StructColumnReader.h"
 #include "bolt/dwio/parquet/thrift/FmtParquetFormatters.h"
@@ -126,12 +128,9 @@ bool acceptsRealFileForReaderCast(const bytedance::bolt::TypePtr& t) {
 }
 
 bool acceptsDoubleFileForReaderCast(const bytedance::bolt::TypePtr& t) {
-#ifdef SPARK_COMPATIBLE
-  return t->kind() == bytedance::bolt::TypeKind::BIGINT ||
+  return (::bytedance::bolt::kSparkCompatible &&
+          t->kind() == bytedance::bolt::TypeKind::BIGINT) ||
       acceptsRealFileForReaderCast(t);
-#else
-  return acceptsRealFileForReaderCast(t);
-#endif
 }
 
 // Compatibility predicate for Parquet INT32-physical source columns
@@ -175,16 +174,16 @@ bool isInt64Compatible(const bytedance::bolt::TypePtr& type) {
 }
 
 bool isUInt64Compatible(const bytedance::bolt::TypePtr& type) {
-#ifdef SPARK_COMPATIBLE
-  if (type->isDecimal()) {
-    // Spark maps Parquet UINT64 to DECIMAL(20, 0) because it has no unsigned
-    // 64-bit type. Keep this as a dedicated Spark representation mapping, not
-    // general integer-to-Decimal schema evolution. The unsigned integer reader
-    // already widens the 8-byte value to 128 bits without rescaling.
-    const auto [precision, scale] = getDecimalPrecisionScale(*type);
-    return precision == 20 && scale == 0;
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (type->isDecimal()) {
+      // Spark maps Parquet UINT64 to DECIMAL(20, 0) because it has no unsigned
+      // 64-bit type. Keep this as a dedicated Spark representation mapping, not
+      // general integer-to-Decimal schema evolution. The unsigned integer
+      // reader already widens the 8-byte value to 128 bits without rescaling.
+      const auto [precision, scale] = getDecimalPrecisionScale(*type);
+      return precision == 20 && scale == 0;
+    }
   }
-#endif
   return isInt64Compatible(type);
 }
 
@@ -1253,19 +1252,19 @@ TypePtr ReaderBase::convertType(
           });
           return TIMESTAMP();
         }
-#ifdef SPARK_COMPATIBLE
-        if (schemaElement.__isset.logicalType &&
-            schemaElement.logicalType.__isset.INTEGER &&
-            !schemaElement.logicalType.INTEGER.isSigned) {
-          BOLT_CHECK_EQ(
-              schemaElement.logicalType.INTEGER.bitWidth,
-              64,
-              "Unsigned INTEGER logical type on INT64 must have bit width 64");
-          checkRequested(
-              [](const TypePtr& t) { return isUInt64Compatible(t); });
-          return BIGINT();
+        if constexpr (::bytedance::bolt::kSparkCompatible) {
+          if (schemaElement.__isset.logicalType &&
+              schemaElement.logicalType.__isset.INTEGER &&
+              !schemaElement.logicalType.INTEGER.isSigned) {
+            BOLT_CHECK_EQ(
+                schemaElement.logicalType.INTEGER.bitWidth,
+                64,
+                "Unsigned INTEGER logical type on INT64 must have bit width 64");
+            checkRequested(
+                [](const TypePtr& t) { return isUInt64Compatible(t); });
+            return BIGINT();
+          }
         }
-#endif
         if (schemaElement.__isset.converted_type &&
             (schemaElement.converted_type ==
                  thrift::ConvertedType::TIMESTAMP_MILLIS ||

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -174,17 +174,15 @@ bool isInt64Compatible(const bytedance::bolt::TypePtr& type) {
 }
 
 bool isUInt64Compatible(const bytedance::bolt::TypePtr& type) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    if (type->isDecimal()) {
-      // Spark maps Parquet UINT64 to DECIMAL(20, 0) because it has no unsigned
-      // 64-bit type. Keep this as a dedicated Spark representation mapping, not
-      // general integer-to-Decimal schema evolution. The unsigned integer
-      // reader already widens the 8-byte value to 128 bits without rescaling.
-      const auto [precision, scale] = getDecimalPrecisionScale(*type);
-      return precision == 20 && scale == 0;
-    }
+  if (!::bytedance::bolt::kSparkCompatible || !type->isDecimal()) {
+    return isInt64Compatible(type);
   }
-  return isInt64Compatible(type);
+  // Spark maps Parquet UINT64 to DECIMAL(20, 0) because it has no unsigned
+  // 64-bit type. Keep this as a dedicated Spark representation mapping, not
+  // general integer-to-Decimal schema evolution. The unsigned integer reader
+  // already widens the 8-byte value to 128 bits without rescaling.
+  const auto [precision, scale] = getDecimalPrecisionScale(*type);
+  return precision == 20 && scale == 0;
 }
 
 } // namespace
@@ -1252,18 +1250,17 @@ TypePtr ReaderBase::convertType(
           });
           return TIMESTAMP();
         }
-        if constexpr (::bytedance::bolt::kSparkCompatible) {
-          if (schemaElement.__isset.logicalType &&
-              schemaElement.logicalType.__isset.INTEGER &&
-              !schemaElement.logicalType.INTEGER.isSigned) {
-            BOLT_CHECK_EQ(
-                schemaElement.logicalType.INTEGER.bitWidth,
-                64,
-                "Unsigned INTEGER logical type on INT64 must have bit width 64");
-            checkRequested(
-                [](const TypePtr& t) { return isUInt64Compatible(t); });
-            return BIGINT();
-          }
+        if (::bytedance::bolt::kSparkCompatible &&
+            schemaElement.__isset.logicalType &&
+            schemaElement.logicalType.__isset.INTEGER &&
+            !schemaElement.logicalType.INTEGER.isSigned) {
+          BOLT_CHECK_EQ(
+              schemaElement.logicalType.INTEGER.bitWidth,
+              64,
+              "Unsigned INTEGER logical type on INT64 must have bit width 64");
+          checkRequested(
+              [](const TypePtr& t) { return isUInt64Compatible(t); });
+          return BIGINT();
         }
         if (schemaElement.__isset.converted_type &&
             (schemaElement.converted_type ==

--- a/bolt/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/bolt/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <vector>
 
 #include "bolt/common/file/FileSystems.h"
@@ -60,9 +62,9 @@ class ParquetTpchTest : public testing::Test {
 
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
-#ifdef SPARK_COMPATIBLE
-    functions::sparksql::registerFunctions("");
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      functions::sparksql::registerFunctions("");
+    }
 
     parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();

--- a/bolt/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/bolt/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -62,7 +62,7 @@ class ParquetTpchTest : public testing::Test {
 
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       functions::sparksql::registerFunctions("");
     }
 

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -28,7 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/dwio/parquet/reader/ParquetReader.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <type/HugeInt.h>
 #include <type/Type.h>
 #include <cstdlib>
@@ -37,6 +38,7 @@
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/QueryCtx.h"
 #include "bolt/dwio/common/DirectBufferedInput.h"
+#include "bolt/dwio/parquet/reader/ParquetReader.h"
 #include "bolt/dwio/parquet/reader/RepeatedColumnReader.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 #include "bolt/dwio/parquet/writer/Writer.h"
@@ -794,23 +796,25 @@ TEST_F(ParquetReaderTest, parseUnsignedInt4) {
             2000000000000000000ULL,
             3000000000000000000ULL})});
 
-#ifdef SPARK_COMPATIBLE
-  const std::string sample(getExampleFilePath("uint.parquet"));
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
-  readerOptions.setFileSchema(rowType);
-  auto reader = createReader(sample, readerOptions);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    const std::string sample(getExampleFilePath("uint.parquet"));
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    readerOptions.setFileSchema(rowType);
+    auto reader = createReader(sample, readerOptions);
 
-  auto rowReaderOpts = getReaderOpts(rowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
-  assertReadWithReaderAndExpected(rowType, *rowReader, expected, *pool_);
-#else
-  assertReadWithExpected("uint.parquet", rowType, expected);
-#endif
+    auto rowReaderOpts = getReaderOpts(rowType);
+    rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+    assertReadWithReaderAndExpected(rowType, *rowReader, expected, *pool_);
+  } else {
+    assertReadWithExpected("uint.parquet", rowType, expected);
+  }
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const std::vector<TypePtr> unsupportedTypes = {
       DECIMAL(18, 0), DECIMAL(19, 0), DECIMAL(20, 1), DECIMAL(21, 0)};
   const std::string sample(getExampleFilePath("uint.parquet"));
@@ -825,7 +829,6 @@ TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
         createReader(sample, readerOptions), kParquetTypeMappingErrorPrefix);
   }
 }
-#endif
 
 TEST_F(ParquetReaderTest, parseUnsignedInt5) {
   auto rowType =
@@ -2825,10 +2828,10 @@ TEST_F(ParquetReaderTest, varcharToBigintSchemaMismatchCast) {
   rowReaderOpts.setScanSpec(scanSpec);
 
   // In non-SPARK builds this is rejected by ParquetColumnReader::matchType.
-#ifndef SPARK_COMPATIBLE
-  EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
-  return;
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
+    return;
+  }
 
   // In SPARK-compatible builds, schema mismatch is allowed and cast is applied.
   auto rowReader = reader->createRowReader(rowReaderOpts);

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -796,7 +796,7 @@ TEST_F(ParquetReaderTest, parseUnsignedInt4) {
             2000000000000000000ULL,
             3000000000000000000ULL})});
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     const std::string sample(getExampleFilePath("uint.parquet"));
     dwio::common::ReaderOptions readerOptions{leafPool_.get()};
     readerOptions.setFileSchema(rowType);
@@ -812,7 +812,7 @@ TEST_F(ParquetReaderTest, parseUnsignedInt4) {
 }
 
 TEST_F(ParquetReaderTest, rejectUnsupportedUInt64DecimalTypes) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const std::vector<TypePtr> unsupportedTypes = {
@@ -2828,7 +2828,7 @@ TEST_F(ParquetReaderTest, varcharToBigintSchemaMismatchCast) {
   rowReaderOpts.setScanSpec(scanSpec);
 
   // In non-SPARK builds this is rejected by ParquetColumnReader::matchType.
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     EXPECT_THROW(reader->createRowReader(rowReaderOpts), BoltRuntimeError);
     return;
   }

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -2086,7 +2086,7 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
     EXPECT_TRUE(assertEqualResults({expected}, {result}));
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     // 4. Auto-cast VARCHAR -> BIGINT: ["100","200","300"] -> [100,200,300].
     //    Skipped in non-Spark builds because matchType() at
     //    ParquetColumnReader.cpp:95 rejects VARCHAR-file -> INT-requested
@@ -2309,7 +2309,7 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharValueFilters) {
 }
 
 TEST_F(ParquetTableScanTest, doubleToBigintValueChecks) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto data = makeRowVector(
@@ -2685,7 +2685,7 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharMapMetadataFilter) {
 }
 
 TEST_F(ParquetTableScanTest, doubleToBigintMapMetadataFilter) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto data = makeRowVector(

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <simdjson.h>
 #include <thrift/protocol/TCompactProtocol.h> //@manual
 #include <thrift/transport/TBufferTransports.h>
@@ -1859,11 +1861,7 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     {"double_to_varchar",              DOUBLE(),        VARCHAR(),          false},
 
     // ---- Hive SerDe-compatible floating point -> BIGINT cast. ----
-#ifdef SPARK_COMPATIBLE
-    {"double_to_bigint",               DOUBLE(),        BIGINT(),           false},
-#else
-    {"double_to_bigint",               DOUBLE(),        BIGINT(),           true},
-#endif
+    {"double_to_bigint",               DOUBLE(),        BIGINT(),           !::bytedance::bolt::kSparkCompatible},
 
     // ---- Reject: float narrowing ----
     {"double_to_real",                 DOUBLE(),        REAL(),             true},
@@ -1919,14 +1917,10 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
     //  extra matchType() check at ParquetColumnReader.cpp:95 then
     //  rejects VARCHAR-file -> INT-requested with its own message, so
     //  the case expectation flips per flavour.
-#ifdef SPARK_COMPATIBLE
-    {"varchar_to_tinyint", VARCHAR(), TINYINT(), false},
-    {"varchar_to_smallint",VARCHAR(), SMALLINT(),false},
-    {"varchar_to_integer", VARCHAR(), INTEGER(), false},
-    {"varchar_to_bigint",  VARCHAR(), BIGINT(),  false},
-#else
-    {"varchar_to_bigint",  VARCHAR(), BIGINT(),  true, "file schema type"},
-#endif
+    {"varchar_to_tinyint", VARCHAR(), TINYINT(), !::bytedance::bolt::kSparkCompatible, "file schema type"},
+    {"varchar_to_smallint",VARCHAR(), SMALLINT(),!::bytedance::bolt::kSparkCompatible, "file schema type"},
+    {"varchar_to_integer", VARCHAR(), INTEGER(), !::bytedance::bolt::kSparkCompatible, "file schema type"},
+    {"varchar_to_bigint",  VARCHAR(), BIGINT(),  !::bytedance::bolt::kSparkCompatible, "file schema type"},
   };
   // clang-format on
 
@@ -2092,28 +2086,28 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
     EXPECT_TRUE(assertEqualResults({expected}, {result}));
   }
 
-#ifdef SPARK_COMPATIBLE
-  // 4. Auto-cast VARCHAR -> BIGINT: ["100","200","300"] -> [100,200,300].
-  //    Skipped in non-Spark builds because matchType() at
-  //    ParquetColumnReader.cpp:95 rejects VARCHAR-file -> INT-requested
-  //    before the column-reader cast can run.
-  {
-    auto data = makeRowVector(
-        {"c0"}, {makeFlatVector<StringView>({"100", "200", "300"})});
-    auto file = exec::test::TempFilePath::create();
-    writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    // 4. Auto-cast VARCHAR -> BIGINT: ["100","200","300"] -> [100,200,300].
+    //    Skipped in non-Spark builds because matchType() at
+    //    ParquetColumnReader.cpp:95 rejects VARCHAR-file -> INT-requested
+    //    before the column-reader cast can run.
+    {
+      auto data = makeRowVector(
+          {"c0"}, {makeFlatVector<StringView>({"100", "200", "300"})});
+      auto file = exec::test::TempFilePath::create();
+      writeToParquetFile(file->getPath(), {data}, WriterOptions{});
 
-    auto declared = ROW({"c0"}, {BIGINT()});
-    auto plan =
-        PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
-    auto result = AssertQueryBuilder(plan)
-                      .split(makeSplit(file->getPath()))
-                      .copyResults(pool());
-    auto expected =
-        makeRowVector({"c0"}, {makeFlatVector<int64_t>({100, 200, 300})});
-    EXPECT_TRUE(assertEqualResults({expected}, {result}));
+      auto declared = ROW({"c0"}, {BIGINT()});
+      auto plan =
+          PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+      auto result = AssertQueryBuilder(plan)
+                        .split(makeSplit(file->getPath()))
+                        .copyResults(pool());
+      auto expected =
+          makeRowVector({"c0"}, {makeFlatVector<int64_t>({100, 200, 300})});
+      EXPECT_TRUE(assertEqualResults({expected}, {result}));
+    }
   }
-#endif
 
   // DATE annotation read as INTEGER: file INT32(DATE) [1,2,3]
   // returns raw epoch-day integers when the Hive/Spark schema says INT.
@@ -2314,8 +2308,10 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharValueFilters) {
   EXPECT_EQ(alwaysFalseResult->size(), 0);
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(ParquetTableScanTest, doubleToBigintValueChecks) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto data = makeRowVector(
       {"c0"},
       {makeNullableFlatVector<double>({1.0, 1.2, -1.8, 0.0, std::nullopt})});
@@ -2351,7 +2347,6 @@ TEST_F(ParquetTableScanTest, doubleToBigintValueChecks) {
           .copyResults(pool()),
       "Cannot apply BIGINT filter to physical DOUBLE Parquet column c0");
 }
-#endif
 
 TEST_F(ParquetTableScanTest, integerToDoubleValueFilters) {
   auto declared = ROW({"c0"}, {DOUBLE()});
@@ -2689,8 +2684,10 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharMapMetadataFilter) {
       1);
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(ParquetTableScanTest, doubleToBigintMapMetadataFilter) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto data = makeRowVector(
       {"c0", "c1"},
       {makeMapVector<StringView, double>(
@@ -2738,7 +2735,6 @@ TEST_F(ParquetTableScanTest, doubleToBigintMapMetadataFilter) {
           .sum,
       1);
 }
-#endif
 
 TEST_F(ParquetTableScanTest, integerReaderCastMetadataFilters) {
   auto test = [&](const RowVectorPtr& data,

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1297,7 +1297,7 @@ TEST_F(ParquetWriterTest, arrowPool) {
 };
 
 TEST_F(ParquetWriterTest, encoderTestSinkResize0) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   int levels_per_page = 100;

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <algorithm>
 #include <cstdio>
 #include <memory>
@@ -714,8 +716,8 @@ TEST_F(ParquetWriterTest, allNulls) {
   ASSERT_EQ(reader->numberOfRows(), kRows);
   ASSERT_EQ(*reader->rowType(), *schema);
   int32_t dataPageCount = 0;
-  for (const auto& stats :
-       reader->fileMetaData().rowGroup(0).columnChunk(0).pageEncodingStats()) {
+  const auto columnChunk = reader->fileMetaData().rowGroup(0).columnChunk(0);
+  for (const auto& stats : columnChunk.pageEncodingStats()) {
     if (stats.page_type == thrift::PageType::DATA_PAGE ||
         stats.page_type == thrift::PageType::DATA_PAGE_V2) {
       dataPageCount += stats.count;
@@ -1294,8 +1296,10 @@ TEST_F(ParquetWriterTest, arrowPool) {
       *leafPool_);
 };
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(ParquetWriterTest, encoderTestSinkResize0) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   int levels_per_page = 100;
   int num_pages = 50;
   auto max_def_level_ = 4;
@@ -1313,4 +1317,3 @@ TEST_F(ParquetWriterTest, encoderTestSinkResize0) {
       getArrowMemoryPool());
   encoder->testSinkResize0();
 };
-#endif

--- a/bolt/exec/Driver.cpp
+++ b/bolt/exec/Driver.cpp
@@ -29,13 +29,16 @@
  */
 
 #include "Driver.h"
+
 #include <folly/ScopeGuard.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <folly/executors/thread_factory/InitThreadFactory.h>
 #include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <optional>
 #include "bolt/common/base/Counters.h"
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/common/base/StatsReporter.h"
-#include "bolt/common/base/logging.h"
 #include "bolt/common/process/ThreadNameHolder.h"
 #include "bolt/common/process/TraceContext.h"
 #include "bolt/common/testutil/TestValue.h"
@@ -772,8 +775,10 @@ StopReason Driver::runInternal(
                     kOpMethodIsFinished);
               });
               if (finished) {
-                LOG_SPARK(INFO) << "Operator " << op->name()
-                                << " finished. nextOp: " << nextOp->name();
+                if constexpr (::bytedance::bolt::kSparkCompatible) {
+                  LOG(INFO) << "Operator " << op->name()
+                            << " finished. nextOp: " << nextOp->name();
+                }
                 auto timer = createDeltaCpuWallTimer(
                     [nextOp, this](const CpuWallTiming& timing) {
                       auto selfDelta = processLazyTiming(*nextOp, timing);
@@ -788,12 +793,14 @@ StopReason Driver::runInternal(
                     curOperatorId_ + 1,
                     kOpMethodNoMoreInput);
                 auto* nextOpPool = nextOp->pool();
-                LOG_SPARK(INFO)
-                    << "Operator " << nextOp->name() << " no more input. "
-                    << nextOpPool->name() << "["
-                    << succinctBytes(nextOpPool->currentBytes()) << ", "
-                    << succinctBytes(nextOpPool->reservedBytes()) << ", "
-                    << succinctBytes(nextOpPool->capacity()) << "]";
+                if constexpr (::bytedance::bolt::kSparkCompatible) {
+                  LOG(INFO)
+                      << "Operator " << nextOp->name() << " no more input. "
+                      << nextOpPool->name() << "["
+                      << succinctBytes(nextOpPool->currentBytes()) << ", "
+                      << succinctBytes(nextOpPool->reservedBytes()) << ", "
+                      << succinctBytes(nextOpPool->capacity()) << "]";
+                }
                 break;
               }
             }
@@ -881,9 +888,10 @@ void Driver::recordYieldCount() {
 
 // static
 void Driver::run(std::shared_ptr<Driver> self) {
-#ifndef SPARK_COMPATIBLE
-  process::ThreadNameHolder holder(self->driverCtx()->task->taskId());
-#endif
+  std::optional<process::ThreadNameHolder> threadNameHolder;
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    threadNameHolder.emplace(self->driverCtx()->task->taskId());
+  }
   process::TraceContext trace("Driver::run");
   bytedance::bolt::process::ScopedThreadDebugInfo scopedInfo(
       self->driverCtx()->threadDebugInfo);

--- a/bolt/exec/Driver.cpp
+++ b/bolt/exec/Driver.cpp
@@ -775,7 +775,7 @@ StopReason Driver::runInternal(
                     kOpMethodIsFinished);
               });
               if (finished) {
-                if constexpr (::bytedance::bolt::kSparkCompatible) {
+                if (::bytedance::bolt::kSparkCompatible) {
                   LOG(INFO) << "Operator " << op->name()
                             << " finished. nextOp: " << nextOp->name();
                 }
@@ -793,7 +793,7 @@ StopReason Driver::runInternal(
                     curOperatorId_ + 1,
                     kOpMethodNoMoreInput);
                 auto* nextOpPool = nextOp->pool();
-                if constexpr (::bytedance::bolt::kSparkCompatible) {
+                if (::bytedance::bolt::kSparkCompatible) {
                   LOG(INFO)
                       << "Operator " << nextOp->name() << " no more input. "
                       << nextOpPool->name() << "["
@@ -889,7 +889,7 @@ void Driver::recordYieldCount() {
 // static
 void Driver::run(std::shared_ptr<Driver> self) {
   std::optional<process::ThreadNameHolder> threadNameHolder;
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     threadNameHolder.emplace(self->driverCtx()->task->taskId());
   }
   process::TraceContext trace("Driver::run");

--- a/bolt/exec/FilterProject.cpp
+++ b/bolt/exec/FilterProject.cpp
@@ -238,12 +238,11 @@ RowVectorPtr FilterProject::getOutput() {
   vector_size_t size = input_->size();
   bool isCompositeInput = RowVector::isComposite(input_);
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    if (skipForCompositeInput_ && isCompositeInput) {
-      BOLT_CHECK(!hasFilter_ && !isIdentityProjection_);
-      numProcessedInputRows_ = size;
-      return fillCompositeOutput(size, input_->children());
-    }
+  if (::bytedance::bolt::kSparkCompatible && skipForCompositeInput_ &&
+      isCompositeInput) {
+    BOLT_CHECK(!hasFilter_ && !isIdentityProjection_);
+    numProcessedInputRows_ = size;
+    return fillCompositeOutput(size, input_->children());
   }
 
   LocalSelectivityVector localRows(*operatorCtx_->execCtx(), size);

--- a/bolt/exec/FilterProject.cpp
+++ b/bolt/exec/FilterProject.cpp
@@ -28,8 +28,10 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/exec/FilterProject.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/core/Expressions.h"
+#include "bolt/exec/FilterProject.h"
 #include "bolt/expression/Expr.h"
 #include "bolt/expression/FieldReference.h"
 #include "bolt/vector/LazyVector.h"
@@ -236,13 +238,13 @@ RowVectorPtr FilterProject::getOutput() {
   vector_size_t size = input_->size();
   bool isCompositeInput = RowVector::isComposite(input_);
 
-#ifdef SPARK_COMPATIBLE
-  if (skipForCompositeInput_ && isCompositeInput) {
-    BOLT_CHECK(!hasFilter_ && !isIdentityProjection_);
-    numProcessedInputRows_ = size;
-    return fillCompositeOutput(size, input_->children());
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (skipForCompositeInput_ && isCompositeInput) {
+      BOLT_CHECK(!hasFilter_ && !isIdentityProjection_);
+      numProcessedInputRows_ = size;
+      return fillCompositeOutput(size, input_->children());
+    }
   }
-#endif
 
   LocalSelectivityVector localRows(*operatorCtx_->execCtx(), size);
   auto* rows = localRows.get();

--- a/bolt/exec/LocalPlanner.cpp
+++ b/bolt/exec/LocalPlanner.cpp
@@ -28,7 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/exec/LocalPlanner.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "RoundRobinPartitionFunction.h"
 #include "bolt/common/process/ExceptionTraceContext.h"
 #include "bolt/core/PlanFragment.h"
@@ -47,6 +48,7 @@
 #include "bolt/exec/HashProbe.h"
 #include "bolt/exec/IndexLookupJoin.h"
 #include "bolt/exec/Limit.h"
+#include "bolt/exec/LocalPlanner.h"
 #include "bolt/exec/LocalShuffle.h"
 #include "bolt/exec/MarkDistinct.h"
 #include "bolt/exec/Merge.h"
@@ -465,21 +467,21 @@ void LocalPlanner::plan(
     factory->maxDrivers = detail::maxDrivers(*factory, queryConfig);
     factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
 
-#ifndef SPARK_COMPATIBLE
-    bool flag = false;
-    for (auto& node : factory->planNodes) {
-      if (std::dynamic_pointer_cast<const core::TableScanNode>(node)) {
-        flag = true;
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      bool flag = false;
+      for (auto& node : factory->planNodes) {
+        if (std::dynamic_pointer_cast<const core::TableScanNode>(node)) {
+          flag = true;
+        }
       }
-    }
-    if (flag && multiDriverOpen) {
-      factory->numDrivers = std::min(factory->maxDrivers, maxDrivers * 10);
+      if (flag && multiDriverOpen) {
+        factory->numDrivers = std::min(factory->maxDrivers, maxDrivers * 10);
+      } else {
+        factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
+      }
     } else {
       factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
     }
-#else
-    factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
-#endif
 
     // Pipelines running grouped/bucketed execution would have separate groups
     // of drivers dealing with separate split groups (one driver can access
@@ -663,54 +665,55 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     else if (
         auto projectNode =
             std::dynamic_pointer_cast<const core::ProjectNode>(planNode)) {
-#ifdef SPARK_COMPATIBLE
-      // partialagg + project + project
-      if (markSkipProject && (i == markSkipProjectAggIndex + 1)) {
-        auto nextProject = std::dynamic_pointer_cast<const core::ProjectNode>(
-            planNodes[markSkipProjectAggIndex + 2]);
-        if (nextProject && nextProject->projections().size() > 0) {
-          auto callTyped = std::dynamic_pointer_cast<const core::CallTypedExpr>(
-              nextProject->projections()[0]);
-          if (LIKELY(
-                  callTyped &&
-                  (callTyped->name() == "hive_hash" ||
-                   callTyped->name() == "hash_with_seed"))) {
-            operators.push_back(std::make_unique<FilterProject>(
-                id,
-                ctx.get(),
-                nullptr,
-                projectNode,
-                FilterProject::ProjectType::kSkipCompositeRowVector));
-            markSkipProject = false;
-            LOG(INFO) << "mark last project as skip";
-            continue;
+      if constexpr (::bytedance::bolt::kSparkCompatible) {
+        // partialagg + project + project
+        if (markSkipProject && (i == markSkipProjectAggIndex + 1)) {
+          auto nextProject = std::dynamic_pointer_cast<const core::ProjectNode>(
+              planNodes[markSkipProjectAggIndex + 2]);
+          if (nextProject && nextProject->projections().size() > 0) {
+            auto callTyped =
+                std::dynamic_pointer_cast<const core::CallTypedExpr>(
+                    nextProject->projections()[0]);
+            if (LIKELY(
+                    callTyped &&
+                    (callTyped->name() == "hive_hash" ||
+                     callTyped->name() == "hash_with_seed"))) {
+              operators.push_back(std::make_unique<FilterProject>(
+                  id,
+                  ctx.get(),
+                  nullptr,
+                  projectNode,
+                  FilterProject::ProjectType::kSkipCompositeRowVector));
+              markSkipProject = false;
+              LOG(INFO) << "mark last project as skip";
+              continue;
+            } else {
+              LOG(INFO) << "next PlanNode is not hashFunction, callTyped = "
+                        << callTyped << ", function name is "
+                        << (callTyped ? callTyped->name() : "unknown");
+            }
           } else {
-            LOG(INFO) << "next PlanNode is not hashFunction, callTyped = "
-                      << callTyped << ", function name is "
-                      << (callTyped ? callTyped->name() : "unknown");
+            LOG(INFO) << "markSkipProject but next PlanNode is not ProjectNode";
           }
-        } else {
-          LOG(INFO) << "markSkipProject but next PlanNode is not ProjectNode";
+          markSkipProject = false;
         }
-        markSkipProject = false;
-      }
 
-      // (valuestream or shuffle reader) + project + agg
-      if (i == 1 &&
-          (planNodes[0]->name() == "ValueStream" ||
-           planNodes[0]->name() == "SparkShuffleReader") &&
-          planNodes.size() >= 3 &&
-          std::dynamic_pointer_cast<const core::AggregationNode>(
-              planNodes[2])) {
-        operators.push_back(std::make_unique<FilterProject>(
-            id,
-            ctx.get(),
-            nullptr,
-            projectNode,
-            FilterProject::ProjectType::kSkipCompositeRowVector));
-        continue;
+        // (valuestream or shuffle reader) + project + agg
+        if (i == 1 &&
+            (planNodes[0]->name() == "ValueStream" ||
+             planNodes[0]->name() == "SparkShuffleReader") &&
+            planNodes.size() >= 3 &&
+            std::dynamic_pointer_cast<const core::AggregationNode>(
+                planNodes[2])) {
+          operators.push_back(std::make_unique<FilterProject>(
+              id,
+              ctx.get(),
+              nullptr,
+              projectNode,
+              FilterProject::ProjectType::kSkipCompositeRowVector));
+          continue;
+        }
       }
-#endif
       operators.push_back(
           std::make_unique<FilterProject>(id, ctx.get(), nullptr, projectNode));
     } else if (
@@ -782,15 +785,15 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
         operators.push_back(std::make_unique<StreamingAggregation>(
             id, ctx.get(), aggregationNode));
       } else {
-#ifdef SPARK_COMPATIBLE
-        // for function like avg/first, intermediate type is ROW<>, eg
-        // ROW<double, bigint> for avg a ProjectNode is added by gluten to
-        // project ROW<double, bigint> to 2 columns and row_contructor these 2
-        // columns back to ROW after shuffle read for CompositeRowVector, skip
-        // project and row_contructor execution
-        markSkipProject =
-            (aggregationNode->isPartial() && i == markSkipProjectAggIndex);
-#endif
+        if constexpr (::bytedance::bolt::kSparkCompatible) {
+          // for function like avg/first, intermediate type is ROW<>, eg
+          // ROW<double, bigint> for avg a ProjectNode is added by gluten to
+          // project ROW<double, bigint> to 2 columns and row_contructor these 2
+          // columns back to ROW after shuffle read for CompositeRowVector, skip
+          // project and row_contructor execution
+          markSkipProject =
+              (aggregationNode->isPartial() && i == markSkipProjectAggIndex);
+        }
 #if defined BOLT_HAS_CUDF && BOLT_HAS_CUDF == 1
         // Check if all aggregates are supported by cuDF Operator
         bool isCudfSupported =

--- a/bolt/exec/LocalPlanner.cpp
+++ b/bolt/exec/LocalPlanner.cpp
@@ -467,20 +467,13 @@ void LocalPlanner::plan(
     factory->maxDrivers = detail::maxDrivers(*factory, queryConfig);
     factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
 
-    if constexpr (!::bytedance::bolt::kSparkCompatible) {
-      bool flag = false;
+    if (!::bytedance::bolt::kSparkCompatible && multiDriverOpen) {
       for (auto& node : factory->planNodes) {
         if (std::dynamic_pointer_cast<const core::TableScanNode>(node)) {
-          flag = true;
+          factory->numDrivers = std::min(factory->maxDrivers, maxDrivers * 10);
+          break;
         }
       }
-      if (flag && multiDriverOpen) {
-        factory->numDrivers = std::min(factory->maxDrivers, maxDrivers * 10);
-      } else {
-        factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
-      }
-    } else {
-      factory->numDrivers = std::min(factory->maxDrivers, maxDrivers);
     }
 
     // Pipelines running grouped/bucketed execution would have separate groups
@@ -665,54 +658,52 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     else if (
         auto projectNode =
             std::dynamic_pointer_cast<const core::ProjectNode>(planNode)) {
-      if constexpr (::bytedance::bolt::kSparkCompatible) {
-        // partialagg + project + project
-        if (markSkipProject && (i == markSkipProjectAggIndex + 1)) {
-          auto nextProject = std::dynamic_pointer_cast<const core::ProjectNode>(
-              planNodes[markSkipProjectAggIndex + 2]);
-          if (nextProject && nextProject->projections().size() > 0) {
-            auto callTyped =
-                std::dynamic_pointer_cast<const core::CallTypedExpr>(
-                    nextProject->projections()[0]);
-            if (LIKELY(
-                    callTyped &&
-                    (callTyped->name() == "hive_hash" ||
-                     callTyped->name() == "hash_with_seed"))) {
-              operators.push_back(std::make_unique<FilterProject>(
-                  id,
-                  ctx.get(),
-                  nullptr,
-                  projectNode,
-                  FilterProject::ProjectType::kSkipCompositeRowVector));
-              markSkipProject = false;
-              LOG(INFO) << "mark last project as skip";
-              continue;
-            } else {
-              LOG(INFO) << "next PlanNode is not hashFunction, callTyped = "
-                        << callTyped << ", function name is "
-                        << (callTyped ? callTyped->name() : "unknown");
-            }
+      // partialagg + project + project
+      if (::bytedance::bolt::kSparkCompatible && markSkipProject &&
+          i == markSkipProjectAggIndex + 1) {
+        auto nextProject = std::dynamic_pointer_cast<const core::ProjectNode>(
+            planNodes[markSkipProjectAggIndex + 2]);
+        if (nextProject && nextProject->projections().size() > 0) {
+          auto callTyped = std::dynamic_pointer_cast<const core::CallTypedExpr>(
+              nextProject->projections()[0]);
+          if (LIKELY(
+                  callTyped &&
+                  (callTyped->name() == "hive_hash" ||
+                   callTyped->name() == "hash_with_seed"))) {
+            operators.push_back(std::make_unique<FilterProject>(
+                id,
+                ctx.get(),
+                nullptr,
+                projectNode,
+                FilterProject::ProjectType::kSkipCompositeRowVector));
+            markSkipProject = false;
+            LOG(INFO) << "mark last project as skip";
+            continue;
           } else {
-            LOG(INFO) << "markSkipProject but next PlanNode is not ProjectNode";
+            LOG(INFO) << "next PlanNode is not hashFunction, callTyped = "
+                      << callTyped << ", function name is "
+                      << (callTyped ? callTyped->name() : "unknown");
           }
-          markSkipProject = false;
+        } else {
+          LOG(INFO) << "markSkipProject but next PlanNode is not ProjectNode";
         }
+        markSkipProject = false;
+      }
 
-        // (valuestream or shuffle reader) + project + agg
-        if (i == 1 &&
-            (planNodes[0]->name() == "ValueStream" ||
-             planNodes[0]->name() == "SparkShuffleReader") &&
-            planNodes.size() >= 3 &&
-            std::dynamic_pointer_cast<const core::AggregationNode>(
-                planNodes[2])) {
-          operators.push_back(std::make_unique<FilterProject>(
-              id,
-              ctx.get(),
-              nullptr,
-              projectNode,
-              FilterProject::ProjectType::kSkipCompositeRowVector));
-          continue;
-        }
+      // (valuestream or shuffle reader) + project + agg
+      if (::bytedance::bolt::kSparkCompatible && i == 1 &&
+          (planNodes[0]->name() == "ValueStream" ||
+           planNodes[0]->name() == "SparkShuffleReader") &&
+          planNodes.size() >= 3 &&
+          std::dynamic_pointer_cast<const core::AggregationNode>(
+              planNodes[2])) {
+        operators.push_back(std::make_unique<FilterProject>(
+            id,
+            ctx.get(),
+            nullptr,
+            projectNode,
+            FilterProject::ProjectType::kSkipCompositeRowVector));
+        continue;
       }
       operators.push_back(
           std::make_unique<FilterProject>(id, ctx.get(), nullptr, projectNode));
@@ -785,15 +776,13 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
         operators.push_back(std::make_unique<StreamingAggregation>(
             id, ctx.get(), aggregationNode));
       } else {
-        if constexpr (::bytedance::bolt::kSparkCompatible) {
-          // for function like avg/first, intermediate type is ROW<>, eg
-          // ROW<double, bigint> for avg a ProjectNode is added by gluten to
-          // project ROW<double, bigint> to 2 columns and row_contructor these 2
-          // columns back to ROW after shuffle read for CompositeRowVector, skip
-          // project and row_contructor execution
-          markSkipProject =
-              (aggregationNode->isPartial() && i == markSkipProjectAggIndex);
-        }
+        // for function like avg/first, intermediate type is ROW<>, eg
+        // ROW<double, bigint> for avg a ProjectNode is added by gluten to
+        // project ROW<double, bigint> to 2 columns and row_contructor these 2
+        // columns back to ROW after shuffle read for CompositeRowVector, skip
+        // project and row_contructor execution
+        markSkipProject = ::bytedance::bolt::kSparkCompatible &&
+            aggregationNode->isPartial() && i == markSkipProjectAggIndex;
 #if defined BOLT_HAS_CUDF && BOLT_HAS_CUDF == 1
         // Check if all aggregates are supported by cuDF Operator
         bool isCudfSupported =

--- a/bolt/exec/TopNRowNumber.cpp
+++ b/bolt/exec/TopNRowNumber.cpp
@@ -28,8 +28,10 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/exec/TopNRowNumber.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/exec/OperatorUtils.h"
+#include "bolt/exec/TopNRowNumber.h"
 namespace bytedance::bolt::exec {
 
 namespace {
@@ -519,19 +521,13 @@ RowVectorPtr TopNRowNumber::getOutputFromMemory() {
   // Loop over partitions and emit sorted rows along with row numbers.
   auto output =
       BaseVector::create<RowVector>(outputType_, outputBatchSize_, pool());
-#ifdef SPARK_COMPATIBLE
-  FlatVector<int32_t>* rowNumbers = nullptr;
+  using RowNumber =
+      std::conditional_t<::bytedance::bolt::kSparkCompatible, int32_t, int64_t>;
+  FlatVector<RowNumber>* rowNumbers = nullptr;
   if (generateRowNumber_) {
-    rowNumbers = output->children().back()->as<FlatVector<int32_t>>();
+    rowNumbers = output->children().back()->as<FlatVector<RowNumber>>();
     rowNumbers->resize(outputBatchSize_);
   }
-#else
-  FlatVector<int64_t>* rowNumbers = nullptr;
-  if (generateRowNumber_) {
-    rowNumbers = output->children().back()->as<FlatVector<int64_t>>();
-    rowNumbers->resize(outputBatchSize_);
-  }
-#endif
 
   vector_size_t offset = 0;
   if (remainingRowsInPartition_ > 0) {
@@ -602,19 +598,13 @@ RowVectorPtr TopNRowNumber::getOutputFromSpill() {
 
   auto output =
       BaseVector::create<RowVector>(outputType_, outputBatchSize_, pool());
-#ifdef SPARK_COMPATIBLE
-  FlatVector<int32_t>* rowNumbers = nullptr;
+  using RowNumber =
+      std::conditional_t<::bytedance::bolt::kSparkCompatible, int32_t, int64_t>;
+  FlatVector<RowNumber>* rowNumbers = nullptr;
   if (generateRowNumber_) {
-    rowNumbers = output->children().back()->as<FlatVector<int32_t>>();
+    rowNumbers = output->children().back()->as<FlatVector<RowNumber>>();
     rowNumbers->resize(outputBatchSize_);
   }
-#else
-  FlatVector<int64_t>* rowNumbers = nullptr;
-  if (generateRowNumber_) {
-    rowNumbers = output->children().back()->as<FlatVector<int64_t>>();
-    rowNumbers->resize(outputBatchSize_);
-  }
-#endif
   for (auto i = 0; i < inputChannels_.size(); ++i) {
     output->childAt(inputChannels_[i])->resize(outputBatchSize_);
   }

--- a/bolt/exec/tests/DriverTest.cpp
+++ b/bolt/exec/tests/DriverTest.cpp
@@ -471,7 +471,7 @@ class DriverTest : public OperatorTestBase {
   expectWithDelay([&]() { return test; }, __FILE__, __LINE__, #test)
 
 TEST_F(DriverTest, error) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   CursorParameters params;
@@ -1431,7 +1431,7 @@ DEBUG_ONLY_TEST_F(DriverTest, driverThreadContext) {
 }
 
 DEBUG_ONLY_TEST_F(DriverTest, driverThreadName) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
 

--- a/bolt/exec/tests/DriverTest.cpp
+++ b/bolt/exec/tests/DriverTest.cpp
@@ -28,9 +28,12 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <bolt/exec/Driver.h>
 #include <folly/Unit.h>
 #include <folly/init/Init.h>
+#include <folly/system/ThreadName.h>
 #include <memory>
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
@@ -467,8 +470,10 @@ class DriverTest : public OperatorTestBase {
 #define EXPECT_WITH_DELAY(test) \
   expectWithDelay([&]() { return test; }, __FILE__, __LINE__, #test)
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(DriverTest, error) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   CursorParameters params;
   params.planNode =
       makeValuesFilterProject(rowType_, "m1 % 0 > 0", "", 100, 10);
@@ -489,7 +494,6 @@ TEST_F(DriverTest, error) {
                   .isReady());
   EXPECT_EQ(tasks_[0]->state(), TaskState::kFailed);
 }
-#endif
 
 TEST_F(DriverTest, cancel) {
   CursorParameters params;
@@ -1424,6 +1428,29 @@ DEBUG_ONLY_TEST_F(DriverTest, driverThreadContext) {
   auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
                   .assertResults("SELECT * FROM tmp");
   ASSERT_EQ(task.get(), capturedTask);
+}
+
+DEBUG_ONLY_TEST_F(DriverTest, driverThreadName) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
+
+  constexpr std::string_view kTaskId = "driver-thread";
+  std::atomic_bool observedExpectedName{false};
+  SCOPED_TESTVALUE_SET(
+      "bytedance::bolt::exec::Driver::runInternal",
+      std::function<void(Driver*)>([&](Driver* /* driver */) {
+        observedExpectedName =
+            folly::getCurrentThreadName().value_or("") == kTaskId;
+      }));
+
+  auto plan = PlanBuilder()
+                  .values({makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})})
+                  .planNode();
+  ASSERT_NO_THROW(AssertQueryBuilder(plan)
+                      .taskId(std::string(kTaskId))
+                      .copyResults(pool()));
+  EXPECT_TRUE(observedExpectedName);
 }
 
 DEBUG_ONLY_TEST_F(DriverTest, nonReclaimableSection) {

--- a/bolt/exec/tests/JoinFuzzerRunner.h
+++ b/bolt/exec/tests/JoinFuzzerRunner.h
@@ -32,6 +32,7 @@
 
 #include <gtest/gtest.h>
 
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/common/file/FileSystems.h"
 #include "bolt/exec/tests/JoinFuzzer.h"
 #include "bolt/serializers/PrestoSerializer.h"
@@ -75,13 +76,13 @@ class JoinFuzzerRunner {
  public:
   static int run(size_t seed) {
     bytedance::bolt::memory::MemoryManager::initialize({});
-#ifdef SPARK_COMPATIBLE
-    bytedance::bolt::serializer::spark::UnsafeRowVectorSerde::
-        registerVectorSerde();
-#else
-    bytedance::bolt::serializer::presto::PrestoVectorSerde::
-        registerVectorSerde();
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      bytedance::bolt::serializer::spark::UnsafeRowVectorSerde::
+          registerVectorSerde();
+    } else {
+      bytedance::bolt::serializer::presto::PrestoVectorSerde::
+          registerVectorSerde();
+    }
     bytedance::bolt::filesystems::registerLocalFileSystem();
 
     bytedance::bolt::exec::test::joinFuzzer(seed);

--- a/bolt/exec/tests/JoinFuzzerRunner.h
+++ b/bolt/exec/tests/JoinFuzzerRunner.h
@@ -76,7 +76,7 @@ class JoinFuzzerRunner {
  public:
   static int run(size_t seed) {
     bytedance::bolt::memory::MemoryManager::initialize({});
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       bytedance::bolt::serializer::spark::UnsafeRowVectorSerde::
           registerVectorSerde();
     } else {

--- a/bolt/exec/tests/JoinFuzzerTest.cpp
+++ b/bolt/exec/tests/JoinFuzzerTest.cpp
@@ -28,8 +28,6 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/common/base/SparkCompatibility.h"
-
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>

--- a/bolt/exec/tests/JoinFuzzerTest.cpp
+++ b/bolt/exec/tests/JoinFuzzerTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>

--- a/bolt/exec/tests/PlanNodeToStringTest.cpp
+++ b/bolt/exec/tests/PlanNodeToStringTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/connectors/hive/HiveConnectorSplit.h"
 #include "bolt/exec/WindowFunction.h"
 #include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
@@ -827,11 +829,9 @@ TEST_F(PlanNodeToStringTest, rowNumber) {
 
   ASSERT_EQ("-- RowNumber[1]\n", plan->toString(false, false, true));
   ASSERT_EQ(
-#ifndef SPARK_COMPATIBLE
-      "-- RowNumber[1][] -> a:VARCHAR, row_number:BIGINT\n",
-#else
-      "-- RowNumber[1][] -> a:VARCHAR, row_number:INTEGER\n",
-#endif
+      ::bytedance::bolt::kSparkCompatible
+          ? "-- RowNumber[1][] -> a:VARCHAR, row_number:INTEGER\n"
+          : "-- RowNumber[1][] -> a:VARCHAR, row_number:BIGINT\n",
       plan->toString(true, false, true));
 
   // Don't emit row number.
@@ -852,11 +852,9 @@ TEST_F(PlanNodeToStringTest, rowNumber) {
 
   ASSERT_EQ("-- RowNumber[1]\n", plan->toString(false, false, true));
   ASSERT_EQ(
-#ifndef SPARK_COMPATIBLE
-      "-- RowNumber[1][partition by (a, b)] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
-#else
-      "-- RowNumber[1][partition by (a, b)] -> a:BIGINT, b:VARCHAR, row_number:INTEGER\n",
-#endif
+      ::bytedance::bolt::kSparkCompatible
+          ? "-- RowNumber[1][partition by (a, b)] -> a:BIGINT, b:VARCHAR, row_number:INTEGER\n"
+          : "-- RowNumber[1][partition by (a, b)] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
       plan->toString(true, false, true));
 
   // Don't emit row number.
@@ -878,11 +876,9 @@ TEST_F(PlanNodeToStringTest, rowNumber) {
 
   ASSERT_EQ("-- RowNumber[1]\n", plan->toString(false, false, true));
   ASSERT_EQ(
-#ifndef SPARK_COMPATIBLE
-      "-- RowNumber[1][partition by (b) limit 10] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
-#else
-      "-- RowNumber[1][partition by (b) limit 10] -> a:BIGINT, b:VARCHAR, row_number:INTEGER\n",
-#endif
+      ::bytedance::bolt::kSparkCompatible
+          ? "-- RowNumber[1][partition by (b) limit 10] -> a:BIGINT, b:VARCHAR, row_number:INTEGER\n"
+          : "-- RowNumber[1][partition by (b) limit 10] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
       plan->toString(true, false, true));
 
   // Don't emit row number.
@@ -916,11 +912,9 @@ TEST_F(PlanNodeToStringTest, topNRowNumber) {
 
   ASSERT_EQ("-- TopNRowNumber[1]\n", plan->toString(false, false, true));
   ASSERT_EQ(
-#ifndef SPARK_COMPATIBLE
-      "-- TopNRowNumber[1][order by (a DESC NULLS LAST) limit 10] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
-#else
-      "-- TopNRowNumber[1][order by (a DESC NULLS LAST) limit 10] -> a:BIGINT, b:VARCHAR, row_number:INTEGER\n",
-#endif
+      ::bytedance::bolt::kSparkCompatible
+          ? "-- TopNRowNumber[1][order by (a DESC NULLS LAST) limit 10] -> a:BIGINT, b:VARCHAR, row_number:INTEGER\n"
+          : "-- TopNRowNumber[1][order by (a DESC NULLS LAST) limit 10] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
       plan->toString(true, false, true));
 
   plan = PlanBuilder()

--- a/bolt/exec/tests/RowNumberTest.cpp
+++ b/bolt/exec/tests/RowNumberTest.cpp
@@ -46,7 +46,7 @@ class RowNumberTest : public OperatorTestBase {
 };
 
 TEST_F(RowNumberTest, spill) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto spillDirectory = exec::test::TempDirectoryPath::create();
@@ -92,7 +92,7 @@ TEST_F(RowNumberTest, spill) {
 }
 
 TEST_F(RowNumberTest, basic) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto data = makeRowVector({
@@ -143,7 +143,7 @@ TEST_F(RowNumberTest, basic) {
 }
 
 TEST_F(RowNumberTest, noPartitionKeys) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto data = makeRowVector({
@@ -193,7 +193,7 @@ TEST_F(RowNumberTest, noPartitionKeys) {
 }
 
 TEST_F(RowNumberTest, largeInput) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto data = makeRowVector({

--- a/bolt/exec/tests/RowNumberTest.cpp
+++ b/bolt/exec/tests/RowNumberTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/common/file/FileSystems.h"
 #include "bolt/exec/PlanNodeStats.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
@@ -43,8 +45,10 @@ class RowNumberTest : public OperatorTestBase {
   }
 };
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(RowNumberTest, spill) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto spillDirectory = exec::test::TempDirectoryPath::create();
 
   auto test = [&](int32_t vectorSize) {
@@ -88,6 +92,9 @@ TEST_F(RowNumberTest, spill) {
 }
 
 TEST_F(RowNumberTest, basic) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto data = makeRowVector({
       makeFlatVector<int64_t>({1, 2, 1, 2, 1, 2, 1}),
       makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
@@ -136,6 +143,9 @@ TEST_F(RowNumberTest, basic) {
 }
 
 TEST_F(RowNumberTest, noPartitionKeys) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto data = makeRowVector({
       makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
   });
@@ -183,6 +193,9 @@ TEST_F(RowNumberTest, noPartitionKeys) {
 }
 
 TEST_F(RowNumberTest, largeInput) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto data = makeRowVector({
       makeFlatVector<int64_t>(10'000, [](auto row) { return row % 7; }),
       makeFlatVector<int64_t>(10'000, [](auto row) { return row; }),
@@ -232,7 +245,6 @@ TEST_F(RowNumberTest, largeInput) {
   testLimit(2'000);
   testLimit(5'000);
 }
-#endif
 
 TEST_F(RowNumberTest, maxSpillBytes) {
   const auto rowType =

--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -4335,7 +4335,7 @@ TEST_F(TableScanTest, timestampPartitionKey) {
               std::end(inputs) - std::begin(inputs),
               [&](auto i) {
                 auto t = util::fromTimestampString(inputs[i], nullptr);
-                if constexpr (!::bytedance::bolt::kSparkCompatible) {
+                if (!::bytedance::bolt::kSparkCompatible) {
                   t.toGMT(Timestamp::defaultTimezone());
                 }
                 return t;

--- a/bolt/exec/tests/TableScanTest.cpp
+++ b/bolt/exec/tests/TableScanTest.cpp
@@ -28,7 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/exec/TableScan.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/common/base/Fs.h"
 #include "bolt/common/base/tests/GTestUtils.h"
@@ -44,6 +45,7 @@
 #include "bolt/dwio/paimon/deletionvectors/DeletionFileReader.h"
 #include "bolt/exec/OutputBufferManager.h"
 #include "bolt/exec/PlanNodeStats.h"
+#include "bolt/exec/TableScan.h"
 #include "bolt/exec/tests/utils/AssertQueryBuilder.h"
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
@@ -4333,9 +4335,9 @@ TEST_F(TableScanTest, timestampPartitionKey) {
               std::end(inputs) - std::begin(inputs),
               [&](auto i) {
                 auto t = util::fromTimestampString(inputs[i], nullptr);
-#ifndef SPARK_COMPATIBLE
-                t.toGMT(Timestamp::defaultTimezone());
-#endif
+                if constexpr (!::bytedance::bolt::kSparkCompatible) {
+                  t.toGMT(Timestamp::defaultTimezone());
+                }
                 return t;
               }),
       });

--- a/bolt/expression/CastExpr-inl.h
+++ b/bolt/expression/CastExpr-inl.h
@@ -33,6 +33,7 @@
 #include <date/tz.h>
 #include "bolt/common/base/CountBits.h"
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/core/CoreTypeSystem.h"
 #include "bolt/expression/PrestoCastHooks.h"
 #include "bolt/expression/StringWriter.h"
@@ -84,7 +85,10 @@ StringView convertToStringView(
     int32_t scale,
     int32_t maxVarcharSize,
     char* const startPosition) {
-  auto strSize = DecimalUtil::convertToString(
+  constexpr auto kDecimalStringFormat = ::bytedance::bolt::kSparkCompatible
+      ? DecimalUtil::DecimalStringFormat::kSpark
+      : DecimalUtil::DecimalStringFormat::kPlain;
+  auto strSize = DecimalUtil::convertToString<kDecimalStringFormat>(
       unscaledValue, scale, maxVarcharSize, startPosition);
   return StringView(startPosition, strSize);
 }
@@ -379,31 +383,32 @@ VectorPtr CastExpr::applyDecimalToFloatCast(
   auto resultBuffer = result->asUnchecked<FlatVector<To>>()->mutableRawValues();
   const auto precisionScale = getDecimalPrecisionScale(*fromType);
   const auto simpleInput = input.as<SimpleVector<FromNativeType>>();
-#ifndef SPARK_COMPATIBLE
-  const auto scaleFactor = DecimalUtil::getPowersOfTen(precisionScale.second);
-  applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-    bool nullOutput = false;
-    auto output = util::Converter<ToKind, void, util::DefaultCastPolicy>::cast(
-        simpleInput->valueAt(row), &nullOutput);
-    if (nullOutput) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    const auto scaleFactor = DecimalUtil::getPowersOfTen(precisionScale.second);
+    applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+      bool nullOutput = false;
+      auto output =
+          util::Converter<ToKind, void, util::DefaultCastPolicy>::cast(
+              simpleInput->valueAt(row), &nullOutput);
+      if (nullOutput) {
+        result->setNull(row, true);
+      } else {
+        resultBuffer[row] = output / scaleFactor;
+      }
+    });
+  } else {
+    const int32_t scale = precisionScale.second;
+    const int32_t precision = precisionScale.first;
+    applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+      auto inputValue = simpleInput->valueAt(row);
+      auto fValue = FloatingDecimal::toFloatFromValue(inputValue, scale);
+      if (fValue.has_value()) {
+        resultBuffer[row] = *fValue;
+        return;
+      }
       result->setNull(row, true);
-    } else {
-      resultBuffer[row] = output / scaleFactor;
-    }
-  });
-#else
-  const int32_t scale = precisionScale.second;
-  const int32_t precision = precisionScale.first;
-  applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-    auto inputValue = simpleInput->valueAt(row);
-    auto fValue = FloatingDecimal::toFloatFromValue(inputValue, scale);
-    if (fValue.has_value()) {
-      resultBuffer[row] = *fValue;
-      return;
-    }
-    result->setNull(row, true);
-  });
-#endif
+    });
+  }
   return result;
 }
 
@@ -579,13 +584,13 @@ VectorPtr CastExpr::applyDecimalToPrimitiveCast(
       return applyDecimalToFloatCast<FromNativeType, TypeKind::REAL>(
           rows, input, context, fromType, toType);
     case TypeKind::DOUBLE:
-#ifndef SPARK_COMPATIBLE
-      return applyDecimalToFloatCast<FromNativeType, TypeKind::DOUBLE>(
-          rows, input, context, fromType, toType);
-#else
-      return applyDecimalToDoubleCast<FromNativeType, TypeKind::DOUBLE>(
-          rows, input, context, fromType, toType);
-#endif
+      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        return applyDecimalToFloatCast<FromNativeType, TypeKind::DOUBLE>(
+            rows, input, context, fromType, toType);
+      } else {
+        return applyDecimalToDoubleCast<FromNativeType, TypeKind::DOUBLE>(
+            rows, input, context, fromType, toType);
+      }
 
     default:
       BOLT_UNSUPPORTED(
@@ -616,7 +621,8 @@ struct CastWithTz<TypeKind::VARCHAR> {
 
   static std::string
   cast(const Timestamp& val, bool& nullOutput, const tz::TimeZone* tz) {
-    return val.toString(TimestampToStringOptions::Precision::kMilliseconds, tz);
+    return val.toString<::bytedance::bolt::kSparkCompatible>(
+        TimestampToStringOptions::Precision::kMilliseconds, tz);
   }
 };
 
@@ -669,8 +675,8 @@ void CastExpr::applyCastPrimitives(
     }
   };
 
-#ifndef SPARK_COMPATIBLE
   if constexpr (
+      !::bytedance::bolt::kSparkCompatible &&
       (FromKind == TypeKind::INTEGER || FromKind == TypeKind::BIGINT ||
        FromKind == TypeKind::REAL || FromKind == TypeKind::DOUBLE ||
        FromKind == TypeKind::BOOLEAN) &&
@@ -679,8 +685,6 @@ void CastExpr::applyCastPrimitives(
       BOLT_FAIL("Cannot cast {} to timestamp", mapTypeKindToName(FromKind));
     }
   }
-#endif
-
   if constexpr (
       CppToType<From>::typeKind == TypeKind::TIMESTAMP &&
       CppToType<To>::typeKind == TypeKind::VARCHAR) {
@@ -731,37 +735,37 @@ void CastExpr::applyCastPrimitives(
     }
   }
 
-#ifndef SPARK_COMPATIBLE
-  // If we're converting to a TIMESTAMP, check if we need to adjust the
-  // current GMT timezone to the user provided session timezone.
-  if constexpr (ToKind == TypeKind::TIMESTAMP) {
-    auto prestoHook = dynamic_cast<PrestoCastHooks*>(hooks_.get());
-    if (FOLLY_LIKELY(prestoHook)) {
-      const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-      // If user explicitly asked us to adjust the timezone.
-      if (queryConfig.adjustTimestampToTimezone()) {
-        auto sessionTzName = queryConfig.sessionTimezone();
-        if (!sessionTzName.empty()) {
-          // When context.throwOnError is false, some rows will be marked as
-          // 'failed'. These rows should not be processed further.
-          // 'remainingRows' will contain a subset of 'rows' that have passed
-          // all the checks (e.g. keys are not nulls and number of keys and
-          // values is the same).
-          exec::LocalSelectivityVector remainingRows(context, rows);
-          context.deselectErrors(*remainingRows);
-          // locate_zone throws runtime_error if the timezone couldn't be found
-          // (so we're safe to dereference the pointer).
-          auto* timeZone = tz::locateZone(sessionTzName);
-          auto rawTimestamps = resultFlatVector->mutableRawValues();
-          applyToSelectedNoThrowLocal(
-              context, *remainingRows, result, [&](int row) {
-                rawTimestamps[row].toGMT(*timeZone);
-              });
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // If we're converting to a TIMESTAMP, check if we need to adjust the
+    // current GMT timezone to the user provided session timezone.
+    if constexpr (ToKind == TypeKind::TIMESTAMP) {
+      auto prestoHook = dynamic_cast<PrestoCastHooks*>(hooks_.get());
+      if (FOLLY_LIKELY(prestoHook)) {
+        const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
+        // If user explicitly asked us to adjust the timezone.
+        if (queryConfig.adjustTimestampToTimezone()) {
+          auto sessionTzName = queryConfig.sessionTimezone();
+          if (!sessionTzName.empty()) {
+            // When context.throwOnError is false, some rows will be marked as
+            // 'failed'. These rows should not be processed further.
+            // 'remainingRows' will contain a subset of 'rows' that have passed
+            // all the checks (e.g. keys are not nulls and number of keys and
+            // values is the same).
+            exec::LocalSelectivityVector remainingRows(context, rows);
+            context.deselectErrors(*remainingRows);
+            // locate_zone throws runtime_error if the timezone couldn't be
+            // found (so we're safe to dereference the pointer).
+            auto* timeZone = tz::locateZone(sessionTzName);
+            auto rawTimestamps = resultFlatVector->mutableRawValues();
+            applyToSelectedNoThrowLocal(
+                context, *remainingRows, result, [&](int row) {
+                  rawTimestamps[row].toGMT(*timeZone);
+                });
+          }
         }
       }
     }
   }
-#endif
 }
 
 template <TypeKind ToKind>
@@ -924,19 +928,19 @@ void CastExpr::applyCastNonPromitiveToVarcharEval(
     auto* newInput =
         input->as<SimpleVector<typename TypeTraits<FromKind>::NativeType>>();
     auto inputRowValue = newInput->valueAt(row);
-#ifdef SPARK_COMPATIBLE
-    if constexpr (FromKind == TypeKind::TIMESTAMP) {
-      static constexpr TimestampToStringOptions options = {
-          .precision = TimestampToStringOptions::Precision::kMicroseconds,
-          .leadingPositiveSign = true,
-          .skipTrailingZeros = true,
-          .zeroPaddingYear = true,
-          .dateTimeSeparator = ' ',
-      };
-      result.append(inputRowValue.toString(options), flatResult);
-      return;
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      if constexpr (FromKind == TypeKind::TIMESTAMP) {
+        static constexpr TimestampToStringOptions options = {
+            .precision = TimestampToStringOptions::Precision::kMicroseconds,
+            .leadingPositiveSign = true,
+            .skipTrailingZeros = true,
+            .zeroPaddingYear = true,
+            .dateTimeSeparator = ' ',
+        };
+        result.append(inputRowValue.toString(options), flatResult);
+        return;
+      }
     }
-#endif
     if constexpr (
         FromKind == TypeKind::HUGEINT || FromKind == TypeKind::BIGINT) {
       if (input->type()->isDecimal()) {

--- a/bolt/expression/CastExpr-inl.h
+++ b/bolt/expression/CastExpr-inl.h
@@ -398,7 +398,6 @@ VectorPtr CastExpr::applyDecimalToFloatCast(
     });
   } else {
     const int32_t scale = precisionScale.second;
-    const int32_t precision = precisionScale.first;
     applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
       auto inputValue = simpleInput->valueAt(row);
       auto fValue = FloatingDecimal::toFloatFromValue(inputValue, scale);
@@ -735,33 +734,32 @@ void CastExpr::applyCastPrimitives(
     }
   }
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    // If we're converting to a TIMESTAMP, check if we need to adjust the
-    // current GMT timezone to the user provided session timezone.
-    if constexpr (ToKind == TypeKind::TIMESTAMP) {
-      auto prestoHook = dynamic_cast<PrestoCastHooks*>(hooks_.get());
-      if (FOLLY_LIKELY(prestoHook)) {
-        const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-        // If user explicitly asked us to adjust the timezone.
-        if (queryConfig.adjustTimestampToTimezone()) {
-          auto sessionTzName = queryConfig.sessionTimezone();
-          if (!sessionTzName.empty()) {
-            // When context.throwOnError is false, some rows will be marked as
-            // 'failed'. These rows should not be processed further.
-            // 'remainingRows' will contain a subset of 'rows' that have passed
-            // all the checks (e.g. keys are not nulls and number of keys and
-            // values is the same).
-            exec::LocalSelectivityVector remainingRows(context, rows);
-            context.deselectErrors(*remainingRows);
-            // locate_zone throws runtime_error if the timezone couldn't be
-            // found (so we're safe to dereference the pointer).
-            auto* timeZone = tz::locateZone(sessionTzName);
-            auto rawTimestamps = resultFlatVector->mutableRawValues();
-            applyToSelectedNoThrowLocal(
-                context, *remainingRows, result, [&](int row) {
-                  rawTimestamps[row].toGMT(*timeZone);
-                });
-          }
+  // If we're converting to a TIMESTAMP, check if we need to adjust the
+  // current GMT timezone to the user provided session timezone.
+  if constexpr (
+      !::bytedance::bolt::kSparkCompatible && ToKind == TypeKind::TIMESTAMP) {
+    auto prestoHook = dynamic_cast<PrestoCastHooks*>(hooks_.get());
+    if (FOLLY_LIKELY(prestoHook)) {
+      const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
+      // If user explicitly asked us to adjust the timezone.
+      if (queryConfig.adjustTimestampToTimezone()) {
+        auto sessionTzName = queryConfig.sessionTimezone();
+        if (!sessionTzName.empty()) {
+          // When context.throwOnError is false, some rows will be marked as
+          // 'failed'. These rows should not be processed further.
+          // 'remainingRows' will contain a subset of 'rows' that have passed
+          // all the checks (e.g. keys are not nulls and number of keys and
+          // values is the same).
+          exec::LocalSelectivityVector remainingRows(context, rows);
+          context.deselectErrors(*remainingRows);
+          // locate_zone throws runtime_error if the timezone couldn't be found
+          // (so we're safe to dereference the pointer).
+          auto* timeZone = tz::locateZone(sessionTzName);
+          auto rawTimestamps = resultFlatVector->mutableRawValues();
+          applyToSelectedNoThrowLocal(
+              context, *remainingRows, result, [&](int row) {
+                rawTimestamps[row].toGMT(*timeZone);
+              });
         }
       }
     }
@@ -928,18 +926,18 @@ void CastExpr::applyCastNonPromitiveToVarcharEval(
     auto* newInput =
         input->as<SimpleVector<typename TypeTraits<FromKind>::NativeType>>();
     auto inputRowValue = newInput->valueAt(row);
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
-      if constexpr (FromKind == TypeKind::TIMESTAMP) {
-        static constexpr TimestampToStringOptions options = {
-            .precision = TimestampToStringOptions::Precision::kMicroseconds,
-            .leadingPositiveSign = true,
-            .skipTrailingZeros = true,
-            .zeroPaddingYear = true,
-            .dateTimeSeparator = ' ',
-        };
-        result.append(inputRowValue.toString(options), flatResult);
-        return;
-      }
+    if constexpr (
+        ::bytedance::bolt::kSparkCompatible &&
+        FromKind == TypeKind::TIMESTAMP) {
+      static constexpr TimestampToStringOptions options = {
+          .precision = TimestampToStringOptions::Precision::kMicroseconds,
+          .leadingPositiveSign = true,
+          .skipTrailingZeros = true,
+          .zeroPaddingYear = true,
+          .dateTimeSeparator = ' ',
+      };
+      result.append(inputRowValue.toString(options), flatResult);
+      return;
     }
     if constexpr (
         FromKind == TypeKind::HUGEINT || FromKind == TypeKind::BIGINT) {

--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/expression/CastExpr-tpl.h"
 
 #if defined(__linux__)
@@ -41,11 +43,10 @@ namespace bytedance::bolt::exec::CastUtils {
 
 constexpr size_t kStackBufSize = 64;
 
-#ifdef SPARK_COMPATIBLE
-constexpr bool isInSpark = true;
-#else
-constexpr bool isInSpark = false;
-#endif
+constexpr bool kIsInSpark = ::bytedance::bolt::kSparkCompatible;
+constexpr auto kDecimalStringFormat = kIsInSpark
+    ? DecimalUtil::DecimalStringFormat::kSpark
+    : DecimalUtil::DecimalStringFormat::kPlain;
 
 // convert status to indicate whether conversion behaviors.
 // Note: for INTEGER_OVERFLOW, the output value should save a wrapped value.
@@ -320,7 +321,7 @@ class Converter {
         }
         return status;
       }
-    } else if constexpr (fromString && isInSpark) {
+    } else if constexpr (fromString && kIsInSpark) {
       // spark support trim and does not accept on/off instead of folly::to
       auto boolOpt = sparkStringToBoolean(folly::StringPiece(from));
       if (boolOpt.has_value()) {
@@ -442,7 +443,7 @@ class Converter {
       }
       return tryToWithFolly(newV, to);
     } else if constexpr (fromDecimal) {
-      if constexpr (isInSpark) {
+      if constexpr (kIsInSpark) {
         std::optional<ToType> fValue;
         if constexpr (std::is_same_v<ToKind, RealKind>) {
           fValue = FloatingDecimal::toFloatFromValue(from, fromScale_);
@@ -493,7 +494,7 @@ class Converter {
               }
             }
             to.set(output);
-          } else if (isInSpark) {
+          } else if (kIsInSpark) {
             constexpr TimestampToStringOptions options = {
                 .precision = TimestampToStringOptions::Precision::kMicroseconds,
                 .leadingPositiveSign = true,
@@ -503,7 +504,7 @@ class Converter {
             ts.toTimezone(*timeZone_);
             to.set(ts.toString(options));
           } else {
-            to.set(from.toString(
+            to.set(from.template toString<::bytedance::bolt::kSparkCompatible>(
                 TimestampToStringOptions::Precision::kMilliseconds, timeZone_));
           }
         } else {
@@ -525,7 +526,7 @@ class Converter {
               }
             }
             to.set(output);
-          } else if (isInSpark) {
+          } else if (kIsInSpark) {
             constexpr TimestampToStringOptions options = {
                 .precision = TimestampToStringOptions::Precision::kMicroseconds,
                 .leadingPositiveSign = true,
@@ -571,7 +572,7 @@ class Converter {
     } else if constexpr (fromDecimal) {
       if (canAsInlinedStr_) {
         char inlined[StringView::kInlineSize];
-        auto strSize = DecimalUtil::convertToString(
+        auto strSize = DecimalUtil::convertToString<kDecimalStringFormat>(
             from, fromScale_, StringView::kInlineSize, inlined);
         to.setNoCopy(std::string_view(inlined, strSize));
       } else {
@@ -580,7 +581,7 @@ class Converter {
             kStackBufSize,
             "DecimalSize must be less than 64");
         char cached[kStackBufSize];
-        auto strSize = DecimalUtil::convertToString(
+        auto strSize = DecimalUtil::convertToString<kDecimalStringFormat>(
             from, fromScale_, fromDecimalMaxSize_, cached);
         to.set(std::string_view(cached, strSize));
       }
@@ -627,7 +628,7 @@ class Converter {
       }
     } else if constexpr (fromString) {
       StringView view(from);
-      if (isInSpark) {
+      if (kIsInSpark) {
         bytedance::bolt::functions::stringImpl::
             trimUnicodeWhiteSpace<true, true, StringView, StringView>(
                 view, from);
@@ -643,7 +644,7 @@ class Converter {
 
   TO_KIND(TimestampKind) convert(const FromType& from, ToType& to) {
     if constexpr (std::is_same_v<FromKind, StringKind>) {
-      if (isInSpark) {
+      if (kIsInSpark) {
         auto resultOpt =
             util::fromTimestampWithTimezoneString(from.data(), from.size());
         if (!resultOpt.has_value()) {
@@ -686,7 +687,7 @@ class Converter {
       }
       return hasError ? ConvertStatus::OTHER_FAILURE : ConvertStatus::SUCCESS;
     } else if constexpr (std::is_same_v<FromKind, BooleanKind>) {
-      if constexpr (isInSpark) {
+      if constexpr (kIsInSpark) {
         // Spark treats boolean as microseconds since epoch when casting to
         // timestamp: false -> 0us, true -> 1us.
         to = Timestamp::fromMicrosNoError(from ? 1 : 0);
@@ -726,9 +727,9 @@ class Converter {
 
   TO_KIND(DateKind) convert(const FromType& from, ToType& to) {
     if constexpr (std::is_same_v<FromKind, StringKind>) {
-      bool isIso8601 = !isInSpark;
+      bool isIso8601 = !kIsInSpark;
       StringView view(from);
-      if (isInSpark) {
+      if (kIsInSpark) {
         bytedance::bolt::functions::stringImpl::
             trimUnicodeWhiteSpace<true, true, StringView, StringView>(
                 view, from);
@@ -908,7 +909,7 @@ class VectorConverter : public ConverterBase {
       exec::EvalCtx& context,
       VectorPtr& result,
       CastErrorPolicy errorPolicy) override {
-    if constexpr (isInSpark) {
+    if constexpr (kIsInSpark) {
       constexpr bool legacy = false;
       constexpr bool truncate = true;
       convertWithPolicy<legacy, truncate>(
@@ -1058,16 +1059,16 @@ void registerConverter() {
   RegisterAllPairs<NumStrType, NumStrType>::apply();
   RegisterAllPairs<DateStrType, DateStrType>::apply();
 
-#ifdef SPARK_COMPATIBLE
-  using IntegerKinds =
-      KindList<TinyintKind, SmallintKind, IntegerKind, BigintKind>;
-  RegisterAllPairs<IntegerKinds, KindList<TimestampKind>>::apply();
-  RegisterAllPairs<KindList<RealKind, DoubleKind>, KindList<TimestampKind>>::
-      apply();
-  RegisterAllPairs<KindList<BooleanKind>, KindList<TimestampKind>>::apply();
-  RegisterAllPairs<IntegerKinds, KindList<BinaryKind>>::apply();
-  RegisterAllPairs<KindList<TimestampKind>, IntegerKinds>::apply();
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    using IntegerKinds =
+        KindList<TinyintKind, SmallintKind, IntegerKind, BigintKind>;
+    RegisterAllPairs<IntegerKinds, KindList<TimestampKind>>::apply();
+    RegisterAllPairs<KindList<RealKind, DoubleKind>, KindList<TimestampKind>>::
+        apply();
+    RegisterAllPairs<KindList<BooleanKind>, KindList<TimestampKind>>::apply();
+    RegisterAllPairs<IntegerKinds, KindList<BinaryKind>>::apply();
+    RegisterAllPairs<KindList<TimestampKind>, IntegerKinds>::apply();
+  }
 }
 
 void doCast(
@@ -1176,7 +1177,7 @@ void doCastArrayToVarchar(
   resultElements->addNulls(remainingRows->asRange().bits(), nestedRows);
 
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-  const bool legacyComplex = isInSpark &&
+  const bool legacyComplex = kIsInSpark &&
       (queryConfig.isSparkLegacyCastComplexTypesToStringEnabled() != "false");
   if (queryConfig.enableFlinkCompatible() &&
       arrayElements->type()->isTimestamp()) {
@@ -1309,7 +1310,7 @@ void doCastMapToVarchar(
   auto rawValues = resultValues->as<FlatVector<StringView>>()->rawValues();
 
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-  const bool legacyComplex = isInSpark &&
+  const bool legacyComplex = kIsInSpark &&
       (queryConfig.isSparkLegacyCastComplexTypesToStringEnabled() != "false");
   const bool isFlinkCompatible = queryConfig.enableFlinkCompatible();
 
@@ -1393,7 +1394,7 @@ void doCastRowToVarchar(
   }
 
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-  const bool legacyComplex = isInSpark &&
+  const bool legacyComplex = kIsInSpark &&
       (queryConfig.isSparkLegacyCastComplexTypesToStringEnabled() != "false");
 
   std::string_view leftBracket = legacyComplex ? "[" : "{";

--- a/bolt/expression/CastExpr.cpp
+++ b/bolt/expression/CastExpr.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/expression/CastExpr.h"
 
 #include <fmt/format.h>
@@ -45,6 +47,11 @@
 #include "bolt/vector/FunctionVector.h"
 #include "bolt/vector/SelectivityVector.h"
 namespace bytedance::bolt::exec {
+
+bool CastExpr::setNullInResultAtError() const {
+  // For Spark, set errors in nested values to null as well.
+  return nullOnFailure() && (::bytedance::bolt::kSparkCompatible || inTopLevel);
+}
 
 namespace {
 void propagateErrorsOrSetNulls(
@@ -166,15 +173,15 @@ VectorPtr CastExpr::applyMap(
       newMapKeys,
       newMapValues);
 
-#ifndef SPARK_COMPATIBLE
-  propagateErrorsOrSetNulls(
-      setNullInResultAtError(),
-      context,
-      nestedRows,
-      elementToTopLevelRows,
-      result,
-      oldErrors);
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    propagateErrorsOrSetNulls(
+        setNullInResultAtError(),
+        context,
+        nestedRows,
+        elementToTopLevelRows,
+        result,
+        oldErrors);
+  }
   // Restore original state.
   context.swapErrors(oldErrors);
   return result;
@@ -234,15 +241,15 @@ VectorPtr CastExpr::applyArray(
       sizes,
       newElements);
 
-#ifndef SPARK_COMPATIBLE
-  propagateErrorsOrSetNulls(
-      setNullInResultAtError(),
-      context,
-      nestedRows,
-      elementToTopLevelRows,
-      result,
-      oldErrors);
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    propagateErrorsOrSetNulls(
+        setNullInResultAtError(),
+        context,
+        nestedRows,
+        elementToTopLevelRows,
+        result,
+        oldErrors);
+  }
 
   // Restore original state.
   context.swapErrors(oldErrors);
@@ -343,20 +350,20 @@ VectorPtr CastExpr::applyRow(
       rows.end(),
       std::move(newChildren));
 
-#ifndef SPARK_COMPATIBLE
-  if (setNullInResultAtError()) {
-    // Set errors as nulls.
-    if (auto errors = context.errors()) {
-      rows.applyToSelected([&](auto row) {
-        if (errors->isIndexInRange(row) && !errors->isNullAt(row)) {
-          result->setNull(row, true);
-        }
-      });
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    if (setNullInResultAtError()) {
+      // Set errors as nulls.
+      if (auto errors = context.errors()) {
+        rows.applyToSelected([&](auto row) {
+          if (errors->isIndexInRange(row) && !errors->isNullAt(row)) {
+            result->setNull(row, true);
+          }
+        });
+      }
+      // Restore original state.
+      context.swapErrors(oldErrors);
     }
-    // Restore original state.
-    context.swapErrors(oldErrors);
   }
-#endif
 
   return result;
 }
@@ -420,15 +427,16 @@ void CastExpr::applyPeeled(
       applyCustomCast();
     }
   } else if (fromType->isPrimitiveType() || toType->isPrimitiveType()) {
-#ifdef SPARK_COMPATIBLE
-    CastUtils::CastErrorPolicy policy = nullOnFailure()
-        ? CastUtils::CastErrorPolicy::NullOnFailure
-        : CastUtils::CastErrorPolicy::SparkCastPolicy;
-#else
-    CastUtils::CastErrorPolicy policy = setNullInResultAtError()
-        ? CastUtils::CastErrorPolicy::NullOnFailure
-        : CastUtils::CastErrorPolicy::ThrowOnFailure;
-#endif
+    const auto policy = [&]() {
+      if constexpr (::bytedance::bolt::kSparkCompatible) {
+        return nullOnFailure() ? CastUtils::CastErrorPolicy::NullOnFailure
+                               : CastUtils::CastErrorPolicy::SparkCastPolicy;
+      } else {
+        return setNullInResultAtError()
+            ? CastUtils::CastErrorPolicy::NullOnFailure
+            : CastUtils::CastErrorPolicy::ThrowOnFailure;
+      }
+    }();
     CastUtils::doCast(rows, input, context, fromType, toType, result, policy);
   } else {
     switch (toType->kind()) {

--- a/bolt/expression/CastExpr.cpp
+++ b/bolt/expression/CastExpr.cpp
@@ -173,7 +173,7 @@ VectorPtr CastExpr::applyMap(
       newMapKeys,
       newMapValues);
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     propagateErrorsOrSetNulls(
         setNullInResultAtError(),
         context,
@@ -241,7 +241,7 @@ VectorPtr CastExpr::applyArray(
       sizes,
       newElements);
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     propagateErrorsOrSetNulls(
         setNullInResultAtError(),
         context,
@@ -350,19 +350,17 @@ VectorPtr CastExpr::applyRow(
       rows.end(),
       std::move(newChildren));
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    if (setNullInResultAtError()) {
-      // Set errors as nulls.
-      if (auto errors = context.errors()) {
-        rows.applyToSelected([&](auto row) {
-          if (errors->isIndexInRange(row) && !errors->isNullAt(row)) {
-            result->setNull(row, true);
-          }
-        });
-      }
-      // Restore original state.
-      context.swapErrors(oldErrors);
+  if (!::bytedance::bolt::kSparkCompatible && setNullInResultAtError()) {
+    // Set errors as nulls.
+    if (auto errors = context.errors()) {
+      rows.applyToSelected([&](auto row) {
+        if (errors->isIndexInRange(row) && !errors->isNullAt(row)) {
+          result->setNull(row, true);
+        }
+      });
     }
+    // Restore original state.
+    context.swapErrors(oldErrors);
   }
 
   return result;
@@ -427,16 +425,11 @@ void CastExpr::applyPeeled(
       applyCustomCast();
     }
   } else if (fromType->isPrimitiveType() || toType->isPrimitiveType()) {
-    const auto policy = [&]() {
-      if constexpr (::bytedance::bolt::kSparkCompatible) {
-        return nullOnFailure() ? CastUtils::CastErrorPolicy::NullOnFailure
-                               : CastUtils::CastErrorPolicy::SparkCastPolicy;
-      } else {
-        return setNullInResultAtError()
-            ? CastUtils::CastErrorPolicy::NullOnFailure
-            : CastUtils::CastErrorPolicy::ThrowOnFailure;
-      }
-    }();
+    const auto policy = setNullInResultAtError()
+        ? CastUtils::CastErrorPolicy::NullOnFailure
+        : (::bytedance::bolt::kSparkCompatible
+               ? CastUtils::CastErrorPolicy::SparkCastPolicy
+               : CastUtils::CastErrorPolicy::ThrowOnFailure);
     CastUtils::doCast(rows, input, context, fromType, toType, result, policy);
   } else {
     switch (toType->kind()) {

--- a/bolt/expression/CastExpr.h
+++ b/bolt/expression/CastExpr.h
@@ -171,14 +171,7 @@ class CastExpr : public SpecialForm {
     return nullOnFailure_;
   }
 
-  bool setNullInResultAtError() const {
-#ifndef SPARK_COMPATIBLE
-    return nullOnFailure() && inTopLevel;
-#else
-    // For spark, set inner as null, not on in the top level
-    return nullOnFailure();
-#endif
-  }
+  bool setNullInResultAtError() const;
 
   CastOperatorPtr getCastOperator(const TypePtr& type);
 

--- a/bolt/expression/fuzzer/DoubleToDecimalFuzzerTest.cpp
+++ b/bolt/expression/fuzzer/DoubleToDecimalFuzzerTest.cpp
@@ -52,8 +52,9 @@ int main(int argc, char** argv) {
     if ((uint64_t)to != decimalValue.low_bits() ||
         (int64_t)(to >> 64) != decimalValue.high_bits()) {
       char cached[64];
-      auto strSize =
-          bytedance::bolt::DecimalUtil::convertToString(to, scale, 64, cached);
+      auto strSize = bytedance::bolt::DecimalUtil::convertToString<
+          bytedance::bolt::DecimalUtil::DecimalStringFormat::kPlain>(
+          to, scale, 64, cached);
       std::cout << std::setprecision(50) << "Mismatch for value: " << d << "\n";
       std::cout << "Expected: " << decimalValue.ToString(scale) << "\n";
       std::cout << "Got: " << std::string_view(cached, strSize) << "\n";

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -419,17 +419,11 @@ TEST_F(CastExprTest, basics) {
       "string", {1, 2, 3, 100, -100}, {"1", "2", "3", "100", "-100"});
   testCast<std::string, int8_t>(
       "tinyint", {"1", "2", "3", "100", "-100"}, {1, 2, 3, 100, -100});
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    testCast<double, int>(
-        "int",
-        {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
-        {2, 3, 4, 100, -100, 1, -2});
-  } else {
-    testCast<double, int>(
-        "int",
-        {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
-        {1, 2, 3, 100, -100, 1, -2});
-  }
+  const auto expectedIntegers = ::bytedance::bolt::kSparkCompatible
+      ? std::vector<std::optional<int>>{1, 2, 3, 100, -100, 1, -2}
+      : std::vector<std::optional<int>>{2, 3, 4, 100, -100, 1, -2};
+  testCast<double, int>(
+      "int", {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0}, expectedIntegers);
 
   testCast<double, double>(
       "double",
@@ -596,93 +590,94 @@ TEST_F(CastExprTest, realAndDoubleToString) {
           "NaN",
       });
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    setLegacyCast(true);
-    testCast<double, std::string>(
-        "string",
-        {
-            12345678901234567000.0,
-            123456789.01234567,
-            10'000'000.0,
-            12345.0,
-            0.001,
-            0.00012,
-            0.0,
-            -0.0,
-            -0.00012,
-            -0.001,
-            -12345.0,
-            -10'000'000.0,
-            -123456789.01234567,
-            -12345678901234567000.0,
-            std::numeric_limits<double>::infinity(),
-            -std::numeric_limits<double>::infinity(),
-            std::numeric_limits<double>::quiet_NaN(),
-            -std::numeric_limits<double>::quiet_NaN(),
-        },
-        {
-            "12345678901234567000.0",
-            "123456789.01234567",
-            "10000000.0",
-            "12345.0",
-            "0.001",
-            "0.00012",
-            "0.0",
-            "-0.0",
-            "-0.00012",
-            "-0.001",
-            "-12345.0",
-            "-10000000.0",
-            "-123456789.01234567",
-            "-12345678901234567000.0",
-            "Infinity",
-            "-Infinity",
-            "NaN",
-            "NaN",
-        });
-    testCast<float, std::string>(
-        "string",
-        {
-            12345678000000000000.0,
-            123456780.0,
-            10'000'000.0,
-            12345.0,
-            0.001,
-            0.00012,
-            0.0,
-            -0.0,
-            -0.00012,
-            -0.001,
-            -12345.0,
-            -10'000'000.0,
-            -123456780.0,
-            -12345678000000000000.0,
-            std::numeric_limits<float>::infinity(),
-            -std::numeric_limits<float>::infinity(),
-            std::numeric_limits<float>::quiet_NaN(),
-            -std::numeric_limits<float>::quiet_NaN(),
-        },
-        {
-            "12345678295994466000.0",
-            "123456784.0",
-            "10000000.0",
-            "12345.0",
-            "0.0010000000474974513",
-            "0.00011999999696854502",
-            "0.0",
-            "-0.0",
-            "-0.00011999999696854502",
-            "-0.0010000000474974513",
-            "-12345.0",
-            "-10000000.0",
-            "-123456784.0",
-            "-12345678295994466000.0",
-            "Infinity",
-            "-Infinity",
-            "NaN",
-            "NaN",
-        });
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
   }
+  setLegacyCast(true);
+  testCast<double, std::string>(
+      "string",
+      {
+          12345678901234567000.0,
+          123456789.01234567,
+          10'000'000.0,
+          12345.0,
+          0.001,
+          0.00012,
+          0.0,
+          -0.0,
+          -0.00012,
+          -0.001,
+          -12345.0,
+          -10'000'000.0,
+          -123456789.01234567,
+          -12345678901234567000.0,
+          std::numeric_limits<double>::infinity(),
+          -std::numeric_limits<double>::infinity(),
+          std::numeric_limits<double>::quiet_NaN(),
+          -std::numeric_limits<double>::quiet_NaN(),
+      },
+      {
+          "12345678901234567000.0",
+          "123456789.01234567",
+          "10000000.0",
+          "12345.0",
+          "0.001",
+          "0.00012",
+          "0.0",
+          "-0.0",
+          "-0.00012",
+          "-0.001",
+          "-12345.0",
+          "-10000000.0",
+          "-123456789.01234567",
+          "-12345678901234567000.0",
+          "Infinity",
+          "-Infinity",
+          "NaN",
+          "NaN",
+      });
+  testCast<float, std::string>(
+      "string",
+      {
+          12345678000000000000.0,
+          123456780.0,
+          10'000'000.0,
+          12345.0,
+          0.001,
+          0.00012,
+          0.0,
+          -0.0,
+          -0.00012,
+          -0.001,
+          -12345.0,
+          -10'000'000.0,
+          -123456780.0,
+          -12345678000000000000.0,
+          std::numeric_limits<float>::infinity(),
+          -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::quiet_NaN(),
+          -std::numeric_limits<float>::quiet_NaN(),
+      },
+      {
+          "12345678295994466000.0",
+          "123456784.0",
+          "10000000.0",
+          "12345.0",
+          "0.0010000000474974513",
+          "0.00011999999696854502",
+          "0.0",
+          "-0.0",
+          "-0.00011999999696854502",
+          "-0.0010000000474974513",
+          "-12345.0",
+          "-10000000.0",
+          "-123456784.0",
+          "-12345678295994466000.0",
+          "Infinity",
+          "-Infinity",
+          "NaN",
+          "NaN",
+      });
 }
 
 TEST_F(CastExprTest, stringToDouble) {
@@ -759,7 +754,7 @@ TEST_F(CastExprTest, stringToTimestamp) {
       Timestamp(7200, 0),
   };
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     input.insert(
         input.end(),
         {"1970-01-01 05:30:01",
@@ -780,7 +775,7 @@ TEST_F(CastExprTest, stringToTimestamp) {
   input.push_back(std::nullopt);
   expected.push_back(std::nullopt);
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     std::vector<std::optional<std::string>> inputOutOfRange{
         "1970-01-32 00:00:00",
         "1970-01-01 00-00-00",
@@ -788,11 +783,6 @@ TEST_F(CastExprTest, stringToTimestamp) {
     };
     std::vector<std::optional<std::string>> inputEmptyString{
         "",
-    };
-    std::vector<std::optional<Timestamp>> expectedException{
-        std::nullopt,
-        std::nullopt,
-        std::nullopt,
     };
     testInvalidCast<std::string>("timestamp", inputOutOfRange, "");
     testInvalidCast<std::string>("timestamp", inputEmptyString, "");
@@ -802,7 +792,7 @@ TEST_F(CastExprTest, stringToTimestamp) {
 }
 
 TEST_F(CastExprTest, timestampToString) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   setLegacyCast(false);
@@ -861,7 +851,7 @@ TEST_F(CastExprTest, timestampToString) {
 }
 
 TEST_F(CastExprTest, timestampToStringFlinkCompatible) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   setLegacyCast(false);
@@ -907,7 +897,7 @@ TEST_F(CastExprTest, numericToTimestampSemantics) {
   });
 
   auto input = makeRowVector({makeFlatVector<int32_t>({1})});
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     auto result =
         evaluate<SimpleVector<Timestamp>>("cast(c0 as timestamp)", input);
     EXPECT_EQ(result->valueAt(0), Timestamp(1, 0));
@@ -954,7 +944,7 @@ TEST_F(CastExprTest, timestampToDate) {
 }
 
 TEST_F(CastExprTest, timestampInvalid) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   testUnsupportedCast<int8_t>(
@@ -978,7 +968,7 @@ TEST_F(CastExprTest, timestampInvalid) {
 }
 
 TEST_F(CastExprTest, timestampAdjustToTimezone) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   setTimezone("America/Los_Angeles");
@@ -1021,7 +1011,7 @@ TEST_F(CastExprTest, date) {
       "+1970-01-02"};
   std::vector<std::optional<int32_t>> expected{
       0, 18262, 60577, -5, -57604, -18262, 3789742, 1, 1, 1, 1};
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     input.push_back("-1-1-1");
     expected.push_back(-719893);
   }
@@ -1052,79 +1042,80 @@ TEST_F(CastExprTest, invalidDate) {
       "date", {12.99}, "Cast from DOUBLE to DATE is not supported", DOUBLE());
 
   // Parsing ill-formatted dates.
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    testInvalidCast<std::string>(
-        "date",
-        {"2012-Oct-23"},
-        "Unable to parse date value: \"2012-Oct-23\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03-18X"},
-        "Unable to parse date value: \"2015-03-18X\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015/03/18"},
-        "Unable to parse date value: \"2015/03/18\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015.03.18"},
-        "Unable to parse date value: \"2015.03.18\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"20150318"},
-        "Unable to parse date value: \"20150318\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-031-8"},
-        "Unable to parse date value: \"2015-031-8\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date", {"12345"}, "Unable to parse date value: \"12345\"", VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03"},
-        "Unable to parse date value: \"2015-03\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03-18 123412"},
-        "Unable to parse date value: \"2015-03-18 123412\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03-18T"},
-        "Unable to parse date value: \"2015-03-18T\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03-18T123412"},
-        "Unable to parse date value: \"2015-03-18T123412\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"2015-03-18 (BC)"},
-        "Unable to parse date value: \"2015-03-18 (BC)\"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {"1970-01-01 "},
-        "Unable to parse date value: \"1970-01-01 \"",
-        VARCHAR());
-    testInvalidCast<std::string>(
-        "date",
-        {" 1970-01-01 "},
-        "Unable to parse date value: \" 1970-01-01 \"",
-        VARCHAR());
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
   }
+  testInvalidCast<std::string>(
+      "date",
+      {"2012-Oct-23"},
+      "Unable to parse date value: \"2012-Oct-23\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18X"},
+      "Unable to parse date value: \"2015-03-18X\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015/03/18"},
+      "Unable to parse date value: \"2015/03/18\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015.03.18"},
+      "Unable to parse date value: \"2015.03.18\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"20150318"},
+      "Unable to parse date value: \"20150318\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-031-8"},
+      "Unable to parse date value: \"2015-031-8\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date", {"12345"}, "Unable to parse date value: \"12345\"", VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03"},
+      "Unable to parse date value: \"2015-03\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18 123412"},
+      "Unable to parse date value: \"2015-03-18 123412\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18T"},
+      "Unable to parse date value: \"2015-03-18T\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18T123412"},
+      "Unable to parse date value: \"2015-03-18T123412\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"2015-03-18 (BC)"},
+      "Unable to parse date value: \"2015-03-18 (BC)\"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {"1970-01-01 "},
+      "Unable to parse date value: \"1970-01-01 \"",
+      VARCHAR());
+  testInvalidCast<std::string>(
+      "date",
+      {" 1970-01-01 "},
+      "Unable to parse date value: \" 1970-01-01 \"",
+      VARCHAR());
 }
 
 TEST_F(CastExprTest, primitiveInvalidCornerCases) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // To integer.
@@ -1233,11 +1224,10 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
   {
     testCast<double, int8_t>("tinyint", {127.1}, {127});
     testCast<double, int64_t>("bigint", {12345.12}, {12345});
-    if constexpr (!::bytedance::bolt::kSparkCompatible) {
-      testCast<double, int64_t>("bigint", {12345.67}, {12346});
-    } else {
-      testCast<double, int64_t>("bigint", {12345.67}, {12345});
-    }
+    testCast<double, int64_t>(
+        "bigint",
+        {12345.67},
+        {::bytedance::bolt::kSparkCompatible ? 12345 : 12346});
     testCast<std::string, int8_t>("tinyint", {"+1"}, {1});
   }
 
@@ -1286,16 +1276,14 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
 
 TEST_F(CastExprTest, truncateVsRound) {
   // Testing round cast from double to int.
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    testCast<double, int>(
-        "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
-  } else {
-    testCast<double, int>(
-        "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {1, 2, 3, 100, -100});
-  }
+  const auto expectedIntegers = ::bytedance::bolt::kSparkCompatible
+      ? std::vector<std::optional<int>>{1, 2, 3, 100, -100}
+      : std::vector<std::optional<int>>{2, 3, 4, 100, -100};
+  testCast<double, int>(
+      "int", {1.888, 2.5, 3.6, 100.44, -100.101}, expectedIntegers);
   testCast<int8_t, int32_t>("int", {111, 2, 3, 10, -10}, {111, 2, 3, 10, -10});
   testCast<int32_t, int8_t>("tinyint", {2, 3}, {2, 3});
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     testInvalidCast<int32_t>(
         "tinyint",
         {1111111, 1000, -100101},
@@ -1364,7 +1352,7 @@ TEST_F(CastExprTest, errorHandling) {
        127,
        -128});
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     testCast<double, int>(
         "integer",
         {1e12, 2.5, 3.6, 100.44, -100.101},
@@ -1386,7 +1374,7 @@ TEST_F(CastExprTest, errorHandling) {
         {std::nullopt, 2, 3, 100, -100});
   }
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     setCastIntByTruncate(false);
     testCast<double, int>(
         "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
@@ -1405,7 +1393,7 @@ TEST_F(CastExprTest, errorHandling) {
 
 TEST_F(CastExprTest, allowDecimal) {
   setCastIntByTruncate(true);
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     testCast<std::string, int32_t>(
         "int",
         {"-.", "0.0", "125.5", "-128.3", "3.61335e+9"},
@@ -1493,7 +1481,7 @@ TEST_F(CastExprTest, mapCast) {
 
   // Nulls in result keys are not allowed.
   {
-    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    if (!::bytedance::bolt::kSparkCompatible) {
       BOLT_ASSERT_THROW(
           testCast(
               inputMap,
@@ -1559,33 +1547,34 @@ TEST_F(CastExprTest, mapCast) {
     }
   }
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    // Error handling.
-    {
-      auto data = makeRowVector(
-          {makeMapVector<StringView, StringView>({{{"1", "2"}}, {{"", "1"}}})});
-      auto copy = createCopy(data);
-      auto result1 = evaluate("try_cast(c0 as map(int, int))", data);
-      auto result2 = evaluate("try(cast(c0 as map(int, int)))", data);
-      ASSERT_FALSE(result1->isNullAt(0));
-      ASSERT_TRUE(result1->isNullAt(1));
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
+  }
+  // Error handling.
+  {
+    auto data = makeRowVector(
+        {makeMapVector<StringView, StringView>({{{"1", "2"}}, {{"", "1"}}})});
+    auto copy = createCopy(data);
+    auto result1 = evaluate("try_cast(c0 as map(int, int))", data);
+    auto result2 = evaluate("try(cast(c0 as map(int, int)))", data);
+    ASSERT_FALSE(result1->isNullAt(0));
+    ASSERT_TRUE(result1->isNullAt(1));
 
-      ASSERT_FALSE(result2->isNullAt(0));
-      ASSERT_TRUE(result2->isNullAt(1));
-      ASSERT_THROW(evaluate("cast(c0 as map(int, int)", data), BoltException);
+    ASSERT_FALSE(result2->isNullAt(0));
+    ASSERT_TRUE(result2->isNullAt(1));
+    ASSERT_THROW(evaluate("cast(c0 as map(int, int)", data), BoltException);
 
-      // Make sure the input vector does not change.
-      assertEqualVectors(data, copy);
-    }
+    // Make sure the input vector does not change.
+    assertEqualVectors(data, copy);
+  }
 
-    {
-      auto result = evaluate(
-          "try_cast(map(array_constructor('1'), array_constructor(''))  as map(int, int))",
-          makeRowVector({makeFlatVector<int32_t>({1, 2})}));
+  {
+    auto result = evaluate(
+        "try_cast(map(array_constructor('1'), array_constructor(''))  as map(int, int))",
+        makeRowVector({makeFlatVector<int32_t>({1, 2})}));
 
-      ASSERT_TRUE(result->isNullAt(0));
-      ASSERT_TRUE(result->isNullAt(1));
-    }
+    ASSERT_TRUE(result->isNullAt(0));
+    ASSERT_TRUE(result->isNullAt(1));
   }
 }
 
@@ -1648,39 +1637,39 @@ TEST_F(CastExprTest, arrayCast) {
     }
   }
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    // Error handling.
-    {
-      auto data =
-          makeRowVector({makeArrayVector<StringView>({{"1", "2"}, {"", "1"}})});
-      auto copy = createCopy(data);
-      auto result1 = evaluate("try_cast(c0 as bigint[])", data);
-      auto result2 = evaluate("try(cast(c0 as bigint[]))", data);
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
+  }
+  // Error handling.
+  {
+    auto data =
+        makeRowVector({makeArrayVector<StringView>({{"1", "2"}, {"", "1"}})});
+    auto copy = createCopy(data);
+    auto result1 = evaluate("try_cast(c0 as bigint[])", data);
+    auto result2 = evaluate("try(cast(c0 as bigint[]))", data);
 
-      auto expected =
-          makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt});
+    auto expected = makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt});
 
-      assertEqualVectors(result1, expected);
-      assertEqualVectors(result2, expected);
+    assertEqualVectors(result1, expected);
+    assertEqualVectors(result2, expected);
 
-      ASSERT_THROW(evaluate("cast(c0 as bigint[])", data), BoltException);
+    ASSERT_THROW(evaluate("cast(c0 as bigint[])", data), BoltException);
 
-      // Make sure the input vector does not change.
-      assertEqualVectors(data, copy);
-    }
+    // Make sure the input vector does not change.
+    assertEqualVectors(data, copy);
+  }
 
-    {
-      auto data = makeNullableNestedArrayVector<StringView>({
-          {{{{"1"_sv, "2"_sv}}, {{""_sv}}}}, // row0
-          {{{{std::nullopt, "4"_sv}}}}, // row1
-      });
-      auto expected = makeNullableNestedArrayVector<int64_t>({
-          std::nullopt, // row0
-          {{{{std::nullopt, 4}}}}, // row1
+  {
+    auto data = makeNullableNestedArrayVector<StringView>({
+        {{{{"1"_sv, "2"_sv}}, {{""_sv}}}}, // row0
+        {{{{std::nullopt, "4"_sv}}}}, // row1
+    });
+    auto expected = makeNullableNestedArrayVector<int64_t>({
+        std::nullopt, // row0
+        {{{{std::nullopt, 4}}}}, // row1
 
-      });
-      testCast(data, expected, true);
-    }
+    });
+    testCast(data, expected, true);
   }
 }
 
@@ -1733,58 +1722,59 @@ TEST_F(CastExprTest, rowCast) {
     testCast(rowVector, expectedRowVector);
   }
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    // Error handling.
-    {
-      auto data = makeRowVector(
-          {makeFlatVector<StringView>({"1", ""}),
-           makeFlatVector<StringView>({"2", "3"})});
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
+  }
+  // Error handling.
+  {
+    auto data = makeRowVector(
+        {makeFlatVector<StringView>({"1", ""}),
+         makeFlatVector<StringView>({"2", "3"})});
 
-      auto expected = makeRowVector(
-          {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int32_t>({2, 3})});
-      expected->setNull(1, true);
+    auto expected = makeRowVector(
+        {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int32_t>({2, 3})});
+    expected->setNull(1, true);
 
-      testCast(data, expected, true);
-    }
+    testCast(data, expected, true);
+  }
 
-    {
-      auto data = makeRowVector(
-          {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
-           makeFlatVector<StringView>({"2", ""})});
+  {
+    auto data = makeRowVector(
+        {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
+         makeFlatVector<StringView>({"2", ""})});
 
-      // expected1 is [null, struct{[3,4], ""}]
-      auto expected1 = makeRowVector(
-          {makeArrayVector<int32_t>({{1 /*will be null*/}, {3, 4}}),
-           makeFlatVector<StringView>({"2" /*will be null*/, ""})});
-      expected1->setNull(0, true);
+    // expected1 is [null, struct{[3,4], ""}]
+    auto expected1 = makeRowVector(
+        {makeArrayVector<int32_t>({{1 /*will be null*/}, {3, 4}}),
+         makeFlatVector<StringView>({"2" /*will be null*/, ""})});
+    expected1->setNull(0, true);
 
-      // expected2 is [struct{["1",""], 2}, null]
-      auto expected2 = makeRowVector(
-          {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
-           makeFlatVector<int32_t>({2, 0 /*null*/})});
-      expected2->setNull(1, true);
+    // expected2 is [struct{["1",""], 2}, null]
+    auto expected2 = makeRowVector(
+        {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
+         makeFlatVector<int32_t>({2, 0 /*null*/})});
+    expected2->setNull(1, true);
 
-      // expected3 is [null, null]
-      auto expected3 = makeRowVector(
-          {makeArrayVector<int32_t>({{1}}), makeFlatVector<int32_t>(1)});
-      expected3->resize(2);
-      expected3->setNull(0, true);
-      expected3->setNull(1, true);
+    // expected3 is [null, null]
+    auto expected3 = makeRowVector(
+        {makeArrayVector<int32_t>({{1}}), makeFlatVector<int32_t>(1)});
+    expected3->resize(2);
+    expected3->setNull(0, true);
+    expected3->setNull(1, true);
 
-      testCast(data, expected1, true);
-      testCast(data, expected2, true);
-      testCast(data, expected3, true);
-    }
+    testCast(data, expected1, true);
+    testCast(data, expected2, true);
+    testCast(data, expected3, true);
+  }
 
-    // Null handling for nested structs.
-    {
-      auto data = makeRowVector(
-          {makeRowVector({makeFlatVector<StringView>({"1", ""})})});
-      auto expected =
-          makeRowVector({makeRowVector({makeFlatVector<int32_t>({1, 0})})});
-      expected->setNull(1, true);
-      testCast(data, expected, true);
-    }
+  // Null handling for nested structs.
+  {
+    auto data =
+        makeRowVector({makeRowVector({makeFlatVector<StringView>({"1", ""})})});
+    auto expected =
+        makeRowVector({makeRowVector({makeFlatVector<int32_t>({1, 0})})});
+    expected->setNull(1, true);
+    testCast(data, expected, true);
   }
 }
 
@@ -1814,7 +1804,7 @@ TEST_F(CastExprTest, testNullOnFailure) {
   // nullOnFailure is true, so we should return null instead of throwing.
   testCast(input, tryExpected, true);
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     testCast(input, expected, false);
   } else {
     // nullOnFailure is false, so we should throw.
@@ -1834,7 +1824,7 @@ TEST_F(CastExprTest, toString) {
 
 // this test case also run in SparkCastExprTest
 TEST_F(CastExprTest, decimalToIntegral) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   testDecimalToIntegralCasts<int64_t>();
@@ -1844,7 +1834,7 @@ TEST_F(CastExprTest, decimalToIntegral) {
 }
 
 TEST_F(CastExprTest, decimalToIntegralOutOfBounds) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   testDecimalToIntegralCastsOutOfBounds<TypeKind::INTEGER>();
@@ -1853,7 +1843,7 @@ TEST_F(CastExprTest, decimalToIntegralOutOfBounds) {
 }
 
 TEST_F(CastExprTest, decimalToIntegralOutOfBoundsSetNullOnFailure) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   testDecimalToIntegralCastsOutOfBoundsSetNullOnFailure<TypeKind::INTEGER>();
@@ -1867,9 +1857,10 @@ TEST_F(CastExprTest, decimalToFloat) {
 }
 
 TEST_F(CastExprTest, decimalToFloatDiff) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    testDecimalToFloatCastsDiff<float>();
+  if (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
   }
+  testDecimalToFloatCastsDiff<float>();
 }
 
 TEST_F(CastExprTest, decimalToBool) {
@@ -1906,28 +1897,16 @@ TEST_F(CastExprTest, decimalToVarchar) {
        DecimalUtil::kShortDecimalMax,
        std::nullopt},
       DECIMAL(18, 18));
-  const auto expectedShortFlat = [&]() {
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
-      return makeNullableFlatVector<StringView>(
-          {"-0.999999999999999999",
-           "-3E-18",
-           "0E-18",
-           "5.5E-17",
-           "0.999999999999999999",
-           std::nullopt});
-    } else {
-      return makeNullableFlatVector<StringView>(
-          {"-0.999999999999999999",
-           "-0.000000000000000003",
-           "0.000000000000000000",
-           "0.000000000000000055",
-           "0.999999999999999999",
-           std::nullopt});
-    }
-  }();
+  const auto expectedShortFlat = makeNullableFlatVector<StringView>(
+      {"-0.999999999999999999",
+       ::bytedance::bolt::kSparkCompatible ? "-3E-18" : "-0.000000000000000003",
+       ::bytedance::bolt::kSparkCompatible ? "0E-18" : "0.000000000000000000",
+       ::bytedance::bolt::kSparkCompatible ? "5.5E-17" : "0.000000000000000055",
+       "0.999999999999999999",
+       std::nullopt});
   testCast(shortFlat, expectedShortFlat);
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     auto shortFlatForScientific = makeNullableFlatVector<int64_t>(
         {DecimalUtil::kShortDecimalMin,
          -3,
@@ -1964,7 +1943,7 @@ TEST_F(CastExprTest, decimalToVarchar) {
            "-0.00001",
            "12089258196146291747.06175",
            std::nullopt}));
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     auto longFlatForScientific = makeNullableFlatVector<int128_t>(
         {DecimalUtil::kLongDecimalMin,
          0,
@@ -2092,7 +2071,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
 }
 
 TEST_F(CastExprTest, integerToBinary) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   testInvalidCast<int8_t>(
@@ -2263,237 +2242,241 @@ TEST_F(CastExprTest, varcharToDecimal) {
           {StringView(fractionRoundDown), StringView(fractionRoundDownExp)}),
       makeConstant<int128_t>(DecimalUtil::kLongDecimalMax, 2, DECIMAL(38, 38)));
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    // Overflows when parsing whole digits.
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {std::string(280, '9')},
-        fmt::format(
-            "Cannot cast VARCHAR '{}' to DECIMAL(38, 0). Value too large.",
-            std::string(280, '9')));
-
-    // Overflows when parsing fractional digits.
-    const std::string fractionOverflow = std::string(36, '9') + '.' + "23456";
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 10),
-        {fractionOverflow},
-        fmt::format(
-            "Cannot cast VARCHAR '{}' to DECIMAL(38, 10). Value too large.",
-            fractionOverflow));
-
-    const std::string fractionRoundUp = "0." + std::string(38, '9') + "6";
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 38),
-        {fractionRoundUp},
-        fmt::format(
-            "Cannot cast VARCHAR '{}' to DECIMAL(38, 38). Value too large.",
-            fractionRoundUp));
-
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {"0.0444a"},
-        "Cannot cast VARCHAR '0.0444a' to DECIMAL(38, 0). Value is not a number. Chars 'a' are invalid.");
-
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {""},
-        "Cannot cast VARCHAR '' to DECIMAL(38, 0). Value is not a number. Input is empty.");
-
-    // Exponent > LongDecimalType::kMaxPrecision.
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {"1.23e67"},
-        "Cannot cast VARCHAR '1.23e67' to DECIMAL(38, 0). Value too large.");
-
-    // Forcing the scale to be zero overflows.
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {"20908.23e35"},
-        "Cannot cast VARCHAR '20908.23e35' to DECIMAL(38, 0). Value too large.");
-
-    // Rescale overflows.
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 38),
-        {"111111111111111111.23"},
-        "Cannot cast VARCHAR '111111111111111111.23' to DECIMAL(38, 38). Value too large.");
-
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {"23e-5d"},
-        "Cannot cast VARCHAR '23e-5d' to DECIMAL(38, 0). Value is not a number. Non-digit character 'd' is not allowed in the exponent part.");
-
-    // Whitespaces.
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {"1. 23"},
-        "Cannot cast VARCHAR '1. 23' to DECIMAL(38, 0). Value is not a number. Chars ' 23' are invalid.");
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(12, 2),
-        {"-3E+ 2"},
-        "Cannot cast VARCHAR '-3E+ 2' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {"1.23 "},
-        "Cannot cast VARCHAR '1.23 ' to DECIMAL(38, 0). Value is not a number. Chars ' ' are invalid.");
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(12, 2),
-        {"-3E+2 "},
-        "Cannot cast VARCHAR '-3E+2 ' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(38, 0),
-        {" 1.23"},
-        "Cannot cast VARCHAR ' 1.23' to DECIMAL(38, 0). Value is not a number. Extracted digits are empty.");
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(12, 2),
-        {" -3E+2"},
-        "Cannot cast VARCHAR ' -3E+2' to DECIMAL(12, 2). Value is not a number. Extracted digits are empty.");
-
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(12, 2),
-        {"-3E+2.1"},
-        "Cannot cast VARCHAR '-3E+2.1' to DECIMAL(12, 2). Value is not a number. Non-digit character '.' is not allowed in the exponent part.");
-
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(12, 2),
-        {"-3E+"},
-        "Cannot cast VARCHAR '-3E+' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
-
-    testThrow<std::string>(
-        VARCHAR(),
-        DECIMAL(12, 2),
-        {"-3E-"},
-        "Cannot cast VARCHAR '-3E-' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
   }
+  // Overflows when parsing whole digits.
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {std::string(280, '9')},
+      fmt::format(
+          "Cannot cast VARCHAR '{}' to DECIMAL(38, 0). Value too large.",
+          std::string(280, '9')));
+
+  // Overflows when parsing fractional digits.
+  const std::string fractionOverflow = std::string(36, '9') + '.' + "23456";
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 10),
+      {fractionOverflow},
+      fmt::format(
+          "Cannot cast VARCHAR '{}' to DECIMAL(38, 10). Value too large.",
+          fractionOverflow));
+
+  const std::string fractionRoundUp = "0." + std::string(38, '9') + "6";
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 38),
+      {fractionRoundUp},
+      fmt::format(
+          "Cannot cast VARCHAR '{}' to DECIMAL(38, 38). Value too large.",
+          fractionRoundUp));
+
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {"0.0444a"},
+      "Cannot cast VARCHAR '0.0444a' to DECIMAL(38, 0). Value is not a number. Chars 'a' are invalid.");
+
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {""},
+      "Cannot cast VARCHAR '' to DECIMAL(38, 0). Value is not a number. Input is empty.");
+
+  // Exponent > LongDecimalType::kMaxPrecision.
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {"1.23e67"},
+      "Cannot cast VARCHAR '1.23e67' to DECIMAL(38, 0). Value too large.");
+
+  // Forcing the scale to be zero overflows.
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {"20908.23e35"},
+      "Cannot cast VARCHAR '20908.23e35' to DECIMAL(38, 0). Value too large.");
+
+  // Rescale overflows.
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 38),
+      {"111111111111111111.23"},
+      "Cannot cast VARCHAR '111111111111111111.23' to DECIMAL(38, 38). Value too large.");
+
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {"23e-5d"},
+      "Cannot cast VARCHAR '23e-5d' to DECIMAL(38, 0). Value is not a number. Non-digit character 'd' is not allowed in the exponent part.");
+
+  // Whitespaces.
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {"1. 23"},
+      "Cannot cast VARCHAR '1. 23' to DECIMAL(38, 0). Value is not a number. Chars ' 23' are invalid.");
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(12, 2),
+      {"-3E+ 2"},
+      "Cannot cast VARCHAR '-3E+ 2' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {"1.23 "},
+      "Cannot cast VARCHAR '1.23 ' to DECIMAL(38, 0). Value is not a number. Chars ' ' are invalid.");
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(12, 2),
+      {"-3E+2 "},
+      "Cannot cast VARCHAR '-3E+2 ' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(38, 0),
+      {" 1.23"},
+      "Cannot cast VARCHAR ' 1.23' to DECIMAL(38, 0). Value is not a number. Extracted digits are empty.");
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(12, 2),
+      {" -3E+2"},
+      "Cannot cast VARCHAR ' -3E+2' to DECIMAL(12, 2). Value is not a number. Extracted digits are empty.");
+
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(12, 2),
+      {"-3E+2.1"},
+      "Cannot cast VARCHAR '-3E+2.1' to DECIMAL(12, 2). Value is not a number. Non-digit character '.' is not allowed in the exponent part.");
+
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(12, 2),
+      {"-3E+"},
+      "Cannot cast VARCHAR '-3E+' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
+
+  testThrow<std::string>(
+      VARCHAR(),
+      DECIMAL(12, 2),
+      {"-3E-"},
+      "Cannot cast VARCHAR '-3E-' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
 }
 
 TEST_F(CastExprTest, castArrayError) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    auto arrayVector = makeNullableArrayVector<StringView>(
-        {{{"1"_sv, ""_sv, "3"_sv, "4"_sv}},
-         // {{"5a"_sv}},  // it is ok, but it is disabled due to the UT
-         // framework issue
-         emptyArray,
-         {{"6"_sv, "7"_sv}},
-         std::nullopt});
-    auto input = makeRowVector({arrayVector});
-    auto expected = makeNullableArrayVector<int64_t>(
-        {{{1, std::nullopt, 3, 4}},
-         // {{std::nullopt}},  UT framework issue.
-         emptyArray,
-         {{6, 7}},
-         std::nullopt});
-
-    auto castExpr = buildCastExprWithDictionaryInput(
-        ARRAY(VARCHAR()), ARRAY(BIGINT()), true);
-
-    auto result = evaluate(castExpr, input);
-
-    //   for (auto i = 0; i < arrayVector->size(); i++) {
-    //     std::cout << "Input:\t" << input->toString(i) << std::endl;
-    //     std::cout << "Result:\t" << result->toString(arrayVector->size() - 1
-    //     - i)
-    //               << std::endl;
-    //     std::cout << "Expected:\t" << expected->toString(i) << std::endl;
-    //   }
-    auto indices = test::makeIndicesInReverse(expected->size(), pool());
-    assertEqualVectors(wrapInDictionary(indices, expected), result);
+  if (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
   }
+  auto arrayVector = makeNullableArrayVector<StringView>(
+      {{{"1"_sv, ""_sv, "3"_sv, "4"_sv}},
+       // {{"5a"_sv}},  // it is ok, but it is disabled due to the UT
+       // framework issue
+       emptyArray,
+       {{"6"_sv, "7"_sv}},
+       std::nullopt});
+  auto input = makeRowVector({arrayVector});
+  auto expected = makeNullableArrayVector<int64_t>(
+      {{{1, std::nullopt, 3, 4}},
+       // {{std::nullopt}},  UT framework issue.
+       emptyArray,
+       {{6, 7}},
+       std::nullopt});
+
+  auto castExpr =
+      buildCastExprWithDictionaryInput(ARRAY(VARCHAR()), ARRAY(BIGINT()), true);
+
+  auto result = evaluate(castExpr, input);
+
+  //   for (auto i = 0; i < arrayVector->size(); i++) {
+  //     std::cout << "Input:\t" << input->toString(i) << std::endl;
+  //     std::cout << "Result:\t" << result->toString(arrayVector->size() - 1
+  //     - i)
+  //               << std::endl;
+  //     std::cout << "Expected:\t" << expected->toString(i) << std::endl;
+  //   }
+  auto indices = test::makeIndicesInReverse(expected->size(), pool());
+  assertEqualVectors(wrapInDictionary(indices, expected), result);
 }
 
 TEST_F(CastExprTest, castMapError) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    auto mapVector = makeNullableMapVector<int32_t, StringView>({
-        std::nullopt,
-        {{{1, std::nullopt}}},
-        {{{2, "2.05"_sv}}},
-        {{{3, "abc"_sv}}},
-        std::nullopt,
-        {{{5, "5.05"}}},
-        {{{6, std::nullopt}}},
-        {{{7, "7.05"}}},
-        std::nullopt,
-        {{{9, ""}}},
-    });
-
-    auto expected = makeNullableMapVector<int32_t, double>({
-        std::nullopt,
-        {{{1, std::nullopt}}},
-        {{{2, 2.05}}},
-        {{{3, std::nullopt}}},
-        std::nullopt,
-        {{{5, 5.05}}},
-        {{{6, std::nullopt}}},
-        {{{7, 7.05}}},
-        std::nullopt,
-        {{{9, std::nullopt}}},
-    });
-
-    auto castExpr = buildCastExprWithDictionaryInput(
-        MAP(INTEGER(), VARCHAR()), MAP(INTEGER(), DOUBLE()), true);
-
-    auto input = makeRowVector({mapVector});
-    auto result = evaluate(castExpr, input);
-
-    //   for (auto i = 0; i < result->size(); i++) {
-    //     std::cout << "Result:\t" << result->toString(i) << std::endl;
-    //   }
-
-    auto indices = test::makeIndicesInReverse(expected->size(), pool());
-    assertEqualVectors(wrapInDictionary(indices, expected), result);
+  if (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
   }
+  auto mapVector = makeNullableMapVector<int32_t, StringView>({
+      std::nullopt,
+      {{{1, std::nullopt}}},
+      {{{2, "2.05"_sv}}},
+      {{{3, "abc"_sv}}},
+      std::nullopt,
+      {{{5, "5.05"}}},
+      {{{6, std::nullopt}}},
+      {{{7, "7.05"}}},
+      std::nullopt,
+      {{{9, ""}}},
+  });
+
+  auto expected = makeNullableMapVector<int32_t, double>({
+      std::nullopt,
+      {{{1, std::nullopt}}},
+      {{{2, 2.05}}},
+      {{{3, std::nullopt}}},
+      std::nullopt,
+      {{{5, 5.05}}},
+      {{{6, std::nullopt}}},
+      {{{7, 7.05}}},
+      std::nullopt,
+      {{{9, std::nullopt}}},
+  });
+
+  auto castExpr = buildCastExprWithDictionaryInput(
+      MAP(INTEGER(), VARCHAR()), MAP(INTEGER(), DOUBLE()), true);
+
+  auto input = makeRowVector({mapVector});
+  auto result = evaluate(castExpr, input);
+
+  //   for (auto i = 0; i < result->size(); i++) {
+  //     std::cout << "Result:\t" << result->toString(i) << std::endl;
+  //   }
+
+  auto indices = test::makeIndicesInReverse(expected->size(), pool());
+  assertEqualVectors(wrapInDictionary(indices, expected), result);
 }
 
 TEST_F(CastExprTest, castStructOnError) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    auto rowVector = makeRowVector(
-        {makeNullableFlatVector<StringView>(
-             {"1.23", std::nullopt, "", "abc"}, VARCHAR()),
-         makeNullableFlatVector<StringView>(
-             {"1", std::nullopt, "2a", ""}, VARCHAR())});
-
-    auto expected = makeRowVector(
-        {makeNullableFlatVector<double>(
-             {1.23, std::nullopt, std::nullopt, std::nullopt}, DOUBLE()),
-         makeNullableFlatVector<int32_t>(
-             {
-                 1,
-                 std::nullopt,
-                 std::nullopt,
-                 std::nullopt,
-             },
-             INTEGER())});
-
-    auto castExpr = buildCastExprWithDictionaryInput(
-        ROW({{"c0", VARCHAR()}, {"c1", VARCHAR()}}),
-        ROW({{"c0", DOUBLE()}, {"c1", INTEGER()}}),
-        true);
-
-    auto input = makeRowVector({rowVector});
-    auto result = evaluate(castExpr, input);
-    auto indices = test::makeIndicesInReverse(expected->size(), pool());
-    assertEqualVectors(wrapInDictionary(indices, expected), result);
+  if (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
   }
+  auto rowVector = makeRowVector(
+      {makeNullableFlatVector<StringView>(
+           {"1.23", std::nullopt, "", "abc"}, VARCHAR()),
+       makeNullableFlatVector<StringView>(
+           {"1", std::nullopt, "2a", ""}, VARCHAR())});
+
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<double>(
+           {1.23, std::nullopt, std::nullopt, std::nullopt}, DOUBLE()),
+       makeNullableFlatVector<int32_t>(
+           {
+               1,
+               std::nullopt,
+               std::nullopt,
+               std::nullopt,
+           },
+           INTEGER())});
+
+  auto castExpr = buildCastExprWithDictionaryInput(
+      ROW({{"c0", VARCHAR()}, {"c1", VARCHAR()}}),
+      ROW({{"c0", DOUBLE()}, {"c1", INTEGER()}}),
+      true);
+
+  auto input = makeRowVector({rowVector});
+  auto result = evaluate(castExpr, input);
+  auto indices = test::makeIndicesInReverse(expected->size(), pool());
+  assertEqualVectors(wrapInDictionary(indices, expected), result);
 }
 
 TEST_F(CastExprTest, castInTry) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Test try(cast(array(varchar) as array(bigint))) whose input vector is
@@ -2838,26 +2821,22 @@ TEST_F(CastExprTest, complexTypeToString) {
             {123456789, -333333333, std::nullopt, 0}, DECIMAL(9, 2)),
     });
 
-    if constexpr (!::bytedance::bolt::kSparkCompatible) {
-      testCast(
-          rowVector,
-          makeFlatVector<StringView>(
-              {"{null, 2000-01-01 00:00:00.000, 1234567.89}",
-               "{first time, null, -3333333.33}",
-               "{1.1380000, 2269-12-29 00:00:00.000, null}",
-               "{last time, 4969-12-04 00:00:00.000, 0.00}"}));
-    } else {
-      testCast(
-          rowVector,
-          makeFlatVector<StringView>(
-              {"{null, 2000-01-01 00:00:00, 1234567.89}",
-               "{first time, null, -3333333.33}",
-               "{1.1380000, 2269-12-29 00:00:00, null}",
-               "{last time, 4969-12-04 00:00:00, 0.00}"}));
-    }
+    testCast(
+        rowVector,
+        makeFlatVector<StringView>(
+            {::bytedance::bolt::kSparkCompatible
+                 ? "{null, 2000-01-01 00:00:00, 1234567.89}"
+                 : "{null, 2000-01-01 00:00:00.000, 1234567.89}",
+             "{first time, null, -3333333.33}",
+             ::bytedance::bolt::kSparkCompatible
+                 ? "{1.1380000, 2269-12-29 00:00:00, null}"
+                 : "{1.1380000, 2269-12-29 00:00:00.000, null}",
+             ::bytedance::bolt::kSparkCompatible
+                 ? "{last time, 4969-12-04 00:00:00, 0.00}"
+                 : "{last time, 4969-12-04 00:00:00.000, 0.00}"}));
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     // legacy map / struct
     {
       setLegacyCastComplexTypeToString(true);
@@ -3194,7 +3173,7 @@ TEST_F(CastExprTest, complexTypeToString) {
          mapOfRow,
          rowNested});
     const auto expected = [&]() {
-      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      if (!::bytedance::bolt::kSparkCompatible) {
         return makeFlatVector<StringView>(
             {"{[null, [1, 100, 2]], [], [], {3 -> [4, 5, 6, 1, 2]}, {1 -> {2 -> 3, 4 -> 5}}, {1 -> {2, 3}, 3 -> {4, 5}}, {{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00.000, 1234567.89}}}",
              "{[[1, 100, 2], [315]], [{1 -> 11, 3 -> 10}, {0 -> 10, 2 -> 11}, {1 -> 11, 1 -> 10}], [null, null], {5 -> [4, null, 1, 2]}, {0 -> {2 -> 3, 4 -> 5}}, {0 -> {2, 3}, 3 -> {null, null}}, {{3 -> 30, 4 -> 40, 9 -> 90}, [2, 3, 4], {null, -3333333.33}}}",
@@ -3492,7 +3471,7 @@ TEST_F(CastExprTest, smallerNonNullRowsSizeThanRows) {
 
 TEST_F(CastExprTest, tryCastDoesNotHideInputsAndExistingErrors) {
   auto testInvalid = [](std::function<void()> func) {
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       ASSERT_NO_THROW(func());
     } else {
       ASSERT_THROW(func(), BoltException);

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <limits>
 #include "bolt/buffer/Buffer.h"
 #include "bolt/common/base/BoltException.h"
@@ -417,17 +419,17 @@ TEST_F(CastExprTest, basics) {
       "string", {1, 2, 3, 100, -100}, {"1", "2", "3", "100", "-100"});
   testCast<std::string, int8_t>(
       "tinyint", {"1", "2", "3", "100", "-100"}, {1, 2, 3, 100, -100});
-#ifndef SPARK_COMPATIBLE
-  testCast<double, int>(
-      "int",
-      {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
-      {2, 3, 4, 100, -100, 1, -2});
-#else
-  testCast<double, int>(
-      "int",
-      {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
-      {1, 2, 3, 100, -100, 1, -2});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    testCast<double, int>(
+        "int",
+        {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
+        {2, 3, 4, 100, -100, 1, -2});
+  } else {
+    testCast<double, int>(
+        "int",
+        {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
+        {1, 2, 3, 100, -100, 1, -2});
+  }
 
   testCast<double, double>(
       "double",
@@ -594,93 +596,93 @@ TEST_F(CastExprTest, realAndDoubleToString) {
           "NaN",
       });
 
-#ifndef SPARK_COMPATIBLE
-  setLegacyCast(true);
-  testCast<double, std::string>(
-      "string",
-      {
-          12345678901234567000.0,
-          123456789.01234567,
-          10'000'000.0,
-          12345.0,
-          0.001,
-          0.00012,
-          0.0,
-          -0.0,
-          -0.00012,
-          -0.001,
-          -12345.0,
-          -10'000'000.0,
-          -123456789.01234567,
-          -12345678901234567000.0,
-          std::numeric_limits<double>::infinity(),
-          -std::numeric_limits<double>::infinity(),
-          std::numeric_limits<double>::quiet_NaN(),
-          -std::numeric_limits<double>::quiet_NaN(),
-      },
-      {
-          "12345678901234567000.0",
-          "123456789.01234567",
-          "10000000.0",
-          "12345.0",
-          "0.001",
-          "0.00012",
-          "0.0",
-          "-0.0",
-          "-0.00012",
-          "-0.001",
-          "-12345.0",
-          "-10000000.0",
-          "-123456789.01234567",
-          "-12345678901234567000.0",
-          "Infinity",
-          "-Infinity",
-          "NaN",
-          "NaN",
-      });
-  testCast<float, std::string>(
-      "string",
-      {
-          12345678000000000000.0,
-          123456780.0,
-          10'000'000.0,
-          12345.0,
-          0.001,
-          0.00012,
-          0.0,
-          -0.0,
-          -0.00012,
-          -0.001,
-          -12345.0,
-          -10'000'000.0,
-          -123456780.0,
-          -12345678000000000000.0,
-          std::numeric_limits<float>::infinity(),
-          -std::numeric_limits<float>::infinity(),
-          std::numeric_limits<float>::quiet_NaN(),
-          -std::numeric_limits<float>::quiet_NaN(),
-      },
-      {
-          "12345678295994466000.0",
-          "123456784.0",
-          "10000000.0",
-          "12345.0",
-          "0.0010000000474974513",
-          "0.00011999999696854502",
-          "0.0",
-          "-0.0",
-          "-0.00011999999696854502",
-          "-0.0010000000474974513",
-          "-12345.0",
-          "-10000000.0",
-          "-123456784.0",
-          "-12345678295994466000.0",
-          "Infinity",
-          "-Infinity",
-          "NaN",
-          "NaN",
-      });
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    setLegacyCast(true);
+    testCast<double, std::string>(
+        "string",
+        {
+            12345678901234567000.0,
+            123456789.01234567,
+            10'000'000.0,
+            12345.0,
+            0.001,
+            0.00012,
+            0.0,
+            -0.0,
+            -0.00012,
+            -0.001,
+            -12345.0,
+            -10'000'000.0,
+            -123456789.01234567,
+            -12345678901234567000.0,
+            std::numeric_limits<double>::infinity(),
+            -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::quiet_NaN(),
+            -std::numeric_limits<double>::quiet_NaN(),
+        },
+        {
+            "12345678901234567000.0",
+            "123456789.01234567",
+            "10000000.0",
+            "12345.0",
+            "0.001",
+            "0.00012",
+            "0.0",
+            "-0.0",
+            "-0.00012",
+            "-0.001",
+            "-12345.0",
+            "-10000000.0",
+            "-123456789.01234567",
+            "-12345678901234567000.0",
+            "Infinity",
+            "-Infinity",
+            "NaN",
+            "NaN",
+        });
+    testCast<float, std::string>(
+        "string",
+        {
+            12345678000000000000.0,
+            123456780.0,
+            10'000'000.0,
+            12345.0,
+            0.001,
+            0.00012,
+            0.0,
+            -0.0,
+            -0.00012,
+            -0.001,
+            -12345.0,
+            -10'000'000.0,
+            -123456780.0,
+            -12345678000000000000.0,
+            std::numeric_limits<float>::infinity(),
+            -std::numeric_limits<float>::infinity(),
+            std::numeric_limits<float>::quiet_NaN(),
+            -std::numeric_limits<float>::quiet_NaN(),
+        },
+        {
+            "12345678295994466000.0",
+            "123456784.0",
+            "10000000.0",
+            "12345.0",
+            "0.0010000000474974513",
+            "0.00011999999696854502",
+            "0.0",
+            "-0.0",
+            "-0.00011999999696854502",
+            "-0.0010000000474974513",
+            "-12345.0",
+            "-10000000.0",
+            "-123456784.0",
+            "-12345678295994466000.0",
+            "Infinity",
+            "-Infinity",
+            "NaN",
+            "NaN",
+        });
+  }
 }
 
 TEST_F(CastExprTest, stringToDouble) {
@@ -748,15 +750,6 @@ TEST_F(CastExprTest, stringToTimestamp) {
       "1970-01-01 00:00:00",
       "2000-01-01 12:21:56",
       "1970-01-01 00:00:00-02:00",
-#ifdef SPARK_COMPATIBLE
-      "1970-01-01 05:30:01",
-      "1970-01-01 05:30",
-      "1970-01-01 05",
-      "1970-01-01",
-      "1970-01",
-      "1970",
-#endif
-      std::nullopt,
   };
   std::vector<std::optional<Timestamp>> expected{
       Timestamp(0, 0),
@@ -764,40 +757,54 @@ TEST_F(CastExprTest, stringToTimestamp) {
       Timestamp(0, 0),
       Timestamp(946729316, 0),
       Timestamp(7200, 0),
-#ifdef SPARK_COMPATIBLE
-      Timestamp(19801, 0),
-      Timestamp(19800, 0),
-      Timestamp(18000, 0),
-      Timestamp(0, 0),
-      Timestamp(0, 0),
-      Timestamp(0, 0),
-#endif
-      std::nullopt,
   };
 
-#ifdef SPARK_COMPATIBLE
-  std::vector<std::optional<std::string>> inputOutOfRange{
-      "1970-01-32 00:00:00",
-      "1970-01-01 00-00-00",
-      "1970-01-01 25:00:00",
-  };
-  std::vector<std::optional<std::string>> inputEmptyString{
-      "",
-  };
-  std::vector<std::optional<Timestamp>> expectedException{
-      std::nullopt,
-      std::nullopt,
-      std::nullopt,
-  };
-  testInvalidCast<std::string>("timestamp", inputOutOfRange, "");
-  testInvalidCast<std::string>("timestamp", inputEmptyString, "");
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    input.insert(
+        input.end(),
+        {"1970-01-01 05:30:01",
+         "1970-01-01 05:30",
+         "1970-01-01 05",
+         "1970-01-01",
+         "1970-01",
+         "1970"});
+    expected.insert(
+        expected.end(),
+        {Timestamp(19801, 0),
+         Timestamp(19800, 0),
+         Timestamp(18000, 0),
+         Timestamp(0, 0),
+         Timestamp(0, 0),
+         Timestamp(0, 0)});
+  }
+  input.push_back(std::nullopt);
+  expected.push_back(std::nullopt);
+
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    std::vector<std::optional<std::string>> inputOutOfRange{
+        "1970-01-32 00:00:00",
+        "1970-01-01 00-00-00",
+        "1970-01-01 25:00:00",
+    };
+    std::vector<std::optional<std::string>> inputEmptyString{
+        "",
+    };
+    std::vector<std::optional<Timestamp>> expectedException{
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+    };
+    testInvalidCast<std::string>("timestamp", inputOutOfRange, "");
+    testInvalidCast<std::string>("timestamp", inputEmptyString, "");
+  }
 
   testCast<std::string, Timestamp>("timestamp", input, expected);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, timestampToString) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   setLegacyCast(false);
   testCast<Timestamp, std::string>(
       "string",
@@ -854,6 +861,9 @@ TEST_F(CastExprTest, timestampToString) {
 }
 
 TEST_F(CastExprTest, timestampToStringFlinkCompatible) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   setLegacyCast(false);
   setFlinkCompatible(true);
   testCast<Timestamp, std::string>(
@@ -871,7 +881,6 @@ TEST_F(CastExprTest, timestampToStringFlinkCompatible) {
           "2000-01-01 12:21:56.999999999",
       });
 }
-#endif
 
 TEST_F(CastExprTest, dateToTimestamp) {
   testCast<int32_t, Timestamp>(
@@ -898,15 +907,15 @@ TEST_F(CastExprTest, numericToTimestampSemantics) {
   });
 
   auto input = makeRowVector({makeFlatVector<int32_t>({1})});
-#ifdef SPARK_COMPATIBLE
-  auto result =
-      evaluate<SimpleVector<Timestamp>>("cast(c0 as timestamp)", input);
-  EXPECT_EQ(result->valueAt(0), Timestamp(1, 0));
-#else
-  BOLT_ASSERT_THROW(
-      evaluate("cast(c0 as timestamp)", input),
-      "unsupported type conversion from INTEGER to TIMESTAMP");
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    auto result =
+        evaluate<SimpleVector<Timestamp>>("cast(c0 as timestamp)", input);
+    EXPECT_EQ(result->valueAt(0), Timestamp(1, 0));
+  } else {
+    BOLT_ASSERT_THROW(
+        evaluate("cast(c0 as timestamp)", input),
+        "unsupported type conversion from INTEGER to TIMESTAMP");
+  }
 }
 
 TEST_F(CastExprTest, timestampToDate) {
@@ -944,8 +953,10 @@ TEST_F(CastExprTest, timestampToDate) {
       DATE());
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, timestampInvalid) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   testUnsupportedCast<int8_t>(
       "timestamp", {12}, "Conversion to Timestamp is not supported");
   testUnsupportedCast<int16_t>(
@@ -965,10 +976,11 @@ TEST_F(CastExprTest, timestampInvalid) {
       {"2012-Oct-01"},
       "Unable to parse timestamp value: \"2012-Oct-01\"");
 }
-#endif
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, timestampAdjustToTimezone) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   setTimezone("America/Los_Angeles");
 
   // Expect unix epochs to be converted to LA timezone (8h offset).
@@ -993,45 +1005,32 @@ TEST_F(CastExprTest, timestampAdjustToTimezone) {
           Timestamp(957164400, 0),
       });
 }
-#endif
 
 TEST_F(CastExprTest, date) {
-  testCast<std::string, int32_t>(
-      "date",
-      {"1970-01-01",
-       "2020-01-01",
-       "2135-11-09",
-       "1969-12-27",
-       "1812-04-15",
-       "1920-01-02",
-       "12345-12-18",
-       "1970-1-2",
-       "1970-01-2",
-       "1970-1-02",
-       "+1970-01-02",
-#ifndef SPARK_COMPATIBLE
-       "-1-1-1",
-#endif
-       " 1970-01-01",
-       std::nullopt},
-      {0,
-       18262,
-       60577,
-       -5,
-       -57604,
-       -18262,
-       3789742,
-       1,
-       1,
-       1,
-       1,
-#ifndef SPARK_COMPATIBLE
-       -719893,
-#endif
-       0,
-       std::nullopt},
-      VARCHAR(),
-      DATE());
+  std::vector<std::optional<std::string>> input{
+      "1970-01-01",
+      "2020-01-01",
+      "2135-11-09",
+      "1969-12-27",
+      "1812-04-15",
+      "1920-01-02",
+      "12345-12-18",
+      "1970-1-2",
+      "1970-01-2",
+      "1970-1-02",
+      "+1970-01-02"};
+  std::vector<std::optional<int32_t>> expected{
+      0, 18262, 60577, -5, -57604, -18262, 3789742, 1, 1, 1, 1};
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    input.push_back("-1-1-1");
+    expected.push_back(-719893);
+  }
+  input.push_back(" 1970-01-01");
+  input.push_back(std::nullopt);
+  expected.push_back(0);
+  expected.push_back(std::nullopt);
+
+  testCast<std::string, int32_t>("date", input, expected, VARCHAR(), DATE());
 }
 
 TEST_F(CastExprTest, invalidDate) {
@@ -1052,80 +1051,82 @@ TEST_F(CastExprTest, invalidDate) {
   testUnsupportedCast<double>(
       "date", {12.99}, "Cast from DOUBLE to DATE is not supported", DOUBLE());
 
-// Parsing ill-formatted dates.
-#ifndef SPARK_COMPATIBLE
-  testInvalidCast<std::string>(
-      "date",
-      {"2012-Oct-23"},
-      "Unable to parse date value: \"2012-Oct-23\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03-18X"},
-      "Unable to parse date value: \"2015-03-18X\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015/03/18"},
-      "Unable to parse date value: \"2015/03/18\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015.03.18"},
-      "Unable to parse date value: \"2015.03.18\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"20150318"},
-      "Unable to parse date value: \"20150318\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-031-8"},
-      "Unable to parse date value: \"2015-031-8\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date", {"12345"}, "Unable to parse date value: \"12345\"", VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03"},
-      "Unable to parse date value: \"2015-03\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03-18 123412"},
-      "Unable to parse date value: \"2015-03-18 123412\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03-18T"},
-      "Unable to parse date value: \"2015-03-18T\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03-18T123412"},
-      "Unable to parse date value: \"2015-03-18T123412\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03-18 (BC)"},
-      "Unable to parse date value: \"2015-03-18 (BC)\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"1970-01-01 "},
-      "Unable to parse date value: \"1970-01-01 \"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {" 1970-01-01 "},
-      "Unable to parse date value: \" 1970-01-01 \"",
-      VARCHAR());
-#endif
+  // Parsing ill-formatted dates.
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    testInvalidCast<std::string>(
+        "date",
+        {"2012-Oct-23"},
+        "Unable to parse date value: \"2012-Oct-23\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-03-18X"},
+        "Unable to parse date value: \"2015-03-18X\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015/03/18"},
+        "Unable to parse date value: \"2015/03/18\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015.03.18"},
+        "Unable to parse date value: \"2015.03.18\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"20150318"},
+        "Unable to parse date value: \"20150318\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-031-8"},
+        "Unable to parse date value: \"2015-031-8\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date", {"12345"}, "Unable to parse date value: \"12345\"", VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-03"},
+        "Unable to parse date value: \"2015-03\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-03-18 123412"},
+        "Unable to parse date value: \"2015-03-18 123412\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-03-18T"},
+        "Unable to parse date value: \"2015-03-18T\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-03-18T123412"},
+        "Unable to parse date value: \"2015-03-18T123412\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"2015-03-18 (BC)"},
+        "Unable to parse date value: \"2015-03-18 (BC)\"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {"1970-01-01 "},
+        "Unable to parse date value: \"1970-01-01 \"",
+        VARCHAR());
+    testInvalidCast<std::string>(
+        "date",
+        {" 1970-01-01 "},
+        "Unable to parse date value: \" 1970-01-01 \"",
+        VARCHAR());
+  }
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, primitiveInvalidCornerCases) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // To integer.
   {
     // Overflow.
@@ -1226,18 +1227,17 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
         "Non-whitespace character found after end of conversion");
   }
 }
-#endif
 
 TEST_F(CastExprTest, primitiveValidCornerCases) {
   // To integer.
   {
     testCast<double, int8_t>("tinyint", {127.1}, {127});
     testCast<double, int64_t>("bigint", {12345.12}, {12345});
-#ifndef SPARK_COMPATIBLE
-    testCast<double, int64_t>("bigint", {12345.67}, {12346});
-#else
-    testCast<double, int64_t>("bigint", {12345.67}, {12345});
-#endif
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      testCast<double, int64_t>("bigint", {12345.67}, {12346});
+    } else {
+      testCast<double, int64_t>("bigint", {12345.67}, {12345});
+    }
     testCast<std::string, int8_t>("tinyint", {"+1"}, {1});
   }
 
@@ -1285,22 +1285,22 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
 }
 
 TEST_F(CastExprTest, truncateVsRound) {
-// Testing round cast from double to int.
-#ifndef SPARK_COMPATIBLE
-  testCast<double, int>(
-      "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
-#else
-  testCast<double, int>(
-      "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {1, 2, 3, 100, -100});
-#endif
+  // Testing round cast from double to int.
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    testCast<double, int>(
+        "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
+  } else {
+    testCast<double, int>(
+        "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {1, 2, 3, 100, -100});
+  }
   testCast<int8_t, int32_t>("int", {111, 2, 3, 10, -10}, {111, 2, 3, 10, -10});
   testCast<int32_t, int8_t>("tinyint", {2, 3}, {2, 3});
-#ifndef SPARK_COMPATIBLE
-  testInvalidCast<int32_t>(
-      "tinyint",
-      {1111111, 1000, -100101},
-      "Cannot cast INTEGER '1111111' to TINYINT. Overflow during arithmetic conversion: (signed char) 1111111");
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    testInvalidCast<int32_t>(
+        "tinyint",
+        {1111111, 1000, -100101},
+        "Cannot cast INTEGER '1111111' to TINYINT. Overflow during arithmetic conversion: (signed char) 1111111");
+  }
 }
 
 TEST_F(CastExprTest, nullInputs) {
@@ -1364,53 +1364,53 @@ TEST_F(CastExprTest, errorHandling) {
        127,
        -128});
 
-#ifdef SPARK_COMPATIBLE
-  testCast<double, int>(
-      "integer",
-      {1e12, 2.5, 3.6, 100.44, -100.101},
-      {std::numeric_limits<int>::max(), 2, 3, 100, -100});
-  testTryCast<double, int>(
-      "integer",
-      {1e12, 2.5, 3.6, 100.44, -100.101},
-      {std::nullopt, 2, 3, 100, -100});
-#else
-  ASSERT_THROW(
-      (testCast<double, int>(
-          "integer",
-          {1e12, 2.5, 3.6, 100.44, -100.101},
-          {std::nullopt, 2, 3, 100, -100})),
-      BoltException);
-  testTryCast<double, int>(
-      "integer",
-      {1e12, 2.5, 3.6, 100.44, -100.101},
-      {std::nullopt, 2, 3, 100, -100});
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    testCast<double, int>(
+        "integer",
+        {1e12, 2.5, 3.6, 100.44, -100.101},
+        {std::numeric_limits<int>::max(), 2, 3, 100, -100});
+    testTryCast<double, int>(
+        "integer",
+        {1e12, 2.5, 3.6, 100.44, -100.101},
+        {std::nullopt, 2, 3, 100, -100});
+  } else {
+    ASSERT_THROW(
+        (testCast<double, int>(
+            "integer",
+            {1e12, 2.5, 3.6, 100.44, -100.101},
+            {std::nullopt, 2, 3, 100, -100})),
+        BoltException);
+    testTryCast<double, int>(
+        "integer",
+        {1e12, 2.5, 3.6, 100.44, -100.101},
+        {std::nullopt, 2, 3, 100, -100});
+  }
 
-#ifndef SPARK_COMPATIBLE
-  setCastIntByTruncate(false);
-  testCast<double, int>(
-      "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    setCastIntByTruncate(false);
+    testCast<double, int>(
+        "int", {1.888, 2.5, 3.6, 100.44, -100.101}, {2, 3, 4, 100, -100});
 
-  testInvalidCast<std::string>(
-      "tinyint",
-      {"1abc", "2", "3", "100", "-100"},
-      "Non-whitespace character found after end of conversion");
+    testInvalidCast<std::string>(
+        "tinyint",
+        {"1abc", "2", "3", "100", "-100"},
+        "Non-whitespace character found after end of conversion");
 
-  testInvalidCast<std::string>(
-      "tinyint",
-      {"1", "2", "3", "100", "-100.5"},
-      "Non-whitespace character found after end of conversion");
-#endif
+    testInvalidCast<std::string>(
+        "tinyint",
+        {"1", "2", "3", "100", "-100.5"},
+        "Non-whitespace character found after end of conversion");
+  }
 }
 
 TEST_F(CastExprTest, allowDecimal) {
   setCastIntByTruncate(true);
-#ifdef SPARK_COMPATIBLE
-  testCast<std::string, int32_t>(
-      "int",
-      {"-.", "0.0", "125.5", "-128.3", "3.61335e+9"},
-      {0, 0, 125, -128, std::nullopt});
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    testCast<std::string, int32_t>(
+        "int",
+        {"-.", "0.0", "125.5", "-128.3", "3.61335e+9"},
+        {0, 0, 125, -128, std::nullopt});
+  }
 
   testTryCast<std::string, int32_t>(
       "int",
@@ -1493,32 +1493,32 @@ TEST_F(CastExprTest, mapCast) {
 
   // Nulls in result keys are not allowed.
   {
-#ifndef SPARK_COMPATIBLE
-    BOLT_ASSERT_THROW(
-        testCast(
-            inputMap,
-            makeMapVector<Timestamp, int64_t>(
-                kVectorSize,
-                sizeAt,
-                [](auto /*row*/) { return Timestamp(); },
-                valueAt,
-                nullEvery(3),
-                nullEvery(7)),
-            false),
-        "");
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      BOLT_ASSERT_THROW(
+          testCast(
+              inputMap,
+              makeMapVector<Timestamp, int64_t>(
+                  kVectorSize,
+                  sizeAt,
+                  [](auto /*row*/) { return Timestamp(); },
+                  valueAt,
+                  nullEvery(3),
+                  nullEvery(7)),
+              false),
+          "");
 
-    BOLT_ASSERT_THROW(
-        testCast(
-            inputMap,
-            makeMapVector<Timestamp, int64_t>(
-                kVectorSize,
-                sizeAt,
-                [](auto /*row*/) { return Timestamp(); },
-                valueAt,
-                [](auto row) { return row % 3 == 0 || row % 5 != 0; }),
-            true),
-        "");
-#endif
+      BOLT_ASSERT_THROW(
+          testCast(
+              inputMap,
+              makeMapVector<Timestamp, int64_t>(
+                  kVectorSize,
+                  sizeAt,
+                  [](auto /*row*/) { return Timestamp(); },
+                  valueAt,
+                  [](auto row) { return row % 3 == 0 || row % 5 != 0; }),
+              true),
+          "");
+    }
   }
 
   // Make sure that the output of map cast has valid(copyable) data even for
@@ -1559,34 +1559,34 @@ TEST_F(CastExprTest, mapCast) {
     }
   }
 
-#ifndef SPARK_COMPATIBLE
-  // Error handling.
-  {
-    auto data = makeRowVector(
-        {makeMapVector<StringView, StringView>({{{"1", "2"}}, {{"", "1"}}})});
-    auto copy = createCopy(data);
-    auto result1 = evaluate("try_cast(c0 as map(int, int))", data);
-    auto result2 = evaluate("try(cast(c0 as map(int, int)))", data);
-    ASSERT_FALSE(result1->isNullAt(0));
-    ASSERT_TRUE(result1->isNullAt(1));
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // Error handling.
+    {
+      auto data = makeRowVector(
+          {makeMapVector<StringView, StringView>({{{"1", "2"}}, {{"", "1"}}})});
+      auto copy = createCopy(data);
+      auto result1 = evaluate("try_cast(c0 as map(int, int))", data);
+      auto result2 = evaluate("try(cast(c0 as map(int, int)))", data);
+      ASSERT_FALSE(result1->isNullAt(0));
+      ASSERT_TRUE(result1->isNullAt(1));
 
-    ASSERT_FALSE(result2->isNullAt(0));
-    ASSERT_TRUE(result2->isNullAt(1));
-    ASSERT_THROW(evaluate("cast(c0 as map(int, int)", data), BoltException);
+      ASSERT_FALSE(result2->isNullAt(0));
+      ASSERT_TRUE(result2->isNullAt(1));
+      ASSERT_THROW(evaluate("cast(c0 as map(int, int)", data), BoltException);
 
-    // Make sure the input vector does not change.
-    assertEqualVectors(data, copy);
+      // Make sure the input vector does not change.
+      assertEqualVectors(data, copy);
+    }
+
+    {
+      auto result = evaluate(
+          "try_cast(map(array_constructor('1'), array_constructor(''))  as map(int, int))",
+          makeRowVector({makeFlatVector<int32_t>({1, 2})}));
+
+      ASSERT_TRUE(result->isNullAt(0));
+      ASSERT_TRUE(result->isNullAt(1));
+    }
   }
-
-  {
-    auto result = evaluate(
-        "try_cast(map(array_constructor('1'), array_constructor(''))  as map(int, int))",
-        makeRowVector({makeFlatVector<int32_t>({1, 2})}));
-
-    ASSERT_TRUE(result->isNullAt(0));
-    ASSERT_TRUE(result->isNullAt(1));
-  }
-#endif
 }
 
 TEST_F(CastExprTest, arrayCast) {
@@ -1648,39 +1648,40 @@ TEST_F(CastExprTest, arrayCast) {
     }
   }
 
-#ifndef SPARK_COMPATIBLE
-  // Error handling.
-  {
-    auto data =
-        makeRowVector({makeArrayVector<StringView>({{"1", "2"}, {"", "1"}})});
-    auto copy = createCopy(data);
-    auto result1 = evaluate("try_cast(c0 as bigint[])", data);
-    auto result2 = evaluate("try(cast(c0 as bigint[]))", data);
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // Error handling.
+    {
+      auto data =
+          makeRowVector({makeArrayVector<StringView>({{"1", "2"}, {"", "1"}})});
+      auto copy = createCopy(data);
+      auto result1 = evaluate("try_cast(c0 as bigint[])", data);
+      auto result2 = evaluate("try(cast(c0 as bigint[]))", data);
 
-    auto expected = makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt});
+      auto expected =
+          makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt});
 
-    assertEqualVectors(result1, expected);
-    assertEqualVectors(result2, expected);
+      assertEqualVectors(result1, expected);
+      assertEqualVectors(result2, expected);
 
-    ASSERT_THROW(evaluate("cast(c0 as bigint[])", data), BoltException);
+      ASSERT_THROW(evaluate("cast(c0 as bigint[])", data), BoltException);
 
-    // Make sure the input vector does not change.
-    assertEqualVectors(data, copy);
+      // Make sure the input vector does not change.
+      assertEqualVectors(data, copy);
+    }
+
+    {
+      auto data = makeNullableNestedArrayVector<StringView>({
+          {{{{"1"_sv, "2"_sv}}, {{""_sv}}}}, // row0
+          {{{{std::nullopt, "4"_sv}}}}, // row1
+      });
+      auto expected = makeNullableNestedArrayVector<int64_t>({
+          std::nullopt, // row0
+          {{{{std::nullopt, 4}}}}, // row1
+
+      });
+      testCast(data, expected, true);
+    }
   }
-
-  {
-    auto data = makeNullableNestedArrayVector<StringView>({
-        {{{{"1"_sv, "2"_sv}}, {{""_sv}}}}, // row0
-        {{{{std::nullopt, "4"_sv}}}}, // row1
-    });
-    auto expected = makeNullableNestedArrayVector<int64_t>({
-        std::nullopt, // row0
-        {{{{std::nullopt, 4}}}}, // row1
-
-    });
-    testCast(data, expected, true);
-  }
-#endif
 }
 
 TEST_F(CastExprTest, rowCast) {
@@ -1732,59 +1733,59 @@ TEST_F(CastExprTest, rowCast) {
     testCast(rowVector, expectedRowVector);
   }
 
-#ifndef SPARK_COMPATIBLE
-  // Error handling.
-  {
-    auto data = makeRowVector(
-        {makeFlatVector<StringView>({"1", ""}),
-         makeFlatVector<StringView>({"2", "3"})});
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // Error handling.
+    {
+      auto data = makeRowVector(
+          {makeFlatVector<StringView>({"1", ""}),
+           makeFlatVector<StringView>({"2", "3"})});
 
-    auto expected = makeRowVector(
-        {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int32_t>({2, 3})});
-    expected->setNull(1, true);
+      auto expected = makeRowVector(
+          {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int32_t>({2, 3})});
+      expected->setNull(1, true);
 
-    testCast(data, expected, true);
+      testCast(data, expected, true);
+    }
+
+    {
+      auto data = makeRowVector(
+          {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
+           makeFlatVector<StringView>({"2", ""})});
+
+      // expected1 is [null, struct{[3,4], ""}]
+      auto expected1 = makeRowVector(
+          {makeArrayVector<int32_t>({{1 /*will be null*/}, {3, 4}}),
+           makeFlatVector<StringView>({"2" /*will be null*/, ""})});
+      expected1->setNull(0, true);
+
+      // expected2 is [struct{["1",""], 2}, null]
+      auto expected2 = makeRowVector(
+          {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
+           makeFlatVector<int32_t>({2, 0 /*null*/})});
+      expected2->setNull(1, true);
+
+      // expected3 is [null, null]
+      auto expected3 = makeRowVector(
+          {makeArrayVector<int32_t>({{1}}), makeFlatVector<int32_t>(1)});
+      expected3->resize(2);
+      expected3->setNull(0, true);
+      expected3->setNull(1, true);
+
+      testCast(data, expected1, true);
+      testCast(data, expected2, true);
+      testCast(data, expected3, true);
+    }
+
+    // Null handling for nested structs.
+    {
+      auto data = makeRowVector(
+          {makeRowVector({makeFlatVector<StringView>({"1", ""})})});
+      auto expected =
+          makeRowVector({makeRowVector({makeFlatVector<int32_t>({1, 0})})});
+      expected->setNull(1, true);
+      testCast(data, expected, true);
+    }
   }
-
-  {
-    auto data = makeRowVector(
-        {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
-         makeFlatVector<StringView>({"2", ""})});
-
-    // expected1 is [null, struct{[3,4], ""}]
-    auto expected1 = makeRowVector(
-        {makeArrayVector<int32_t>({{1 /*will be null*/}, {3, 4}}),
-         makeFlatVector<StringView>({"2" /*will be null*/, ""})});
-    expected1->setNull(0, true);
-
-    // expected2 is [struct{["1",""], 2}, null]
-    auto expected2 = makeRowVector(
-        {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
-         makeFlatVector<int32_t>({2, 0 /*null*/})});
-    expected2->setNull(1, true);
-
-    // expected3 is [null, null]
-    auto expected3 = makeRowVector(
-        {makeArrayVector<int32_t>({{1}}), makeFlatVector<int32_t>(1)});
-    expected3->resize(2);
-    expected3->setNull(0, true);
-    expected3->setNull(1, true);
-
-    testCast(data, expected1, true);
-    testCast(data, expected2, true);
-    testCast(data, expected3, true);
-  }
-
-  // Null handling for nested structs.
-  {
-    auto data =
-        makeRowVector({makeRowVector({makeFlatVector<StringView>({"1", ""})})});
-    auto expected =
-        makeRowVector({makeRowVector({makeFlatVector<int32_t>({1, 0})})});
-    expected->setNull(1, true);
-    testCast(data, expected, true);
-  }
-#endif
 }
 
 TEST_F(CastExprTest, nulls) {
@@ -1813,12 +1814,12 @@ TEST_F(CastExprTest, testNullOnFailure) {
   // nullOnFailure is true, so we should return null instead of throwing.
   testCast(input, tryExpected, true);
 
-#ifdef SPARK_COMPATIBLE
-  testCast(input, expected, false);
-#else
-  // nullOnFailure is false, so we should throw.
-  EXPECT_THROW(testCast(input, expected, false), BoltUserError);
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    testCast(input, expected, false);
+  } else {
+    // nullOnFailure is false, so we should throw.
+    EXPECT_THROW(testCast(input, expected, false), BoltUserError);
+  }
 }
 
 TEST_F(CastExprTest, toString) {
@@ -1832,8 +1833,10 @@ TEST_F(CastExprTest, toString) {
 }
 
 // this test case also run in SparkCastExprTest
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, decimalToIntegral) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   testDecimalToIntegralCasts<int64_t>();
   testDecimalToIntegralCasts<int32_t>();
   testDecimalToIntegralCasts<int16_t>();
@@ -1841,17 +1844,22 @@ TEST_F(CastExprTest, decimalToIntegral) {
 }
 
 TEST_F(CastExprTest, decimalToIntegralOutOfBounds) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   testDecimalToIntegralCastsOutOfBounds<TypeKind::INTEGER>();
   testDecimalToIntegralCastsOutOfBounds<TypeKind::SMALLINT>();
   testDecimalToIntegralCastsOutOfBounds<TypeKind::TINYINT>();
 }
 
 TEST_F(CastExprTest, decimalToIntegralOutOfBoundsSetNullOnFailure) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   testDecimalToIntegralCastsOutOfBoundsSetNullOnFailure<TypeKind::INTEGER>();
   testDecimalToIntegralCastsOutOfBoundsSetNullOnFailure<TypeKind::SMALLINT>();
   testDecimalToIntegralCastsOutOfBoundsSetNullOnFailure<TypeKind::TINYINT>();
 }
-#endif
 
 TEST_F(CastExprTest, decimalToFloat) {
   testDecimalToFloatCasts<float>();
@@ -1859,9 +1867,9 @@ TEST_F(CastExprTest, decimalToFloat) {
 }
 
 TEST_F(CastExprTest, decimalToFloatDiff) {
-#ifdef SPARK_COMPATIBLE
-  testDecimalToFloatCastsDiff<float>();
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    testDecimalToFloatCastsDiff<float>();
+  }
 }
 
 TEST_F(CastExprTest, decimalToBool) {
@@ -1898,41 +1906,46 @@ TEST_F(CastExprTest, decimalToVarchar) {
        DecimalUtil::kShortDecimalMax,
        std::nullopt},
       DECIMAL(18, 18));
-  testCast(
-      shortFlat,
-      makeNullableFlatVector<StringView>(
+  const auto expectedShortFlat = [&]() {
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      return makeNullableFlatVector<StringView>(
           {"-0.999999999999999999",
-#ifdef SPARK_COMPATIBLE
            "-3E-18",
            "0E-18",
            "5.5E-17",
-#else
+           "0.999999999999999999",
+           std::nullopt});
+    } else {
+      return makeNullableFlatVector<StringView>(
+          {"-0.999999999999999999",
            "-0.000000000000000003",
            "0.000000000000000000",
            "0.000000000000000055",
-#endif
            "0.999999999999999999",
-           std::nullopt}));
+           std::nullopt});
+    }
+  }();
+  testCast(shortFlat, expectedShortFlat);
 
-#ifdef SPARK_COMPATIBLE
-  auto shortFlatForScientific = makeNullableFlatVector<int64_t>(
-      {DecimalUtil::kShortDecimalMin,
-       -3,
-       0,
-       55,
-       DecimalUtil::kShortDecimalMax,
-       std::nullopt},
-      DECIMAL(18, 10));
-  testCast(
-      shortFlatForScientific,
-      makeNullableFlatVector<StringView>(
-          {"-99999999.9999999999",
-           "-3E-10",
-           "0E-10",
-           "5.5E-9",
-           "99999999.9999999999",
-           std::nullopt}));
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    auto shortFlatForScientific = makeNullableFlatVector<int64_t>(
+        {DecimalUtil::kShortDecimalMin,
+         -3,
+         0,
+         55,
+         DecimalUtil::kShortDecimalMax,
+         std::nullopt},
+        DECIMAL(18, 10));
+    testCast(
+        shortFlatForScientific,
+        makeNullableFlatVector<StringView>(
+            {"-99999999.9999999999",
+             "-3E-10",
+             "0E-10",
+             "5.5E-9",
+             "99999999.9999999999",
+             std::nullopt}));
+  }
 
   auto longFlat = makeNullableFlatVector<int128_t>(
       {DecimalUtil::kLongDecimalMin,
@@ -1951,25 +1964,25 @@ TEST_F(CastExprTest, decimalToVarchar) {
            "-0.00001",
            "12089258196146291747.06175",
            std::nullopt}));
-#ifdef SPARK_COMPATIBLE
-  auto longFlatForScientific = makeNullableFlatVector<int128_t>(
-      {DecimalUtil::kLongDecimalMin,
-       0,
-       DecimalUtil::kLongDecimalMax,
-       HugeInt::build(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull),
-       HugeInt::build(0xffff, 0xffffffffffffffff),
-       std::nullopt},
-      DECIMAL(38, 10));
-  testCast(
-      longFlatForScientific,
-      makeNullableFlatVector<StringView>(
-          {"-9999999999999999999999999999.9999999999",
-           "0E-10",
-           "9999999999999999999999999999.9999999999",
-           "-1E-10",
-           "120892581961462.9174706175",
-           std::nullopt}));
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    auto longFlatForScientific = makeNullableFlatVector<int128_t>(
+        {DecimalUtil::kLongDecimalMin,
+         0,
+         DecimalUtil::kLongDecimalMax,
+         HugeInt::build(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull),
+         HugeInt::build(0xffff, 0xffffffffffffffff),
+         std::nullopt},
+        DECIMAL(38, 10));
+    testCast(
+        longFlatForScientific,
+        makeNullableFlatVector<StringView>(
+            {"-9999999999999999999999999999.9999999999",
+             "0E-10",
+             "9999999999999999999999999999.9999999999",
+             "-1E-10",
+             "120892581961462.9174706175",
+             std::nullopt}));
+  }
 
   auto longFlatForZero = makeNullableFlatVector<int128_t>({0}, DECIMAL(25, 0));
   testCast(longFlatForZero, makeNullableFlatVector<StringView>({"0"}));
@@ -2078,8 +2091,10 @@ TEST_F(CastExprTest, decimalToDecimal) {
       "Cannot cast DECIMAL '-99999999999999999999999999999999999999' to DECIMAL(38, 1)");
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, integerToBinary) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   testInvalidCast<int8_t>(
       "varbinary", {12}, "Cannot cast TINYINT to VARBINARY.");
   testInvalidCast<int16_t>(
@@ -2089,7 +2104,6 @@ TEST_F(CastExprTest, integerToBinary) {
   testInvalidCast<int64_t>(
       "varbinary", {12}, "Cannot cast BIGINT to VARBINARY.");
 }
-#endif
 
 TEST_F(CastExprTest, integerToDecimal) {
   testIntToDecimalCasts<int8_t>();
@@ -2249,237 +2263,239 @@ TEST_F(CastExprTest, varcharToDecimal) {
           {StringView(fractionRoundDown), StringView(fractionRoundDownExp)}),
       makeConstant<int128_t>(DecimalUtil::kLongDecimalMax, 2, DECIMAL(38, 38)));
 
-#ifndef SPARK_COMPATIBLE
-  // Overflows when parsing whole digits.
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {std::string(280, '9')},
-      fmt::format(
-          "Cannot cast VARCHAR '{}' to DECIMAL(38, 0). Value too large.",
-          std::string(280, '9')));
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // Overflows when parsing whole digits.
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {std::string(280, '9')},
+        fmt::format(
+            "Cannot cast VARCHAR '{}' to DECIMAL(38, 0). Value too large.",
+            std::string(280, '9')));
 
-  // Overflows when parsing fractional digits.
-  const std::string fractionOverflow = std::string(36, '9') + '.' + "23456";
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 10),
-      {fractionOverflow},
-      fmt::format(
-          "Cannot cast VARCHAR '{}' to DECIMAL(38, 10). Value too large.",
-          fractionOverflow));
+    // Overflows when parsing fractional digits.
+    const std::string fractionOverflow = std::string(36, '9') + '.' + "23456";
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 10),
+        {fractionOverflow},
+        fmt::format(
+            "Cannot cast VARCHAR '{}' to DECIMAL(38, 10). Value too large.",
+            fractionOverflow));
 
-  const std::string fractionRoundUp = "0." + std::string(38, '9') + "6";
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 38),
-      {fractionRoundUp},
-      fmt::format(
-          "Cannot cast VARCHAR '{}' to DECIMAL(38, 38). Value too large.",
-          fractionRoundUp));
+    const std::string fractionRoundUp = "0." + std::string(38, '9') + "6";
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 38),
+        {fractionRoundUp},
+        fmt::format(
+            "Cannot cast VARCHAR '{}' to DECIMAL(38, 38). Value too large.",
+            fractionRoundUp));
 
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {"0.0444a"},
-      "Cannot cast VARCHAR '0.0444a' to DECIMAL(38, 0). Value is not a number. Chars 'a' are invalid.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {"0.0444a"},
+        "Cannot cast VARCHAR '0.0444a' to DECIMAL(38, 0). Value is not a number. Chars 'a' are invalid.");
 
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {""},
-      "Cannot cast VARCHAR '' to DECIMAL(38, 0). Value is not a number. Input is empty.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {""},
+        "Cannot cast VARCHAR '' to DECIMAL(38, 0). Value is not a number. Input is empty.");
 
-  // Exponent > LongDecimalType::kMaxPrecision.
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {"1.23e67"},
-      "Cannot cast VARCHAR '1.23e67' to DECIMAL(38, 0). Value too large.");
+    // Exponent > LongDecimalType::kMaxPrecision.
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {"1.23e67"},
+        "Cannot cast VARCHAR '1.23e67' to DECIMAL(38, 0). Value too large.");
 
-  // Forcing the scale to be zero overflows.
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {"20908.23e35"},
-      "Cannot cast VARCHAR '20908.23e35' to DECIMAL(38, 0). Value too large.");
+    // Forcing the scale to be zero overflows.
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {"20908.23e35"},
+        "Cannot cast VARCHAR '20908.23e35' to DECIMAL(38, 0). Value too large.");
 
-  // Rescale overflows.
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 38),
-      {"111111111111111111.23"},
-      "Cannot cast VARCHAR '111111111111111111.23' to DECIMAL(38, 38). Value too large.");
+    // Rescale overflows.
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 38),
+        {"111111111111111111.23"},
+        "Cannot cast VARCHAR '111111111111111111.23' to DECIMAL(38, 38). Value too large.");
 
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {"23e-5d"},
-      "Cannot cast VARCHAR '23e-5d' to DECIMAL(38, 0). Value is not a number. Non-digit character 'd' is not allowed in the exponent part.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {"23e-5d"},
+        "Cannot cast VARCHAR '23e-5d' to DECIMAL(38, 0). Value is not a number. Non-digit character 'd' is not allowed in the exponent part.");
 
-  // Whitespaces.
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {"1. 23"},
-      "Cannot cast VARCHAR '1. 23' to DECIMAL(38, 0). Value is not a number. Chars ' 23' are invalid.");
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(12, 2),
-      {"-3E+ 2"},
-      "Cannot cast VARCHAR '-3E+ 2' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {"1.23 "},
-      "Cannot cast VARCHAR '1.23 ' to DECIMAL(38, 0). Value is not a number. Chars ' ' are invalid.");
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(12, 2),
-      {"-3E+2 "},
-      "Cannot cast VARCHAR '-3E+2 ' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(38, 0),
-      {" 1.23"},
-      "Cannot cast VARCHAR ' 1.23' to DECIMAL(38, 0). Value is not a number. Extracted digits are empty.");
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(12, 2),
-      {" -3E+2"},
-      "Cannot cast VARCHAR ' -3E+2' to DECIMAL(12, 2). Value is not a number. Extracted digits are empty.");
+    // Whitespaces.
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {"1. 23"},
+        "Cannot cast VARCHAR '1. 23' to DECIMAL(38, 0). Value is not a number. Chars ' 23' are invalid.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(12, 2),
+        {"-3E+ 2"},
+        "Cannot cast VARCHAR '-3E+ 2' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {"1.23 "},
+        "Cannot cast VARCHAR '1.23 ' to DECIMAL(38, 0). Value is not a number. Chars ' ' are invalid.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(12, 2),
+        {"-3E+2 "},
+        "Cannot cast VARCHAR '-3E+2 ' to DECIMAL(12, 2). Value is not a number. Non-digit character ' ' is not allowed in the exponent part.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(38, 0),
+        {" 1.23"},
+        "Cannot cast VARCHAR ' 1.23' to DECIMAL(38, 0). Value is not a number. Extracted digits are empty.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(12, 2),
+        {" -3E+2"},
+        "Cannot cast VARCHAR ' -3E+2' to DECIMAL(12, 2). Value is not a number. Extracted digits are empty.");
 
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(12, 2),
-      {"-3E+2.1"},
-      "Cannot cast VARCHAR '-3E+2.1' to DECIMAL(12, 2). Value is not a number. Non-digit character '.' is not allowed in the exponent part.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(12, 2),
+        {"-3E+2.1"},
+        "Cannot cast VARCHAR '-3E+2.1' to DECIMAL(12, 2). Value is not a number. Non-digit character '.' is not allowed in the exponent part.");
 
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(12, 2),
-      {"-3E+"},
-      "Cannot cast VARCHAR '-3E+' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(12, 2),
+        {"-3E+"},
+        "Cannot cast VARCHAR '-3E+' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
 
-  testThrow<std::string>(
-      VARCHAR(),
-      DECIMAL(12, 2),
-      {"-3E-"},
-      "Cannot cast VARCHAR '-3E-' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
-#endif
+    testThrow<std::string>(
+        VARCHAR(),
+        DECIMAL(12, 2),
+        {"-3E-"},
+        "Cannot cast VARCHAR '-3E-' to DECIMAL(12, 2). Value is not a number. The exponent part only contains sign.");
+  }
 }
 
 TEST_F(CastExprTest, castArrayError) {
-#ifdef SPARK_COMPATIBLE
-  auto arrayVector = makeNullableArrayVector<StringView>(
-      {{{"1"_sv, ""_sv, "3"_sv, "4"_sv}},
-       // {{"5a"_sv}},  // it is ok, but it is disabled due to the UT framework
-       // issue
-       emptyArray,
-       {{"6"_sv, "7"_sv}},
-       std::nullopt});
-  auto input = makeRowVector({arrayVector});
-  auto expected = makeNullableArrayVector<int64_t>(
-      {{{1, std::nullopt, 3, 4}},
-       // {{std::nullopt}},  UT framework issue.
-       emptyArray,
-       {{6, 7}},
-       std::nullopt});
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    auto arrayVector = makeNullableArrayVector<StringView>(
+        {{{"1"_sv, ""_sv, "3"_sv, "4"_sv}},
+         // {{"5a"_sv}},  // it is ok, but it is disabled due to the UT
+         // framework issue
+         emptyArray,
+         {{"6"_sv, "7"_sv}},
+         std::nullopt});
+    auto input = makeRowVector({arrayVector});
+    auto expected = makeNullableArrayVector<int64_t>(
+        {{{1, std::nullopt, 3, 4}},
+         // {{std::nullopt}},  UT framework issue.
+         emptyArray,
+         {{6, 7}},
+         std::nullopt});
 
-  auto castExpr =
-      buildCastExprWithDictionaryInput(ARRAY(VARCHAR()), ARRAY(BIGINT()), true);
+    auto castExpr = buildCastExprWithDictionaryInput(
+        ARRAY(VARCHAR()), ARRAY(BIGINT()), true);
 
-  auto result = evaluate(castExpr, input);
+    auto result = evaluate(castExpr, input);
 
-  //   for (auto i = 0; i < arrayVector->size(); i++) {
-  //     std::cout << "Input:\t" << input->toString(i) << std::endl;
-  //     std::cout << "Result:\t" << result->toString(arrayVector->size() - 1 -
-  //     i)
-  //               << std::endl;
-  //     std::cout << "Expected:\t" << expected->toString(i) << std::endl;
-  //   }
-  auto indices = test::makeIndicesInReverse(expected->size(), pool());
-  assertEqualVectors(wrapInDictionary(indices, expected), result);
-#endif
+    //   for (auto i = 0; i < arrayVector->size(); i++) {
+    //     std::cout << "Input:\t" << input->toString(i) << std::endl;
+    //     std::cout << "Result:\t" << result->toString(arrayVector->size() - 1
+    //     - i)
+    //               << std::endl;
+    //     std::cout << "Expected:\t" << expected->toString(i) << std::endl;
+    //   }
+    auto indices = test::makeIndicesInReverse(expected->size(), pool());
+    assertEqualVectors(wrapInDictionary(indices, expected), result);
+  }
 }
 
 TEST_F(CastExprTest, castMapError) {
-#ifdef SPARK_COMPATIBLE
-  auto mapVector = makeNullableMapVector<int32_t, StringView>({
-      std::nullopt,
-      {{{1, std::nullopt}}},
-      {{{2, "2.05"_sv}}},
-      {{{3, "abc"_sv}}},
-      std::nullopt,
-      {{{5, "5.05"}}},
-      {{{6, std::nullopt}}},
-      {{{7, "7.05"}}},
-      std::nullopt,
-      {{{9, ""}}},
-  });
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    auto mapVector = makeNullableMapVector<int32_t, StringView>({
+        std::nullopt,
+        {{{1, std::nullopt}}},
+        {{{2, "2.05"_sv}}},
+        {{{3, "abc"_sv}}},
+        std::nullopt,
+        {{{5, "5.05"}}},
+        {{{6, std::nullopt}}},
+        {{{7, "7.05"}}},
+        std::nullopt,
+        {{{9, ""}}},
+    });
 
-  auto expected = makeNullableMapVector<int32_t, double>({
-      std::nullopt,
-      {{{1, std::nullopt}}},
-      {{{2, 2.05}}},
-      {{{3, std::nullopt}}},
-      std::nullopt,
-      {{{5, 5.05}}},
-      {{{6, std::nullopt}}},
-      {{{7, 7.05}}},
-      std::nullopt,
-      {{{9, std::nullopt}}},
-  });
+    auto expected = makeNullableMapVector<int32_t, double>({
+        std::nullopt,
+        {{{1, std::nullopt}}},
+        {{{2, 2.05}}},
+        {{{3, std::nullopt}}},
+        std::nullopt,
+        {{{5, 5.05}}},
+        {{{6, std::nullopt}}},
+        {{{7, 7.05}}},
+        std::nullopt,
+        {{{9, std::nullopt}}},
+    });
 
-  auto castExpr = buildCastExprWithDictionaryInput(
-      MAP(INTEGER(), VARCHAR()), MAP(INTEGER(), DOUBLE()), true);
+    auto castExpr = buildCastExprWithDictionaryInput(
+        MAP(INTEGER(), VARCHAR()), MAP(INTEGER(), DOUBLE()), true);
 
-  auto input = makeRowVector({mapVector});
-  auto result = evaluate(castExpr, input);
+    auto input = makeRowVector({mapVector});
+    auto result = evaluate(castExpr, input);
 
-  //   for (auto i = 0; i < result->size(); i++) {
-  //     std::cout << "Result:\t" << result->toString(i) << std::endl;
-  //   }
+    //   for (auto i = 0; i < result->size(); i++) {
+    //     std::cout << "Result:\t" << result->toString(i) << std::endl;
+    //   }
 
-  auto indices = test::makeIndicesInReverse(expected->size(), pool());
-  assertEqualVectors(wrapInDictionary(indices, expected), result);
-#endif
+    auto indices = test::makeIndicesInReverse(expected->size(), pool());
+    assertEqualVectors(wrapInDictionary(indices, expected), result);
+  }
 }
 
 TEST_F(CastExprTest, castStructOnError) {
-#ifdef SPARK_COMPATIBLE
-  auto rowVector = makeRowVector(
-      {makeNullableFlatVector<StringView>(
-           {"1.23", std::nullopt, "", "abc"}, VARCHAR()),
-       makeNullableFlatVector<StringView>(
-           {"1", std::nullopt, "2a", ""}, VARCHAR())});
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    auto rowVector = makeRowVector(
+        {makeNullableFlatVector<StringView>(
+             {"1.23", std::nullopt, "", "abc"}, VARCHAR()),
+         makeNullableFlatVector<StringView>(
+             {"1", std::nullopt, "2a", ""}, VARCHAR())});
 
-  auto expected = makeRowVector(
-      {makeNullableFlatVector<double>(
-           {1.23, std::nullopt, std::nullopt, std::nullopt}, DOUBLE()),
-       makeNullableFlatVector<int32_t>(
-           {
-               1,
-               std::nullopt,
-               std::nullopt,
-               std::nullopt,
-           },
-           INTEGER())});
+    auto expected = makeRowVector(
+        {makeNullableFlatVector<double>(
+             {1.23, std::nullopt, std::nullopt, std::nullopt}, DOUBLE()),
+         makeNullableFlatVector<int32_t>(
+             {
+                 1,
+                 std::nullopt,
+                 std::nullopt,
+                 std::nullopt,
+             },
+             INTEGER())});
 
-  auto castExpr = buildCastExprWithDictionaryInput(
-      ROW({{"c0", VARCHAR()}, {"c1", VARCHAR()}}),
-      ROW({{"c0", DOUBLE()}, {"c1", INTEGER()}}),
-      true);
+    auto castExpr = buildCastExprWithDictionaryInput(
+        ROW({{"c0", VARCHAR()}, {"c1", VARCHAR()}}),
+        ROW({{"c0", DOUBLE()}, {"c1", INTEGER()}}),
+        true);
 
-  auto input = makeRowVector({rowVector});
-  auto result = evaluate(castExpr, input);
-  auto indices = test::makeIndicesInReverse(expected->size(), pool());
-  assertEqualVectors(wrapInDictionary(indices, expected), result);
-#endif
+    auto input = makeRowVector({rowVector});
+    auto result = evaluate(castExpr, input);
+    auto indices = test::makeIndicesInReverse(expected->size(), pool());
+    assertEqualVectors(wrapInDictionary(indices, expected), result);
+  }
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(CastExprTest, castInTry) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Test try(cast(array(varchar) as array(bigint))) whose input vector is
   // wrapped in dictionary encoding. The row of ["2a"] should trigger an error
   // during casting and the try expression should turn this error into a null
@@ -2526,7 +2542,6 @@ TEST_F(CastExprTest, castInTry) {
   evaluateAndVerifyCastInTryDictEncoding(
       ARRAY(ARRAY(VARCHAR())), ARRAY(ARRAY(BIGINT())), nested, nestedExpected);
 }
-#endif
 
 TEST_F(CastExprTest, doubleToDecimal) {
   // Double to short decimal.
@@ -2823,102 +2838,101 @@ TEST_F(CastExprTest, complexTypeToString) {
             {123456789, -333333333, std::nullopt, 0}, DECIMAL(9, 2)),
     });
 
-#ifndef SPARK_COMPATIBLE
-    testCast(
-        rowVector,
-        makeFlatVector<StringView>(
-            {"{null, 2000-01-01 00:00:00.000, 1234567.89}",
-             "{first time, null, -3333333.33}",
-             "{1.1380000, 2269-12-29 00:00:00.000, null}",
-             "{last time, 4969-12-04 00:00:00.000, 0.00}"}));
-#else
-
-    testCast(
-        rowVector,
-        makeFlatVector<StringView>(
-            {"{null, 2000-01-01 00:00:00, 1234567.89}",
-             "{first time, null, -3333333.33}",
-             "{1.1380000, 2269-12-29 00:00:00, null}",
-             "{last time, 4969-12-04 00:00:00, 0.00}"}));
-#endif
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      testCast(
+          rowVector,
+          makeFlatVector<StringView>(
+              {"{null, 2000-01-01 00:00:00.000, 1234567.89}",
+               "{first time, null, -3333333.33}",
+               "{1.1380000, 2269-12-29 00:00:00.000, null}",
+               "{last time, 4969-12-04 00:00:00.000, 0.00}"}));
+    } else {
+      testCast(
+          rowVector,
+          makeFlatVector<StringView>(
+              {"{null, 2000-01-01 00:00:00, 1234567.89}",
+               "{first time, null, -3333333.33}",
+               "{1.1380000, 2269-12-29 00:00:00, null}",
+               "{last time, 4969-12-04 00:00:00, 0.00}"}));
+    }
   }
 
-#ifdef SPARK_COMPATIBLE
-  // legacy map / struct
-  {
-    setLegacyCastComplexTypeToString(true);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    // legacy map / struct
+    {
+      setLegacyCastComplexTypeToString(true);
 
-    auto mapVector = makeNullableMapVector<int32_t, double>(
-        {{{{1, 1.25}, {2, std::nullopt}, {3, 4.5}}},
-         std::nullopt,
-         emptyArray,
-         {{{5, 13.25}, {6, 1e7}}}},
-        MAP(INTEGER(), DOUBLE()));
-    testCast(
-        mapVector,
-        makeNullableFlatVector<StringView>(
-            {"[1 -> 1.25, 2 ->, 3 -> 4.5]",
-             std::nullopt,
-             "[]",
-             "[5 -> 13.25, 6 -> 1.0E7]"}));
+      auto mapVector = makeNullableMapVector<int32_t, double>(
+          {{{{1, 1.25}, {2, std::nullopt}, {3, 4.5}}},
+           std::nullopt,
+           emptyArray,
+           {{{5, 13.25}, {6, 1e7}}}},
+          MAP(INTEGER(), DOUBLE()));
+      testCast(
+          mapVector,
+          makeNullableFlatVector<StringView>(
+              {"[1 -> 1.25, 2 ->, 3 -> 4.5]",
+               std::nullopt,
+               "[]",
+               "[5 -> 13.25, 6 -> 1.0E7]"}));
 
-    auto rowVector = makeRowVector({
-        makeNullableFlatVector<StringView>(
-            {std::nullopt, "first time", "1.1380000", "last time"}),
-        makeNullableFlatVector<Timestamp>(
-            {Timestamp(946684800, 0),
-             std::nullopt,
-             Timestamp(9466848000, 0),
-             Timestamp(94668480000, 0)}),
-        makeNullableFlatVector<int64_t>(
-            {123456789, -333333333, std::nullopt, 0}, DECIMAL(9, 2)),
-    });
+      auto rowVector = makeRowVector({
+          makeNullableFlatVector<StringView>(
+              {std::nullopt, "first time", "1.1380000", "last time"}),
+          makeNullableFlatVector<Timestamp>(
+              {Timestamp(946684800, 0),
+               std::nullopt,
+               Timestamp(9466848000, 0),
+               Timestamp(94668480000, 0)}),
+          makeNullableFlatVector<int64_t>(
+              {123456789, -333333333, std::nullopt, 0}, DECIMAL(9, 2)),
+      });
 
-    testCast(
-        rowVector,
-        makeFlatVector<StringView>(
-            {"[, 2000-01-01 00:00:00, 1234567.89]",
-             "[first time,, -3333333.33]",
-             "[1.1380000, 2269-12-29 00:00:00,]",
-             "[last time, 4969-12-04 00:00:00, 0.00]"}));
+      testCast(
+          rowVector,
+          makeFlatVector<StringView>(
+              {"[, 2000-01-01 00:00:00, 1234567.89]",
+               "[first time,, -3333333.33]",
+               "[1.1380000, 2269-12-29 00:00:00,]",
+               "[last time, 4969-12-04 00:00:00, 0.00]"}));
+    }
+    {
+      setLegacyCastComplexTypeToString(false);
+      auto mapVector = makeNullableMapVector<int32_t, double>(
+          {{{{1, 1.25}, {2, std::nullopt}, {3, 4.5}}},
+           std::nullopt,
+           emptyArray,
+           {{{5, 13.25}, {6, 1e7}}}},
+          MAP(INTEGER(), DOUBLE()));
+      testCast(
+          mapVector,
+          makeNullableFlatVector<StringView>(
+              {"{1 -> 1.25, 2 -> null, 3 -> 4.5}",
+               std::nullopt,
+               "{}",
+               "{5 -> 13.25, 6 -> 1.0E7}"}));
+
+      auto rowVector = makeRowVector({
+          makeNullableFlatVector<StringView>(
+              {std::nullopt, "first time", "1.1380000", "last time"}),
+          makeNullableFlatVector<Timestamp>(
+              {Timestamp(946684800, 0),
+               std::nullopt,
+               Timestamp(9466848000, 0),
+               Timestamp(94668480000, 0)}),
+          makeNullableFlatVector<int64_t>(
+              {123456789, -333333333, std::nullopt, 0}, DECIMAL(9, 2)),
+      });
+
+      testCast(
+          rowVector,
+          makeFlatVector<StringView>(
+              {"{null, 2000-01-01 00:00:00, 1234567.89}",
+               "{first time, null, -3333333.33}",
+               "{1.1380000, 2269-12-29 00:00:00, null}",
+               "{last time, 4969-12-04 00:00:00, 0.00}"}));
+    }
   }
-  {
-    setLegacyCastComplexTypeToString(false);
-    auto mapVector = makeNullableMapVector<int32_t, double>(
-        {{{{1, 1.25}, {2, std::nullopt}, {3, 4.5}}},
-         std::nullopt,
-         emptyArray,
-         {{{5, 13.25}, {6, 1e7}}}},
-        MAP(INTEGER(), DOUBLE()));
-    testCast(
-        mapVector,
-        makeNullableFlatVector<StringView>(
-            {"{1 -> 1.25, 2 -> null, 3 -> 4.5}",
-             std::nullopt,
-             "{}",
-             "{5 -> 13.25, 6 -> 1.0E7}"}));
-
-    auto rowVector = makeRowVector({
-        makeNullableFlatVector<StringView>(
-            {std::nullopt, "first time", "1.1380000", "last time"}),
-        makeNullableFlatVector<Timestamp>(
-            {Timestamp(946684800, 0),
-             std::nullopt,
-             Timestamp(9466848000, 0),
-             Timestamp(94668480000, 0)}),
-        makeNullableFlatVector<int64_t>(
-            {123456789, -333333333, std::nullopt, 0}, DECIMAL(9, 2)),
-    });
-
-    testCast(
-        rowVector,
-        makeFlatVector<StringView>(
-            {"{null, 2000-01-01 00:00:00, 1234567.89}",
-             "{first time, null, -3333333.33}",
-             "{1.1380000, 2269-12-29 00:00:00, null}",
-             "{last time, 4969-12-04 00:00:00, 0.00}"}));
-  }
-#endif
 
   // nested complex type, like map(map)
   {
@@ -3041,14 +3055,11 @@ TEST_F(CastExprTest, complexTypeToString) {
          })});
     testCast(
         rowNested,
-        makeFlatVector<StringView>({
-#ifndef SPARK_COMPATIBLE
-            "{{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00.000, 1234567.89}}",
-#else
-            "{{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00, 1234567.89}}",
-#endif
-            "{{3 -> 30, 4 -> 40}, [null, 3], {null, -3333333.33}}",
-        }));
+        makeFlatVector<StringView>(
+            {::bytedance::bolt::kSparkCompatible
+                 ? "{{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00, 1234567.89}}"
+                 : "{{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00.000, 1234567.89}}",
+             "{{3 -> 30, 4 -> 40}, [null, 3], {null, -3333333.33}}"}));
 
     auto rowOfUnknownChildren = makeRowVector({
         makeFlatUnknownVector(2),
@@ -3182,21 +3193,22 @@ TEST_F(CastExprTest, complexTypeToString) {
          mapOfMap,
          mapOfRow,
          rowNested});
-    testCast(
-        finalRowVector,
-#ifndef SPARK_COMPATIBLE
-        makeFlatVector<StringView>(
+    const auto expected = [&]() {
+      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        return makeFlatVector<StringView>(
             {"{[null, [1, 100, 2]], [], [], {3 -> [4, 5, 6, 1, 2]}, {1 -> {2 -> 3, 4 -> 5}}, {1 -> {2, 3}, 3 -> {4, 5}}, {{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00.000, 1234567.89}}}",
              "{[[1, 100, 2], [315]], [{1 -> 11, 3 -> 10}, {0 -> 10, 2 -> 11}, {1 -> 11, 1 -> 10}], [null, null], {5 -> [4, null, 1, 2]}, {0 -> {2 -> 3, 4 -> 5}}, {0 -> {2, 3}, 3 -> {null, null}}, {{3 -> 30, 4 -> 40, 9 -> 90}, [2, 3, 4], {null, -3333333.33}}}",
              "{[[1, 100, null]], [{0 -> null}, {0 -> 10}], [{2, red}, null, {1, blue}], {}, {1 -> {2 -> 3, 4 -> null}}, {1 -> {2, null}, 3 -> {null, 5}}, {{5 -> null, 6 -> 60}, [6, null, 7], {2269-12-29 00:00:00.000, null}}}",
-             "{[[315]], [{}, {2 -> 10}], [{1, green}, {null, red}], {7 -> null}, {6 -> null}, {6 -> {7, 8}}, {{7 -> null}, [null, null], {4969-12-04 00:00:00.000, 0.00}}}"}));
-#else
-        makeFlatVector<StringView>(
+             "{[[315]], [{}, {2 -> 10}], [{1, green}, {null, red}], {7 -> null}, {6 -> null}, {6 -> {7, 8}}, {{7 -> null}, [null, null], {4969-12-04 00:00:00.000, 0.00}}}"});
+      } else {
+        return makeFlatVector<StringView>(
             {"{[null, [1, 100, 2]], [], [], {3 -> [4, 5, 6, 1, 2]}, {1 -> {2 -> 3, 4 -> 5}}, {1 -> {2, 3}, 3 -> {4, 5}}, {{1 -> 10, 2 -> 20}, [0, 1], {2000-01-01 00:00:00, 1234567.89}}}",
              "{[[1, 100, 2], [315]], [{1 -> 11, 3 -> 10}, {0 -> 10, 2 -> 11}, {1 -> 11, 1 -> 10}], [null, null], {5 -> [4, null, 1, 2]}, {0 -> {2 -> 3, 4 -> 5}}, {0 -> {2, 3}, 3 -> {null, null}}, {{3 -> 30, 4 -> 40, 9 -> 90}, [2, 3, 4], {null, -3333333.33}}}",
              "{[[1, 100, null]], [{0 -> null}, {0 -> 10}], [{2, red}, null, {1, blue}], {}, {1 -> {2 -> 3, 4 -> null}}, {1 -> {2, null}, 3 -> {null, 5}}, {{5 -> null, 6 -> 60}, [6, null, 7], {2269-12-29 00:00:00, null}}}",
-             "{[[315]], [{}, {2 -> 10}], [{1, green}, {null, red}], {7 -> null}, {6 -> null}, {6 -> {7, 8}}, {{7 -> null}, [null, null], {4969-12-04 00:00:00, 0.00}}}"}));
-#endif
+             "{[[315]], [{}, {2 -> 10}], [{1, green}, {null, red}], {7 -> null}, {6 -> null}, {6 -> {7, 8}}, {{7 -> null}, [null, null], {4969-12-04 00:00:00, 0.00}}}"});
+      }
+    }();
+    testCast(finalRowVector, expected);
   }
 }
 
@@ -3480,11 +3492,11 @@ TEST_F(CastExprTest, smallerNonNullRowsSizeThanRows) {
 
 TEST_F(CastExprTest, tryCastDoesNotHideInputsAndExistingErrors) {
   auto testInvalid = [](std::function<void()> func) {
-#ifdef SPARK_COMPATIBLE
-    ASSERT_NO_THROW(func());
-#else
-    ASSERT_THROW(func(), BoltException);
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      ASSERT_NO_THROW(func());
+    } else {
+      ASSERT_THROW(func(), BoltException);
+    }
   };
   auto test = [&](const std::string& castExprThatThrow,
                   const std::string& type,
@@ -3659,7 +3671,7 @@ TEST_F(CastExprTest, complexTypeToStringWrappedNestedInput) {
         {{{{1, 1.25}, {2, std::nullopt}}},
          std::nullopt,
          {{{3, 4.5}}},
-         {{}},
+         emptyArray,
          {{{5, 13.25}, {6, 1e7}}}},
         MAP(INTEGER(), DOUBLE()));
     castWrappedAndFlat(maps, {0, 2, 3, 5}, {});
@@ -3668,7 +3680,7 @@ TEST_F(CastExprTest, complexTypeToStringWrappedNestedInput) {
   // ARRAY<ARRAY<...>> where the inner ARRAY child is dictionary-encoded.
   {
     auto inner = makeNullableArrayVector<int32_t>(
-        {{{0, 1}}, {{}}, {{2, std::nullopt, 3}}, std::nullopt, {{4}}});
+        {{{0, 1}}, emptyArray, {{2, std::nullopt, 3}}, std::nullopt, {{4}}});
     castWrappedAndFlat(inner, {0, 2, 5, 5}, {2});
   }
 }

--- a/bolt/expression/tests/ExprEncodingsTest.cpp
+++ b/bolt/expression/tests/ExprEncodingsTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "gtest/gtest.h"
 
 #include "bolt/common/base/Exceptions.h"
@@ -557,8 +559,10 @@ TEST_P(ExprEncodingsTest, moreConditional) {
       });
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_P(ExprEncodingsTest, errors) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   prepareTestData();
 
   if (isAllNulls(testData_.bigint2.vector)) {
@@ -568,7 +572,6 @@ TEST_P(ExprEncodingsTest, errors) {
     runWithError("bigint2 % 0");
   }
 }
-#endif
 
 TEST_P(ExprEncodingsTest, maskedErrors) {
   prepareTestData();

--- a/bolt/expression/tests/ExprEncodingsTest.cpp
+++ b/bolt/expression/tests/ExprEncodingsTest.cpp
@@ -560,7 +560,7 @@ TEST_P(ExprEncodingsTest, moreConditional) {
 }
 
 TEST_P(ExprEncodingsTest, errors) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   prepareTestData();

--- a/bolt/expression/tests/ExprStatsTest.cpp
+++ b/bolt/expression/tests/ExprStatsTest.cpp
@@ -380,7 +380,7 @@ TEST_F(ExprStatsTest, specialForms) {
 }
 
 TEST_F(ExprStatsTest, errorLog) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Register a listener to log exceptions.

--- a/bolt/expression/tests/ExprStatsTest.cpp
+++ b/bolt/expression/tests/ExprStatsTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <gmock/gmock.h>
 #include "bolt/core/Expressions.h"
 #include "bolt/expression/EvalCtx.h"
@@ -377,8 +379,10 @@ TEST_F(ExprStatsTest, specialForms) {
   ASSERT_TRUE(exec::unregisterExprSetListener(listener));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(ExprStatsTest, errorLog) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Register a listener to log exceptions.
   std::vector<Event> events;
   std::vector<std::string> exceptions;
@@ -421,9 +425,9 @@ TEST_F(ExprStatsTest, errorLog) {
   ASSERT_EQ(4, listener->exceptionCount());
   ASSERT_EQ(4, exceptions.size());
 
-  // Test with nested try expressions. Expect errors at rows 2, 3, 4, and 6. Row
-  // 5 in c2 does not cause an error because the corresponding row in c0 is
-  // null, so this row is not evaluated for the division.
+  // Test with nested try expressions. Expect errors at rows 2, 3, 4, and 6.
+  // Row 5 in c2 does not cause an error because the corresponding row in c0
+  // is null, so this row is not evaluated for the division.
   listener->reset();
   exprSet = compileExpressions(
       {"try(try(cast(c0 as integer)) / cast(c2 as integer))"}, rowType);
@@ -450,7 +454,6 @@ TEST_F(ExprStatsTest, errorLog) {
 
   ASSERT_TRUE(exec::unregisterExprSetListener(listener));
 }
-#endif
 
 TEST_F(ExprStatsTest, complexConstants) {
   // Expressions with constants of types not expressible in SQL should use

--- a/bolt/expression/tests/ExprTest.cpp
+++ b/bolt/expression/tests/ExprTest.cpp
@@ -2464,7 +2464,7 @@ struct ThrowRuntimeError {
 } // namespace
 
 TEST_P(ParameterizedExprTest, exceptionContext) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto data = makeRowVector({

--- a/bolt/expression/tests/ExprTest.cpp
+++ b/bolt/expression/tests/ExprTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <cstdint>
 #include <exception>
 #include <fstream>
@@ -2461,8 +2463,10 @@ struct ThrowRuntimeError {
 };
 } // namespace
 
-#ifndef SPARK_COMPATIBLE
 TEST_P(ParameterizedExprTest, exceptionContext) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3}),
       makeFlatVector<int32_t>({1, 2, 3}),
@@ -2590,7 +2594,6 @@ TEST_P(ParameterizedExprTest, exceptionContext) {
     verifyDataAndSqlPaths(e, data);
   }
 }
-#endif
 
 namespace {
 

--- a/bolt/expression/tests/TryExprTest.cpp
+++ b/bolt/expression/tests/TryExprTest.cpp
@@ -141,7 +141,7 @@ TEST_F(TryExprTest, nestedTryParentErrors) {
 }
 
 TEST_F(TryExprTest, skipExecution) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
@@ -158,7 +158,7 @@ TEST_F(TryExprTest, skipExecution) {
 }
 
 TEST_F(TryExprTest, skipExecutionEvalSimplified) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
@@ -176,7 +176,7 @@ TEST_F(TryExprTest, skipExecutionEvalSimplified) {
 }
 
 TEST_F(TryExprTest, skipExecutionWholeBatchEvalSimplified) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
@@ -195,7 +195,7 @@ TEST_F(TryExprTest, skipExecutionWholeBatchEvalSimplified) {
 /// Verify that subsequent inputs to a non-default-null-behavior function are
 /// not evaluated if previous inputs generated errors.
 TEST_F(TryExprTest, skipExecutionOnInputErrors) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Fail all rows.

--- a/bolt/expression/tests/TryExprTest.cpp
+++ b/bolt/expression/tests/TryExprTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -138,8 +140,10 @@ TEST_F(TryExprTest, nestedTryParentErrors) {
       result);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(TryExprTest, skipExecution) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
   std::vector<std::optional<int64_t>> expected{
@@ -154,11 +158,14 @@ TEST_F(TryExprTest, skipExecution) {
 }
 
 TEST_F(TryExprTest, skipExecutionEvalSimplified) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
-  // Test that when a subset of the inputs to a function wrapped in a TRY throw
-  // exceptions, that function is only evaluated on the inputs that did not
-  // throw exceptions.
+  // Test that when a subset of the inputs to a function wrapped in a TRY
+  // throw exceptions, that function is only evaluated on the inputs that did
+  // not throw exceptions.
   auto flatVector = makeFlatVector<StringView>({"1", "a", "1", "a", "1"});
   auto result = evaluateSimplified<FlatVector<int64_t>>(
       "try(count_calls(cast(c0 as integer)))", makeRowVector({flatVector}));
@@ -169,6 +176,9 @@ TEST_F(TryExprTest, skipExecutionEvalSimplified) {
 }
 
 TEST_F(TryExprTest, skipExecutionWholeBatchEvalSimplified) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
   // Test that when all the inputs to a function wrapped in a TRY throw
@@ -185,6 +195,9 @@ TEST_F(TryExprTest, skipExecutionWholeBatchEvalSimplified) {
 /// Verify that subsequent inputs to a non-default-null-behavior function are
 /// not evaluated if previous inputs generated errors.
 TEST_F(TryExprTest, skipExecutionOnInputErrors) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Fail all rows.
   auto input = makeRowVector({
       makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv}),
@@ -223,7 +236,6 @@ TEST_F(TryExprTest, skipExecutionOnInputErrors) {
   EXPECT_EQ(2, stats.at("array_constructor").numProcessedRows);
   EXPECT_EQ(2, stats.at("length").numProcessedRows);
 }
-#endif
 
 namespace {
 // A function that sets result to be a ConstantVector and then throws an

--- a/bolt/functions/flinksql/tests/FlinkCastExprTest.cpp
+++ b/bolt/functions/flinksql/tests/FlinkCastExprTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/flinksql/registration/Register.h"
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/parse/TypeResolver.h"

--- a/bolt/functions/flinksql/tests/FlinkCastExprTest.cpp
+++ b/bolt/functions/flinksql/tests/FlinkCastExprTest.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "bolt/common/base/SparkCompatibility.h"
-
 #include "bolt/functions/flinksql/registration/Register.h"
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/parse/TypeResolver.h"

--- a/bolt/functions/lib/CheckedArithmetic.h
+++ b/bolt/functions/lib/CheckedArithmetic.h
@@ -70,19 +70,16 @@ struct CheckedDivideFunction {
   }
 };
 
-template <typename T>
+template <typename T, bool NullOnDivideByZero = false>
 struct CheckedModulusFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool
   call(TInput& result, const TInput& a, const TInput& b) {
     auto res = checkedModulus(a, b);
-    // When any number mod 0, spark's logic returns null, while presto's logic
-    // throws an exception, so using `SPARK_COMPATIBLE` macro to constrain the
-    // behavior of both
     if (UNLIKELY(!res.has_value())) {
-#ifdef SPARK_COMPATIBLE
-      return false;
-#endif
+      if constexpr (NullOnDivideByZero) {
+        return false;
+      }
       BOLT_ARITHMETIC_ERROR("Cannot divide by 0");
     }
     result = *res;

--- a/bolt/functions/lib/CheckedArithmetic.h
+++ b/bolt/functions/lib/CheckedArithmetic.h
@@ -32,6 +32,7 @@
 
 #include "CheckedArithmeticImpl.h"
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/SparkCompatibility.h"
 namespace bytedance::bolt::functions {
 
 template <typename T>
@@ -70,7 +71,9 @@ struct CheckedDivideFunction {
   }
 };
 
-template <typename T, bool NullOnDivideByZero = false>
+template <
+    typename T,
+    bool NullOnDivideByZero = ::bytedance::bolt::kSparkCompatible>
 struct CheckedModulusFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool

--- a/bolt/functions/lib/DateTimeFormatter.cpp
+++ b/bolt/functions/lib/DateTimeFormatter.cpp
@@ -364,44 +364,42 @@ int64_t parseTimezone(
           {"PDT", tz::getTimeZoneID("America/Los_Angeles")},
       };
       std::string_view zone(cur, 3);
-      std::string upper;
-      if constexpr (::bytedance::bolt::kSparkCompatible) {
+      auto it = defaultTzNames.find(zone);
+      if (::bytedance::bolt::kSparkCompatible && it == defaultTzNames.end()) {
         // spark accept timezone in lower case
+        std::string upper;
         for (auto& c : zone) {
           upper.push_back(toupper(c));
         }
-        zone = upper;
+        it = defaultTzNames.find(upper);
       }
-      auto it = defaultTzNames.find(zone);
       if (it != defaultTzNames.end()) {
         date.timezoneId = it->second;
         return 3;
       }
     }
-    if constexpr (!::bytedance::bolt::kSparkCompatible) {
-      // The format 'UT' is also accepted for UTC.
-      if ((end - cur == 2) && (*cur == 'U') && (*(cur + 1) == 'T')) {
-        date.timezoneId = 0;
-        return 2;
+    // The format 'UT' is also accepted for UTC.
+    if (!::bytedance::bolt::kSparkCompatible && end - cur == 2 && *cur == 'U' &&
+        *(cur + 1) == 'T') {
+      date.timezoneId = 0;
+      return 2;
+    }
+    if (::bytedance::bolt::kSparkCompatible && (*cur == '+' || *cur == '-')) {
+      int64_t timezoneId = -1;
+      int64_t length = 0;
+      if (legacySpark && (end - cur) >= 5) {
+        // spark LEGACY accept (+/-)HHMM as time zone
+        std::string tz = std::string(cur, 3) + ":" + std::string(cur + 3, 2);
+        timezoneId = tz::getTimeZoneID(tz, false);
+        length = 5;
+      } else if (!legacySpark && (end - cur) >= 6 && *(cur + 3) == ':') {
+        // spark CORRECTED accept (+/-)HH:MM as time zone
+        timezoneId = tz::getTimeZoneID(std::string_view(cur, 6), false);
+        length = 6;
       }
-    } else {
-      if ((*cur == '+') || (*cur == '-')) {
-        int64_t timezoneId = -1;
-        int64_t length = 0;
-        if (legacySpark && (end - cur) >= 5) {
-          // spark LEGACY accept (+/-)HHMM as time zone
-          std::string tz = std::string(cur, 3) + ":" + std::string(cur + 3, 2);
-          timezoneId = tz::getTimeZoneID(tz, false);
-          length = 5;
-        } else if (!legacySpark && (end - cur) >= 6 && *(cur + 3) == ':') {
-          // spark CORRECTED accept (+/-)HH:MM as time zone
-          timezoneId = tz::getTimeZoneID(std::string_view(cur, 6), false);
-          length = 6;
-        }
-        if (timezoneId != -1) {
-          date.timezoneId = timezoneId;
-          return length;
-        }
+      if (timezoneId != -1) {
+        date.timezoneId = timezoneId;
+        return length;
       }
     }
   }
@@ -765,7 +763,7 @@ ErrorCode parseFromPattern(
     if (size == -1) {
       return ErrorCode::PARSE_HALFDAY_ERROR;
     }
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       date.isHourOfHalfDay = true; // for get_timestamp("PM", "a") case
     }
     cur += size;
@@ -1052,11 +1050,9 @@ ErrorCode parseFromPattern(
         break;
 
       case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
-        if constexpr (::bytedance::bolt::kSparkCompatible) {
-          date.microsecond = number;
-        } else {
-          date.microsecond = number * util::kMicrosPerMsec;
-        }
+        date.microsecond = ::bytedance::bolt::kSparkCompatible
+            ? number
+            : number * util::kMicrosPerMsec;
         break;
 
       case DateTimeFormatSpecifier::WEEK_YEAR:
@@ -1085,7 +1081,7 @@ ErrorCode parseFromPattern(
         break;
 
       case DateTimeFormatSpecifier::WEEK_OF_MONTH:
-        if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        if (!::bytedance::bolt::kSparkCompatible) {
           BOLT_NYI(
               "Numeric Joda specifier DateTimeFormatSpecifier::" +
               getSpecifierName(curPattern.specifier) + " not implemented yet.");
@@ -1099,7 +1095,7 @@ ErrorCode parseFromPattern(
         break;
 
       case DateTimeFormatSpecifier::DAY_OF_WEEK_IN_MONTH:
-        if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        if (!::bytedance::bolt::kSparkCompatible) {
           BOLT_NYI(
               "Numeric Joda specifier DateTimeFormatSpecifier::" +
               getSpecifierName(curPattern.specifier) + " not implemented yet.");
@@ -1143,12 +1139,10 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
       size += token.literal.size();
       continue;
     }
-    if constexpr (!::bytedance::bolt::kSparkCompatible) {
-      if (isSparkOnlyFormatSpecifier(token.pattern.specifier)) {
-        BOLT_UNSUPPORTED(
-            "format is not supported for specifier {}",
-            token.pattern.specifier);
-      }
+    if (!::bytedance::bolt::kSparkCompatible &&
+        isSparkOnlyFormatSpecifier(token.pattern.specifier)) {
+      BOLT_UNSUPPORTED(
+          "format is not supported for specifier {}", token.pattern.specifier);
     }
     switch (token.pattern.specifier) {
       case DateTimeFormatSpecifier::ERA:
@@ -1256,12 +1250,6 @@ int32_t DateTimeFormatter::format(
   const auto weekdayNum = civilDateTime.weekday;
   const auto dayOfYear = civilDateTime.dayOfYear;
   const auto daysSinceEpoch = civilDateTime.daysSinceEpoch;
-  // Compute the UTC civil date/time of the same instant for timezone-aware
-  // formatting decisions (e.g., suppress '+' when local crosses year boundary
-  // but UTC year is still <= 9999).
-  const auto civilDateTimeUtc =
-      util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
-  const auto& calDateUtc = civilDateTimeUtc.date;
   auto weekdayFromDays = [](int64_t daysSinceEpochInput) {
     auto weekday = static_cast<int32_t>((daysSinceEpochInput + 4) % 7);
     return weekday < 0 ? weekday + 7 : weekday;
@@ -1274,12 +1262,11 @@ int32_t DateTimeFormatter::format(
       std::memcpy(result, token.literal.data(), token.literal.size());
       result += token.literal.size();
     } else {
-      if constexpr (!::bytedance::bolt::kSparkCompatible) {
-        if (isSparkOnlyFormatSpecifier(token.pattern.specifier)) {
-          BOLT_UNSUPPORTED(
-              "format is not supported for specifier {}",
-              token.pattern.specifier);
-        }
+      if (!::bytedance::bolt::kSparkCompatible &&
+          isSparkOnlyFormatSpecifier(token.pattern.specifier)) {
+        BOLT_UNSUPPORTED(
+            "format is not supported for specifier {}",
+            token.pattern.specifier);
       }
       switch (token.pattern.specifier) {
         case DateTimeFormatSpecifier::ERA: {
@@ -1306,25 +1293,23 @@ int32_t DateTimeFormatter::format(
                 padContent(std::abs(year) % 100, '0', 2, maxResultEnd, result);
           } else {
             year = year <= 0 ? std::abs(year - 1) : year;
-            if constexpr (::bytedance::bolt::kSparkCompatible) {
-              // spark compatibility: year should contain sign if > 9999.
-              // However, if a timezone is applied and the same instant in UTC
-              // has year-of-era <= 9999 (e.g., Asia/Shanghai at
-              // 10000-01-01 07:59:59 equals 9999-12-31 23:59:59 UTC), suppress
-              // the leading '+'.
-              bool addPlus =
-                  (year > 9999 && token.pattern.minRepresentDigits >= 4);
-              if (timezone != nullptr) {
-                int32_t utcYearEra = calDateUtc.year <= 0
-                    ? std::abs(calDateUtc.year - 1)
-                    : calDateUtc.year;
-                if (utcYearEra <= 9999) {
-                  addPlus = false;
-                }
-              }
-              if (addPlus) {
-                *result++ = '+';
-              }
+            // spark compatibility: year should contain sign if > 9999.
+            // However, if a timezone is applied and the same instant in UTC
+            // has year-of-era <= 9999 (e.g., Asia/Shanghai at
+            // 10000-01-01 07:59:59 equals 9999-12-31 23:59:59 UTC), suppress
+            // the leading '+'.
+            bool addPlus = ::bytedance::bolt::kSparkCompatible && year > 9999 &&
+                token.pattern.minRepresentDigits >= 4;
+            if (addPlus && timezone != nullptr) {
+              const auto civilDateTimeUtc =
+                  util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
+              const auto utcYearEra = civilDateTimeUtc.date.year <= 0
+                  ? std::abs(civilDateTimeUtc.date.year - 1)
+                  : civilDateTimeUtc.date.year;
+              addPlus = utcYearEra > 9999;
+            }
+            if (addPlus) {
+              *result++ = '+';
             }
             result += padContent(
                 year,
@@ -1366,27 +1351,27 @@ int32_t DateTimeFormatter::format(
           [[fallthrough]];
         case DateTimeFormatSpecifier::YEAR: {
           auto year = calDate.year;
-          if constexpr (::bytedance::bolt::kSparkCompatible) {
-            if (token.pattern.specifier == DateTimeFormatSpecifier::WEEK_YEAR) {
-              BOLT_USER_CHECK_EQ(
-                  timePolicy,
-                  TimePolicy::LEGACY,
-                  "WEEK_YEAR is only supported in Spark LEGACY policy");
-              auto weekYear = year;
-              if (calDate.month == 12) {
-                // If the date is in the last week of the year, and this week
-                // contains next year's first day, the week year is next year.
-                if (calDate.day - weekdayNum + 6 > 31) {
-                  weekYear += 1;
-                }
+          if (::bytedance::bolt::kSparkCompatible &&
+              token.pattern.specifier == DateTimeFormatSpecifier::WEEK_YEAR) {
+            BOLT_USER_CHECK_EQ(
+                timePolicy,
+                TimePolicy::LEGACY,
+                "WEEK_YEAR is only supported in Spark LEGACY policy");
+            auto weekYear = year;
+            if (calDate.month == 12) {
+              // If the date is in the last week of the year, and this week
+              // contains next year's first day, the week year is next year.
+              if (calDate.day - weekdayNum + 6 > 31) {
+                weekYear += 1;
               }
-              year = weekYear;
             }
-            if (year < 0 && (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
-              // for spark compatibility, year should be positive for LEGACY
-              // policy or has Era
-              year = abs(year) + 1;
-            }
+            year = weekYear;
+          }
+          if (::bytedance::bolt::kSparkCompatible && year < 0 &&
+              (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
+            // for spark compatibility, year should be positive for LEGACY
+            // policy or has Era
+            year = abs(year) + 1;
           }
           if (token.pattern.minRepresentDigits == 2) {
             year = std::abs(year);
@@ -1398,25 +1383,23 @@ int32_t DateTimeFormatter::format(
                 maxResultEnd,
                 result);
           } else {
-            if constexpr (::bytedance::bolt::kSparkCompatible) {
-              // spark compatibility: year should contain sign if > 9999.
-              // If a timezone is applied and the same instant in UTC has
-              // (adjusted) year <= 9999, suppress the leading '+'.
-              bool addPlus =
-                  (year > 9999 && token.pattern.minRepresentDigits >= 4);
-              if (timezone != nullptr) {
-                int32_t utcYearAdj = calDateUtc.year;
-                if (utcYearAdj < 0 &&
-                    (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
-                  utcYearAdj = std::abs(utcYearAdj) + 1;
-                }
-                if (utcYearAdj <= 9999) {
-                  addPlus = false;
-                }
+            // spark compatibility: year should contain sign if > 9999.
+            // If a timezone is applied and the same instant in UTC has
+            // (adjusted) year <= 9999, suppress the leading '+'.
+            bool addPlus = ::bytedance::bolt::kSparkCompatible && year > 9999 &&
+                token.pattern.minRepresentDigits >= 4;
+            if (addPlus && timezone != nullptr) {
+              const auto civilDateTimeUtc =
+                  util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
+              auto utcYear = civilDateTimeUtc.date.year;
+              if (utcYear < 0 &&
+                  (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
+                utcYear = std::abs(utcYear) + 1;
               }
-              if (addPlus) {
-                *result++ = '+';
-              }
+              addPlus = utcYear > 9999;
+            }
+            if (addPlus) {
+              *result++ = '+';
             }
             result += padContent(
                 year,
@@ -2191,11 +2174,8 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
           builder.appendDayOfMonth(count);
           break;
         case 'a':
-          if constexpr (::bytedance::bolt::kSparkCompatible) {
-            if (count > 1) {
-              BOLT_USER_FAIL(
-                  "The am-pm-of-day pattern letter count must be 1.");
-            }
+          if (::bytedance::bolt::kSparkCompatible && count > 1) {
+            BOLT_USER_FAIL("The am-pm-of-day pattern letter count must be 1.");
           }
           builder.appendHalfDayOfDay();
           break;
@@ -2227,7 +2207,7 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
           builder.appendTimeZone(count);
           break;
         case 'X':
-          if constexpr (!::bytedance::bolt::kSparkCompatible) {
+          if (!::bytedance::bolt::kSparkCompatible) {
             BOLT_UNSUPPORTED("Specifier X is not supported.");
           }
           [[fallthrough]];
@@ -2439,11 +2419,8 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
           builder.appendDayOfMonth(count);
           break;
         case 'a':
-          if constexpr (::bytedance::bolt::kSparkCompatible) {
-            if (count > 1) {
-              BOLT_USER_FAIL(
-                  "The am-pm-of-day pattern letter count must be 1.");
-            }
+          if (::bytedance::bolt::kSparkCompatible && count > 1) {
+            BOLT_USER_FAIL("The am-pm-of-day pattern letter count must be 1.");
           }
           builder.appendHalfDayOfDay();
           break;
@@ -2481,7 +2458,7 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
           builder.appendTimeZone(count);
           break;
         case 'X':
-          if constexpr (!::bytedance::bolt::kSparkCompatible) {
+          if (!::bytedance::bolt::kSparkCompatible) {
             BOLT_UNSUPPORTED("Specifier X is not supported.");
           }
           [[fallthrough]];

--- a/bolt/functions/lib/DateTimeFormatter.cpp
+++ b/bolt/functions/lib/DateTimeFormatter.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/lib/DateTimeFormatter.h"
 
 #include <bolt/common/base/Exceptions.h>
@@ -103,6 +105,19 @@ constexpr std::string_view weekdaysFull[] = {
     "Saturday"};
 constexpr std::string_view weekdaysShort[] =
     {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+constexpr bool isSparkOnlyFormatSpecifier(DateTimeFormatSpecifier specifier) {
+  switch (specifier) {
+    case DateTimeFormatSpecifier::WEEK_YEAR:
+    case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
+    case DateTimeFormatSpecifier::WEEK_OF_MONTH:
+    case DateTimeFormatSpecifier::DAY_OF_WEEK_IN_MONTH:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static std::
     unordered_map<std::string_view, std::pair<std::string_view, int64_t>>
         dayOfWeekMap{
@@ -349,46 +364,46 @@ int64_t parseTimezone(
           {"PDT", tz::getTimeZoneID("America/Los_Angeles")},
       };
       std::string_view zone(cur, 3);
-#ifdef SPARK_COMPATIBLE
-      // spark accept timezone in lower case
       std::string upper;
-      for (auto& c : zone) {
-        upper.push_back(toupper(c));
+      if constexpr (::bytedance::bolt::kSparkCompatible) {
+        // spark accept timezone in lower case
+        for (auto& c : zone) {
+          upper.push_back(toupper(c));
+        }
+        zone = upper;
       }
-      zone = upper;
-#endif
       auto it = defaultTzNames.find(zone);
       if (it != defaultTzNames.end()) {
         date.timezoneId = it->second;
         return 3;
       }
     }
-#ifndef SPARK_COMPATIBLE
-    // The format 'UT' is also accepted for UTC.
-    else if ((end - cur == 2) && (*cur == 'U') && (*(cur + 1) == 'T')) {
-      date.timezoneId = 0;
-      return 2;
-    }
-#else
-    if ((*cur == '+') || (*cur == '-')) {
-      int64_t timezoneId = -1;
-      int64_t length = 0;
-      if (legacySpark && (end - cur) >= 5) {
-        // spark LEGACY accept (+/-)HHMM as time zone
-        std::string tz = std::string(cur, 3) + ":" + std::string(cur + 3, 2);
-        timezoneId = tz::getTimeZoneID(tz, false);
-        length = 5;
-      } else if (!legacySpark && (end - cur) >= 6 && *(cur + 3) == ':') {
-        // spark CORRECTED accept (+/-)HH:MM as time zone
-        timezoneId = tz::getTimeZoneID(std::string_view(cur, 6), false);
-        length = 6;
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      // The format 'UT' is also accepted for UTC.
+      if ((end - cur == 2) && (*cur == 'U') && (*(cur + 1) == 'T')) {
+        date.timezoneId = 0;
+        return 2;
       }
-      if (timezoneId != -1) {
-        date.timezoneId = timezoneId;
-        return length;
+    } else {
+      if ((*cur == '+') || (*cur == '-')) {
+        int64_t timezoneId = -1;
+        int64_t length = 0;
+        if (legacySpark && (end - cur) >= 5) {
+          // spark LEGACY accept (+/-)HHMM as time zone
+          std::string tz = std::string(cur, 3) + ":" + std::string(cur + 3, 2);
+          timezoneId = tz::getTimeZoneID(tz, false);
+          length = 5;
+        } else if (!legacySpark && (end - cur) >= 6 && *(cur + 3) == ':') {
+          // spark CORRECTED accept (+/-)HH:MM as time zone
+          timezoneId = tz::getTimeZoneID(std::string_view(cur, 6), false);
+          length = 6;
+        }
+        if (timezoneId != -1) {
+          date.timezoneId = timezoneId;
+          return length;
+        }
       }
     }
-#endif
   }
   return -1;
 }
@@ -750,9 +765,9 @@ ErrorCode parseFromPattern(
     if (size == -1) {
       return ErrorCode::PARSE_HALFDAY_ERROR;
     }
-#ifdef SPARK_COMPATIBLE
-    date.isHourOfHalfDay = true; // for get_timestamp("PM", "a") case
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      date.isHourOfHalfDay = true; // for get_timestamp("PM", "a") case
+    }
     cur += size;
   } else if (
       curPattern.specifier == DateTimeFormatSpecifier::DAY_OF_WEEK_TEXT) {
@@ -806,32 +821,32 @@ ErrorCode parseFromPattern(
           return ErrorCode::PARSE_FRACTION_ERROR;
         }
       }
-#ifdef SPARK_COMPATIBLE
-      // .8 + S => .8 CORRECTED
-      // .8 + SS => .8 CORRECTED
-      // .8 + SSS => .8 CORRECTED
-      // .8 + SSSS => .8 CORRECTED
-      // .80 + SSS => .8 CORRECTED
-      // .800 + SSS => .8 CORRECTED
-      // .1234 + SSSS => .1234 CORRECTED
-      // .1234 + SSSSS => .1234 CORRECTED
+      if constexpr (::bytedance::bolt::kSparkCompatible) {
+        // .8 + S => .8 CORRECTED
+        // .8 + SS => .8 CORRECTED
+        // .8 + SSS => .8 CORRECTED
+        // .8 + SSSS => .8 CORRECTED
+        // .80 + SSS => .8 CORRECTED
+        // .800 + SSS => .8 CORRECTED
+        // .1234 + SSSS => .1234 CORRECTED
+        // .1234 + SSSSS => .1234 CORRECTED
 
-      // .8 + S => .008 LEGACY
-      // .8 + SS => .008 LEGACY
-      // .8 + SSS => .008 LEGACY
-      // .8 + SSSS => .008 LEGACY
-      // .80 + SSS => .08 LEGACY
-      // .800 + SSS => .8 LEGACY
-      // .1234 + SSSS => null LEGACY
-      // .1234 + SSSSS => null LEGACY
-      if (!legacySpark) {
-        number *= std::pow(10, 9 - count) / 1000;
+        // .8 + S => .008 LEGACY
+        // .8 + SS => .008 LEGACY
+        // .8 + SSS => .008 LEGACY
+        // .8 + SSSS => .008 LEGACY
+        // .80 + SSS => .08 LEGACY
+        // .800 + SSS => .8 LEGACY
+        // .1234 + SSSS => null LEGACY
+        // .1234 + SSSSS => null LEGACY
+        if (!legacySpark) {
+          number *= std::pow(10, 9 - count) / 1000;
+        } else {
+          number *= 1000;
+        }
       } else {
-        number *= 1000;
+        number *= std::pow(10, 3 - count);
       }
-#else
-      number *= std::pow(10, 3 - count);
-#endif
     } else if (
         (curPattern.specifier == DateTimeFormatSpecifier::YEAR ||
          curPattern.specifier == DateTimeFormatSpecifier::YEAR_OF_ERA ||
@@ -1037,11 +1052,11 @@ ErrorCode parseFromPattern(
         break;
 
       case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
-#ifdef SPARK_COMPATIBLE
-        date.microsecond = number;
-#else
-        date.microsecond = number * util::kMicrosPerMsec;
-#endif
+        if constexpr (::bytedance::bolt::kSparkCompatible) {
+          date.microsecond = number;
+        } else {
+          date.microsecond = number * util::kMicrosPerMsec;
+        }
         break;
 
       case DateTimeFormatSpecifier::WEEK_YEAR:
@@ -1069,8 +1084,12 @@ ErrorCode parseFromPattern(
         }
         break;
 
-#ifdef SPARK_COMPATIBLE
       case DateTimeFormatSpecifier::WEEK_OF_MONTH:
+        if constexpr (!::bytedance::bolt::kSparkCompatible) {
+          BOLT_NYI(
+              "Numeric Joda specifier DateTimeFormatSpecifier::" +
+              getSpecifierName(curPattern.specifier) + " not implemented yet.");
+        }
         if (number < 1 || number > 5) {
           return ErrorCode::WEEK_OUT_OF_RANGE;
         }
@@ -1080,6 +1099,11 @@ ErrorCode parseFromPattern(
         break;
 
       case DateTimeFormatSpecifier::DAY_OF_WEEK_IN_MONTH:
+        if constexpr (!::bytedance::bolt::kSparkCompatible) {
+          BOLT_NYI(
+              "Numeric Joda specifier DateTimeFormatSpecifier::" +
+              getSpecifierName(curPattern.specifier) + " not implemented yet.");
+        }
         if (number < 1 || number > 5) {
           return ErrorCode::WEEK_OUT_OF_RANGE;
         }
@@ -1087,7 +1111,6 @@ ErrorCode parseFromPattern(
         date.weekDateFormat = true;
         date.dayOfYearFormat = false;
         break;
-#endif
 
       case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED:
         if (number < 1 || number > 7) {
@@ -1120,6 +1143,13 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
       size += token.literal.size();
       continue;
     }
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      if (isSparkOnlyFormatSpecifier(token.pattern.specifier)) {
+        BOLT_UNSUPPORTED(
+            "format is not supported for specifier {}",
+            token.pattern.specifier);
+      }
+    }
     switch (token.pattern.specifier) {
       case DateTimeFormatSpecifier::ERA:
       case DateTimeFormatSpecifier::HALFDAY_OF_DAY:
@@ -1139,10 +1169,9 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
         // 9 is the max size of elements in weekdaysFull or monthsFull.
         size += token.pattern.minRepresentDigits <= 3 ? 3 : 9;
         break;
-      case DateTimeFormatSpecifier::YEAR:
-#ifdef SPARK_COMPATIBLE
       case DateTimeFormatSpecifier::WEEK_YEAR:
-#endif
+        [[fallthrough]];
+      case DateTimeFormatSpecifier::YEAR:
         // Timestamp is in [-32767-01-01, 32767-12-31] range.
         size += token.pattern.minRepresentDigits == 2
             ? 2
@@ -1160,11 +1189,9 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
       case DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY:
       case DateTimeFormatSpecifier::MINUTE_OF_HOUR:
       case DateTimeFormatSpecifier::SECOND_OF_MINUTE:
-#ifdef SPARK_COMPATIBLE
       case DateTimeFormatSpecifier::WEEK_OF_MONTH:
       case DateTimeFormatSpecifier::DAY_OF_WEEK_IN_MONTH:
       case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
-#endif
         size += std::max((int)token.pattern.minRepresentDigits, 2);
         break;
       case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
@@ -1235,12 +1262,10 @@ int32_t DateTimeFormatter::format(
   const auto civilDateTimeUtc =
       util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
   const auto& calDateUtc = civilDateTimeUtc.date;
-#ifdef SPARK_COMPATIBLE
   auto weekdayFromDays = [](int64_t daysSinceEpochInput) {
     auto weekday = static_cast<int32_t>((daysSinceEpochInput + 4) % 7);
     return weekday < 0 ? weekday + 7 : weekday;
   };
-#endif
 
   const char* resultStart = result;
   char* maxResultEnd = result + maxResultSize;
@@ -1249,6 +1274,13 @@ int32_t DateTimeFormatter::format(
       std::memcpy(result, token.literal.data(), token.literal.size());
       result += token.literal.size();
     } else {
+      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        if (isSparkOnlyFormatSpecifier(token.pattern.specifier)) {
+          BOLT_UNSUPPORTED(
+              "format is not supported for specifier {}",
+              token.pattern.specifier);
+        }
+      }
       switch (token.pattern.specifier) {
         case DateTimeFormatSpecifier::ERA: {
           const std::string_view piece = calDate.year > 0 ? "AD" : "BC";
@@ -1274,26 +1306,26 @@ int32_t DateTimeFormatter::format(
                 padContent(std::abs(year) % 100, '0', 2, maxResultEnd, result);
           } else {
             year = year <= 0 ? std::abs(year - 1) : year;
-#ifdef SPARK_COMPATIBLE
-            // spark compatibility: year should contain sign if > 9999.
-            // However, if a timezone is applied and the same instant in UTC
-            // has year-of-era <= 9999 (e.g., Asia/Shanghai at
-            // 10000-01-01 07:59:59 equals 9999-12-31 23:59:59 UTC), suppress
-            // the leading '+'.
-            bool addPlus =
-                (year > 9999 && token.pattern.minRepresentDigits >= 4);
-            if (timezone != nullptr) {
-              int32_t utcYearEra = calDateUtc.year <= 0
-                  ? std::abs(calDateUtc.year - 1)
-                  : calDateUtc.year;
-              if (utcYearEra <= 9999) {
-                addPlus = false;
+            if constexpr (::bytedance::bolt::kSparkCompatible) {
+              // spark compatibility: year should contain sign if > 9999.
+              // However, if a timezone is applied and the same instant in UTC
+              // has year-of-era <= 9999 (e.g., Asia/Shanghai at
+              // 10000-01-01 07:59:59 equals 9999-12-31 23:59:59 UTC), suppress
+              // the leading '+'.
+              bool addPlus =
+                  (year > 9999 && token.pattern.minRepresentDigits >= 4);
+              if (timezone != nullptr) {
+                int32_t utcYearEra = calDateUtc.year <= 0
+                    ? std::abs(calDateUtc.year - 1)
+                    : calDateUtc.year;
+                if (utcYearEra <= 9999) {
+                  addPlus = false;
+                }
+              }
+              if (addPlus) {
+                *result++ = '+';
               }
             }
-            if (addPlus) {
-              *result++ = '+';
-            }
-#endif
             result += padContent(
                 year,
                 '0',
@@ -1330,33 +1362,32 @@ int32_t DateTimeFormatter::format(
           result += piece.length();
         } break;
 
-#ifdef SPARK_COMPATIBLE
         case DateTimeFormatSpecifier::WEEK_YEAR:
-#endif
+          [[fallthrough]];
         case DateTimeFormatSpecifier::YEAR: {
           auto year = calDate.year;
-#ifdef SPARK_COMPATIBLE
-          if (token.pattern.specifier == DateTimeFormatSpecifier::WEEK_YEAR) {
-            BOLT_USER_CHECK_EQ(
-                timePolicy,
-                TimePolicy::LEGACY,
-                "WEEK_YEAR is only supported in Spark LEGACY policy");
-            auto weekYear = year;
-            if (calDate.month == 12) {
-              // If the date is in the last week of the year, and this week
-              // contains next year's first day, the week year is next year.
-              if (calDate.day - weekdayNum + 6 > 31) {
-                weekYear += 1;
+          if constexpr (::bytedance::bolt::kSparkCompatible) {
+            if (token.pattern.specifier == DateTimeFormatSpecifier::WEEK_YEAR) {
+              BOLT_USER_CHECK_EQ(
+                  timePolicy,
+                  TimePolicy::LEGACY,
+                  "WEEK_YEAR is only supported in Spark LEGACY policy");
+              auto weekYear = year;
+              if (calDate.month == 12) {
+                // If the date is in the last week of the year, and this week
+                // contains next year's first day, the week year is next year.
+                if (calDate.day - weekdayNum + 6 > 31) {
+                  weekYear += 1;
+                }
               }
+              year = weekYear;
             }
-            year = weekYear;
+            if (year < 0 && (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
+              // for spark compatibility, year should be positive for LEGACY
+              // policy or has Era
+              year = abs(year) + 1;
+            }
           }
-          if (year < 0 && (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
-            // for spark compatibility, year should be positive for LEGACY
-            // policy or has Era
-            year = abs(year) + 1;
-          }
-#endif
           if (token.pattern.minRepresentDigits == 2) {
             year = std::abs(year);
             auto twoDigitYear = year % 100;
@@ -1367,26 +1398,26 @@ int32_t DateTimeFormatter::format(
                 maxResultEnd,
                 result);
           } else {
-#ifdef SPARK_COMPATIBLE
-            // spark compatibility: year should contain sign if > 9999.
-            // If a timezone is applied and the same instant in UTC has
-            // (adjusted) year <= 9999, suppress the leading '+'.
-            bool addPlus =
-                (year > 9999 && token.pattern.minRepresentDigits >= 4);
-            if (timezone != nullptr) {
-              int32_t utcYearAdj = calDateUtc.year;
-              if (utcYearAdj < 0 &&
-                  (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
-                utcYearAdj = std::abs(utcYearAdj) + 1;
+            if constexpr (::bytedance::bolt::kSparkCompatible) {
+              // spark compatibility: year should contain sign if > 9999.
+              // If a timezone is applied and the same instant in UTC has
+              // (adjusted) year <= 9999, suppress the leading '+'.
+              bool addPlus =
+                  (year > 9999 && token.pattern.minRepresentDigits >= 4);
+              if (timezone != nullptr) {
+                int32_t utcYearAdj = calDateUtc.year;
+                if (utcYearAdj < 0 &&
+                    (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
+                  utcYearAdj = std::abs(utcYearAdj) + 1;
+                }
+                if (utcYearAdj <= 9999) {
+                  addPlus = false;
+                }
               }
-              if (utcYearAdj <= 9999) {
-                addPlus = false;
+              if (addPlus) {
+                *result++ = '+';
               }
             }
-            if (addPlus) {
-              *result++ = '+';
-            }
-#endif
             result += padContent(
                 year,
                 '0',
@@ -1396,7 +1427,6 @@ int32_t DateTimeFormatter::format(
           }
         } break;
 
-#ifdef SPARK_COMPATIBLE
         case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR: {
           // Calculate week of week year based on Java SimpleDateFormat
 
@@ -1432,7 +1462,8 @@ int32_t DateTimeFormatter::format(
         case DateTimeFormatSpecifier::WEEK_OF_MONTH: {
           // Calculate week of month based on Java SimpleDateFormat
 
-          // like WEEK_OF_WEEK_YEAR, but calculate from the first day of month
+          // like WEEK_OF_WEEK_YEAR, but calculate from the first day of
+          // month
           auto firstDayOfMonth =
               util::daysSinceEpochFromDate(calDate.year, calDate.month, 1);
 
@@ -1457,8 +1488,8 @@ int32_t DateTimeFormatter::format(
         case DateTimeFormatSpecifier::DAY_OF_WEEK_IN_MONTH: {
           // Calculate day of week in month based on Java SimpleDateFormat
 
-          // like WEEK_OF_MONTH, but calculates which occurrence of this weekday
-          // in the month
+          // like WEEK_OF_MONTH, but calculates which occurrence of this
+          // weekday in the month
           auto currentDayOfWeek = weekdayNum; // 0=Sunday, 6=Saturday
           auto dayOfMonth = calDate.day;
 
@@ -1466,8 +1497,8 @@ int32_t DateTimeFormatter::format(
               util::daysSinceEpochFromDate(calDate.year, calDate.month, 1);
           auto firstDayOfMonthWeekday = weekdayFromDays(firstDayOfMonth);
 
-          // Calculate the first occurrence of the current day of week in the
-          // month
+          // Calculate the first occurrence of the current day of week in
+          // the month
           int firstOccurrence =
               (currentDayOfWeek - firstDayOfMonthWeekday + 7) % 7 + 1;
 
@@ -1481,7 +1512,6 @@ int32_t DateTimeFormatter::format(
               maxResultEnd,
               result);
         } break;
-#endif
 
         case DateTimeFormatSpecifier::DAY_OF_YEAR: {
           result += padContent(
@@ -2161,11 +2191,12 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
           builder.appendDayOfMonth(count);
           break;
         case 'a':
-#ifdef SPARK_COMPATIBLE
-          if (count > 1) {
-            BOLT_USER_FAIL("The am-pm-of-day pattern letter count must be 1.");
+          if constexpr (::bytedance::bolt::kSparkCompatible) {
+            if (count > 1) {
+              BOLT_USER_FAIL(
+                  "The am-pm-of-day pattern letter count must be 1.");
+            }
           }
-#endif
           builder.appendHalfDayOfDay();
           break;
         case 'K':
@@ -2195,10 +2226,12 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
         case 'z':
           builder.appendTimeZone(count);
           break;
-        case 'Z':
-#ifdef SPARK_COMPATIBLE
         case 'X':
-#endif
+          if constexpr (!::bytedance::bolt::kSparkCompatible) {
+            BOLT_UNSUPPORTED("Specifier X is not supported.");
+          }
+          [[fallthrough]];
+        case 'Z':
           builder.appendTimeZoneOffsetId(count);
           break;
         default:
@@ -2406,11 +2439,12 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
           builder.appendDayOfMonth(count);
           break;
         case 'a':
-#ifdef SPARK_COMPATIBLE
-          if (count > 1) {
-            BOLT_USER_FAIL("The am-pm-of-day pattern letter count must be 1.");
+          if constexpr (::bytedance::bolt::kSparkCompatible) {
+            if (count > 1) {
+              BOLT_USER_FAIL(
+                  "The am-pm-of-day pattern letter count must be 1.");
+            }
           }
-#endif
           builder.appendHalfDayOfDay();
           break;
         case 'K':
@@ -2446,10 +2480,12 @@ std::shared_ptr<DateTimeFormatter> buildLegacySparkDateTimeFormatter(
         case 'z':
           builder.appendTimeZone(count);
           break;
-        case 'Z':
-#ifdef SPARK_COMPATIBLE
         case 'X':
-#endif
+          if constexpr (!::bytedance::bolt::kSparkCompatible) {
+            BOLT_UNSUPPORTED("Specifier X is not supported.");
+          }
+          [[fallthrough]];
+        case 'Z':
           builder.appendTimeZoneOffsetId(count);
           break;
         default:

--- a/bolt/functions/lib/Sequence.cpp
+++ b/bolt/functions/lib/Sequence.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-#include "bolt/functions/lib/Sequence.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/expression/DecodedArgs.h"
+#include "bolt/functions/lib/Sequence.h"
 #include "bolt/functions/lib/TimeDiffUtils.h"
 #include "bolt/functions/prestosql/DateTimeImpl.h"
 
@@ -202,12 +204,10 @@ vector_size_t SequenceFunction<T, K>::checkArguments(
   T stop = stopVector->valueAt<T>(row);
   auto step = getStep(
       toInt64(start), toInt64(stop), stepVector, row, isDate, isYearMonth);
-#ifdef SPARK_COMPATIBLE
   // Unlike Presto, Spark permits a zero step when both bounds are equal.
-  if (step == 0 && start == stop) {
+  if (::bytedance::bolt::kSparkCompatible && step == 0 && start == stop) {
     return 1;
   }
-#endif
   BOLT_USER_CHECK_NE(step, 0, "step must not be zero");
   BOLT_USER_CHECK(
       step > 0 ? stop >= start : stop <= start,

--- a/bolt/functions/lib/tests/CheckedArithmeticTest.cpp
+++ b/bolt/functions/lib/tests/CheckedArithmeticTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <cstdint>
 #include "bolt/functions/prestosql/tests/utils/FunctionBaseTest.h"
 using namespace bytedance::bolt;
@@ -25,15 +27,15 @@ TEST_F(CheckedArithmeticTest, Mod) {
   auto firstVector = makeFlatVector<int32_t>({10, 20, 30});
   auto secondVector = makeFlatVector<int32_t>({0, 1, 2});
   auto expected = makeNullableFlatVector<int32_t>({std::nullopt, 0, 0});
-#ifndef SPARK_COMPATIBLE
-  // When any number mod 0, presto's logic throws an exception
-  EXPECT_THROW(
-      evaluate<SimpleVector<int32_t>>(
-          "mod(c0, c1)", makeRowVector({firstVector, secondVector})),
-      BoltUserError);
-#else
-  auto result = evaluate<SimpleVector<int32_t>>(
-      "mod(c0, c1)", makeRowVector({firstVector, secondVector}));
-  assertEqualVectors(expected, result);
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // When any number mod 0, presto's logic throws an exception
+    EXPECT_THROW(
+        evaluate<SimpleVector<int32_t>>(
+            "mod(c0, c1)", makeRowVector({firstVector, secondVector})),
+        BoltUserError);
+  } else {
+    auto result = evaluate<SimpleVector<int32_t>>(
+        "mod(c0, c1)", makeRowVector({firstVector, secondVector}));
+    assertEqualVectors(expected, result);
+  }
 }

--- a/bolt/functions/lib/tests/CheckedArithmeticTest.cpp
+++ b/bolt/functions/lib/tests/CheckedArithmeticTest.cpp
@@ -17,17 +17,28 @@
 #include "bolt/common/base/SparkCompatibility.h"
 
 #include <cstdint>
+#include "bolt/functions/lib/CheckedArithmetic.h"
 #include "bolt/functions/prestosql/tests/utils/FunctionBaseTest.h"
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::test;
 
 class CheckedArithmeticTest : public functions::test::FunctionBaseTest {};
 
+TEST_F(CheckedArithmeticTest, DefaultModulusCompatibility) {
+  functions::CheckedModulusFunction<int32_t> modulus;
+  int32_t result;
+  if (::bytedance::bolt::kSparkCompatible) {
+    EXPECT_FALSE(modulus.call(result, 1, 0));
+  } else {
+    EXPECT_THROW(modulus.call(result, 1, 0), BoltUserError);
+  }
+}
+
 TEST_F(CheckedArithmeticTest, Mod) {
   auto firstVector = makeFlatVector<int32_t>({10, 20, 30});
   auto secondVector = makeFlatVector<int32_t>({0, 1, 2});
   auto expected = makeNullableFlatVector<int32_t>({std::nullopt, 0, 0});
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     // When any number mod 0, presto's logic throws an exception
     EXPECT_THROW(
         evaluate<SimpleVector<int32_t>>(

--- a/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -28,10 +28,12 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/functions/lib/DateTimeFormatter.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <bolt/common/base/BoltException.h>
 #include <bolt/type/StringView.h>
 #include <date/tz.h>
+#include "bolt/functions/lib/DateTimeFormatter.h"
 
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/functions/lib/DateTimeFormatterBuilder.h"
@@ -270,17 +272,17 @@ TEST_F(JodaDateTimeFormatterTest, validJodaBuild) {
   // d specifier case
   testTokenRange('d', 1, 4, DateTimeFormatSpecifier::DAY_OF_MONTH);
 
-#ifndef SPARK_COMPATIBLE
-  // a specifier case
-  expected = {
-      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2})};
-  EXPECT_EQ(expected, buildJodaDateTimeFormatter("a")->tokens());
-  // minRepresentDigits should be unchanged with higher number of specifier for
-  // HALFDAY_OF_DAY
-  expected = {
-      DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2})};
-  EXPECT_EQ(expected, buildJodaDateTimeFormatter("aa")->tokens());
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // a specifier case
+    expected = {DateTimeToken(
+        FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2})};
+    EXPECT_EQ(expected, buildJodaDateTimeFormatter("a")->tokens());
+    // minRepresentDigits should be unchanged with higher number of specifier
+    // for HALFDAY_OF_DAY
+    expected = {DateTimeToken(
+        FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2})};
+    EXPECT_EQ(expected, buildJodaDateTimeFormatter("aa")->tokens());
+  }
 
   // K specifier case
   testTokenRange('K', 1, 4, DateTimeFormatSpecifier::HOUR_OF_HALFDAY);
@@ -373,13 +375,13 @@ TEST_F(JodaDateTimeFormatterTest, validJodaBuild) {
       DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2}),
   };
 
-#ifndef SPARK_COMPATIBLE
-  EXPECT_EQ(
-      expected,
-      buildJodaDateTimeFormatter(
-          "''CCC-YYYY/xxx//www-00-eeee--EEEEEE---yyyyy///DDDDMM-MMMMddddKKhhhkkHHmmsSSSSSSzzzZZZGGGG'abcdefghijklmnopqrstuvwxyz'aaa")
-          ->tokens());
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(
+        expected,
+        buildJodaDateTimeFormatter(
+            "''CCC-YYYY/xxx//www-00-eeee--EEEEEE---yyyyy///DDDDMM-MMMMddddKKhhhkkHHmmsSSSSSSzzzZZZGGGG'abcdefghijklmnopqrstuvwxyz'aaa")
+            ->tokens());
+  }
 }
 
 TEST_F(JodaDateTimeFormatterTest, invalidJodaBuild) {
@@ -403,8 +405,10 @@ TEST_F(JodaDateTimeFormatterTest, invalid) {
   EXPECT_THROW(parseJoda("", "Y '"), BoltUserError);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(JodaDateTimeFormatterTest, parseJodaEra) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Normal era cases
   EXPECT_EQ(
       util::fromTimestampString("-100-01-01", nullptr),
@@ -463,7 +467,6 @@ TEST_F(JodaDateTimeFormatterTest, parseJodaEra) {
   EXPECT_THROW(parseJoda("bC", "G"), BoltUserError);
   EXPECT_THROW(parseJoda("Bc", "G"), BoltUserError);
 }
-#endif
 
 TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
   // By the default, assume epoch.
@@ -527,9 +530,12 @@ TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
   EXPECT_THROW(parseJoda("+100", "Y"), BoltUserError);
 }
 
-#ifndef SPARK_COMPATIBLE
-// Same semantic as YEAR_OF_ERA, except that it accepts zero and negative years.
+// Same semantic as YEAR_OF_ERA, except that it accepts zero and negative
+// years.
 TEST_F(JodaDateTimeFormatterTest, parseYear) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   EXPECT_EQ(
       util::fromTimestampString("123-01-01", nullptr),
       parseJoda("123", "y").timestamp);
@@ -604,6 +610,9 @@ TEST_F(JodaDateTimeFormatterTest, parseYear) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Covers entire range of possible week year start dates (12-29 to 01-04)
   EXPECT_EQ(
       util::fromTimestampString("1969-12-29 00:00:00", nullptr),
@@ -682,6 +691,9 @@ TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseCenturyOfEra) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Probe century range
   EXPECT_EQ(
       util::fromTimestampString("292278900-01-01 00:00:00", nullptr),
@@ -694,7 +706,6 @@ TEST_F(JodaDateTimeFormatterTest, parseCenturyOfEra) {
   EXPECT_THROW(parseJoda("-1", "CCCCCCC"), BoltUserError);
   EXPECT_THROW(parseJoda("2922790", "CCCCCCC"), BoltUserError);
 }
-#endif
 
 TEST_F(JodaDateTimeFormatterTest, parseJodaMonth) {
   // Joda has this weird behavior where if minute or hour is specified, year
@@ -968,8 +979,10 @@ TEST_F(JodaDateTimeFormatterTest, parseClockHourOfHalfDay) {
   //   EXPECT_THROW(parseJoda("123456789", "h"), BoltUserError);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Half of day has no effect if hour or clockhour of day is provided
   // hour of day tests
   EXPECT_EQ(
@@ -1078,7 +1091,8 @@ TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
       util::fromTimestampString("1970-01-01 12:00:00", nullptr),
       parseJoda("1 AM 12", "h a H").timestamp);
 
-  // Half of day still has effect even though hour or clockhour is not provided.
+  // Half of day still has effect even though hour or clockhour is not
+  // provided.
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00", nullptr),
       parseJoda("PM", "a").timestamp);
@@ -1091,6 +1105,9 @@ TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMinute) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:08:00", nullptr),
       parseJoda("8", "m").timestamp);
@@ -1105,7 +1122,6 @@ TEST_F(JodaDateTimeFormatterTest, parseMinute) {
   EXPECT_THROW(parseJoda("-1", "m"), BoltUserError);
   //   EXPECT_THROW(parseJoda("123456789", "m"), BoltUserError);
 }
-#endif
 
 TEST_F(JodaDateTimeFormatterTest, parseSecond) {
   EXPECT_EQ(
@@ -1185,8 +1201,10 @@ TEST_F(JodaDateTimeFormatterTest, parseTimezoneOffset) {
   EXPECT_THROW(parseTZ("-16", "ZZ"), BoltUserError);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(JodaDateTimeFormatterTest, parseTimezone) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   EXPECT_THROW(parseJoda("", "z"), BoltUserError);
   EXPECT_THROW(parseJoda("ANY", "z"), BoltUserError);
   EXPECT_THROW(parseJoda("GM", "z"), BoltUserError);
@@ -1201,7 +1219,6 @@ TEST_F(JodaDateTimeFormatterTest, parseTimezone) {
   EXPECT_EQ("+00:00", parseTZ("UTC", "z"));
   EXPECT_EQ("+00:00", parseTZ("UT", "z"));
 }
-#endif
 
 TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Common patterns found.
@@ -1568,8 +1585,10 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
   EXPECT_THROW(buildMysqlDateTimeFormatter(""), BoltUserError);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(MysqlDateTimeTest, formatYear) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto* timezone = tz::locateZone("GMT");
   EXPECT_EQ(
       formatMysqlDateTime(
@@ -1614,6 +1633,9 @@ TEST_F(MysqlDateTimeTest, formatYear) {
 }
 
 TEST_F(MysqlDateTimeTest, formatMonthDay) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
@@ -1663,7 +1685,6 @@ TEST_F(MysqlDateTimeTest, formatMonthDay) {
           "%m~%d", util::fromTimestampString("1999-02-29", nullptr), timezone),
       BoltUserError);
 }
-#endif
 
 TEST_F(MysqlDateTimeTest, formatWeekday) {
   auto* timezone = tz::locateZone("GMT");
@@ -2036,9 +2057,12 @@ TEST_F(MysqlDateTimeTest, formatCompositeTime) {
       "23:59:59");
 }
 
-#ifndef SPARK_COMPATIBLE
-// Same semantic as YEAR_OF_ERA, except that it accepts zero and negative years.
+// Same semantic as YEAR_OF_ERA, except that it accepts zero and negative
+// years.
 TEST_F(MysqlDateTimeTest, parseFourDigitYear) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   EXPECT_EQ(
       util::fromTimestampString("123-01-01", nullptr), parseMysql("123", "%Y"));
   EXPECT_EQ(
@@ -2080,7 +2104,6 @@ TEST_F(MysqlDateTimeTest, parseFourDigitYear) {
       util::fromTimestampString("9999-01-01", nullptr),
       parseMysql("9999", "%Y"));
 }
-#endif
 
 TEST_F(MysqlDateTimeTest, parseTwoDigitYear) {
   EXPECT_EQ(
@@ -2096,8 +2119,10 @@ TEST_F(MysqlDateTimeTest, parseTwoDigitYear) {
       parseMysql("80 30", "%y %y"));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(MysqlDateTimeTest, parseWeekYear) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Covers entire range of possible week year start dates (12-29 to 01-04)
   EXPECT_EQ(
       util::fromTimestampString("1969-12-29 00:00:00", nullptr),
@@ -2147,7 +2172,6 @@ TEST_F(MysqlDateTimeTest, parseWeekYear) {
   //   EXPECT_THROW(parseMysql("-292275055", "%x"), BoltUserError);
   //   EXPECT_THROW(parseMysql("292278994", "%x"), BoltUserError);
 }
-#endif
 
 TEST_F(MysqlDateTimeTest, parseMonth) {
   // Joda has this weird behavior where if minute or hour is specified, year
@@ -2432,8 +2456,10 @@ TEST_F(MysqlDateTimeTest, parseClockHourOfHalfDay) {
   //   EXPECT_THROW(parseMysql("123456789", "%l"), BoltUserError);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(MysqlDateTimeTest, parseHalfOfDay) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   // Half of day has no effect if hour of day is provided
   // hour of day tests
   EXPECT_EQ(
@@ -2558,7 +2584,6 @@ TEST_F(MysqlDateTimeTest, parseHalfOfDay) {
       util::fromTimestampString("1970-01-01 12:00:00", nullptr),
       parseMysql("1 AM 12", "%h %p %H"));
 }
-#endif
 
 TEST_F(MysqlDateTimeTest, parseMinute) {
   EXPECT_EQ(

--- a/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -272,7 +272,7 @@ TEST_F(JodaDateTimeFormatterTest, validJodaBuild) {
   // d specifier case
   testTokenRange('d', 1, 4, DateTimeFormatSpecifier::DAY_OF_MONTH);
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     // a specifier case
     expected = {DateTimeToken(
         FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2})};
@@ -375,7 +375,7 @@ TEST_F(JodaDateTimeFormatterTest, validJodaBuild) {
       DateTimeToken(FormatPattern{DateTimeFormatSpecifier::HALFDAY_OF_DAY, 2}),
   };
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     EXPECT_EQ(
         expected,
         buildJodaDateTimeFormatter(
@@ -406,7 +406,7 @@ TEST_F(JodaDateTimeFormatterTest, invalid) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseJodaEra) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Normal era cases
@@ -533,7 +533,7 @@ TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
 // Same semantic as YEAR_OF_ERA, except that it accepts zero and negative
 // years.
 TEST_F(JodaDateTimeFormatterTest, parseYear) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   EXPECT_EQ(
@@ -610,7 +610,7 @@ TEST_F(JodaDateTimeFormatterTest, parseYear) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Covers entire range of possible week year start dates (12-29 to 01-04)
@@ -691,7 +691,7 @@ TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseCenturyOfEra) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Probe century range
@@ -980,7 +980,7 @@ TEST_F(JodaDateTimeFormatterTest, parseClockHourOfHalfDay) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Half of day has no effect if hour or clockhour of day is provided
@@ -1105,7 +1105,7 @@ TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMinute) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   EXPECT_EQ(
@@ -1202,7 +1202,7 @@ TEST_F(JodaDateTimeFormatterTest, parseTimezoneOffset) {
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseTimezone) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   EXPECT_THROW(parseJoda("", "z"), BoltUserError);
@@ -1586,7 +1586,7 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
 }
 
 TEST_F(MysqlDateTimeTest, formatYear) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto* timezone = tz::locateZone("GMT");
@@ -1633,7 +1633,7 @@ TEST_F(MysqlDateTimeTest, formatYear) {
 }
 
 TEST_F(MysqlDateTimeTest, formatMonthDay) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto* timezone = tz::locateZone("GMT");
@@ -2060,7 +2060,7 @@ TEST_F(MysqlDateTimeTest, formatCompositeTime) {
 // Same semantic as YEAR_OF_ERA, except that it accepts zero and negative
 // years.
 TEST_F(MysqlDateTimeTest, parseFourDigitYear) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   EXPECT_EQ(
@@ -2120,7 +2120,7 @@ TEST_F(MysqlDateTimeTest, parseTwoDigitYear) {
 }
 
 TEST_F(MysqlDateTimeTest, parseWeekYear) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Covers entire range of possible week year start dates (12-29 to 01-04)
@@ -2457,7 +2457,7 @@ TEST_F(MysqlDateTimeTest, parseClockHourOfHalfDay) {
 }
 
 TEST_F(MysqlDateTimeTest, parseHalfOfDay) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   // Half of day has no effect if hour of day is provided

--- a/bolt/functions/prestosql/DateTimeFunctions.h
+++ b/bolt/functions/prestosql/DateTimeFunctions.h
@@ -1593,7 +1593,7 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
   bool isConstFormat_ = false;
 };
 
-template <typename T>
+template <typename T, bool SparkCompatible = false>
 struct JodaDateFormatFunction : public TimestampWithTimezoneSupport<T> {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 
@@ -1623,14 +1623,12 @@ struct JodaDateFormatFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Timestamp>* /*timestamp*/,
       const arg_type<Varchar>* formatString) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
-#ifdef SPARK_COMPATIBLE
-    timePolicy_ = parseTimePolicy(config.timeParserPolicy());
-#else
-    if (formatString != nullptr) {
+    if constexpr (SparkCompatible) {
+      timePolicy_ = parseTimePolicy(config.timeParserPolicy());
+    } else if (formatString != nullptr) {
       ensureFormatLegal(
           std::string_view(formatString->data(), formatString->size()));
     }
-#endif
     setFormatter(formatString);
   }
 
@@ -1639,14 +1637,12 @@ struct JodaDateFormatFunction : public TimestampWithTimezoneSupport<T> {
       const core::QueryConfig& config,
       const arg_type<TimestampWithTimezone>* /*timestamp*/,
       const arg_type<Varchar>* formatString) {
-#ifdef SPARK_COMPATIBLE
-    timePolicy_ = parseTimePolicy(config.timeParserPolicy());
-#else
-    if (formatString != nullptr) {
+    if constexpr (SparkCompatible) {
+      timePolicy_ = parseTimePolicy(config.timeParserPolicy());
+    } else if (formatString != nullptr) {
       ensureFormatLegal(
           std::string_view(formatString->data(), formatString->size()));
     }
-#endif
     setFormatter(formatString);
   }
 
@@ -1655,10 +1651,10 @@ struct JodaDateFormatFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Timestamp>& timestamp,
       const arg_type<Varchar>& formatString) {
     if (!isConstFormat_) {
-#ifndef SPARK_COMPATIBLE
-      ensureFormatLegal(
-          std::string_view(formatString.data(), formatString.size()));
-#endif
+      if constexpr (!SparkCompatible) {
+        ensureFormatLegal(
+            std::string_view(formatString.data(), formatString.size()));
+      }
       setFormatter(&formatString);
     }
 

--- a/bolt/functions/prestosql/DateTimeFunctions.h
+++ b/bolt/functions/prestosql/DateTimeFunctions.h
@@ -32,6 +32,7 @@
 
 #include <boost/date_time.hpp>
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/functions/lib/DateTimeFormatter.h"
 #include "bolt/functions/lib/TimeUtils.h"
 #include "bolt/functions/prestosql/DateTimeImpl.h"
@@ -1593,7 +1594,9 @@ struct DateFormatFunction : public TimestampWithTimezoneSupport<T> {
   bool isConstFormat_ = false;
 };
 
-template <typename T, bool SparkCompatible = false>
+template <
+    typename T,
+    bool SparkCompatible = ::bytedance::bolt::kSparkCompatible>
 struct JodaDateFormatFunction : public TimestampWithTimezoneSupport<T> {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 

--- a/bolt/functions/prestosql/StringFunctions.cpp
+++ b/bolt/functions/prestosql/StringFunctions.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/functions/prestosql/StringFunctions.h"
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/expression/EvalCtx.h"
 #include "bolt/expression/Expr.h"
 #include "bolt/expression/StringWriter.h"
@@ -45,6 +47,10 @@
 namespace bytedance::bolt::functions {
 
 using namespace stringCore;
+
+bool locateEmptyStringsReturnZero() {
+  return !::bytedance::bolt::kSparkCompatible;
+}
 
 namespace {
 /**

--- a/bolt/functions/prestosql/StringFunctions.h
+++ b/bolt/functions/prestosql/StringFunctions.h
@@ -614,6 +614,8 @@ struct LevenshteinDistanceFunction {
 /// locate(substr, str[, pos]) -> int
 /// Returns the position of the first occurrence of substr in str after position
 /// pos. The given pos and return value are 1-based.
+bool locateEmptyStringsReturnZero();
+
 template <typename T>
 struct LocateFunction {
   BOLT_DEFINE_FUNCTION_TYPES(T);
@@ -627,13 +629,12 @@ struct LocateFunction {
       result = 0;
       return;
     }
-#ifndef SPARK_COMPATIBLE
-    // follow presto semantics
-    if (UNLIKELY(substr.size() == 0 && str.size() == 0)) {
+    if (UNLIKELY(
+            substr.size() == 0 && str.size() == 0 &&
+            locateEmptyStringsReturnZero())) {
       result = 0;
       return;
     }
-#endif
     auto ans = stringCore::findNthInstanceByteIndexFromStart(
         std::string_view(str.data(), str.size()),
         std::string_view(substr.data(), substr.size()),

--- a/bolt/functions/prestosql/aggregates/Compare.cpp
+++ b/bolt/functions/prestosql/aggregates/Compare.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/prestosql/aggregates/Compare.h"
 using namespace bytedance::bolt::functions::aggregate;
 namespace bytedance::bolt::aggregate::prestosql {
@@ -40,12 +42,10 @@ int32_t compare(
       true, // nullsFirst
       true, // ascending
       false, // equalsOnly
-#ifdef SPARK_COMPATIBLE
-      CompareFlags::NullHandlingMode::kNullAsValue,
-      true
-#else
-      CompareFlags::NullHandlingMode::kNullAsIndeterminate
-#endif
+      ::bytedance::bolt::kSparkCompatible
+          ? CompareFlags::NullHandlingMode::kNullAsValue
+          : CompareFlags::NullHandlingMode::kNullAsIndeterminate,
+      ::bytedance::bolt::kSparkCompatible,
   };
 
   auto result = accumulator->compare(decoded, index, kCompareFlags);

--- a/bolt/functions/prestosql/aggregates/MapSumAggregate.cpp
+++ b/bolt/functions/prestosql/aggregates/MapSumAggregate.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/exec/Aggregate.h"
 #include "bolt/exec/Strings.h"
 #include "bolt/expression/FunctionSignature.h"
@@ -272,11 +274,11 @@ class MapSumAggregate : public exec::Aggregate {
     auto i = map.find(key);
     if (LIKELY(i != map.end())) {
       // aggregate_map_sum does not handle overflow
-#ifdef SPARK_COMPATIBLE
-      i->second += val;
-#else
-      i->second = plus(i->second, val);
-#endif
+      if constexpr (::bytedance::bolt::kSparkCompatible) {
+        i->second += val;
+      } else {
+        i->second = plus(i->second, val);
+      }
       return;
     }
     auto tracker = trackRowSize(group);

--- a/bolt/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/bolt/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <folly/Likely.h>
 #include <limits>
 #include "bolt/exec/Aggregate.h"
@@ -321,13 +323,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
       const TypePtr& resultType,
       bool throwOnNestedNulls)
       : exec::Aggregate(resultType),
-#ifdef SPARK_COMPATIBLE
-        throwOnNestedNulls_(false)
-#else
-        throwOnNestedNulls_(throwOnNestedNulls)
-#endif
-  {
-  }
+        throwOnNestedNulls_(
+            ::bytedance::bolt::kSparkCompatible ? false : throwOnNestedNulls) {}
 
   bool isFixedSize() const override {
     return false;
@@ -1039,15 +1036,15 @@ exec::AggregateRegistrationResult registerMinMax(
                            .argumentType("UNKNOWN")
                            .build());
 
-#ifdef SPARK_COMPATIBLE
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .typeVariable("K")
-                           .typeVariable("V")
-                           .argumentType("MAP(K,V)")
-                           .returnType("MAP(K,V)")
-                           .intermediateType("MAP(K,V)")
-                           .build());
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .typeVariable("K")
+                             .typeVariable("V")
+                             .argumentType("MAP(K,V)")
+                             .returnType("MAP(K,V)")
+                             .intermediateType("MAP(K,V)")
+                             .build());
+  }
 
   for (const auto& type :
        {"tinyint", "integer", "smallint", "bigint", "real", "double"}) {

--- a/bolt/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/bolt/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -324,7 +324,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
       bool throwOnNestedNulls)
       : exec::Aggregate(resultType),
         throwOnNestedNulls_(
-            ::bytedance::bolt::kSparkCompatible ? false : throwOnNestedNulls) {}
+            !::bytedance::bolt::kSparkCompatible && throwOnNestedNulls) {}
 
   bool isFixedSize() const override {
     return false;
@@ -1036,7 +1036,7 @@ exec::AggregateRegistrationResult registerMinMax(
                            .argumentType("UNKNOWN")
                            .build());
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .typeVariable("K")
                              .typeVariable("V")

--- a/bolt/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/bolt/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -28,10 +28,12 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/exec/Aggregate.h"
 #include "bolt/functions/lib/aggregates/BitDaysOrAggregate.h"
 #include "bolt/functions/lib/aggregates/CollectSetAggregate.h"
+#include "bolt/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 namespace bytedance::bolt::aggregate::prestosql {
 
 extern void registerApproxMostFrequentAggregate(const std::string& prefix);
@@ -159,10 +161,10 @@ void registerAllAggregateFunctions(
       prefix, withCompanionFunctions, overwrite);
   functions::aggregate::registerBitDaysOrAggregate(
       prefix + "bit_days_or", withCompanionFunctions, overwrite);
-#ifndef SPARK_COMPATIBLE
-  // hive.udaf.percentile for presto.default.percentile
-  registerHiveUDAFPercentileAggregate(prefix);
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // hive.udaf.percentile for presto.default.percentile
+    registerHiveUDAFPercentileAggregate(prefix);
+  }
 }
 
 extern void registerCountDistinctAggregate(const std::string& prefix);

--- a/bolt/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/bolt/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -161,10 +161,11 @@ void registerAllAggregateFunctions(
       prefix, withCompanionFunctions, overwrite);
   functions::aggregate::registerBitDaysOrAggregate(
       prefix + "bit_days_or", withCompanionFunctions, overwrite);
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    // hive.udaf.percentile for presto.default.percentile
-    registerHiveUDAFPercentileAggregate(prefix);
+  if (::bytedance::bolt::kSparkCompatible) {
+    return;
   }
+  // hive.udaf.percentile for presto.default.percentile
+  registerHiveUDAFPercentileAggregate(prefix);
 }
 
 extern void registerCountDistinctAggregate(const std::string& prefix);

--- a/bolt/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/exec/tests/utils/PlanBuilder.h"
 #include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
@@ -192,11 +194,7 @@ TEST_P(CovarianceAggregationTest, allSameValue) {
   createDuckDbTable({data});
 
   auto aggName = GetParam();
-#ifdef SPARK_COMPATIBLE
-  bool isInSpark = true;
-#else
-  bool isInSpark = false;
-#endif
+  constexpr bool isInSpark = ::bytedance::bolt::kSparkCompatible;
   if (isInSpark && (aggName == "covar_samp" || aggName == "corr")) {
     std::unordered_map<std::string, std::string> config = {
         {core::QueryConfig::kSparkLegacyStatisticalAggregate, "true"}};

--- a/bolt/functions/prestosql/aggregates/tests/MapSumAggregateTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/MapSumAggregateTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "bolt/functions/prestosql/ArithmeticImpl.h"
 #include "bolt/type/Conversions.h"
@@ -358,15 +360,14 @@ TEST_F(MapSumAggTest, overflow) {
       std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
           {{"0", std::numeric_limits<int64_t>::max()}},
           {{"0", std::numeric_limits<int64_t>::max()}}};
-#ifdef SPARK_COMPATIBLE
-  auto expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", -2}}};
-#else
-  auto expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", std::numeric_limits<int64_t>::max()}}};
-#endif
+  using Expected =
+      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>;
+  auto expected = Expected{{
+      {"0",
+       ::bytedance::bolt::kSparkCompatible
+           ? int64_t{-2}
+           : std::numeric_limits<int64_t>::max()},
+  }};
 
   auto inputVec = makeMapVector(data);
   auto expectedVec = makeMapVector(expected);
@@ -381,15 +382,12 @@ TEST_F(MapSumAggTest, overflow) {
       std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
           {{"0", std::numeric_limits<int64_t>::min()}},
           {{"0", std::numeric_limits<int64_t>::min()}}};
-#ifdef SPARK_COMPATIBLE
-  expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", 0}}};
-#else
-  expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", std::numeric_limits<int64_t>::min()}}};
-#endif
+  expected = Expected{{
+      {"0",
+       ::bytedance::bolt::kSparkCompatible
+           ? int64_t{0}
+           : std::numeric_limits<int64_t>::min()},
+  }};
   inputVec = makeMapVector(data);
   expectedVec = makeMapVector(expected);
 
@@ -405,15 +403,14 @@ TEST_F(MapSumAggTest, castOverflow) {
       std::vector<std::vector<std::pair<StringView, std::optional<double>>>>{
           {{"0", std::numeric_limits<double>::max()}},
           {{"0", std::numeric_limits<double>::max()}}};
-#ifdef SPARK_COMPATIBLE
-  auto expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", -2}}};
-#else
-  auto expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", std::numeric_limits<int64_t>::max()}}};
-#endif
+  using Expected =
+      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>;
+  auto expected = Expected{{
+      {"0",
+       ::bytedance::bolt::kSparkCompatible
+           ? int64_t{-2}
+           : std::numeric_limits<int64_t>::max()},
+  }};
 
   auto inputVec = makeMapVector(data);
   auto expectedVec = makeMapVector(expected);
@@ -428,15 +425,12 @@ TEST_F(MapSumAggTest, castOverflow) {
       {{"0", -std::numeric_limits<double>::max()}},
       {{"0", -std::numeric_limits<double>::max()}}};
 
-#ifdef SPARK_COMPATIBLE
-  expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", 0}}};
-#else
-  expected =
-      std::vector<std::vector<std::pair<StringView, std::optional<int64_t>>>>{
-          {{"0", std::numeric_limits<int64_t>::min()}}};
-#endif
+  expected = Expected{{
+      {"0",
+       ::bytedance::bolt::kSparkCompatible
+           ? int64_t{0}
+           : std::numeric_limits<int64_t>::min()},
+  }};
 
   inputVec = makeMapVector(data);
   expectedVec = makeMapVector(expected);

--- a/bolt/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <vector/ComplexVector.h>
 #include <limits>
 #include "bolt/common/base/tests/GTestUtils.h"
@@ -381,11 +383,11 @@ TEST_F(MinMaxTest, array) {
       }),
   });
 
-#ifndef SPARK_COMPATIBLE
-  BOLT_ASSERT_THROW(
-      testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
-      "ARRAY comparison not supported for values that contain nulls");
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    BOLT_ASSERT_THROW(
+        testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
+        "ARRAY comparison not supported for values that contain nulls");
+  }
 
   data = makeRowVector({
       makeNullableArrayVector<int64_t>({
@@ -422,11 +424,11 @@ TEST_F(MinMaxTest, row) {
            makeFlatVector<StringView>({"hij"_sv})}),
   });
 
-#ifndef SPARK_COMPATIBLE
-  BOLT_ASSERT_THROW(
-      testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
-      "ROW comparison not supported for values that contain nulls");
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    BOLT_ASSERT_THROW(
+        testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
+        "ROW comparison not supported for values that contain nulls");
+  }
 
   data = makeRowVector({
       makeRowVector({
@@ -472,20 +474,20 @@ TEST_F(MinMaxTest, arrayCheckNulls) {
       }),
   });
 
-#ifndef SPARK_COMPATIBLE
-  for (const auto& expr : {"min(c0)", "max(c0)"}) {
-    testFailingAggregations(
-        {batch, batchWithNull},
-        {},
-        {expr},
-        "ARRAY comparison not supported for values that contain nulls");
-    testFailingAggregations(
-        {batch, batchWithNull},
-        {"c1"},
-        {expr},
-        "ARRAY comparison not supported for values that contain nulls");
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    for (const auto& expr : {"min(c0)", "max(c0)"}) {
+      testFailingAggregations(
+          {batch, batchWithNull},
+          {},
+          {expr},
+          "ARRAY comparison not supported for values that contain nulls");
+      testFailingAggregations(
+          {batch, batchWithNull},
+          {"c1"},
+          {expr},
+          "ARRAY comparison not supported for values that contain nulls");
+    }
   }
-#endif
 }
 
 TEST_F(MinMaxTest, rowCheckNull) {
@@ -521,24 +523,26 @@ TEST_F(MinMaxTest, rowCheckNull) {
       makeFlatVector<int8_t>({1, 2, 3}),
   });
 
-#ifndef SPARK_COMPATIBLE
-  for (const auto& expr : {"min(c0)", "max(c0)"}) {
-    testFailingAggregations(
-        {batch, batchWithNull},
-        {},
-        {expr},
-        "ROW comparison not supported for values that contain nulls");
-    testFailingAggregations(
-        {batch, batchWithNull},
-        {"c1"},
-        {expr},
-        "ROW comparison not supported for values that contain nulls");
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    for (const auto& expr : {"min(c0)", "max(c0)"}) {
+      testFailingAggregations(
+          {batch, batchWithNull},
+          {},
+          {expr},
+          "ROW comparison not supported for values that contain nulls");
+      testFailingAggregations(
+          {batch, batchWithNull},
+          {"c1"},
+          {expr},
+          "ROW comparison not supported for values that contain nulls");
+    }
   }
-#endif
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(MinMaxTest, map) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto expected = makeRowVector({
       makeMapVector<StringView, StringView>({{
           {"cpu p96消耗"_sv, "95.4"_sv},
@@ -574,7 +578,6 @@ TEST_F(MinMaxTest, map) {
 
   testAggregations({data}, {}, {"max(c0)"}, {expected});
 }
-#endif
 
 TEST_F(MinMaxTest, failOnUnorderableType) {
   auto data = makeRowVector({
@@ -588,17 +591,17 @@ TEST_F(MinMaxTest, failOnUnorderableType) {
     {
       auto builder = PlanBuilder().values({data});
 
-#ifndef SPARK_COMPATIBLE
-      BOLT_ASSERT_THROW(builder.singleAggregation({}, {expr}), kErrorMessage);
-#endif
+      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        BOLT_ASSERT_THROW(builder.singleAggregation({}, {expr}), kErrorMessage);
+      }
     }
 
     {
       auto builder = PlanBuilder().values({data});
-#ifndef SPARK_COMPATIBLE
-      BOLT_ASSERT_THROW(
-          builder.singleAggregation({"c1"}, {expr}), kErrorMessage);
-#endif
+      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+        BOLT_ASSERT_THROW(
+            builder.singleAggregation({"c1"}, {expr}), kErrorMessage);
+      }
     }
   }
 }

--- a/bolt/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -383,7 +383,7 @@ TEST_F(MinMaxTest, array) {
       }),
   });
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     BOLT_ASSERT_THROW(
         testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
         "ARRAY comparison not supported for values that contain nulls");
@@ -424,7 +424,7 @@ TEST_F(MinMaxTest, row) {
            makeFlatVector<StringView>({"hij"_sv})}),
   });
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     BOLT_ASSERT_THROW(
         testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
         "ROW comparison not supported for values that contain nulls");
@@ -474,7 +474,7 @@ TEST_F(MinMaxTest, arrayCheckNulls) {
       }),
   });
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     for (const auto& expr : {"min(c0)", "max(c0)"}) {
       testFailingAggregations(
           {batch, batchWithNull},
@@ -523,7 +523,7 @@ TEST_F(MinMaxTest, rowCheckNull) {
       makeFlatVector<int8_t>({1, 2, 3}),
   });
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     for (const auto& expr : {"min(c0)", "max(c0)"}) {
       testFailingAggregations(
           {batch, batchWithNull},
@@ -540,7 +540,7 @@ TEST_F(MinMaxTest, rowCheckNull) {
 }
 
 TEST_F(MinMaxTest, map) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto expected = makeRowVector({
@@ -591,14 +591,14 @@ TEST_F(MinMaxTest, failOnUnorderableType) {
     {
       auto builder = PlanBuilder().values({data});
 
-      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      if (!::bytedance::bolt::kSparkCompatible) {
         BOLT_ASSERT_THROW(builder.singleAggregation({}, {expr}), kErrorMessage);
       }
     }
 
     {
       auto builder = PlanBuilder().values({data});
-      if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      if (!::bytedance::bolt::kSparkCompatible) {
         BOLT_ASSERT_THROW(
             builder.singleAggregation({"c1"}, {expr}), kErrorMessage);
       }

--- a/bolt/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
+++ b/bolt/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/lib/RegistrationHelpers.h"
 #include "bolt/functions/prestosql/Bitwise.h"
@@ -55,16 +57,17 @@ void registerBitwiseFunctions(const std::string& prefix) {
   registerBitwiseUnaryIntegral<BitwiseNotFunction>({prefix + "bitwise_not"});
   registerBitwiseBinaryIntegral<BitwiseOrFunction>({prefix + "bitwise_or"});
   registerBitwiseBinaryIntegral<BitwiseXorFunction>({prefix + "bitwise_xor"});
-#ifdef SPARK_COMPATIBLE
-  registerBitwiseBinaryIntegral<BitCountFunction>({prefix + "bit_count"});
-#else
-  // built-in bit_count(bigint, bigint) -> bigint
-  registerFunction<BitCountFunction, int64_t, int64_t, int64_t>(
-      {prefix + "bit_count"});
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    registerBitwiseBinaryIntegral<BitCountFunction>({prefix + "bit_count"});
+  } else {
+    // built-in bit_count(bigint, bigint) -> bigint
+    registerFunction<BitCountFunction, int64_t, int64_t, int64_t>(
+        {prefix + "bit_count"});
 
-  // hive.udf.bit_count(bigint) -> integer
-  registerFunction<BitCountFunction, int32_t, int64_t>({prefix + "bit_count"});
-#endif // SPARK_COMPATIBLE
+    // hive.udf.bit_count(bigint) -> integer
+    registerFunction<BitCountFunction, int32_t, int64_t>(
+        {prefix + "bit_count"});
+  }
 
   registerFunction<BitDaysCountFunction, int32_t, Array<int64_t>>(
       {prefix + "bit_days_count"});

--- a/bolt/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
+++ b/bolt/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
@@ -28,15 +28,22 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/lib/CheckedArithmetic.h"
 #include "bolt/functions/lib/RegistrationHelpers.h"
 namespace bytedance::bolt::functions {
+namespace {
+template <typename T>
+using BuildCheckedModulusFunction =
+    CheckedModulusFunction<T, ::bytedance::bolt::kSparkCompatible>;
+} // namespace
 
 void registerCheckedArithmeticFunctions(const std::string& prefix) {
   registerBinaryIntegral<CheckedPlusFunction>({prefix + "plus"});
   registerBinaryIntegral<CheckedMinusFunction>({prefix + "minus"});
   registerBinaryIntegral<CheckedMultiplyFunction>({prefix + "multiply"});
-  registerBinaryIntegral<CheckedModulusFunction>({prefix + "mod"});
+  registerBinaryIntegral<BuildCheckedModulusFunction>({prefix + "mod"});
   registerBinaryIntegral<CheckedDivideFunction>({prefix + "divide"});
   registerUnaryIntegral<CheckedNegateFunction>({prefix + "negate"});
 }

--- a/bolt/functions/prestosql/registration/DateTimeFunctionsArithmeticRegistration.cpp
+++ b/bolt/functions/prestosql/registration/DateTimeFunctionsArithmeticRegistration.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/expression/VectorFunction.h"
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/prestosql/DateTimeFunctions.h"
@@ -51,16 +53,16 @@ void registerArithmeticFunctionsInternal(const std::string& prefix) {
   registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
       {prefix + "timestampdiff"});
 
-#ifndef SPARK_COMPATIBLE
-  registerFunction<
-      DateDiffFunction,
-      int64_t,
-      Varchar,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "date_diff"});
-  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
-      {prefix + "date_format"});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    registerFunction<
+        DateDiffFunction,
+        int64_t,
+        Varchar,
+        TimestampWithTimezone,
+        TimestampWithTimezone>({prefix + "date_diff"});
+    registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
+        {prefix + "date_format"});
+  }
 
   registerFunction<DateAddFunction, Date, Varchar, int64_t, Date>(
       {prefix + "date_add"});
@@ -80,24 +82,27 @@ void registerArithmeticFunctionsInternal(const std::string& prefix) {
   registerFunction<DateAddFunction, Date, Date, int16_t>({prefix + "date_add"});
   registerFunction<DateAddFunction, Date, Date, int8_t>({prefix + "date_add"});
 
-#ifndef SPARK_COMPATIBLE
-  registerFunction<
-      DateDiffFunction,
-      int64_t,
-      Varchar,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "date_diff"});
-  registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
-      {prefix + "date_diff"});
-  registerFunction<DateDiffFunction, int64_t, Date, Date>(
-      {prefix + "date_diff"});
-  registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
-      {prefix + "date_format"});
-  registerFunction<DateFormatFunction, Varchar, TimestampWithTimezone, Varchar>(
-      {prefix + "date_format"});
-  registerFunction<sparksql::LastDayFunction, Varchar, Date>(
-      {prefix + "last_day"});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    registerFunction<
+        DateDiffFunction,
+        int64_t,
+        Varchar,
+        TimestampWithTimezone,
+        TimestampWithTimezone>({prefix + "date_diff"});
+    registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
+        {prefix + "date_diff"});
+    registerFunction<DateDiffFunction, int64_t, Date, Date>(
+        {prefix + "date_diff"});
+    registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
+        {prefix + "date_format"});
+    registerFunction<
+        DateFormatFunction,
+        Varchar,
+        TimestampWithTimezone,
+        Varchar>({prefix + "date_format"});
+    registerFunction<sparksql::LastDayFunction, Varchar, Date>(
+        {prefix + "last_day"});
+  }
   registerFunction<HiveDateDiffFunction, int32_t, Date, Date>(
       {prefix + "datediff"});
   registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(

--- a/bolt/functions/prestosql/registration/DateTimeFunctionsBasicConversionRegistration.cpp
+++ b/bolt/functions/prestosql/registration/DateTimeFunctionsBasicConversionRegistration.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/expression/VectorFunction.h"
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/prestosql/DateTimeFunctions.h"
@@ -57,12 +59,15 @@ void registerBasicConversionFunctionsInternal(const std::string& prefix) {
   registerFunction<ToTimestampFunction, Timestamp, int32_t>(
       {prefix + "to_timestamp"});
 
-#ifndef SPARK_COMPATIBLE
-  registerFunction<DateFormatFunction, Varchar, TimestampWithTimezone, Varchar>(
-      {prefix + "date_format"});
-  registerFunction<sparksql::LastDayFunction, Varchar, Date>(
-      {prefix + "last_day"});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    registerFunction<
+        DateFormatFunction,
+        Varchar,
+        TimestampWithTimezone,
+        Varchar>({prefix + "date_format"});
+    registerFunction<sparksql::LastDayFunction, Varchar, Date>(
+        {prefix + "last_day"});
+  }
 
   registerFunction<FormatDateTimeFunction, Varchar, Timestamp, Varchar>(
       {prefix + "format_datetime"});

--- a/bolt/functions/prestosql/registration/DateTimeFunctionsDateComponentExtractionRegistration.cpp
+++ b/bolt/functions/prestosql/registration/DateTimeFunctionsDateComponentExtractionRegistration.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/prestosql/DateTimeFunctions.h"
 #include "bolt/functions/sparksql/DateTimeFunctions.h"
@@ -22,23 +24,23 @@ namespace bytedance::bolt::functions {
 namespace {
 void registerDateTimeDateComponentExtractionFunctionsInternal(
     const std::string& prefix) {
-#ifndef SPARK_COMPATIBLE
-  registerFunction<YearFunction, int64_t, Date>({prefix + "year"});
-  registerFunction<YearFunction, int64_t, Timestamp>({prefix + "year"});
-  registerFunction<QuarterFunction, int64_t, Timestamp>({prefix + "quarter"});
-  registerFunction<QuarterFunction, int64_t, Date>({prefix + "quarter"});
-  registerFunction<MonthFunction, int64_t, Timestamp>({prefix + "month"});
-  registerFunction<MonthFunction, int64_t, Date>({prefix + "month"});
-  registerFunction<WeekFunction, int64_t, Timestamp>(
-      {prefix + "week", prefix + "week_of_year"});
-  registerFunction<WeekFunction, int64_t, Date>(
-      {prefix + "week", prefix + "week_of_year"});
-  registerFunction<HourFunction, int64_t, Timestamp>({prefix + "hour"});
-  registerFunction<MinuteFunction, int64_t, Timestamp>({prefix + "minute"});
-  registerFunction<SecondFunction, int64_t, Timestamp>({prefix + "second"});
-  registerFunction<MillisecondFunction, int64_t, Timestamp>(
-      {prefix + "millisecond"});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    registerFunction<YearFunction, int64_t, Date>({prefix + "year"});
+    registerFunction<YearFunction, int64_t, Timestamp>({prefix + "year"});
+    registerFunction<QuarterFunction, int64_t, Timestamp>({prefix + "quarter"});
+    registerFunction<QuarterFunction, int64_t, Date>({prefix + "quarter"});
+    registerFunction<MonthFunction, int64_t, Timestamp>({prefix + "month"});
+    registerFunction<MonthFunction, int64_t, Date>({prefix + "month"});
+    registerFunction<WeekFunction, int64_t, Timestamp>(
+        {prefix + "week", prefix + "week_of_year"});
+    registerFunction<WeekFunction, int64_t, Date>(
+        {prefix + "week", prefix + "week_of_year"});
+    registerFunction<HourFunction, int64_t, Timestamp>({prefix + "hour"});
+    registerFunction<MinuteFunction, int64_t, Timestamp>({prefix + "minute"});
+    registerFunction<SecondFunction, int64_t, Timestamp>({prefix + "second"});
+    registerFunction<MillisecondFunction, int64_t, Timestamp>(
+        {prefix + "millisecond"});
+  }
 
   registerFunction<YearFunction, int64_t, TimestampWithTimezone>(
       {prefix + "year"});

--- a/bolt/functions/prestosql/registration/DateTimeFunctionsTimeComponentExtractionRegistration.cpp
+++ b/bolt/functions/prestosql/registration/DateTimeFunctionsTimeComponentExtractionRegistration.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/prestosql/DateTimeFunctions.h"
 #include "bolt/functions/sparksql/DateTimeFunctions.h"
@@ -42,24 +44,25 @@ void registerDateTimeTimeComponentExtractionFunctionsInternal(
   registerFunction<MillisecondFunction, int64_t, TimestampWithTimezone>(
       {prefix + "millisecond"});
 
-#ifndef SPARK_COMPATIBLE
-  registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
-      {prefix + "date_trunc"});
-  registerFunction<DateTruncFunction, Date, Varchar, Date>(
-      {prefix + "date_trunc"});
-  registerFunction<
-      DateTruncFunction,
-      TimestampWithTimezone,
-      Varchar,
-      TimestampWithTimezone>({prefix + "date_trunc"});
-  registerFunction<DateTruncFunction, Date, Date, Varchar>({prefix + "trunc"});
-  registerFunction<DateTruncFunction, Date, Timestamp, Varchar>(
-      {prefix + "trunc"});
-  registerFunction<DateTruncFunction, Date, TimestampWithTimezone, Varchar>(
-      {prefix + "trunc"});
-  registerFunction<DateTruncFunction, Date, Varchar, Varchar>(
-      {prefix + "trunc"});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
+        {prefix + "date_trunc"});
+    registerFunction<DateTruncFunction, Date, Varchar, Date>(
+        {prefix + "date_trunc"});
+    registerFunction<
+        DateTruncFunction,
+        TimestampWithTimezone,
+        Varchar,
+        TimestampWithTimezone>({prefix + "date_trunc"});
+    registerFunction<DateTruncFunction, Date, Date, Varchar>(
+        {prefix + "trunc"});
+    registerFunction<DateTruncFunction, Date, Timestamp, Varchar>(
+        {prefix + "trunc"});
+    registerFunction<DateTruncFunction, Date, TimestampWithTimezone, Varchar>(
+        {prefix + "trunc"});
+    registerFunction<DateTruncFunction, Date, Varchar, Varchar>(
+        {prefix + "trunc"});
+  }
 }
 } // namespace
 

--- a/bolt/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/bolt/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/Registerer.h"
 #include "bolt/functions/lib/Re2Functions.h"
 #include "bolt/functions/lib/StringUtil.h"
@@ -121,10 +123,10 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       Varchar>({prefix + "split_to_map"});
   BOLT_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
-#ifndef SPARK_COMPATIBLE
-  // spark has another implementation
-  BOLT_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // spark has another implementation
+    BOLT_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
+  }
   BOLT_REGISTER_VECTOR_FUNCTION(udf_reverse, prefix + "reverse");
   BOLT_REGISTER_VECTOR_FUNCTION(udf_to_utf8, prefix + "to_utf8");
   registerFromUtf8(prefix + "from_utf8");
@@ -180,12 +182,12 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       int32_t>({prefix + "locate"});
 
-#ifndef SPARK_COMPATIBLE
-  registerFunction<ParseURLFunction, Varchar, Varchar, Varchar>(
-      {prefix + "parse_url"});
-  registerFunction<ParseURLFunction, Varchar, Varchar, Varchar, Varchar>(
-      {prefix + "parse_url"});
-#endif
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    registerFunction<ParseURLFunction, Varchar, Varchar, Varchar>(
+        {prefix + "parse_url"});
+    registerFunction<ParseURLFunction, Varchar, Varchar, Varchar, Varchar>(
+        {prefix + "parse_url"});
+  }
 
   BOLT_REGISTER_VECTOR_FUNCTION(udf_printf, {prefix + "printf"})
 }

--- a/bolt/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/bolt/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -123,7 +123,7 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       Varchar>({prefix + "split_to_map"});
   BOLT_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     // spark has another implementation
     BOLT_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
   }

--- a/bolt/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/bolt/functions/prestosql/tests/ArithmeticTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <cmath>
 #include <limits>
 #include <optional>
@@ -263,8 +265,10 @@ TEST_F(ArithmeticTest, mod) {
       {kNan, kNan, kNan, kNan, 5.1});
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(ArithmeticTest, modInt) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   std::vector<int64_t> numerInt = {
       9, 10, 0, -9, -10, -11, std::numeric_limits<int64_t>::min()};
   std::vector<int64_t> denomInt = {3, -3, 11, -1, 199999, 77, -1};
@@ -274,7 +278,6 @@ TEST_F(ArithmeticTest, modInt) {
       "mod(c0, c1)", numerInt, denomInt, expectedInt);
   assertError<int64_t>("mod(c0, c1)", {10}, {0}, "Cannot divide by 0");
 }
-#endif
 
 TEST_F(ArithmeticTest, power) {
   std::vector<double> baseDouble = {

--- a/bolt/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/bolt/functions/prestosql/tests/ArithmeticTest.cpp
@@ -266,7 +266,7 @@ TEST_F(ArithmeticTest, mod) {
 }
 
 TEST_F(ArithmeticTest, modInt) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   std::vector<int64_t> numerInt = {

--- a/bolt/functions/prestosql/tests/BitwiseTest.cpp
+++ b/bolt/functions/prestosql/tests/BitwiseTest.cpp
@@ -158,7 +158,7 @@ TEST_F(BitwiseTest, bitCount) {
   EXPECT_EQ(bitCount(kMax64, kMaxBits), 63);
   EXPECT_EQ(bitCount(-2, 2), 1);
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     EXPECT_EQ(bitCount(9), 2);
     EXPECT_EQ(bitCount(-7), 62);
     EXPECT_EQ(bitCount(9), 2);

--- a/bolt/functions/prestosql/tests/BitwiseTest.cpp
+++ b/bolt/functions/prestosql/tests/BitwiseTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <optional>
 
 #include "bolt/common/base/tests/GTestUtils.h"
@@ -75,15 +77,13 @@ class BitwiseTest : public functions::test::FunctionBaseTest {
     return evaluateOnce<int64_t>("bit_count(c0, c1)", num, bits);
   }
 
-#ifndef SPARK_COMPATIBLE
-  std::optional<int32_t> bitCount(std::optional<int64_t> num) {
-    return evaluateOnce<int32_t>("bit_count(c0)", num);
+  auto bitCount(std::optional<int64_t> num) {
+    if constexpr (!::bytedance::bolt::kSparkCompatible) {
+      return evaluateOnce<int32_t>("bit_count(c0)", num);
+    } else {
+      return evaluateOnce<int64_t>("bit_count(c0)", num);
+    }
   }
-#else
-  std::optional<int64_t> bitCount(std::optional<int64_t> num) {
-    return evaluateOnce<int64_t>("bit_count(c0)", num);
-  }
-#endif
 
   std::optional<int64_t> bitwiseArithmeticShiftRight(
       std::optional<int64_t> a,
@@ -158,13 +158,13 @@ TEST_F(BitwiseTest, bitCount) {
   EXPECT_EQ(bitCount(kMax64, kMaxBits), 63);
   EXPECT_EQ(bitCount(-2, 2), 1);
 
-#ifndef SPARK_COMPATIBLE
-  EXPECT_EQ(bitCount(9), 2);
-  EXPECT_EQ(bitCount(-7), 62);
-  EXPECT_EQ(bitCount(9), 2);
-  EXPECT_EQ(bitCount(kMin64), 1);
-  EXPECT_EQ(bitCount(kMax64), 63);
-#endif // SPARK_COMPATIBLE
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(bitCount(9), 2);
+    EXPECT_EQ(bitCount(-7), 62);
+    EXPECT_EQ(bitCount(9), 2);
+    EXPECT_EQ(bitCount(kMin64), 1);
+    EXPECT_EQ(bitCount(kMax64), 63);
+  }
 
   auto assertInvalidBits = [this](int64_t num, int64_t bits) {
     BOLT_ASSERT_THROW(

--- a/bolt/functions/prestosql/tests/CastBaseTest.h
+++ b/bolt/functions/prestosql/tests/CastBaseTest.h
@@ -198,7 +198,7 @@ class CastBaseTest : public FunctionBaseTest {
       const std::vector<std::optional<TFrom>>& input,
       const std::string& expectedErrorMessage,
       const TypePtr& fromType = CppToType<TFrom>::create()) {
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       auto result = evaluate(
           fmt::format("cast(c0 as {})", typeString),
           makeRowVector({makeNullableFlatVector(input, fromType)}));
@@ -237,7 +237,7 @@ class CastBaseTest : public FunctionBaseTest {
       const VectorPtr& input,
       const VectorPtr& expected,
       const std::string& expectedErrorMessage) {
-    if constexpr (::bytedance::bolt::kSparkCompatible) {
+    if (::bytedance::bolt::kSparkCompatible) {
       testCast(input, expected);
     } else {
       auto msg = queryCtx_->queryConfig().enableOptimizedCast()

--- a/bolt/functions/prestosql/tests/CastBaseTest.h
+++ b/bolt/functions/prestosql/tests/CastBaseTest.h
@@ -32,6 +32,7 @@
 
 #include <gtest/gtest.h>
 
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/core/Expressions.h"
 #include "bolt/core/ITypedExpr.h"
@@ -197,23 +198,23 @@ class CastBaseTest : public FunctionBaseTest {
       const std::vector<std::optional<TFrom>>& input,
       const std::string& expectedErrorMessage,
       const TypePtr& fromType = CppToType<TFrom>::create()) {
-#ifdef SPARK_COMPATIBLE
-    auto result = evaluate(
-        fmt::format("cast(c0 as {})", typeString),
-        makeRowVector({makeNullableFlatVector(input, fromType)}));
-    for (vector_size_t i = 0; i < result->size(); ++i) {
-      ASSERT_TRUE(result->isNullAt(i));
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      auto result = evaluate(
+          fmt::format("cast(c0 as {})", typeString),
+          makeRowVector({makeNullableFlatVector(input, fromType)}));
+      for (vector_size_t i = 0; i < result->size(); ++i) {
+        ASSERT_TRUE(result->isNullAt(i));
+      }
+    } else {
+      auto msg = queryCtx_->queryConfig().enableOptimizedCast()
+          ? "Cannot cast"
+          : expectedErrorMessage;
+      BOLT_ASSERT_THROW(
+          evaluate(
+              fmt::format("cast(c0 as {})", typeString),
+              makeRowVector({makeNullableFlatVector(input, fromType)})),
+          "");
     }
-#else
-    auto msg = queryCtx_->queryConfig().enableOptimizedCast()
-        ? "Cannot cast"
-        : expectedErrorMessage;
-    BOLT_ASSERT_THROW(
-        evaluate(
-            fmt::format("cast(c0 as {})", typeString),
-            makeRowVector({makeNullableFlatVector(input, fromType)})),
-        "");
-#endif
   }
 
   template <typename TFrom>
@@ -236,14 +237,14 @@ class CastBaseTest : public FunctionBaseTest {
       const VectorPtr& input,
       const VectorPtr& expected,
       const std::string& expectedErrorMessage) {
-#ifdef SPARK_COMPATIBLE
-    testCast(input, expected);
-#else
-    auto msg = queryCtx_->queryConfig().enableOptimizedCast()
-        ? "Cannot cast"
-        : expectedErrorMessage;
-    BOLT_ASSERT_THROW(testCast(input, expected), msg);
-#endif
+    if constexpr (::bytedance::bolt::kSparkCompatible) {
+      testCast(input, expected);
+    } else {
+      auto msg = queryCtx_->queryConfig().enableOptimizedCast()
+          ? "Cannot cast"
+          : expectedErrorMessage;
+      BOLT_ASSERT_THROW(testCast(input, expected), msg);
+    }
   }
 
   void testCast(
@@ -340,11 +341,8 @@ class CastBaseTest : public FunctionBaseTest {
       const TypePtr& toType,
       const std::vector<std::optional<TFrom>>& input,
       const std::string& expectedErrorMessage) {
-#ifdef SPARK_COMPATIBLE
-    bool expectException = std::string_view(fromType->name()) == "JSON";
-#else
-    bool expectException = true;
-#endif
+    const bool expectException = !::bytedance::bolt::kSparkCompatible ||
+        std::string_view(fromType->name()) == "JSON";
     if (expectException) {
       BOLT_ASSERT_THROW(
           evaluateCast(

--- a/bolt/functions/prestosql/tests/HyperLogLogCastTest.cpp
+++ b/bolt/functions/prestosql/tests/HyperLogLogCastTest.cpp
@@ -28,8 +28,6 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/common/base/SparkCompatibility.h"
-
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/functions/prestosql/types/HyperLogLogType.h"
 using namespace bytedance::bolt;

--- a/bolt/functions/prestosql/tests/HyperLogLogCastTest.cpp
+++ b/bolt/functions/prestosql/tests/HyperLogLogCastTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/functions/prestosql/types/HyperLogLogType.h"
 using namespace bytedance::bolt;

--- a/bolt/functions/prestosql/tests/JsonCastTest.cpp
+++ b/bolt/functions/prestosql/tests/JsonCastTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
 using namespace bytedance::bolt;

--- a/bolt/functions/prestosql/tests/JsonCastTest.cpp
+++ b/bolt/functions/prestosql/tests/JsonCastTest.cpp
@@ -28,8 +28,6 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/common/base/SparkCompatibility.h"
-
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
 using namespace bytedance::bolt;

--- a/bolt/functions/prestosql/tests/PrestoSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/prestosql/tests/PrestoSqlDateTimeFunctionsTest.cpp
@@ -268,7 +268,7 @@ bool operator==(
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncSignatures) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto signatures = getSignatureStrings("date_trunc");
@@ -540,7 +540,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, fromUnixtime) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, year) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto year = [&](std::optional<Timestamp> date) {
@@ -566,7 +566,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, year) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, yearDate) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto year = [&](std::optional<int32_t> date) {
@@ -609,7 +609,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, yearTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, weekDate) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto weekDate = [&](const char* dateString) {
@@ -638,7 +638,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, weekDate) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, week) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto weekTimestamp = [&](const char* time) {
@@ -688,7 +688,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, weekTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, quarter) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto quarter = [&](std::optional<Timestamp> date) {
@@ -714,7 +714,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, quarter) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, quarterDate) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto quarter = [&](std::optional<int32_t> date) {
@@ -760,7 +760,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, quarterTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, month) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto month = [&](std::optional<Timestamp> date) {
@@ -786,7 +786,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, month) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, monthDate) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto month = [&](std::optional<int32_t> date) {
@@ -829,7 +829,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, monthTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, hour) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto hour = [&](std::optional<Timestamp> date) {
@@ -1333,7 +1333,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, yearOfWeekTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, minute) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto minute = [&](std::optional<Timestamp> date) {
@@ -1418,7 +1418,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, minuteTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, second) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto second = [&](std::optional<Timestamp> timestamp) {
@@ -1476,7 +1476,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, secondTimestampWithTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, millisecond) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto millisecond = [&](std::optional<Timestamp> timestamp) {
@@ -1539,7 +1539,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, millisecondTimestampWithTimezone) {
 
 // date_trunc cannot be access in presto ut
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTrunc) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   std::string optimizationFlags[] = {"true", "false"};
@@ -1652,7 +1652,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTrunc) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, trunc) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const static auto trunc = [&](std::optional<int32_t> date,
@@ -1682,7 +1682,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, trunc) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncDate) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto dateTrunc = [&](const std::string& unit,
@@ -1751,7 +1751,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncDate) {
 
 // Reference dateTruncDateForWeek for test cases explanations
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampForWeek) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto dateTrunc = [&](const std::string& unit,
@@ -1788,7 +1788,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampForWeek) {
 // 4. Convert Back to UTC (remove Time Zone offset)
 // 5. Convert Back to Milliseconds Since the Unix Epoch
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto evaluateDateTrunc = [&](const std::string& truncUnit,
@@ -1837,7 +1837,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
 TEST_F(
     PrestoSqlDateTimeFunctionsTest,
     dateTruncTimeStampWithTimezoneStringForWeek) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto evaluateDateTruncFromStrings = [&](const std::string& truncUnit,
@@ -1884,7 +1884,7 @@ TEST_F(
       "week", "2024-03-01+23:01:02+14:00", "2024-02-26+00:00:00+14:00");
 }
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto evaluateDateTrunc = [&](const std::string& truncUnit,
@@ -2164,7 +2164,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, parseDatetime) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, formatDateTime) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   using util::fromTimestampString;
@@ -2607,7 +2607,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, formatDateTimeTimezone) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormat) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto dateFormatOnce = [&](std::optional<Timestamp> timestamp,
@@ -2966,7 +2966,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormat) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto testDateFormat =
@@ -3684,7 +3684,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, monthsBetween) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, lastDay) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto lastDayFunc = [&](const std::optional<int32_t>& date) {

--- a/bolt/functions/prestosql/tests/PrestoSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/prestosql/tests/PrestoSqlDateTimeFunctionsTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <date/tz.h>
 #include <optional>
 #include <string>
@@ -265,8 +267,10 @@ bool operator==(
   return a.milliSeconds_ == b.milliSeconds_ && a.timezoneId_ == b.timezoneId_;
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncSignatures) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto signatures = getSignatureStrings("date_trunc");
   ASSERT_EQ(3, signatures.size());
 
@@ -277,7 +281,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncSignatures) {
   ASSERT_EQ(1, signatures.count("(varchar,date) -> date"));
   ASSERT_EQ(1, signatures.count("(varchar,timestamp) -> timestamp"));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, parseDatetimeSignatures) {
   auto signatures = getSignatureStrings("parse_datetime");
@@ -327,11 +330,7 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, civilDateTimeMillisecondRange) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesPrestoParity) {
-#ifdef SPARK_COMPATIBLE
-  const std::string prefix = "+";
-#else
-  const std::string prefix;
-#endif
+  const std::string prefix = ::bytedance::bolt::kSparkCompatible ? "+" : "";
   auto fromUnixTime = [&](int64_t unixTime) {
     return evaluateOnce<std::string>(
                "format_datetime("
@@ -540,8 +539,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, fromUnixtime) {
   EXPECT_EQ(Timestamp(0, 0), fromUnixtime(kNan));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, year) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto year = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("year(c0)", date);
   };
@@ -565,6 +566,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, year) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, yearDate) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto year = [&](std::optional<int32_t> date) {
     return evaluateOnce<int64_t, int32_t>("year(c0)", {date}, {DATE()});
   };
@@ -574,7 +578,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, yearDate) {
   EXPECT_EQ(2020, year(DATE()->toDays("2020-01-01")));
   EXPECT_EQ(1920, year(DATE()->toDays("1920-12-31")));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, yearTimestampWithTimezone) {
   EXPECT_EQ(
@@ -605,8 +608,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, yearTimestampWithTimezone) {
           "year(c0)", std::nullopt, std::nullopt));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, weekDate) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto weekDate = [&](const char* dateString) {
     auto date = std::make_optional(parseDate(dateString));
     auto week =
@@ -633,6 +638,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, weekDate) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, week) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto weekTimestamp = [&](const char* time) {
     auto timestampInSeconds = util::fromTimeString(time, nullptr) / 1'000'000;
     auto timestamp =
@@ -652,7 +660,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, week) {
   EXPECT_EQ(27, weekTimestamp("12:00:01"));
   EXPECT_EQ(7, weekTimestamp("12:59:59"));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, weekTimestampWithTimezone) {
   const auto weekTimestampTimezone = [&](const char* time,
@@ -680,8 +687,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, weekTimestampWithTimezone) {
   EXPECT_EQ(47, weekTimestampTimezone("12:00:01", "+12:00"));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, quarter) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto quarter = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("quarter(c0)", date);
   };
@@ -705,6 +714,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, quarter) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, quarterDate) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto quarter = [&](std::optional<int32_t> date) {
     return evaluateOnce<int64_t, int32_t>("quarter(c0)", {date}, {DATE()});
   };
@@ -717,7 +729,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, quarterDate) {
   EXPECT_EQ(1, quarter(18262));
   EXPECT_EQ(1, quarter(-18262));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, quarterTimestampWithTimezone) {
   EXPECT_EQ(
@@ -748,8 +759,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, quarterTimestampWithTimezone) {
           "quarter(c0)", std::nullopt, std::nullopt));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, month) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto month = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("month(c0)", date);
   };
@@ -773,6 +786,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, month) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, monthDate) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto month = [&](std::optional<int32_t> date) {
     return evaluateOnce<int64_t, int32_t>("month(c0)", {date}, {DATE()});
   };
@@ -784,7 +800,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, monthDate) {
   EXPECT_EQ(1, month(18262));
   EXPECT_EQ(1, month(-18262));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, monthTimestampWithTimezone) {
   EXPECT_EQ(
@@ -813,8 +828,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, monthTimestampWithTimezone) {
           "month(c0)", std::nullopt, std::nullopt));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, hour) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto hour = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("hour(c0)", date);
   };
@@ -839,7 +856,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, hour) {
   EXPECT_EQ(23, hour(Timestamp(998474645, 321000000)));
   EXPECT_EQ(8, hour(Timestamp(998423705, 321000000)));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, hourTimestampWithTimezone) {
   EXPECT_EQ(
@@ -1316,8 +1332,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, yearOfWeekTimestampWithTimezone) {
           "year_of_week(c0)", std::nullopt, std::nullopt));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, minute) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto minute = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("minute(c0)", date);
   };
@@ -1345,7 +1363,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, minute) {
   EXPECT_EQ(34, minute(Timestamp(998474645, 321000000)));
   EXPECT_EQ(25, minute(Timestamp(998423705, 321000000)));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, minuteDate) {
   const auto minute = [&](std::optional<int32_t> date) {
@@ -1400,8 +1417,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, minuteTimestampWithTimezone) {
           "minute(c0)", -1000, "+05:30"));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, second) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto second = [&](std::optional<Timestamp> timestamp) {
     return evaluateOnce<int64_t>("second(c0)", timestamp);
   };
@@ -1411,7 +1430,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, second) {
   EXPECT_EQ(59, second(Timestamp(-1, 123000000)));
   EXPECT_EQ(59, second(Timestamp(-1, Timestamp::kMaxNanos)));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, secondDate) {
   const auto second = [&](std::optional<int32_t> date) {
@@ -1457,8 +1475,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, secondTimestampWithTimezone) {
           "second(c0)", -1000, "+05:30"));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, millisecond) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto millisecond = [&](std::optional<Timestamp> timestamp) {
     return evaluateOnce<int64_t>("millisecond(c0)", timestamp);
   };
@@ -1468,7 +1488,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, millisecond) {
   EXPECT_EQ(123, millisecond(Timestamp(-1, 123000000)));
   EXPECT_EQ(999, millisecond(Timestamp(-1, Timestamp::kMaxNanos)));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, millisecondDate) {
   const auto millisecond = [&](std::optional<int32_t> date) {
@@ -1519,8 +1538,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, millisecondTimestampWithTimezone) {
 }
 
 // date_trunc cannot be access in presto ut
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTrunc) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   std::string optimizationFlags[] = {"true", "false"};
   for (const std::string& flag : optimizationFlags) {
     setQueryDateTruncOptimization(flag);
@@ -1631,6 +1652,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTrunc) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, trunc) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const static auto trunc = [&](std::optional<int32_t> date,
                                 const std::string& unit) {
     return evaluateOnce<int32_t, int32_t>(
@@ -1658,6 +1682,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, trunc) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncDate) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<int32_t> date) {
     return evaluateOnce<int32_t, int32_t>(
@@ -1707,13 +1734,15 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncDate) {
 //   // Date(19579) is 2023-08-10, Thur, should return Monday
 //   EXPECT_EQ(Date(19576), dateTrunc("week", Date(19579)));
 
-//   // Date(19570) is 2023-08-01, A non-Monday(Tue) date at the beginning of a
+//   // Date(19570) is 2023-08-01, A non-Monday(Tue) date at the beginning of
+//   a
 //   // month when the preceding Monday falls in the previous month. should
 //   return
 //   // 2023-07-31(19569), which is previous Monday
 //   EXPECT_EQ(Date(19569), dateTrunc("week", Date(19570)));
 
-//   // Date(19358) is 2023-01-01, A non-Monday(Sunday) date at the beginning of
+//   // Date(19358) is 2023-01-01, A non-Monday(Sunday) date at the beginning
+//   of
 //   // January where the preceding Monday falls in the previous year. should
 //   // return 2022-12-26(19352), which is previous Monday
 //   EXPECT_EQ(Date(19352), dateTrunc("week", Date(19358)));
@@ -1722,6 +1751,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncDate) {
 
 // Reference dateTruncDateForWeek for test cases explanations
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampForWeek) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto dateTrunc = [&](const std::string& unit,
                              std::optional<Timestamp> timestamp) {
     return evaluateOnce<Timestamp>(
@@ -1756,6 +1788,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampForWeek) {
 // 4. Convert Back to UTC (remove Time Zone offset)
 // 5. Convert Back to Milliseconds Since the Unix Epoch
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto evaluateDateTrunc = [&](const std::string& truncUnit,
                                      int64_t inputTimestamp,
                                      const std::string& timeZone,
@@ -1773,16 +1808,16 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
   auto outputMilli = inputMilli - int64_t(1) * 60 * 60 * 1000;
   evaluateDateTrunc("week", inputMilli, "+01:00", outputMilli);
 
-  // Date(19579) is 2023-08-10, Thur, should return Monday UTC (previous Sunday
-  // in +03:00 timezone)
+  // Date(19579) is 2023-08-10, Thur, should return Monday UTC (previous
+  // Sunday in +03:00 timezone)
   inputMilli = int64_t(19579) * 24 * 60 * 60 * 1000;
   outputMilli = inputMilli - int64_t(3) * 24 * 60 * 60 * 1000 -
       int64_t(3) * 60 * 60 * 1000;
   evaluateDateTrunc("week", inputMilli, "+03:00", outputMilli);
 
   // Date(19570) is 2023-08-01, A non-Monday(Tue) date at the beginning of a
-  // month when the preceding Monday falls in the previous month. should return
-  // 2023-07-31(19569), which is previous Monday EXPECT_EQ(19569,
+  // month when the preceding Monday falls in the previous month. should
+  // return 2023-07-31(19569), which is previous Monday EXPECT_EQ(19569,
   // dateTrunc("week", 19570));
   inputMilli = int64_t(19570) * 24 * 60 * 60 * 1000;
   outputMilli = inputMilli - int64_t(1) * 24 * 60 * 60 * 1000 -
@@ -1790,8 +1825,8 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
   evaluateDateTrunc("week", inputMilli, "+03:00", outputMilli);
 
   // Date(19570) is 2023-08-01, which is Tuesday; TimeZone is -05:00, so input
-  // will become Monday. 2023-07-31 19:00:00, which will truncate to 2023-07-31
-  // 00:00:00
+  // will become Monday. 2023-07-31 19:00:00, which will truncate to
+  // 2023-07-31 00:00:00
   // TODO : Need to double-check with presto logic
   inputMilli = int64_t(19570) * 24 * 60 * 60 * 1000;
   outputMilli =
@@ -1802,6 +1837,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimeStampWithTimezoneForWeek) {
 TEST_F(
     PrestoSqlDateTimeFunctionsTest,
     dateTruncTimeStampWithTimezoneStringForWeek) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto evaluateDateTruncFromStrings = [&](const std::string& truncUnit,
                                                 const std::string&
                                                     inputTimestamp,
@@ -1828,8 +1866,8 @@ TEST_F(
       "week", "2023-08-10+23:01:02+14:00", "2023-08-07+00:00:00+14:00");
 
   // 2023-08-01, A non-Monday(Tue) date at the beginning of a
-  // month when the preceding Monday falls in the previous month. should return
-  // 2023-07-31, which is previous Monday
+  // month when the preceding Monday falls in the previous month. should
+  // return 2023-07-31, which is previous Monday
   evaluateDateTruncFromStrings(
       "week", "2023-08-01+23:01:02+14:00", "2023-07-31+00:00:00+14:00");
 
@@ -1846,6 +1884,9 @@ TEST_F(
       "week", "2024-03-01+23:01:02+14:00", "2024-02-26+00:00:00+14:00");
 }
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto evaluateDateTrunc = [&](const std::string& truncUnit,
                                      int64_t inputTimestamp,
                                      const std::string& timeZone,
@@ -1937,7 +1978,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
   evaluateDateTruncFromStrings(
       "year", "1968-05-20+23:01:02+05:30", "1968-01-01+00:00:00+05:30");
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, timestampdiff) {
   const auto timestampdiff = [&](const std::string& unit,
@@ -2123,8 +2163,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, parseDatetime) {
       parseDatetime("1969-12-31+07:30+02:00", "YYYY-MM-dd+HH:mmZZ"));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, formatDateTime) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   using util::fromTimestampString;
 
   // era test cases - 'G'
@@ -2531,7 +2573,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, formatDateTime) {
       formatDatetime(fromTimestampString("1970-01-01", nullptr), "'abcd"),
       BoltUserError);
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, formatDateTimeTimezone) {
   using util::fromTimestampString;
@@ -2565,8 +2606,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, formatDateTimeTimezone) {
       formatDatetimeWithTimezone(zeroTs, "+00:07", "YYYY-MM-dd HH:mm:ss"));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormat) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto dateFormatOnce = [&](std::optional<Timestamp> timestamp,
                                   const std::string& formatString) {
     return evaluateOnce<std::string>(
@@ -2923,6 +2966,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormat) {
 }
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto testDateFormat =
       [&](const std::string& formatString,
           std::optional<int64_t> timestamp,
@@ -2954,7 +3000,6 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, dateFormatTimestampWithTimezone) {
       "69-May-11 20:04:45 PM",
       testDateFormat("%y-%M-%e %T %p", -20220915000, "-03:00"));
 }
-#endif
 
 TEST_F(PrestoSqlDateTimeFunctionsTest, dateParse) {
   // Check null behavior.
@@ -3313,11 +3358,9 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, timeZoneHour) {
       "Unable to parse timestamp value: \"invalid_date\", expected format is (YYYY-MM-DD HH:MM:SS[.MS])");
   BOLT_ASSERT_THROW(
       timezone_hour("123456", "Canada/Atlantic"),
-#ifndef SPARK_COMPATIBLE
-      "Unable to parse timestamp value: \"123456\", expected format is (YYYY-MM-DD HH:MM:SS[.MS])");
-#else
-      "Timestamp with timezone overflow: 3833727840000000 ms");
-#endif
+      ::bytedance::bolt::kSparkCompatible
+          ? "Timestamp with timezone overflow: 3833727840000000 ms"
+          : "Unable to parse timestamp value: \"123456\", expected format is (YYYY-MM-DD HH:MM:SS[.MS])");
   BOLT_ASSERT_THROW(
       timezone_hour("123456-01-01 00:00:00", "Canada/Atlantic"),
       "Timestamp with timezone overflow: 3833727840000000 ms");
@@ -3640,8 +3683,10 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, monthsBetween) {
           .value());
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(PrestoSqlDateTimeFunctionsTest, lastDay) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto lastDayFunc = [&](const std::optional<int32_t>& date) {
     return evaluateOnce<std::string, int32_t>("last_day(c0)", {date}, {DATE()});
   };
@@ -3665,4 +3710,3 @@ TEST_F(PrestoSqlDateTimeFunctionsTest, lastDay) {
   EXPECT_EQ(lastDay("2016-02-07"), "2016-02-29");
   EXPECT_EQ(lastDayFunc(std::nullopt), std::nullopt);
 }
-#endif

--- a/bolt/functions/prestosql/tests/SequenceTest.cpp
+++ b/bolt/functions/prestosql/tests/SequenceTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "bolt/type/TimestampConversion.h"
@@ -161,8 +163,10 @@ TEST_F(SequenceTest, invalidStep) {
       expected);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(SequenceTest, equalBoundsWithZeroStep) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   const auto startVector = makeFlatVector<int64_t>({1});
   const auto stopVector = makeFlatVector<int64_t>({1});
   const auto stepVector = makeFlatVector<int64_t>({0});
@@ -171,7 +175,6 @@ TEST_F(SequenceTest, equalBoundsWithZeroStep) {
       {startVector, stopVector, stepVector},
       "(0 vs. 0) step must not be zero");
 }
-#endif
 
 TEST_F(SequenceTest, dateArguments) {
   const auto startVector = makeFlatVector<int32_t>({1991, 1992, 1992}, DATE());

--- a/bolt/functions/prestosql/tests/SequenceTest.cpp
+++ b/bolt/functions/prestosql/tests/SequenceTest.cpp
@@ -164,7 +164,7 @@ TEST_F(SequenceTest, invalidStep) {
 }
 
 TEST_F(SequenceTest, equalBoundsWithZeroStep) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   const auto startVector = makeFlatVector<int64_t>({1});

--- a/bolt/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/bolt/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1416,7 +1416,7 @@ void StringFunctionsTest::testReplaceFlatVector(
 }
 
 TEST_F(StringFunctionsTest, replace) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   replace_input_test_t testsThreeArgs = {
@@ -1460,7 +1460,7 @@ TEST_F(StringFunctionsTest, replace) {
 }
 
 TEST_F(StringFunctionsTest, replaceWithReusableInputButNoInplace) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto c0 = ({
@@ -1979,7 +1979,7 @@ TEST_F(StringFunctionsTest, concatInSwitchExpr) {
 }
 
 TEST_F(StringFunctionsTest, parseUrl) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto parse_url = [&](std::optional<std::string> url,

--- a/bolt/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/bolt/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <gtest/gtest.h>
 #include <array>
 #include <cctype>
@@ -1413,8 +1415,10 @@ void StringFunctionsTest::testReplaceFlatVector(
   }
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(StringFunctionsTest, replace) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   replace_input_test_t testsThreeArgs = {
       {{"aaa", "a", "aa"}, {"aaaaaa"}},
       {{"123tech123", "123", "tech"}, {"techtechtech"}},
@@ -1456,6 +1460,9 @@ TEST_F(StringFunctionsTest, replace) {
 }
 
 TEST_F(StringFunctionsTest, replaceWithReusableInputButNoInplace) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto c0 = ({
     auto values = makeFlatVector<std::string>({"foo"});
     auto indices = allocateIndices(100, execCtx_.pool());
@@ -1478,7 +1485,6 @@ TEST_F(StringFunctionsTest, replaceWithReusableInputButNoInplace) {
     EXPECT_TRUE(result->isNullAt(i));
   }
 }
-#endif
 
 TEST_F(StringFunctionsTest, controlExprEncodingPropagation) {
   std::vector<std::string> dataASCII({"ali", "ali", "ali"});
@@ -1972,8 +1978,10 @@ TEST_F(StringFunctionsTest, concatInSwitchExpr) {
   test::assertEqualVectors(expected, result);
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST_F(StringFunctionsTest, parseUrl) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto parse_url = [&](std::optional<std::string> url,
                        std::optional<std::string> part,
                        std::optional<std::string> key = std::nullopt) {
@@ -2022,7 +2030,6 @@ TEST_F(StringFunctionsTest, parseUrl) {
       "facebook.com");
   EXPECT_EQ(parse_url("about:blank", "HOST"), std::nullopt);
 }
-#endif
 
 TEST_F(StringFunctionsTest, varbinaryLength) {
   auto vector = makeFlatVector<std::string>(

--- a/bolt/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/bolt/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/functions/prestosql/types/TimestampWithTimeZoneType.h"
 using namespace bytedance::bolt;

--- a/bolt/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/bolt/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -28,8 +28,6 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/common/base/SparkCompatibility.h"
-
 #include "bolt/functions/prestosql/tests/CastBaseTest.h"
 #include "bolt/functions/prestosql/types/TimestampWithTimeZoneType.h"
 using namespace bytedance::bolt;

--- a/bolt/functions/prestosql/tests/ToJsonTest.cpp
+++ b/bolt/functions/prestosql/tests/ToJsonTest.cpp
@@ -133,32 +133,31 @@ TEST_F(ToJsonTest, fromArray) {
         "to_json(c0)", {arrayVector}, expectedVector);
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    // Test array with short decimal column
-    std::vector<std::vector<int64_t>> decimalArray{
-        {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
-    auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
-    std::vector<std::optional<JsonNativeType>> expected{
-        R"([0.00000,0.00100])",
-        R"([1.23456,12345.67890])",
-        R"([840.59812,12345.67800])"};
-    auto expectedVector =
-        makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
-    toJsonSimple("to_json(c0)", {arrayVector}, expectedVector);
+  // Test array with short decimal column
+  std::vector<std::vector<int64_t>> decimalArray{
+      {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
+  auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
+  std::vector<std::optional<JsonNativeType>> expected{
+      R"([0.00000,0.00100])",
+      R"([1.23456,12345.67890])",
+      R"([840.59812,12345.67800])"};
+  auto expectedVector =
+      makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
+  toJsonSimple("to_json(c0)", {arrayVector}, expectedVector);
 
-    // Test array with long decimal column
-    std::vector<std::vector<int128_t>> longDecimalArray{
-        {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
-    auto longArrayVector =
-        makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
-    std::vector<std::optional<JsonNativeType>> longExpected{
-        R"([0E-10,1.00E-8])",
-        R"([0.0000123456,12.3456789112])",
-        R"([0.0084059812,1.2345678000])"};
-    auto longExpectedVector =
-        makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
-    toJsonSimple("to_json(c0)", {longArrayVector}, longExpectedVector);
-  }
+  // Test array with long decimal column
+  std::vector<std::vector<int128_t>> longDecimalArray{
+      {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
+  auto longArrayVector =
+      makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
+  std::vector<std::optional<JsonNativeType>> longExpected{
+      ::bytedance::bolt::kSparkCompatible ? R"([0E-10,1.00E-8])"
+                                          : R"([0.0000000000,0.0000000100])",
+      R"([0.0000123456,12.3456789112])",
+      R"([0.0084059812,1.2345678000])"};
+  auto longExpectedVector =
+      makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
+  toJsonSimple("to_json(c0)", {longArrayVector}, longExpectedVector);
 }
 
 TEST_F(ToJsonTest, fromMap) {
@@ -213,37 +212,37 @@ TEST_F(ToJsonTest, fromMap) {
     toJsonSimple("to_json(c0)", {mapVector}, expectedVector);
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    // Tests map with short decimal values.
-    std::vector<std::vector<Pair<StringView, int64_t>>> maps{
-        {{"a", 0}, {"b", 100}},
-        {{"c", 123456}, {"d", 1234567890}},
-        {{"e", 84059812}, {"f", 1234567800}}};
-    std::vector<std::optional<JsonNativeType>> expected{
-        R"({"a":0.00000,"b":0.00100})",
-        R"({"c":1.23456,"d":12345.67890})",
-        R"({"e":840.59812,"f":12345.67800})"};
-    auto mapVector = makeMapVector<StringView, int64_t>(
-        maps, MAP(VARCHAR(), DECIMAL(10, 5)));
-    auto expectedVector =
-        makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
-    toJsonSimple("to_json(c0)", {mapVector}, expectedVector);
+  // Tests map with short decimal values.
+  std::vector<std::vector<Pair<StringView, int64_t>>> maps{
+      {{"a", 0}, {"b", 100}},
+      {{"c", 123456}, {"d", 1234567890}},
+      {{"e", 84059812}, {"f", 1234567800}}};
+  std::vector<std::optional<JsonNativeType>> expected{
+      R"({"a":0.00000,"b":0.00100})",
+      R"({"c":1.23456,"d":12345.67890})",
+      R"({"e":840.59812,"f":12345.67800})"};
+  auto mapVector =
+      makeMapVector<StringView, int64_t>(maps, MAP(VARCHAR(), DECIMAL(10, 5)));
+  auto expectedVector =
+      makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
+  toJsonSimple("to_json(c0)", {mapVector}, expectedVector);
 
-    // Tests map with long decimal values.
-    std::vector<std::vector<Pair<StringView, int128_t>>> longDecimalMaps{
-        {{"a", 0}, {"b", 100}},
-        {{"c", 123456}, {"d", 123456789112LL}},
-        {{"e", 84059812}, {"f", 12345678000}}};
-    std::vector<std::optional<JsonNativeType>> longExpected{
-        R"({"a":0E-10,"b":1.00E-8})",
-        R"({"c":0.0000123456,"d":12.3456789112})",
-        R"({"e":0.0084059812,"f":1.2345678000})"};
-    auto longDecimalMapVector = makeMapVector<StringView, int128_t>(
-        longDecimalMaps, MAP(VARCHAR(), DECIMAL(30, 10)));
-    auto longExpectedVector =
-        makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
-    toJsonSimple("to_json(c0)", {longDecimalMapVector}, longExpectedVector);
-  }
+  // Tests map with long decimal values.
+  std::vector<std::vector<Pair<StringView, int128_t>>> longDecimalMaps{
+      {{"a", 0}, {"b", 100}},
+      {{"c", 123456}, {"d", 123456789112LL}},
+      {{"e", 84059812}, {"f", 12345678000}}};
+  std::vector<std::optional<JsonNativeType>> longExpected{
+      ::bytedance::bolt::kSparkCompatible
+          ? R"({"a":0E-10,"b":1.00E-8})"
+          : R"({"a":0.0000000000,"b":0.0000000100})",
+      R"({"c":0.0000123456,"d":12.3456789112})",
+      R"({"e":0.0084059812,"f":1.2345678000})"};
+  auto longDecimalMapVector = makeMapVector<StringView, int128_t>(
+      longDecimalMaps, MAP(VARCHAR(), DECIMAL(30, 10)));
+  auto longExpectedVector =
+      makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
+  toJsonSimple("to_json(c0)", {longDecimalMapVector}, longExpectedVector);
 
   {
     // Tests map whose values are of unknown type.
@@ -397,42 +396,41 @@ TEST_F(ToJsonTest, fromRow) {
     toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    // Test row with short decimal column
-    auto child1 =
-        makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
-    auto child2 = makeFlatVector<int64_t>(
-        {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
-    auto rowVector = makeRowVector({child1, child2});
-    std::vector<std::optional<JsonNativeType>> expected{
-        R"({"c0":"a","c1":0.00000})",
-        R"({"c0":"b","c1":0.00100})",
-        R"({"c0":"c","c1":1.23456})",
-        R"({"c0":"d","c1":12345.67890})",
-        R"({"c0":"e","c1":840.59812})",
-        R"({"c0":"f","c1":12345.67800})"};
-    auto expectedVector =
-        makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
-    toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
+  // Test row with short decimal column
+  auto child1 =
+      makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
+  auto child2 = makeFlatVector<int64_t>(
+      {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
+  auto rowVector = makeRowVector({child1, child2});
+  std::vector<std::optional<JsonNativeType>> expected{
+      R"({"c0":"a","c1":0.00000})",
+      R"({"c0":"b","c1":0.00100})",
+      R"({"c0":"c","c1":1.23456})",
+      R"({"c0":"d","c1":12345.67890})",
+      R"({"c0":"e","c1":840.59812})",
+      R"({"c0":"f","c1":12345.67800})"};
+  auto expectedVector =
+      makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
+  toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
 
-    // Test row with long decimal column
-    auto longChild1 =
-        makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
-    auto longChild2 = makeFlatVector<int128_t>(
-        {0, 100, 123456, 123456789112LL, 84059812, 12345678000},
-        DECIMAL(30, 10));
-    auto longRowVector = makeRowVector({longChild1, longChild2});
-    std::vector<std::optional<JsonNativeType>> longExpected{
-        R"({"c0":"a","c1":0E-10})",
-        R"({"c0":"b","c1":1.00E-8})",
-        R"({"c0":"c","c1":0.0000123456})",
-        R"({"c0":"d","c1":12.3456789112})",
-        R"({"c0":"e","c1":0.0084059812})",
-        R"({"c0":"f","c1":1.2345678000})"};
-    auto longExpectedVector =
-        makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
-    toJsonSimple("to_json(c0)", {longRowVector}, longExpectedVector);
-  }
+  // Test row with long decimal column
+  auto longChild1 =
+      makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
+  auto longChild2 = makeFlatVector<int128_t>(
+      {0, 100, 123456, 123456789112LL, 84059812, 12345678000}, DECIMAL(30, 10));
+  auto longRowVector = makeRowVector({longChild1, longChild2});
+  std::vector<std::optional<JsonNativeType>> longExpected{
+      ::bytedance::bolt::kSparkCompatible ? R"({"c0":"a","c1":0E-10})"
+                                          : R"({"c0":"a","c1":0.0000000000})",
+      ::bytedance::bolt::kSparkCompatible ? R"({"c0":"b","c1":1.00E-8})"
+                                          : R"({"c0":"b","c1":0.0000000100})",
+      R"({"c0":"c","c1":0.0000123456})",
+      R"({"c0":"d","c1":12.3456789112})",
+      R"({"c0":"e","c1":0.0084059812})",
+      R"({"c0":"f","c1":1.2345678000})"};
+  auto longExpectedVector =
+      makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
+  toJsonSimple("to_json(c0)", {longRowVector}, longExpectedVector);
 
   // dorado id 111899126, date = 20240106
   {

--- a/bolt/functions/prestosql/tests/ToJsonTest.cpp
+++ b/bolt/functions/prestosql/tests/ToJsonTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
@@ -131,32 +133,32 @@ TEST_F(ToJsonTest, fromArray) {
         "to_json(c0)", {arrayVector}, expectedVector);
   }
 
-#ifdef SPARK_COMPATIBLE
-  // Test array with short decimal column
-  std::vector<std::vector<int64_t>> decimalArray{
-      {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
-  auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
-  std::vector<std::optional<JsonNativeType>> expected{
-      R"([0.00000,0.00100])",
-      R"([1.23456,12345.67890])",
-      R"([840.59812,12345.67800])"};
-  auto expectedVector =
-      makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
-  toJsonSimple("to_json(c0)", {arrayVector}, expectedVector);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    // Test array with short decimal column
+    std::vector<std::vector<int64_t>> decimalArray{
+        {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
+    auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
+    std::vector<std::optional<JsonNativeType>> expected{
+        R"([0.00000,0.00100])",
+        R"([1.23456,12345.67890])",
+        R"([840.59812,12345.67800])"};
+    auto expectedVector =
+        makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
+    toJsonSimple("to_json(c0)", {arrayVector}, expectedVector);
 
-  // Test array with long decimal column
-  std::vector<std::vector<int128_t>> longDecimalArray{
-      {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
-  auto longArrayVector =
-      makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
-  std::vector<std::optional<JsonNativeType>> longExpected{
-      R"([0E-10,1.00E-8])",
-      R"([0.0000123456,12.3456789112])",
-      R"([0.0084059812,1.2345678000])"};
-  auto longExpectedVector =
-      makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
-  toJsonSimple("to_json(c0)", {longArrayVector}, longExpectedVector);
-#endif
+    // Test array with long decimal column
+    std::vector<std::vector<int128_t>> longDecimalArray{
+        {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
+    auto longArrayVector =
+        makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
+    std::vector<std::optional<JsonNativeType>> longExpected{
+        R"([0E-10,1.00E-8])",
+        R"([0.0000123456,12.3456789112])",
+        R"([0.0084059812,1.2345678000])"};
+    auto longExpectedVector =
+        makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
+    toJsonSimple("to_json(c0)", {longArrayVector}, longExpectedVector);
+  }
 }
 
 TEST_F(ToJsonTest, fromMap) {
@@ -211,37 +213,37 @@ TEST_F(ToJsonTest, fromMap) {
     toJsonSimple("to_json(c0)", {mapVector}, expectedVector);
   }
 
-#ifdef SPARK_COMPATIBLE
-  // Tests map with short decimal values.
-  std::vector<std::vector<Pair<StringView, int64_t>>> maps{
-      {{"a", 0}, {"b", 100}},
-      {{"c", 123456}, {"d", 1234567890}},
-      {{"e", 84059812}, {"f", 1234567800}}};
-  std::vector<std::optional<JsonNativeType>> expected{
-      R"({"a":0.00000,"b":0.00100})",
-      R"({"c":1.23456,"d":12345.67890})",
-      R"({"e":840.59812,"f":12345.67800})"};
-  auto mapVector =
-      makeMapVector<StringView, int64_t>(maps, MAP(VARCHAR(), DECIMAL(10, 5)));
-  auto expectedVector =
-      makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
-  toJsonSimple("to_json(c0)", {mapVector}, expectedVector);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    // Tests map with short decimal values.
+    std::vector<std::vector<Pair<StringView, int64_t>>> maps{
+        {{"a", 0}, {"b", 100}},
+        {{"c", 123456}, {"d", 1234567890}},
+        {{"e", 84059812}, {"f", 1234567800}}};
+    std::vector<std::optional<JsonNativeType>> expected{
+        R"({"a":0.00000,"b":0.00100})",
+        R"({"c":1.23456,"d":12345.67890})",
+        R"({"e":840.59812,"f":12345.67800})"};
+    auto mapVector = makeMapVector<StringView, int64_t>(
+        maps, MAP(VARCHAR(), DECIMAL(10, 5)));
+    auto expectedVector =
+        makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
+    toJsonSimple("to_json(c0)", {mapVector}, expectedVector);
 
-  // Tests map with long decimal values.
-  std::vector<std::vector<Pair<StringView, int128_t>>> longDecimalMaps{
-      {{"a", 0}, {"b", 100}},
-      {{"c", 123456}, {"d", 123456789112LL}},
-      {{"e", 84059812}, {"f", 12345678000}}};
-  std::vector<std::optional<JsonNativeType>> longExpected{
-      R"({"a":0E-10,"b":1.00E-8})",
-      R"({"c":0.0000123456,"d":12.3456789112})",
-      R"({"e":0.0084059812,"f":1.2345678000})"};
-  auto longDecimalMapVector = makeMapVector<StringView, int128_t>(
-      longDecimalMaps, MAP(VARCHAR(), DECIMAL(30, 10)));
-  auto longExpectedVector =
-      makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
-  toJsonSimple("to_json(c0)", {longDecimalMapVector}, longExpectedVector);
-#endif
+    // Tests map with long decimal values.
+    std::vector<std::vector<Pair<StringView, int128_t>>> longDecimalMaps{
+        {{"a", 0}, {"b", 100}},
+        {{"c", 123456}, {"d", 123456789112LL}},
+        {{"e", 84059812}, {"f", 12345678000}}};
+    std::vector<std::optional<JsonNativeType>> longExpected{
+        R"({"a":0E-10,"b":1.00E-8})",
+        R"({"c":0.0000123456,"d":12.3456789112})",
+        R"({"e":0.0084059812,"f":1.2345678000})"};
+    auto longDecimalMapVector = makeMapVector<StringView, int128_t>(
+        longDecimalMaps, MAP(VARCHAR(), DECIMAL(30, 10)));
+    auto longExpectedVector =
+        makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
+    toJsonSimple("to_json(c0)", {longDecimalMapVector}, longExpectedVector);
+  }
 
   {
     // Tests map whose values are of unknown type.
@@ -395,41 +397,42 @@ TEST_F(ToJsonTest, fromRow) {
     toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
   }
 
-#ifdef SPARK_COMPATIBLE
-  // Test row with short decimal column
-  auto child1 =
-      makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
-  auto child2 = makeFlatVector<int64_t>(
-      {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
-  auto rowVector = makeRowVector({child1, child2});
-  std::vector<std::optional<JsonNativeType>> expected{
-      R"({"c0":"a","c1":0.00000})",
-      R"({"c0":"b","c1":0.00100})",
-      R"({"c0":"c","c1":1.23456})",
-      R"({"c0":"d","c1":12345.67890})",
-      R"({"c0":"e","c1":840.59812})",
-      R"({"c0":"f","c1":12345.67800})"};
-  auto expectedVector =
-      makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
-  toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    // Test row with short decimal column
+    auto child1 =
+        makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
+    auto child2 = makeFlatVector<int64_t>(
+        {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
+    auto rowVector = makeRowVector({child1, child2});
+    std::vector<std::optional<JsonNativeType>> expected{
+        R"({"c0":"a","c1":0.00000})",
+        R"({"c0":"b","c1":0.00100})",
+        R"({"c0":"c","c1":1.23456})",
+        R"({"c0":"d","c1":12345.67890})",
+        R"({"c0":"e","c1":840.59812})",
+        R"({"c0":"f","c1":12345.67800})"};
+    auto expectedVector =
+        makeNullableFlatVector<JsonNativeType>(expected, VARCHAR());
+    toJsonSimple("to_json(c0)", {rowVector}, expectedVector);
 
-  // Test row with long decimal column
-  auto longChild1 =
-      makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
-  auto longChild2 = makeFlatVector<int128_t>(
-      {0, 100, 123456, 123456789112LL, 84059812, 12345678000}, DECIMAL(30, 10));
-  auto longRowVector = makeRowVector({longChild1, longChild2});
-  std::vector<std::optional<JsonNativeType>> longExpected{
-      R"({"c0":"a","c1":0E-10})",
-      R"({"c0":"b","c1":1.00E-8})",
-      R"({"c0":"c","c1":0.0000123456})",
-      R"({"c0":"d","c1":12.3456789112})",
-      R"({"c0":"e","c1":0.0084059812})",
-      R"({"c0":"f","c1":1.2345678000})"};
-  auto longExpectedVector =
-      makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
-  toJsonSimple("to_json(c0)", {longRowVector}, longExpectedVector);
-#endif
+    // Test row with long decimal column
+    auto longChild1 =
+        makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
+    auto longChild2 = makeFlatVector<int128_t>(
+        {0, 100, 123456, 123456789112LL, 84059812, 12345678000},
+        DECIMAL(30, 10));
+    auto longRowVector = makeRowVector({longChild1, longChild2});
+    std::vector<std::optional<JsonNativeType>> longExpected{
+        R"({"c0":"a","c1":0E-10})",
+        R"({"c0":"b","c1":1.00E-8})",
+        R"({"c0":"c","c1":0.0000123456})",
+        R"({"c0":"d","c1":12.3456789112})",
+        R"({"c0":"e","c1":0.0084059812})",
+        R"({"c0":"f","c1":1.2345678000})"};
+    auto longExpectedVector =
+        makeNullableFlatVector<JsonNativeType>(longExpected, VARCHAR());
+    toJsonSimple("to_json(c0)", {longRowVector}, longExpectedVector);
+  }
 
   // dorado id 111899126, date = 20240106
   {

--- a/bolt/functions/sparksql/ToJson.h
+++ b/bolt/functions/sparksql/ToJson.h
@@ -33,6 +33,7 @@
 #include <cstring>
 #include <string>
 
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/common/encode/Base64.h"
 #include "bolt/expression/ComplexViewTypes.h"
 #include "bolt/expression/VectorReaders.h"
@@ -76,7 +77,11 @@ void appendDecimal(const T& value, const Type& type, std::string& result) {
   // scientific exponent and leading zero.
   constexpr size_t kMaxDecimalStringSize = LongDecimalType::kMaxPrecision + 7;
   char buffer[kMaxDecimalStringSize];
-  size_t len = DecimalUtil::convertToString<T>(value, scale, maxSize, buffer);
+  constexpr auto kDecimalStringFormat = ::bytedance::bolt::kSparkCompatible
+      ? DecimalUtil::DecimalStringFormat::kSpark
+      : DecimalUtil::DecimalStringFormat::kPlain;
+  size_t len = DecimalUtil::convertToString<kDecimalStringFormat>(
+      value, scale, maxSize, buffer);
   result.append(buffer, len);
 }
 

--- a/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -40,11 +40,14 @@ add_executable(
   LastAggregateTest.cpp
   MinMaxByAggregationTest.cpp
   ModeAggregateTest.cpp
-  PercentileAggregateTest.cpp
   PercentileApproxTest.cpp
   RegrReplacementAggregationTest.cpp
   SumAggregationTest.cpp
 )
+
+if(BOLT_ENABLE_SPARK_COMPATIBLE)
+  target_sources(bolt_functions_spark_aggregates_test PRIVATE PercentileAggregateTest.cpp)
+endif()
 
 add_test(bolt_functions_spark_aggregates_test bolt_functions_spark_aggregates_test)
 

--- a/bolt/functions/sparksql/aggregates/tests/PercentileAggregateTest.cpp
+++ b/bolt/functions/sparksql/aggregates/tests/PercentileAggregateTest.cpp
@@ -26,7 +26,6 @@ using namespace bytedance::bolt::exec::test;
 using namespace bytedance::bolt::functions::aggregate::test;
 namespace bytedance::bolt::functions::aggregate::sparksql::test {
 
-#ifdef SPARK_COMPATIBLE
 namespace {
 
 // Return the argument types of an aggregation when the aggregation is
@@ -204,7 +203,8 @@ class PercentileTest : public AggregationTestBase {
           {expected});
 
       // Companion functions of percentile do not support test streaming
-      // because intermediate results are KLL that has non-deterministic shape.
+      // because intermediate results are KLL that has non-deterministic
+      // shape.
       disableTestStreaming();
       testAggregationsWithCompanion(
           {rows},
@@ -556,5 +556,4 @@ TEST_F(PercentileTest, nullPercentile) {
 }
 
 } // namespace
-#endif
 } // namespace bytedance::bolt::functions::aggregate::sparksql::test

--- a/bolt/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/bolt/functions/sparksql/registration/RegisterDatetime.cpp
@@ -28,10 +28,18 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/functions/lib/RegistrationHelpers.h"
 #include "bolt/functions/prestosql/DateTimeFunctions.h"
 #include "bolt/functions/sparksql/DateTimeFunctions.h"
 namespace bytedance::bolt::functions::sparksql {
+namespace {
+template <typename T>
+using BuildJodaDateFormatFunction =
+    JodaDateFormatFunction<T, ::bytedance::bolt::kSparkCompatible>;
+} // namespace
+
 void registerDatetimeFunctions(const std::string& prefix) {
   // Register date functions.
   registerFunction<Date2PDateFunction, Varchar, Varchar>(
@@ -182,10 +190,10 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<MillisecondFunction, int32_t, Timestamp>(
       {prefix + "millisecond"});
 
-  registerFunction<JodaDateFormatFunction, Varchar, Timestamp, Varchar>(
+  registerFunction<BuildJodaDateFormatFunction, Varchar, Timestamp, Varchar>(
       {prefix + "date_format"});
   registerFunction<
-      JodaDateFormatFunction,
+      BuildJodaDateFormatFunction,
       Varchar,
       TimestampWithTimezone,
       Varchar>({prefix + "date_format"});

--- a/bolt/functions/sparksql/tests/CMakeLists.txt
+++ b/bolt/functions/sparksql/tests/CMakeLists.txt
@@ -89,7 +89,6 @@ add_executable(
   SizeTest.cpp
   SortArrayTest.cpp
   SparkArraySortTest.cpp
-  SparkCastExprTest.cpp
   SparkPartitionIdTest.cpp
   SparkRoundTest.cpp
   SparkSqlDateTimeFunctionsTest.cpp
@@ -107,6 +106,10 @@ add_executable(
   VariantFunctionTest.cpp
   XxHash64Test.cpp
 )
+
+if(BOLT_ENABLE_SPARK_COMPATIBLE)
+  target_sources(bolt_functions_spark_test PRIVATE SparkCastExprTest.cpp)
+endif()
 
 add_test(
   NAME bolt_functions_spark_test

--- a/bolt/functions/sparksql/tests/SequenceTest.cpp
+++ b/bolt/functions/sparksql/tests/SequenceTest.cpp
@@ -27,6 +27,8 @@
  * This modified file is released under the same license.
  * --------------------------------------------------------------------------
  */
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <optional>
 
 #include <gtest/gtest.h>
@@ -84,8 +86,10 @@ TEST_F(SequenceTest, singleElement) {
   assertEqualVectors(expected, result);
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(SequenceTest, singleElementWithZeroStep) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   auto bigintResult = evaluate(
       "sequence(c0, c1, c2)",
       makeRowVector({
@@ -104,7 +108,6 @@ TEST_F(SequenceTest, singleElementWithZeroStep) {
       }));
   assertEqualVectors(makeArrayVector<int32_t>({{1}}), integerResult);
 }
-#endif
 
 TEST_F(SequenceTest, integerType) {
   auto result = evaluate(

--- a/bolt/functions/sparksql/tests/SequenceTest.cpp
+++ b/bolt/functions/sparksql/tests/SequenceTest.cpp
@@ -87,7 +87,7 @@ TEST_F(SequenceTest, singleElement) {
 }
 
 TEST_F(SequenceTest, singleElementWithZeroStep) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   auto bigintResult = evaluate(

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -131,8 +131,6 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
   }
 };
 
-#ifdef SPARK_COMPATIBLE
-
 TEST_F(SparkCastExprTest, date) {
   testTryCast<std::string, int32_t>(
       "date",
@@ -605,9 +603,7 @@ TEST_F(SparkCastExprTest, errorHandling) {
       {"-",
        "-0",
        " @w 123",
-#ifdef SPARK_COMPATIBLE
        "123 ",
-#endif
        "  122",
        "",
        "-12-3",
@@ -624,9 +620,7 @@ TEST_F(SparkCastExprTest, errorHandling) {
       {std::nullopt,
        0,
        std::nullopt,
-#ifdef SPARK_COMPATIBLE
        123,
-#endif
        122,
        std::nullopt,
        std::nullopt,
@@ -812,20 +806,9 @@ TEST_F(SparkCastExprTest, fromString) {
   // String with leading and trailing whitespaces.
   testCast(
       makeFlatVector<StringView>(
-          {" 9999999999.99",
-#ifdef SPARK_COMPATIBLE
-           "9999999999.99 ",
-           "-3E+2 ",
-#endif
-           " -3E+2"}),
+          {" 9999999999.99", "9999999999.99 ", "-3E+2 ", " -3E+2"}),
       makeFlatVector<int64_t>(
-          {999'999'999'999,
-#ifdef SPARK_COMPATIBLE
-           999'999'999'999,
-           -30000,
-#endif
-           -30000},
-          DECIMAL(12, 2)));
+          {999'999'999'999, 999'999'999'999, -30000, -30000}, DECIMAL(12, 2)));
 }
 
 TEST_F(SparkCastExprTest, testInvalidDate) {
@@ -923,7 +906,5 @@ TEST_F(SparkCastExprTest, bigintToBinary) {
        std::string("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 8),
        std::string("\x80\x00\x00\x00\x00\x00\x00\x00", 8)});
 }
-
-#endif
 } // namespace
 } // namespace bytedance::bolt::test

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -22,6 +22,8 @@
 #include <cstdlib>
 #include <fstream>
 #include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/expression/UdfTypeResolver.h"
+#include "bolt/functions/prestosql/DateTimeFunctions.h"
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "bolt/type/tz/TimeZoneMap.h"
 namespace bytedance::bolt::functions::sparksql::test {
@@ -1749,7 +1751,7 @@ TEST_F(SparkSqlDateTimeFunctionsTest, getTimestamp) {
   // to_timestamp exception mode
   setQueryTimeZone("America/Los_Angeles");
   // legacy timeparser
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     EXPECT_EQ(
         Timestamp(
             1580184371,
@@ -1758,7 +1760,7 @@ TEST_F(SparkSqlDateTimeFunctionsTest, getTimestamp) {
             .value());
   }
   setQueryTimeZone("UTC");
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     EXPECT_EQ(
         "2020-01-28 01:06:11.847000000",
         getTimestampString(
@@ -1854,7 +1856,7 @@ TEST_F(SparkSqlDateTimeFunctionsTest, getTimestamp) {
 
   // corrected
   setTimeParserPolicy("corrected");
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     EXPECT_EQ(
         std::nullopt,
         getTimestamp(
@@ -2133,7 +2135,7 @@ TEST_F(SparkSqlDateTimeFunctionsTest, fromUnixtime) {
       fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
       "2020-07-01 07:59:59");
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     setPolicyAndTimeZone("corrected", "Asia/Shanghai");
     EXPECT_EQ(
         fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
@@ -2186,7 +2188,7 @@ TEST_F(SparkSqlDateTimeFunctionsTest, fromUnixtimeIllegal) {
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, CastStringToLargeTimestamp) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   using util::fromTimestampString;
@@ -2247,13 +2249,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkTimezone) {
 
   EXPECT_EQ(
       fromUnixTime(253402300799, "Asia/Shanghai"), "10000-01-01 07:59:59");
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    EXPECT_EQ(
-        fromUnixTime(253402300801, "Asia/Shanghai"), "+10000-01-01 08:00:01");
-  } else {
-    EXPECT_EQ(
-        fromUnixTime(253402300801, "Asia/Shanghai"), "10000-01-01 08:00:01");
-  }
+  EXPECT_EQ(
+      fromUnixTime(253402300801, "Asia/Shanghai"),
+      ::bytedance::bolt::kSparkCompatible ? "+10000-01-01 08:00:01"
+                                          : "10000-01-01 08:00:01");
   EXPECT_EQ(
       fromUnixTime(253402300801, "America/Los_Angeles"), "9999-12-31 16:00:01");
 }
@@ -2324,8 +2323,22 @@ TEST_F(SparkSqlDateTimeFunctionsTest, dateFormat) {
           Timestamp(1520989323L, 123456789L), "yyy-MM-dd HH:mm:ss.SSSSSSSSS"));
 }
 
+TEST_F(SparkSqlDateTimeFunctionsTest, jodaDateFormatDefaultCompatibility) {
+  core::QueryConfig config({});
+  StringView format("YYYY-ww-ee");
+  const Timestamp* timestamp = nullptr;
+  JodaDateFormatFunction<exec::VectorExec> function;
+
+  if (::bytedance::bolt::kSparkCompatible) {
+    EXPECT_NO_THROW(function.initialize({}, config, timestamp, &format));
+  } else {
+    EXPECT_THROW(
+        function.initialize({}, config, timestamp, &format), BoltUserError);
+  }
+}
+
 TEST_F(SparkSqlDateTimeFunctionsTest, weekBased) {
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   using util::fromTimestampString;

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <common/base/BoltException.h>
 #include <fmt/core.h>
 #include <type/Type.h>
@@ -1746,52 +1748,55 @@ TEST_F(SparkSqlDateTimeFunctionsTest, getTimestamp) {
 
   // to_timestamp exception mode
   setQueryTimeZone("America/Los_Angeles");
-// legacy timeparser
-#ifdef SPARK_COMPATIBLE
-  EXPECT_EQ(
-      Timestamp(
-          1580184371,
-          847000000), // Timestamp.valueOf("2020-01-27 20:06:11.847")
-      getTimestamp("2020-01-27 20:06:11.847-0800", "yyyy-MM-dd HH:mm:ss.SSSz")
-          .value());
-#endif
+  // legacy timeparser
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(
+        Timestamp(
+            1580184371,
+            847000000), // Timestamp.valueOf("2020-01-27 20:06:11.847")
+        getTimestamp("2020-01-27 20:06:11.847-0800", "yyyy-MM-dd HH:mm:ss.SSSz")
+            .value());
+  }
   setQueryTimeZone("UTC");
-#ifdef SPARK_COMPATIBLE
-  EXPECT_EQ(
-      "2020-01-28 01:06:11.847000000",
-      getTimestampString(
-          "2020-01-27 20:06:11.847est", "yyyy-MM-dd HH:mm:ss.SSSz"));
-  EXPECT_EQ(
-      "2020-01-28 01:06:11.847000000",
-      getTimestampString(
-          "2020-01-27 20:06:11.847Est", "yyyy-MM-dd HH:mm:ss.SSSz"));
-  EXPECT_EQ(
-      "null",
-      getTimestampString(
-          "2020-01-27 20:06:11.847UT", "yyyy-MM-dd HH:mm:ss.SSSz"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.847000000",
-      getTimestampString(
-          "2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.SSSS"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.847000000",
-      getTimestampString("2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.SSS"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.847000000",
-      getTimestampString("2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.SS"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.847000000",
-      getTimestampString("2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.S"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.084000000",
-      getTimestampString("2020-01-27 20:06:11.84", "yyyy-MM-dd HH:mm:ss.SS"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.008000000",
-      getTimestampString("2020-01-27 20:06:11.8", "yyyy-MM-dd HH:mm:ss.S"));
-  EXPECT_EQ(
-      "2020-01-27 20:06:11.008000000",
-      getTimestampString("2020-01-27 20:06:11.8", "yyyy-MM-dd HH:mm:ss.SSSS"));
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(
+        "2020-01-28 01:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847est", "yyyy-MM-dd HH:mm:ss.SSSz"));
+    EXPECT_EQ(
+        "2020-01-28 01:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847Est", "yyyy-MM-dd HH:mm:ss.SSSz"));
+    EXPECT_EQ(
+        "null",
+        getTimestampString(
+            "2020-01-27 20:06:11.847UT", "yyyy-MM-dd HH:mm:ss.SSSz"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.SSSS"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.SSS"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.SS"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.847000000",
+        getTimestampString("2020-01-27 20:06:11.847", "yyyy-MM-dd HH:mm:ss.S"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.084000000",
+        getTimestampString("2020-01-27 20:06:11.84", "yyyy-MM-dd HH:mm:ss.SS"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.008000000",
+        getTimestampString("2020-01-27 20:06:11.8", "yyyy-MM-dd HH:mm:ss.S"));
+    EXPECT_EQ(
+        "2020-01-27 20:06:11.008000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.8", "yyyy-MM-dd HH:mm:ss.SSSS"));
+  }
   EXPECT_EQ(
       std::nullopt,
       getTimestamp("2020-01-27 20:06:11.1234", "yyyy-MM-dd HH:mm:ss.SSSS"));
@@ -1849,19 +1854,20 @@ TEST_F(SparkSqlDateTimeFunctionsTest, getTimestamp) {
 
   // corrected
   setTimeParserPolicy("corrected");
-#ifdef SPARK_COMPATIBLE
-  EXPECT_EQ(
-      std::nullopt,
-      getTimestamp("2020-01-27 20:06:11.847-0800", "yyyy-MM-dd HH:mm:ss.SSSz"));
-  EXPECT_EQ(
-      "2020-01-28 04:06:11.847000000",
-      getTimestampString(
-          "2020-01-27 20:06:11.847-08:00", "yyyy-MM-dd HH:mm:ss.SSSz"));
-  EXPECT_EQ(
-      "2020-01-28 01:06:11.847000000",
-      getTimestampString(
-          "2020-01-27 20:06:11.847est", "yyyy-MM-dd HH:mm:ss.SSSz"));
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(
+        std::nullopt,
+        getTimestamp(
+            "2020-01-27 20:06:11.847-0800", "yyyy-MM-dd HH:mm:ss.SSSz"));
+    EXPECT_EQ(
+        "2020-01-28 04:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847-08:00", "yyyy-MM-dd HH:mm:ss.SSSz"));
+    EXPECT_EQ(
+        "2020-01-28 01:06:11.847000000",
+        getTimestampString(
+            "2020-01-27 20:06:11.847est", "yyyy-MM-dd HH:mm:ss.SSSz"));
+  }
   EXPECT_EQ(std::nullopt, getTimestamp("", "yyyy-MM-dd"));
   EXPECT_EQ(std::nullopt, getTimestamp("1970", "yyyy-MM-dd"));
   EXPECT_EQ(std::nullopt, getTimestamp("1970-01", "yyyy-MM-dd"));
@@ -2127,34 +2133,34 @@ TEST_F(SparkSqlDateTimeFunctionsTest, fromUnixtime) {
       fromUnixTime(getUnixTime("2020-06-30 23:59:59"), "yyyy-MM-dd HH:mm:ss"),
       "2020-07-01 07:59:59");
 
-#ifdef SPARK_COMPATIBLE
-  setPolicyAndTimeZone("corrected", "Asia/Shanghai");
-  EXPECT_EQ(
-      fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
-      "0002-11-28 00:05:43 BC");
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    setPolicyAndTimeZone("corrected", "Asia/Shanghai");
+    EXPECT_EQ(
+        fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
+        "0002-11-28 00:05:43 BC");
 
-  setPolicyAndTimeZone("exception", "Asia/Shanghai");
+    setPolicyAndTimeZone("exception", "Asia/Shanghai");
 #ifndef __APPLE__
-  EXPECT_EQ(
-      fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss").value(),
-      "-0001-11-28 00:05:43");
+    EXPECT_EQ(
+        fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss").value(),
+        "-0001-11-28 00:05:43");
 #endif
 
-  EXPECT_EQ(
-      fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
-      "0002-11-28 00:05:43 BC");
+    EXPECT_EQ(
+        fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
+        "0002-11-28 00:05:43 BC");
 
-  setPolicyAndTimeZone("legacy", "Asia/Shanghai");
-  EXPECT_EQ(
-      fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss").value(),
-      "0002-11-28 00:05:43");
+    setPolicyAndTimeZone("legacy", "Asia/Shanghai");
+    EXPECT_EQ(
+        fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss").value(),
+        "0002-11-28 00:05:43");
 
-  EXPECT_EQ(
-      fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
-      "0002-11-28 00:05:43 BC");
+    EXPECT_EQ(
+        fromUnixTime(-62170185600, "yyyy-MM-dd HH:mm:ss G").value(),
+        "0002-11-28 00:05:43 BC");
 
-  EXPECT_EQ(fromUnixTime(0, "FF/MM/dd").value(), "01/01/01");
-#endif
+    EXPECT_EQ(fromUnixTime(0, "FF/MM/dd").value(), "01/01/01");
+  }
 
   // Invalid format.
   BOLT_ASSERT_THROW(
@@ -2179,8 +2185,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, fromUnixtimeIllegal) {
   EXPECT_NO_THROW(fromUnixTime("-20231228101858000", "yyyy-MM-dd"));
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(SparkSqlDateTimeFunctionsTest, CastStringToLargeTimestamp) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   using util::fromTimestampString;
 
   auto result = evaluateOnce<Timestamp>(
@@ -2190,14 +2198,9 @@ TEST_F(SparkSqlDateTimeFunctionsTest, CastStringToLargeTimestamp) {
       result.value(),
       fromTimestampString(StringView("32768-01-01 00:00:00"), nullptr));
 }
-#endif
 
 TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkParity) {
-#ifdef SPARK_COMPATIBLE
-  const std::string prefix = "+";
-#else
-  const std::string prefix;
-#endif
+  const std::string prefix = ::bytedance::bolt::kSparkCompatible ? "+" : "";
   auto fromUnixTime = [&](int64_t unixTime) {
     return evaluateOnce<std::string>(
                "from_unixtime(c0, 'yyyy-MM-dd HH:mm:ss')",
@@ -2244,13 +2247,13 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkTimezone) {
 
   EXPECT_EQ(
       fromUnixTime(253402300799, "Asia/Shanghai"), "10000-01-01 07:59:59");
-#ifdef SPARK_COMPATIBLE
-  EXPECT_EQ(
-      fromUnixTime(253402300801, "Asia/Shanghai"), "+10000-01-01 08:00:01");
-#else
-  EXPECT_EQ(
-      fromUnixTime(253402300801, "Asia/Shanghai"), "10000-01-01 08:00:01");
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(
+        fromUnixTime(253402300801, "Asia/Shanghai"), "+10000-01-01 08:00:01");
+  } else {
+    EXPECT_EQ(
+        fromUnixTime(253402300801, "Asia/Shanghai"), "10000-01-01 08:00:01");
+  }
   EXPECT_EQ(
       fromUnixTime(253402300801, "America/Los_Angeles"), "9999-12-31 16:00:01");
 }
@@ -2321,8 +2324,10 @@ TEST_F(SparkSqlDateTimeFunctionsTest, dateFormat) {
           Timestamp(1520989323L, 123456789L), "yyy-MM-dd HH:mm:ss.SSSSSSSSS"));
 }
 
-#ifdef SPARK_COMPATIBLE
 TEST_F(SparkSqlDateTimeFunctionsTest, weekBased) {
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   using util::fromTimestampString;
 
   const auto dateFormat = [&](const std::string& dateStr,
@@ -2437,7 +2442,6 @@ TEST_F(SparkSqlDateTimeFunctionsTest, weekBased) {
   EXPECT_EQ("2025-01-08", getTimestamp("2025-01-02-03", "yyyy-MM-FF-uu"));
   EXPECT_EQ("2025-01-09", getTimestamp("2025-01-02-04", "yyyy-MM-FF-uu"));
 }
-#endif
 
 TEST_F(SparkSqlDateTimeFunctionsTest, formatPdate) {
   const auto formatPdate = [&](std::optional<StringView> dateStr) {

--- a/bolt/functions/sparksql/tests/ToJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/ToJsonTest.cpp
@@ -26,6 +26,8 @@
  * This modified file is released under the same license.
  * --------------------------------------------------------------------------
  */
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
 #include "bolt/functions/sparksql/tests/JsonTestUtil.h"
@@ -229,11 +231,8 @@ TEST_F(ToJsonTest, longDecimal) {
   auto input = makeRowVector({"a"}, {data});
   auto expected = makeFlatVector<std::string>(
       {R"({"a":123456789.0123456789})",
-#ifdef SPARK_COMPATIBLE
-       R"({"a":0E-10})",
-#else
-       R"({"a":0.0000000000})",
-#endif
+       ::bytedance::bolt::kSparkCompatible ? R"({"a":0E-10})"
+                                           : R"({"a":0.0000000000})",
        R"({"a":-98765432109.8765432100})",
        R"({"a":9999999999999999999999999999.9999999999})",
        R"({"a":-9999999999999999999999999999.9999999999})",
@@ -332,80 +331,81 @@ TEST_F(ToJsonTest, nestedMap) {
 }
 
 // Tests ported from prestosql/tests/ToJsonTest.cpp using testToJson.
-TEST_F(ToJsonTest, fromArray){
-    {// Array of JSON-like strings.
-     std::vector<std::vector<std::optional<std::string>>>
-         array{{"red", "blue"}, {std::nullopt, std::nullopt, "purple"}, {}};
-auto arrayVector =
-    makeNullableArrayVector<std::string>(array, ARRAY(VARCHAR()));
-auto expected = makeNullableFlatVector<std::string>(
-    {R"(["red","blue"])", R"([null,null,"purple"])", "[]"});
-testToJson(arrayVector, expected);
-} // namespace
-{
-  // Array with Unknown elements.
-  auto arrayVector = makeArrayWithDictionaryElements<UnknownValue>(
-      {std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt,
-       std::nullopt},
-      2,
-      ARRAY(UNKNOWN()));
-  auto expected = makeNullableFlatVector<std::string>(
-      {"[null,null]", "[null,null]", "[null,null]"});
-  testToJson(arrayVector, expected);
-}
-{
-  // Array with dictionary-wrapped elements.
-  auto arrayVector =
-      makeArrayWithDictionaryElements<int64_t>({1, -2, 3, -4, 5, -6, 7}, 2);
-  auto expected = makeNullableFlatVector<std::string>(
-      {"[null,-6]", "[5,-4]", "[3,-2]", "[1]"});
-  testToJson(arrayVector, expected);
-}
-{
-  // Array with JSON-typed elements and dictionary.
-  auto arrayVector = makeArrayWithDictionaryElements<StringView>(
-      {"a", "b", "c", "d", "e", "f", "g"}, 2, ARRAY(JSON()));
-  auto expected = makeNullableFlatVector<JsonNativeType>(
-      {R"([null,"f"])", R"(["e","d"])", R"(["c","b"])", R"(["a"])"}, VARCHAR());
-  testToJson(arrayVector, expected);
-}
-{
-  // All-null array rows.
-  auto arrayVector = makeAllNullArrayVector(5, BIGINT());
-  auto expected = makeNullableFlatVector<std::string>(
-      {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
-  testToJson(arrayVector, expected);
-}
+TEST_F(ToJsonTest, fromArray) {
+  { // Array of JSON-like strings.
+    std::vector<std::vector<std::optional<std::string>>> array{
+        {"red", "blue"}, {std::nullopt, std::nullopt, "purple"}, {}};
+    auto arrayVector =
+        makeNullableArrayVector<std::string>(array, ARRAY(VARCHAR()));
+    auto expected = makeNullableFlatVector<std::string>(
+        {R"(["red","blue"])", R"([null,null,"purple"])", "[]"});
+    testToJson(arrayVector, expected);
+  } // namespace
+  {
+    // Array with Unknown elements.
+    auto arrayVector = makeArrayWithDictionaryElements<UnknownValue>(
+        {std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt,
+         std::nullopt},
+        2,
+        ARRAY(UNKNOWN()));
+    auto expected = makeNullableFlatVector<std::string>(
+        {"[null,null]", "[null,null]", "[null,null]"});
+    testToJson(arrayVector, expected);
+  }
+  {
+    // Array with dictionary-wrapped elements.
+    auto arrayVector =
+        makeArrayWithDictionaryElements<int64_t>({1, -2, 3, -4, 5, -6, 7}, 2);
+    auto expected = makeNullableFlatVector<std::string>(
+        {"[null,-6]", "[5,-4]", "[3,-2]", "[1]"});
+    testToJson(arrayVector, expected);
+  }
+  {
+    // Array with JSON-typed elements and dictionary.
+    auto arrayVector = makeArrayWithDictionaryElements<StringView>(
+        {"a", "b", "c", "d", "e", "f", "g"}, 2, ARRAY(JSON()));
+    auto expected = makeNullableFlatVector<JsonNativeType>(
+        {R"([null,"f"])", R"(["e","d"])", R"(["c","b"])", R"(["a"])"},
+        VARCHAR());
+    testToJson(arrayVector, expected);
+  }
+  {
+    // All-null array rows.
+    auto arrayVector = makeAllNullArrayVector(5, BIGINT());
+    auto expected = makeNullableFlatVector<std::string>(
+        {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+    testToJson(arrayVector, expected);
+  }
 
-#ifdef SPARK_COMPATIBLE
-{
-  // Array with short decimals.
-  std::vector<std::vector<int64_t>> decimalArray{
-      {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
-  auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
-  auto expected = makeNullableFlatVector<std::string>(
-      {R"([0.00000,0.00100])",
-       R"([1.23456,12345.67890])",
-       R"([840.59812,12345.67800])"});
-  testToJson(arrayVector, expected);
-}
-{
-  // Array with long decimals.
-  std::vector<std::vector<int128_t>> longDecimalArray{
-      {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
-  auto longArrayVector =
-      makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
-  auto expected = makeNullableFlatVector<std::string>(
-      {R"([0E-10,1.00E-8])",
-       R"([0.0000123456,12.3456789112])",
-       R"([0.0084059812,1.2345678000])"});
-  testToJson(longArrayVector, expected);
-}
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    {
+      // Array with short decimals.
+      std::vector<std::vector<int64_t>> decimalArray{
+          {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
+      auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
+      auto expected = makeNullableFlatVector<std::string>(
+          {R"([0.00000,0.00100])",
+           R"([1.23456,12345.67890])",
+           R"([840.59812,12345.67800])"});
+      testToJson(arrayVector, expected);
+    }
+    {
+      // Array with long decimals.
+      std::vector<std::vector<int128_t>> longDecimalArray{
+          {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
+      auto longArrayVector =
+          makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
+      auto expected = makeNullableFlatVector<std::string>(
+          {R"([0E-10,1.00E-8])",
+           R"([0.0000123456,12.3456789112])",
+           R"([0.0084059812,1.2345678000])"});
+      testToJson(longArrayVector, expected);
+    }
+  }
 } // namespace bytedance::bolt::functions::sparksql::test
 
 TEST_F(ToJsonTest, fromMap) {
@@ -445,34 +445,34 @@ TEST_F(ToJsonTest, fromMap) {
     testToJson(mapVector, expected);
   }
 
-#ifdef SPARK_COMPATIBLE
-  {
-    // Map with short decimals.
-    auto mapVector = makeMapVector<std::string, int64_t>(
-        {{{"a", 0}, {"b", 100}},
-         {{"c", 123456}, {"d", 1234567890}},
-         {{"e", 84059812}, {"f", 1234567800}}},
-        MAP(VARCHAR(), DECIMAL(10, 5)));
-    auto expected = makeNullableFlatVector<std::string>(
-        {R"({"a":0.00000,"b":0.00100})",
-         R"({"c":1.23456,"d":12345.67890})",
-         R"({"e":840.59812,"f":12345.67800})"});
-    testToJson(mapVector, expected);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    {
+      // Map with short decimals.
+      auto mapVector = makeMapVector<std::string, int64_t>(
+          {{{"a", 0}, {"b", 100}},
+           {{"c", 123456}, {"d", 1234567890}},
+           {{"e", 84059812}, {"f", 1234567800}}},
+          MAP(VARCHAR(), DECIMAL(10, 5)));
+      auto expected = makeNullableFlatVector<std::string>(
+          {R"({"a":0.00000,"b":0.00100})",
+           R"({"c":1.23456,"d":12345.67890})",
+           R"({"e":840.59812,"f":12345.67800})"});
+      testToJson(mapVector, expected);
+    }
+    {
+      // Map with long decimals.
+      auto mapVector = makeMapVector<std::string, int128_t>(
+          {{{"a", 0}, {"b", 100}},
+           {{"c", 123456}, {"d", 123456789112LL}},
+           {{"e", 84059812}, {"f", 12345678000}}},
+          MAP(VARCHAR(), DECIMAL(30, 10)));
+      auto expected = makeNullableFlatVector<std::string>(
+          {R"({"a":0E-10,"b":1.00E-8})",
+           R"({"c":0.0000123456,"d":12.3456789112})",
+           R"({"e":0.0084059812,"f":1.2345678000})"});
+      testToJson(mapVector, expected);
+    }
   }
-  {
-    // Map with long decimals.
-    auto mapVector = makeMapVector<std::string, int128_t>(
-        {{{"a", 0}, {"b", 100}},
-         {{"c", 123456}, {"d", 123456789112LL}},
-         {{"e", 84059812}, {"f", 12345678000}}},
-        MAP(VARCHAR(), DECIMAL(30, 10)));
-    auto expected = makeNullableFlatVector<std::string>(
-        {R"({"a":0E-10,"b":1.00E-8})",
-         R"({"c":0.0000123456,"d":12.3456789112})",
-         R"({"e":0.0084059812,"f":1.2345678000})"});
-    testToJson(mapVector, expected);
-  }
-#endif
 
   {
     // Map with Unknown values.
@@ -607,41 +607,41 @@ TEST_F(ToJsonTest, fromRow) {
     testToJson(input, expected);
   }
 
-#ifdef SPARK_COMPATIBLE
-  {
-    // Row with short decimal.
-    auto a =
-        makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
-    auto b = makeFlatVector<int64_t>(
-        {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
-    auto input = makeRowVector({a, b});
-    auto expected = makeNullableFlatVector<std::string>(
-        {R"({"c0":"a","c1":0.00000})",
-         R"({"c0":"b","c1":0.00100})",
-         R"({"c0":"c","c1":1.23456})",
-         R"({"c0":"d","c1":12345.67890})",
-         R"({"c0":"e","c1":840.59812})",
-         R"({"c0":"f","c1":12345.67800})"});
-    testToJson(input, expected);
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    {
+      // Row with short decimal.
+      auto a = makeFlatVector<std::string>(
+          {"a", "b", "c", "d", "e", "f"}, VARCHAR());
+      auto b = makeFlatVector<int64_t>(
+          {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
+      auto input = makeRowVector({a, b});
+      auto expected = makeNullableFlatVector<std::string>(
+          {R"({"c0":"a","c1":0.00000})",
+           R"({"c0":"b","c1":0.00100})",
+           R"({"c0":"c","c1":1.23456})",
+           R"({"c0":"d","c1":12345.67890})",
+           R"({"c0":"e","c1":840.59812})",
+           R"({"c0":"f","c1":12345.67800})"});
+      testToJson(input, expected);
+    }
+    {
+      // Row with long decimal.
+      auto a = makeFlatVector<std::string>(
+          {"a", "b", "c", "d", "e", "f"}, VARCHAR());
+      auto b = makeFlatVector<int128_t>(
+          {0, 100, 123456, 123456789112LL, 84059812, 12345678000},
+          DECIMAL(30, 10));
+      auto input = makeRowVector({a, b});
+      auto expected = makeNullableFlatVector<std::string>(
+          {R"({"c0":"a","c1":0E-10})",
+           R"({"c0":"b","c1":1.00E-8})",
+           R"({"c0":"c","c1":0.0000123456})",
+           R"({"c0":"d","c1":12.3456789112})",
+           R"({"c0":"e","c1":0.0084059812})",
+           R"({"c0":"f","c1":1.2345678000})"});
+      testToJson(input, expected);
+    }
   }
-  {
-    // Row with long decimal.
-    auto a =
-        makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
-    auto b = makeFlatVector<int128_t>(
-        {0, 100, 123456, 123456789112LL, 84059812, 12345678000},
-        DECIMAL(30, 10));
-    auto input = makeRowVector({a, b});
-    auto expected = makeNullableFlatVector<std::string>(
-        {R"({"c0":"a","c1":0E-10})",
-         R"({"c0":"b","c1":1.00E-8})",
-         R"({"c0":"c","c1":0.0000123456})",
-         R"({"c0":"d","c1":12.3456789112})",
-         R"({"c0":"e","c1":0.0084059812})",
-         R"({"c0":"f","c1":1.2345678000})"});
-    testToJson(input, expected);
-  }
-#endif
 
   {
     // Dorado case: nested row with strings and numbers.

--- a/bolt/functions/sparksql/tests/ToJsonTest.cpp
+++ b/bolt/functions/sparksql/tests/ToJsonTest.cpp
@@ -381,30 +381,29 @@ TEST_F(ToJsonTest, fromArray) {
     testToJson(arrayVector, expected);
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    {
-      // Array with short decimals.
-      std::vector<std::vector<int64_t>> decimalArray{
-          {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
-      auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
-      auto expected = makeNullableFlatVector<std::string>(
-          {R"([0.00000,0.00100])",
-           R"([1.23456,12345.67890])",
-           R"([840.59812,12345.67800])"});
-      testToJson(arrayVector, expected);
-    }
-    {
-      // Array with long decimals.
-      std::vector<std::vector<int128_t>> longDecimalArray{
-          {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
-      auto longArrayVector =
-          makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
-      auto expected = makeNullableFlatVector<std::string>(
-          {R"([0E-10,1.00E-8])",
-           R"([0.0000123456,12.3456789112])",
-           R"([0.0084059812,1.2345678000])"});
-      testToJson(longArrayVector, expected);
-    }
+  {
+    // Array with short decimals.
+    std::vector<std::vector<int64_t>> decimalArray{
+        {0, 100}, {123456, 1234567890}, {84059812, 1234567800}};
+    auto arrayVector = makeArrayVector<int64_t>(decimalArray, DECIMAL(10, 5));
+    auto expected = makeNullableFlatVector<std::string>(
+        {R"([0.00000,0.00100])",
+         R"([1.23456,12345.67890])",
+         R"([840.59812,12345.67800])"});
+    testToJson(arrayVector, expected);
+  }
+  {
+    // Array with long decimals.
+    std::vector<std::vector<int128_t>> longDecimalArray{
+        {0, 100}, {123456, 123456789112LL}, {84059812, 12345678000}};
+    auto longArrayVector =
+        makeArrayVector<int128_t>(longDecimalArray, DECIMAL(30, 10));
+    auto expected = makeNullableFlatVector<std::string>(
+        {::bytedance::bolt::kSparkCompatible ? R"([0E-10,1.00E-8])"
+                                             : R"([0.0000000000,0.0000000100])",
+         R"([0.0000123456,12.3456789112])",
+         R"([0.0084059812,1.2345678000])"});
+    testToJson(longArrayVector, expected);
   }
 } // namespace bytedance::bolt::functions::sparksql::test
 
@@ -445,33 +444,33 @@ TEST_F(ToJsonTest, fromMap) {
     testToJson(mapVector, expected);
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    {
-      // Map with short decimals.
-      auto mapVector = makeMapVector<std::string, int64_t>(
-          {{{"a", 0}, {"b", 100}},
-           {{"c", 123456}, {"d", 1234567890}},
-           {{"e", 84059812}, {"f", 1234567800}}},
-          MAP(VARCHAR(), DECIMAL(10, 5)));
-      auto expected = makeNullableFlatVector<std::string>(
-          {R"({"a":0.00000,"b":0.00100})",
-           R"({"c":1.23456,"d":12345.67890})",
-           R"({"e":840.59812,"f":12345.67800})"});
-      testToJson(mapVector, expected);
-    }
-    {
-      // Map with long decimals.
-      auto mapVector = makeMapVector<std::string, int128_t>(
-          {{{"a", 0}, {"b", 100}},
-           {{"c", 123456}, {"d", 123456789112LL}},
-           {{"e", 84059812}, {"f", 12345678000}}},
-          MAP(VARCHAR(), DECIMAL(30, 10)));
-      auto expected = makeNullableFlatVector<std::string>(
-          {R"({"a":0E-10,"b":1.00E-8})",
-           R"({"c":0.0000123456,"d":12.3456789112})",
-           R"({"e":0.0084059812,"f":1.2345678000})"});
-      testToJson(mapVector, expected);
-    }
+  {
+    // Map with short decimals.
+    auto mapVector = makeMapVector<std::string, int64_t>(
+        {{{"a", 0}, {"b", 100}},
+         {{"c", 123456}, {"d", 1234567890}},
+         {{"e", 84059812}, {"f", 1234567800}}},
+        MAP(VARCHAR(), DECIMAL(10, 5)));
+    auto expected = makeNullableFlatVector<std::string>(
+        {R"({"a":0.00000,"b":0.00100})",
+         R"({"c":1.23456,"d":12345.67890})",
+         R"({"e":840.59812,"f":12345.67800})"});
+    testToJson(mapVector, expected);
+  }
+  {
+    // Map with long decimals.
+    auto mapVector = makeMapVector<std::string, int128_t>(
+        {{{"a", 0}, {"b", 100}},
+         {{"c", 123456}, {"d", 123456789112LL}},
+         {{"e", 84059812}, {"f", 12345678000}}},
+        MAP(VARCHAR(), DECIMAL(30, 10)));
+    auto expected = makeNullableFlatVector<std::string>(
+        {::bytedance::bolt::kSparkCompatible
+             ? R"({"a":0E-10,"b":1.00E-8})"
+             : R"({"a":0.0000000000,"b":0.0000000100})",
+         R"({"c":0.0000123456,"d":12.3456789112})",
+         R"({"e":0.0084059812,"f":1.2345678000})"});
+    testToJson(mapVector, expected);
   }
 
   {
@@ -607,40 +606,42 @@ TEST_F(ToJsonTest, fromRow) {
     testToJson(input, expected);
   }
 
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    {
-      // Row with short decimal.
-      auto a = makeFlatVector<std::string>(
-          {"a", "b", "c", "d", "e", "f"}, VARCHAR());
-      auto b = makeFlatVector<int64_t>(
-          {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
-      auto input = makeRowVector({a, b});
-      auto expected = makeNullableFlatVector<std::string>(
-          {R"({"c0":"a","c1":0.00000})",
-           R"({"c0":"b","c1":0.00100})",
-           R"({"c0":"c","c1":1.23456})",
-           R"({"c0":"d","c1":12345.67890})",
-           R"({"c0":"e","c1":840.59812})",
-           R"({"c0":"f","c1":12345.67800})"});
-      testToJson(input, expected);
-    }
-    {
-      // Row with long decimal.
-      auto a = makeFlatVector<std::string>(
-          {"a", "b", "c", "d", "e", "f"}, VARCHAR());
-      auto b = makeFlatVector<int128_t>(
-          {0, 100, 123456, 123456789112LL, 84059812, 12345678000},
-          DECIMAL(30, 10));
-      auto input = makeRowVector({a, b});
-      auto expected = makeNullableFlatVector<std::string>(
-          {R"({"c0":"a","c1":0E-10})",
-           R"({"c0":"b","c1":1.00E-8})",
-           R"({"c0":"c","c1":0.0000123456})",
-           R"({"c0":"d","c1":12.3456789112})",
-           R"({"c0":"e","c1":0.0084059812})",
-           R"({"c0":"f","c1":1.2345678000})"});
-      testToJson(input, expected);
-    }
+  {
+    // Row with short decimal.
+    auto a =
+        makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
+    auto b = makeFlatVector<int64_t>(
+        {0, 100, 123456, 1234567890, 84059812, 1234567800}, DECIMAL(10, 5));
+    auto input = makeRowVector({a, b});
+    auto expected = makeNullableFlatVector<std::string>(
+        {R"({"c0":"a","c1":0.00000})",
+         R"({"c0":"b","c1":0.00100})",
+         R"({"c0":"c","c1":1.23456})",
+         R"({"c0":"d","c1":12345.67890})",
+         R"({"c0":"e","c1":840.59812})",
+         R"({"c0":"f","c1":12345.67800})"});
+    testToJson(input, expected);
+  }
+  {
+    // Row with long decimal.
+    auto a =
+        makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}, VARCHAR());
+    auto b = makeFlatVector<int128_t>(
+        {0, 100, 123456, 123456789112LL, 84059812, 12345678000},
+        DECIMAL(30, 10));
+    auto input = makeRowVector({a, b});
+    auto expected = makeNullableFlatVector<std::string>(
+        {::bytedance::bolt::kSparkCompatible
+             ? R"({"c0":"a","c1":0E-10})"
+             : R"({"c0":"a","c1":0.0000000000})",
+         ::bytedance::bolt::kSparkCompatible
+             ? R"({"c0":"b","c1":1.00E-8})"
+             : R"({"c0":"b","c1":0.0000000100})",
+         R"({"c0":"c","c1":0.0000123456})",
+         R"({"c0":"d","c1":12.3456789112})",
+         R"({"c0":"e","c1":0.0084059812})",
+         R"({"c0":"f","c1":1.2345678000})"});
+    testToJson(input, expected);
   }
 
   {

--- a/bolt/type/DecimalUtil.cpp
+++ b/bolt/type/DecimalUtil.cpp
@@ -29,9 +29,23 @@
  */
 
 #include "bolt/type/DecimalUtil.h"
+#include "bolt/common/base/SparkCompatibility.h"
 #include "bolt/type/HugeInt.h"
 namespace bytedance::bolt {
 namespace {
+template <typename T>
+size_t convertToStringForBuild(
+    T unscaledValue,
+    int32_t scale,
+    int32_t maxVarcharSize,
+    char* startPosition) {
+  constexpr auto kFormat = kSparkCompatible
+      ? DecimalUtil::DecimalStringFormat::kSpark
+      : DecimalUtil::DecimalStringFormat::kPlain;
+  return DecimalUtil::convertToString<kFormat>(
+      unscaledValue, scale, maxVarcharSize, startPosition);
+}
+
 std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
   BOLT_DCHECK_GE(scale, 0);
   BOLT_DCHECK_LT(static_cast<size_t>(scale), sizeof(DecimalUtil::kPowersOfTen));
@@ -78,6 +92,24 @@ int32_t DecimalUtil::stringSize(int32_t precision, int32_t scale) {
     ++strSize; // Leading zero.
   }
   return strSize;
+}
+
+size_t DecimalUtil::convertToString(
+    int64_t unscaledValue,
+    int32_t scale,
+    int32_t maxVarcharSize,
+    char* startPosition) {
+  return convertToStringForBuild(
+      unscaledValue, scale, maxVarcharSize, startPosition);
+}
+
+size_t DecimalUtil::convertToString(
+    int128_t unscaledValue,
+    int32_t scale,
+    int32_t maxVarcharSize,
+    char* startPosition) {
+  return convertToStringForBuild(
+      unscaledValue, scale, maxVarcharSize, startPosition);
 }
 
 std::string DecimalUtil::toString(int128_t value, const TypePtr& type) {

--- a/bolt/type/DecimalUtil.cpp
+++ b/bolt/type/DecimalUtil.cpp
@@ -94,40 +94,13 @@ int32_t DecimalUtil::stringSize(int32_t precision, int32_t scale) {
   return strSize;
 }
 
-size_t DecimalUtil::convertToString(
-    int64_t unscaledValue,
-    int32_t scale,
-    int32_t maxVarcharSize,
-    char* startPosition) {
-  return convertToStringForBuild(
-      unscaledValue, scale, maxVarcharSize, startPosition);
-}
-
-size_t DecimalUtil::convertToString(
-    uint64_t unscaledValue,
-    int32_t scale,
-    int32_t maxVarcharSize,
-    char* startPosition) {
-  return convertToStringForBuild(
-      unscaledValue, scale, maxVarcharSize, startPosition);
-}
-
-size_t DecimalUtil::convertToString(
-    int128_t unscaledValue,
-    int32_t scale,
-    int32_t maxVarcharSize,
-    char* startPosition) {
-  return convertToStringForBuild(
-      unscaledValue, scale, maxVarcharSize, startPosition);
-}
-
 std::string DecimalUtil::toString(int128_t value, const TypePtr& type) {
   auto [precision, scale] = getDecimalPrecisionScale(*type);
   auto maxStrSize = stringSize(precision, scale);
   std::string decimalStr;
   decimalStr.resize(maxStrSize);
   auto actualSize =
-      convertToString(value, scale, maxStrSize, decimalStr.data());
+      convertToStringForBuild(value, scale, maxStrSize, decimalStr.data());
   decimalStr.resize(actualSize);
   return decimalStr;
 }

--- a/bolt/type/DecimalUtil.cpp
+++ b/bolt/type/DecimalUtil.cpp
@@ -104,6 +104,15 @@ size_t DecimalUtil::convertToString(
 }
 
 size_t DecimalUtil::convertToString(
+    uint64_t unscaledValue,
+    int32_t scale,
+    int32_t maxVarcharSize,
+    char* startPosition) {
+  return convertToStringForBuild(
+      unscaledValue, scale, maxVarcharSize, startPosition);
+}
+
+size_t DecimalUtil::convertToString(
     int128_t unscaledValue,
     int32_t scale,
     int32_t maxVarcharSize,

--- a/bolt/type/DecimalUtil.h
+++ b/bolt/type/DecimalUtil.h
@@ -264,61 +264,6 @@ class DecimalUtil {
     }
   }
 
-  /// @brief Convert the unscaled value of a decimal to varchar and write to raw
-  /// string buffer from start position.
-  /// @tparam T The type of input value.
-  /// @param unscaledValue The input unscaled value.
-  /// @param scale The scale of decimal.
-  /// @param maxVarcharSize The estimated max size of a varchar.
-  /// @param startPosition The start position to write from.
-  /// @return write size
-  template <typename T>
-  inline static size_t convertToString(
-      T unscaledValue,
-      int32_t scale,
-      int32_t maxVarcharSize,
-      char* const startPosition) {
-    if constexpr (sizeof(T) <= sizeof(int64_t)) {
-      if constexpr (std::is_signed_v<T>) {
-        return convertToString(
-            static_cast<int64_t>(unscaledValue),
-            scale,
-            maxVarcharSize,
-            startPosition);
-      } else {
-        return convertToString(
-            static_cast<uint64_t>(unscaledValue),
-            scale,
-            maxVarcharSize,
-            startPosition);
-      }
-    } else {
-      return convertToString(
-          static_cast<int128_t>(unscaledValue),
-          scale,
-          maxVarcharSize,
-          startPosition);
-    }
-  }
-
-  static size_t convertToString(
-      int64_t unscaledValue,
-      int32_t scale,
-      int32_t maxVarcharSize,
-      char* startPosition);
-
-  static size_t convertToString(
-      uint64_t unscaledValue,
-      int32_t scale,
-      int32_t maxVarcharSize,
-      char* startPosition);
-
-  static size_t convertToString(
-      int128_t unscaledValue,
-      int32_t scale,
-      int32_t maxVarcharSize,
-      char* startPosition);
-
   template <typename T>
   inline static void fillDecimals(
       T* decimals,

--- a/bolt/type/DecimalUtil.h
+++ b/bolt/type/DecimalUtil.h
@@ -278,14 +278,32 @@ class DecimalUtil {
       int32_t scale,
       int32_t maxVarcharSize,
       char* const startPosition) {
-#ifdef SPARK_COMPATIBLE
-    return convertToString<DecimalStringFormat::kSpark>(
-        unscaledValue, scale, maxVarcharSize, startPosition);
-#else
-    return convertToString<DecimalStringFormat::kPlain>(
-        unscaledValue, scale, maxVarcharSize, startPosition);
-#endif
+    if constexpr (sizeof(T) <= sizeof(int64_t)) {
+      return convertToString(
+          static_cast<int64_t>(unscaledValue),
+          scale,
+          maxVarcharSize,
+          startPosition);
+    } else {
+      return convertToString(
+          static_cast<int128_t>(unscaledValue),
+          scale,
+          maxVarcharSize,
+          startPosition);
+    }
   }
+
+  static size_t convertToString(
+      int64_t unscaledValue,
+      int32_t scale,
+      int32_t maxVarcharSize,
+      char* startPosition);
+
+  static size_t convertToString(
+      int128_t unscaledValue,
+      int32_t scale,
+      int32_t maxVarcharSize,
+      char* startPosition);
 
   template <typename T>
   inline static void fillDecimals(

--- a/bolt/type/DecimalUtil.h
+++ b/bolt/type/DecimalUtil.h
@@ -279,11 +279,19 @@ class DecimalUtil {
       int32_t maxVarcharSize,
       char* const startPosition) {
     if constexpr (sizeof(T) <= sizeof(int64_t)) {
-      return convertToString(
-          static_cast<int64_t>(unscaledValue),
-          scale,
-          maxVarcharSize,
-          startPosition);
+      if constexpr (std::is_signed_v<T>) {
+        return convertToString(
+            static_cast<int64_t>(unscaledValue),
+            scale,
+            maxVarcharSize,
+            startPosition);
+      } else {
+        return convertToString(
+            static_cast<uint64_t>(unscaledValue),
+            scale,
+            maxVarcharSize,
+            startPosition);
+      }
     } else {
       return convertToString(
           static_cast<int128_t>(unscaledValue),
@@ -295,6 +303,12 @@ class DecimalUtil {
 
   static size_t convertToString(
       int64_t unscaledValue,
+      int32_t scale,
+      int32_t maxVarcharSize,
+      char* startPosition);
+
+  static size_t convertToString(
+      uint64_t unscaledValue,
       int32_t scale,
       int32_t maxVarcharSize,
       char* startPosition);

--- a/bolt/type/Timestamp.cpp
+++ b/bolt/type/Timestamp.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/type/Timestamp.h"
 
 #include <date/tz.h>
@@ -57,6 +59,12 @@ Timestamp Timestamp::now() {
                      now.time_since_epoch())
                      .count();
   return fromMillis(epochMs);
+}
+
+std::string Timestamp::toString(
+    const TimestampToStringOptions::Precision& precision,
+    const tz::TimeZone* tz) const {
+  return toString<::bytedance::bolt::kSparkCompatible>(precision, tz);
 }
 
 void Timestamp::toGMT(const tz::TimeZone& zone, bool* hasError) {

--- a/bolt/type/Timestamp.h
+++ b/bolt/type/Timestamp.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -507,8 +508,8 @@ struct Timestamp {
     return tmToString(tm, nanos_, options);
   }
 
-  FOLLY_ALWAYS_INLINE
-  std::string toString(
+  template <bool SkipTrailingZeros>
+  FOLLY_ALWAYS_INLINE std::string toString(
       const TimestampToStringOptions::Precision& precision,
       const tz::TimeZone* tz) const {
     using namespace std::chrono;
@@ -519,13 +520,6 @@ struct Timestamp {
     const auto timeOfDay = duration_cast<seconds>(seconds(localSec) - days);
     const auto ymd = ::date::year_month_day(::date::sys_days(days));
     const auto hhmmss = ::date::time_of_day<seconds>(timeOfDay);
-#ifndef SPARK_COMPATIBLE
-    const auto fracWidth = static_cast<int>(precision);
-    const auto fracValue =
-        precision == TimestampToStringOptions::Precision::kMilliseconds
-        ? nanos_ / 1'000'000
-        : nanos_;
-#endif
     std::ostringstream oss;
     oss << std::setfill('0') << std::setw(4) << static_cast<int>(ymd.year())
         << "-" << std::setw(2) << static_cast<unsigned>(ymd.month()) << "-"
@@ -533,20 +527,29 @@ struct Timestamp {
         << std::setw(2) << hhmmss.hours().count() << ":" << std::setw(2)
         << hhmmss.minutes().count() << ":" << std::setw(2)
         << hhmmss.seconds().count();
-#ifndef SPARK_COMPATIBLE
-    oss << "." << std::setw(fracWidth) << fracValue;
-#else
-    if (nanos_ > 0) {
-      auto nanos = nanos_;
-      while (nanos % 10 == 0) {
-        nanos /= 10;
+    if constexpr (SkipTrailingZeros) {
+      if (nanos_ > 0) {
+        auto nanos = nanos_;
+        while (nanos % 10 == 0) {
+          nanos /= 10;
+        }
+        oss << "." << nanos;
       }
-      oss << "." << nanos;
+    } else {
+      const auto fracWidth = static_cast<int>(precision);
+      const auto fracValue =
+          precision == TimestampToStringOptions::Precision::kMilliseconds
+          ? nanos_ / 1'000'000
+          : nanos_;
+      oss << "." << std::setw(fracWidth) << fracValue;
     }
-#endif
 
     return oss.str();
   }
+
+  std::string toString(
+      const TimestampToStringOptions::Precision& precision,
+      const tz::TimeZone* tz) const;
 
   operator std::string() const {
     return toString();

--- a/bolt/type/TimestampConversion.cpp
+++ b/bolt/type/TimestampConversion.cpp
@@ -54,12 +54,14 @@
  * SOFTWARE.
  */
 
-#include "bolt/type/TimestampConversion.h"
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <iostream>
 #include <limits>
 #include <set>
 #include "bolt/common/base/CheckedArithmetic.h"
 #include "bolt/common/base/Exceptions.h"
+#include "bolt/type/TimestampConversion.h"
 #include "bolt/type/tz/TimeZoneMap.h"
 namespace bytedance::bolt::util {
 
@@ -350,40 +352,40 @@ DateParseResult tryParseDateString(
     return DateParseResult::kUnexpectedEnd;
   }
 
-#ifndef SPARK_COMPATIBLE
-  if (!sparkCompatible) {
-    // Check for an optional trailing " (BC)".
-    if (len - pos >= 5 && characterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
-        buf[pos + 2] == 'B' && buf[pos + 3] == 'C' && buf[pos + 4] == ')') {
-      if (yearneg || year == 0) {
-        return DateParseResult::kInvalidYear;
-      }
-      year = -year + 1;
-      pos += 5;
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    if (!sparkCompatible) {
+      // Check for an optional trailing " (BC)".
+      if (len - pos >= 5 && characterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
+          buf[pos + 2] == 'B' && buf[pos + 3] == 'C' && buf[pos + 4] == ')') {
+        if (yearneg || year == 0) {
+          return DateParseResult::kInvalidYear;
+        }
+        year = -year + 1;
+        pos += 5;
 
-      if (year < kMinYear) {
-        return DateParseResult::kInvalidYear;
+        if (year < kMinYear) {
+          return DateParseResult::kInvalidYear;
+        }
       }
-    }
 
-    // In strict mode, check remaining string for non-space characters.
-    if (mode & ParseMode::kStrict) {
-      // Skip trailing spaces.
-      while (pos < len && characterIsSpace(buf[pos])) {
-        pos++;
-      }
-      // Check position. if end was not reached, non-space chars remaining.
-      if (pos < len) {
-        return DateParseResult::kUnexpectedEnd;
-      }
-    } else {
-      // In non-strict mode, check for any direct trailing digits.
-      if (pos < len && characterIsDigit(buf[pos])) {
-        return DateParseResult::kUnexpectedEnd;
+      // In strict mode, check remaining string for non-space characters.
+      if (mode & ParseMode::kStrict) {
+        // Skip trailing spaces.
+        while (pos < len && characterIsSpace(buf[pos])) {
+          pos++;
+        }
+        // Check position. if end was not reached, non-space chars remaining.
+        if (pos < len) {
+          return DateParseResult::kUnexpectedEnd;
+        }
+      } else {
+        // In non-strict mode, check for any direct trailing digits.
+        if (pos < len && characterIsDigit(buf[pos])) {
+          return DateParseResult::kUnexpectedEnd;
+        }
       }
     }
   }
-#endif
 
   daysSinceEpoch = daysSinceEpochFromDate(year, month, day, &isValid);
   return isValid ? DateParseResult::kSuccess : DateParseResult::kInvalidDate;
@@ -867,16 +869,11 @@ int64_t fromTimeString(const char* str, size_t len, bool* nullOutput) {
     pos++;
   }
 
+  constexpr auto kParseMode = ::bytedance::bolt::kSparkCompatible
+      ? ParseMode::kNonStrict | ParseMode::kNonStandardCast
+      : ParseMode::kStrict;
   if (!tryParseTimeString(
-          str + pos,
-          len - pos,
-          pos,
-          microsSinceMidnight,
-#ifndef SPARK_COMPATIBLE
-          ParseMode::kStrict)) {
-#else
-          ParseMode::kNonStrict | ParseMode::kNonStandardCast)) {
-#endif
+          str + pos, len - pos, pos, microsSinceMidnight, kParseMode)) {
     if (nullOutput != nullptr) {
       *nullOutput = true;
       return 0;
@@ -915,16 +912,10 @@ Timestamp fromTimestampString(const char* str, size_t len, bool* nullOutput) {
   int64_t daysSinceEpoch;
   int64_t microsSinceMidnight;
 
-  auto result = tryParseDateString(
-      str,
-      len,
-      pos,
-      daysSinceEpoch,
-#ifndef SPARK_COMPATIBLE
-      ParseMode::kNonStrict);
-#else
-      ParseMode::kNonStrict | ParseMode::kNonStandardCast);
-#endif
+  constexpr auto kParseMode = ::bytedance::bolt::kSparkCompatible
+      ? ParseMode::kNonStrict | ParseMode::kNonStandardCast
+      : ParseMode::kNonStrict;
+  auto result = tryParseDateString(str, len, pos, daysSinceEpoch, kParseMode);
   if (result != DateParseResult::kSuccess) {
     if (nullOutput != nullptr) {
       *nullOutput = true;
@@ -946,15 +937,7 @@ Timestamp fromTimestampString(const char* str, size_t len, bool* nullOutput) {
 
   size_t timePos = 0;
   if (!tryParseTimeString(
-          str + pos,
-          len - pos,
-          timePos,
-          microsSinceMidnight,
-#ifndef SPARK_COMPATIBLE
-          ParseMode::kNonStrict)) {
-#else
-          ParseMode::kNonStrict | ParseMode::kNonStandardCast)) {
-#endif
+          str + pos, len - pos, timePos, microsSinceMidnight, kParseMode)) {
     if (nullOutput != nullptr) {
       *nullOutput = true;
       return Timestamp{};
@@ -1080,7 +1063,6 @@ std::optional<std::pair<Timestamp, int16_t>> fromTimestampWithTimezoneString(
 }
 
 namespace {
-
 CivilDate civilFromDaysSinceEpoch(int64_t daysSinceEpoch) {
   // Algorithm derived from Howard Hinnant's civil calendar conversions.
   // https://howardhinnant.github.io/date_algorithms.html
@@ -1127,9 +1109,10 @@ CivilTime nanosToCivilTime(uint64_t nanosInDay) {
 }
 
 void validateCivilDateTimeRange(const Timestamp& timestamp, bool isPrecision) {
-  // Spark stores timestamps as int64 microseconds, while Presto stores them as
-  // int64 milliseconds. Make sure the incoming timestamp can be represented in
-  // the corresponding integer range before breaking it into calendar fields.
+  // Spark stores timestamps as int64 microseconds, while Presto stores
+  // them as int64 milliseconds. Make sure the incoming timestamp can be
+  // represented in the corresponding integer range before breaking it
+  // into calendar fields.
   if (isPrecision) {
     (void)timestamp.toMillis();
   } else {

--- a/bolt/type/TimestampConversion.cpp
+++ b/bolt/type/TimestampConversion.cpp
@@ -352,37 +352,35 @@ DateParseResult tryParseDateString(
     return DateParseResult::kUnexpectedEnd;
   }
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
-    if (!sparkCompatible) {
-      // Check for an optional trailing " (BC)".
-      if (len - pos >= 5 && characterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
-          buf[pos + 2] == 'B' && buf[pos + 3] == 'C' && buf[pos + 4] == ')') {
-        if (yearneg || year == 0) {
-          return DateParseResult::kInvalidYear;
-        }
-        year = -year + 1;
-        pos += 5;
-
-        if (year < kMinYear) {
-          return DateParseResult::kInvalidYear;
-        }
+  if (!::bytedance::bolt::kSparkCompatible && !sparkCompatible) {
+    // Check for an optional trailing " (BC)".
+    if (len - pos >= 5 && characterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
+        buf[pos + 2] == 'B' && buf[pos + 3] == 'C' && buf[pos + 4] == ')') {
+      if (yearneg || year == 0) {
+        return DateParseResult::kInvalidYear;
       }
+      year = -year + 1;
+      pos += 5;
 
-      // In strict mode, check remaining string for non-space characters.
-      if (mode & ParseMode::kStrict) {
-        // Skip trailing spaces.
-        while (pos < len && characterIsSpace(buf[pos])) {
-          pos++;
-        }
-        // Check position. if end was not reached, non-space chars remaining.
-        if (pos < len) {
-          return DateParseResult::kUnexpectedEnd;
-        }
-      } else {
-        // In non-strict mode, check for any direct trailing digits.
-        if (pos < len && characterIsDigit(buf[pos])) {
-          return DateParseResult::kUnexpectedEnd;
-        }
+      if (year < kMinYear) {
+        return DateParseResult::kInvalidYear;
+      }
+    }
+
+    // In strict mode, check remaining string for non-space characters.
+    if (mode & ParseMode::kStrict) {
+      // Skip trailing spaces.
+      while (pos < len && characterIsSpace(buf[pos])) {
+        pos++;
+      }
+      // Check position. if end was not reached, non-space chars remaining.
+      if (pos < len) {
+        return DateParseResult::kUnexpectedEnd;
+      }
+    } else {
+      // In non-strict mode, check for any direct trailing digits.
+      if (pos < len && characterIsDigit(buf[pos])) {
+        return DateParseResult::kUnexpectedEnd;
       }
     }
   }

--- a/bolt/type/tests/DecimalTest.cpp
+++ b/bolt/type/tests/DecimalTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include <gtest/gtest.h>
 
 #include "bolt/common/base/Doubles.h"
@@ -117,15 +119,15 @@ TEST(DecimalTest, decimalToString) {
 
   ASSERT_EQ("1000", DecimalUtil::toString(1000, DECIMAL(20, 0)));
   ASSERT_EQ("1.000", DecimalUtil::toString(1000, DECIMAL(20, 3)));
-#ifdef SPARK_COMPATIBLE
-  ASSERT_EQ("1.000E-7", DecimalUtil::toString(1000, DECIMAL(20, 10)));
-  ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
-  ASSERT_EQ("0E-9", DecimalUtil::toString(0, DECIMAL(20, 9)));
-#else
-  ASSERT_EQ("0.0000001000", DecimalUtil::toString(1000, DECIMAL(20, 10)));
-  ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
-  ASSERT_EQ("0.000000000", DecimalUtil::toString(0, DECIMAL(20, 9)));
-#endif
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    ASSERT_EQ("1.000E-7", DecimalUtil::toString(1000, DECIMAL(20, 10)));
+    ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
+    ASSERT_EQ("0E-9", DecimalUtil::toString(0, DECIMAL(20, 9)));
+  } else {
+    ASSERT_EQ("0.0000001000", DecimalUtil::toString(1000, DECIMAL(20, 10)));
+    ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
+    ASSERT_EQ("0.000000000", DecimalUtil::toString(0, DECIMAL(20, 9)));
+  }
   ASSERT_EQ("-0.001000", DecimalUtil::toString(-1000, DECIMAL(20, 6)));
 
   const auto minShortDecimal =

--- a/bolt/type/tests/DecimalTest.cpp
+++ b/bolt/type/tests/DecimalTest.cpp
@@ -119,15 +119,13 @@ TEST(DecimalTest, decimalToString) {
 
   ASSERT_EQ("1000", DecimalUtil::toString(1000, DECIMAL(20, 0)));
   ASSERT_EQ("1.000", DecimalUtil::toString(1000, DECIMAL(20, 3)));
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
-    ASSERT_EQ("1.000E-7", DecimalUtil::toString(1000, DECIMAL(20, 10)));
-    ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
-    ASSERT_EQ("0E-9", DecimalUtil::toString(0, DECIMAL(20, 9)));
-  } else {
-    ASSERT_EQ("0.0000001000", DecimalUtil::toString(1000, DECIMAL(20, 10)));
-    ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
-    ASSERT_EQ("0.000000000", DecimalUtil::toString(0, DECIMAL(20, 9)));
-  }
+  ASSERT_EQ(
+      ::bytedance::bolt::kSparkCompatible ? "1.000E-7" : "0.0000001000",
+      DecimalUtil::toString(1000, DECIMAL(20, 10)));
+  ASSERT_EQ("0.0000010000", DecimalUtil::toString(10000, DECIMAL(20, 10)));
+  ASSERT_EQ(
+      ::bytedance::bolt::kSparkCompatible ? "0E-9" : "0.000000000",
+      DecimalUtil::toString(0, DECIMAL(20, 9)));
   ASSERT_EQ("-0.001000", DecimalUtil::toString(-1000, DECIMAL(20, 6)));
 
   const auto minShortDecimal =
@@ -151,6 +149,14 @@ TEST(DecimalTest, decimalToString) {
       DecimalUtil::toString(DecimalUtil::kLongDecimalMax, DECIMAL(38, 0));
   ASSERT_EQ("99999999999999999999999999999999999999", maxLongDecimal);
   ASSERT_EQ(maxLongDecimal.length(), 38);
+}
+
+TEST(DecimalTest, unsignedDecimalToString) {
+  std::string result(32, '\0');
+  const auto size = DecimalUtil::convertToString(
+      std::numeric_limits<uint64_t>::max(), 0, result.size(), result.data());
+  result.resize(size);
+  EXPECT_EQ("18446744073709551615", result);
 }
 
 TEST(DecimalTest, limits) {

--- a/bolt/type/tests/DecimalTest.cpp
+++ b/bolt/type/tests/DecimalTest.cpp
@@ -153,8 +153,12 @@ TEST(DecimalTest, decimalToString) {
 
 TEST(DecimalTest, unsignedDecimalToString) {
   std::string result(32, '\0');
-  const auto size = DecimalUtil::convertToString(
-      std::numeric_limits<uint64_t>::max(), 0, result.size(), result.data());
+  const auto size =
+      DecimalUtil::convertToString<DecimalUtil::DecimalStringFormat::kPlain>(
+          std::numeric_limits<uint64_t>::max(),
+          0,
+          result.size(),
+          result.data());
   result.resize(size);
   EXPECT_EQ("18446744073709551615", result);
 }

--- a/bolt/type/tests/TimestampConversionTest.cpp
+++ b/bolt/type/tests/TimestampConversionTest.cpp
@@ -28,6 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
+#include "bolt/common/base/SparkCompatibility.h"
+
 #include "bolt/type/TimestampConversion.h"
 
 #include <date/tz.h>
@@ -86,11 +88,11 @@ TEST(DateTimeUtilTest, fromDateString) {
   EXPECT_EQ(-719893, fromDateString("-1-1-1", nullptr));
   EXPECT_EQ(-720258, fromDateString("-2-1-1", nullptr));
 
-// 1BC is equal 0-1-1.
-#ifndef SPARK_COMPATIBLE
-  EXPECT_EQ(-719528, fromDateString("1-1-1 (BC)", nullptr));
-  EXPECT_EQ(-719893, fromDateString("2-1-1 (BC)", nullptr));
-#endif
+  // 1BC is equal 0-1-1.
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    EXPECT_EQ(-719528, fromDateString("1-1-1 (BC)", nullptr));
+    EXPECT_EQ(-719893, fromDateString("2-1-1 (BC)", nullptr));
+  }
 
   // Leading zeros and spaces.
   EXPECT_EQ(-719162, fromDateString("00001-1-1", nullptr));
@@ -117,15 +119,15 @@ TEST(DateTimeUtilTest, fromDateStrInvalid) {
   EXPECT_THROW(fromDateString("2000/01-01", nullptr), BoltUserError);
   EXPECT_THROW(fromDateString("2000 01-01", nullptr), BoltUserError);
 
-#ifndef SPARK_COMPATIBLE
-  // Trailing characters.
-  EXPECT_THROW(fromDateString("2000-01-01   asdf", nullptr), BoltUserError);
-  EXPECT_THROW(fromDateString("2000-01-01 0", nullptr), BoltUserError);
+  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+    // Trailing characters.
+    EXPECT_THROW(fromDateString("2000-01-01   asdf", nullptr), BoltUserError);
+    EXPECT_THROW(fromDateString("2000-01-01 0", nullptr), BoltUserError);
 
-  // Too large of a year.
-  EXPECT_THROW(fromDateString("1000000", nullptr), BoltUserError);
-  EXPECT_THROW(fromDateString("-1000000", nullptr), BoltUserError);
-#endif
+    // Too large of a year.
+    EXPECT_THROW(fromDateString("1000000", nullptr), BoltUserError);
+    EXPECT_THROW(fromDateString("-1000000", nullptr), BoltUserError);
+  }
 }
 
 TEST(DateTimeUtilTest, castFromDateString) {
@@ -209,8 +211,10 @@ TEST(DateTimeUtilTest, fromTimeString) {
   EXPECT_EQ(0, fromTimeString("   \t \n 00:00:00.00  \t", nullptr));
 }
 
-#ifndef SPARK_COMPATIBLE
 TEST(DateTimeUtilTest, fromTimeStrInvalid) {
+  if constexpr (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
   EXPECT_THROW(fromTimeString("", nullptr), BoltUserError);
   EXPECT_THROW(fromTimeString("00", nullptr), BoltUserError);
   EXPECT_THROW(fromTimeString("00:00", nullptr), BoltUserError);
@@ -223,7 +227,6 @@ TEST(DateTimeUtilTest, fromTimeStrInvalid) {
   // Trailing characters.
   EXPECT_THROW(fromTimeString("00:00:00   12", nullptr), BoltUserError);
 }
-#endif
 
 // bash command to verify:
 // $ date -d "2000-01-01 12:21:56Z" +%s

--- a/bolt/type/tests/TimestampConversionTest.cpp
+++ b/bolt/type/tests/TimestampConversionTest.cpp
@@ -89,7 +89,7 @@ TEST(DateTimeUtilTest, fromDateString) {
   EXPECT_EQ(-720258, fromDateString("-2-1-1", nullptr));
 
   // 1BC is equal 0-1-1.
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     EXPECT_EQ(-719528, fromDateString("1-1-1 (BC)", nullptr));
     EXPECT_EQ(-719893, fromDateString("2-1-1 (BC)", nullptr));
   }
@@ -119,7 +119,7 @@ TEST(DateTimeUtilTest, fromDateStrInvalid) {
   EXPECT_THROW(fromDateString("2000/01-01", nullptr), BoltUserError);
   EXPECT_THROW(fromDateString("2000 01-01", nullptr), BoltUserError);
 
-  if constexpr (!::bytedance::bolt::kSparkCompatible) {
+  if (!::bytedance::bolt::kSparkCompatible) {
     // Trailing characters.
     EXPECT_THROW(fromDateString("2000-01-01   asdf", nullptr), BoltUserError);
     EXPECT_THROW(fromDateString("2000-01-01 0", nullptr), BoltUserError);
@@ -212,7 +212,7 @@ TEST(DateTimeUtilTest, fromTimeString) {
 }
 
 TEST(DateTimeUtilTest, fromTimeStrInvalid) {
-  if constexpr (::bytedance::bolt::kSparkCompatible) {
+  if (::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();
   }
   EXPECT_THROW(fromTimeString("", nullptr), BoltUserError);

--- a/conanfile.py
+++ b/conanfile.py
@@ -577,8 +577,9 @@ class BoltConan(ConanFile):
         if self.options.enable_arrow_connector:
             tc.cache_variables["BOLT_ENABLE_ARROW_CONNECTOR"] = "ON"
 
-        if self.options.spark_compatible:
-            tc.cache_variables["BOLT_ENABLE_SPARK_COMPATIBLE"] = "ON"
+        tc.cache_variables["BOLT_ENABLE_SPARK_COMPATIBLE"] = (
+            "ON" if self.options.spark_compatible else "OFF"
+        )
 
         if self.options.get_safe("enable_testutil"):
             tc.cache_variables["BOLT_ENABLE_DUCKDB"] = "ON"

--- a/doc/coding-style.md
+++ b/doc/coding-style.md
@@ -273,6 +273,43 @@ macro names are always upper-snake-case. Also:
     if/for/while even if they don't use braces and forces use of a trailing
     semicolon.
 
+## Build-Mode Configuration
+
+* Do not use global compile definitions to implement build-mode-specific
+  behavior. In particular, do not reintroduce the `SPARK_COMPATIBLE` macro.
+* Keep build-mode-dependent logic in the implementation files that need it.
+  Prefer a configured `constexpr` value for C++ branches and CMake source
+  selection when an entire source file belongs to one build mode.
+* Do not include build-mode configuration from public or widely included
+  headers unless a template definition itself must vary. Keep unavoidable
+  template-dependent logic in the narrowest internal or `-inl.h` header.
+* Switching build modes must not invalidate unrelated translation units. Check
+  the incremental build scope when adding a new build-mode-dependent branch.
+
+## Command-Line Flags (gflags)
+
+* A flag used by more than one source file must have one owner. Put the only
+  `DECLARE_*` in the owner's header and the only `DEFINE_*` in its source file.
+  Consumers include the owner header and use `FLAGS_xxx`; they must not repeat
+  either macro.
+* A `DEFINE_*` may remain local to a source file only when that source file
+  builds an independent binary and the flag is used nowhere else. Both
+  conditions are required. Typical cases include a single-file benchmark,
+  coverage tool, or a runner's private command-line option.
+* If a local flag gains a second consumer, move it to an owner header and
+  source file instead of adding declarations next to each consumer.
+* Use the existing shared owners when applicable:
+  * Production flags: `bolt/common/flags/BoltFlags.h` and `BoltFlags.cpp`.
+  * Test flags: `bolt/common/testutil/BoltTestFlags.h` and `BoltTestFlags.cpp`.
+  * Fuzzer flags: `bolt/exec/fuzzer/FuzzerFlags.h` and `FuzzerFlags.cpp`.
+  A module may define its own owner pair, but the one-declaration,
+  one-definition rule still applies.
+* Use the corresponding prefix for new flag names:
+  * Production: `bolt_`.
+  * Tests: `bolt_testing_`.
+  * Fuzzers: `bolt_fuzzer_`.
+  * Benchmarks: `bolt_benchmark_`.
+
 ## Headers and Includes
 
 * All header files must have a single-inclusion guard using `#pragma once`


### PR DESCRIPTION
### What problem does this PR solve?

`SPARK_COMPATIBLE` was applied as a global compile definition. Switching
between the default and Spark builds therefore invalidated translation units
that do not contain Spark-specific behavior. Compatibility branches had also
spread into public and widely included headers, increasing the rebuild scope.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Replace the global compile definition with a configured
  `kSparkCompatible` constant and pass the option explicitly from Conan.
- Keep compatibility-dependent branches in the affected implementation files,
  and select Spark-only tests in CMake.
- Preserve compile-time specialization for the timestamp and decimal hot paths
  instead of adding runtime branches.
- Remove the misspelled `SPARK_COMPATIABL` guard. The affected branch now
  follows the configured Spark mode.
- Document the test-target, build-mode, and gflags ownership conventions in
  `CONTRIBUTING.md`, `doc/coding-style.md`, and `AGENTS.md`.

Most of the line churn in affected test and function files is formatting after
the preprocessor branches were removed.

Validation:

- Built the complete Release tree in the default mode.
- Ran the full default-mode CTest suite. One
  `HashJoinTest.outOfJoinKeyColumnOrder/3` shard failed on the first pass and
  passed when rerun in isolation.
- Built the complete Release tree in Spark mode and ran CTest: 432 tests passed
  and 5 were disabled.
- Switched the same tree back to the default mode and rebuilt successfully.
- After the final naming cleanup, rebuilt the Release tree and ran
  `bolt_expression_test`, `bolt_functions_lib_test`,
  `bolt_functions_spark_test`, and
  `bolt_functions_spark_aggregates_test`: 4/4 passed.
- Installed the Release tree and verified that the configured compatibility
  header is included in the installation.
- Ran the repository formatting and lint hooks. The staged C++ diff completed
  a full clang-tidy pass; the final follow-up changed only reported identifier
  names and documentation.

Incremental Ninja dry-run after switching modes:

- Default to Spark: 167 C++ compilations and 201 link actions.
- Spark to default: 120 C++ compilations and 191 link actions.

### Performance Impact

- [x] **No Impact**: Runtime compatibility choices remain compile-time
  specialized. This change reduces build invalidation and does not add a
  runtime branch to the timestamp or decimal hot paths.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Not applicable.
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
- Localized Spark compatibility configuration to avoid recompiling unrelated
  sources when switching build modes.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug). Release was
  verified; Debug was not run.
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Not applicable.
    ```
    </details>
