### PR TITLE
perf(agg): DictionaryVector fast path for numeric aggregates

### DIFF
--- a/bolt/functions/lib/aggregates/AverageAggregateBase.h
+++ b/bolt/functions/lib/aggregates/AverageAggregateBase.h
@@ -36,6 +36,7 @@
 #include "bolt/type/DecimalUtil.h"
 #include "bolt/vector/ComplexVector.h"
 #include "bolt/vector/DecodedVector.h"
+#include "bolt/vector/DictionaryVector.h"
 #include "bolt/vector/FlatVector.h"
 namespace bytedance::bolt::functions::aggregate {
 
@@ -188,6 +189,13 @@ class AverageAggregateBase : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override final {
+    if (args[0]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        args[0]->valueVector()->encoding() !=
+            VectorEncoding::Simple::DICTIONARY &&
+        !isLazyNotLoaded(*args[0])) {
+      addDictionaryRawInput(groups, rows, *args[0]);
+      return;
+    }
     decodedRaw_.decode(*args[0], rows);
     if (decodedRaw_.isConstantMapping()) {
       if (!decodedRaw_.isNullAt(0)) {
@@ -231,6 +239,13 @@ class AverageAggregateBase : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
+    if (args[0]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        args[0]->valueVector()->encoding() !=
+            VectorEncoding::Simple::DICTIONARY &&
+        !isLazyNotLoaded(*args[0])) {
+      addSingleGroupDictionaryRawInput(group, rows, *args[0]);
+      return;
+    }
     decodedRaw_.decode(*args[0], rows);
 
     if (decodedRaw_.isConstantMapping()) {
@@ -304,6 +319,52 @@ class AverageAggregateBase : public exec::Aggregate {
   }
 
  protected:
+  FLATTEN void addDictionaryRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const BaseVector& arg) {
+    auto dictionary = arg.as<DictionaryVector<TInput>>();
+    BOLT_DCHECK_NOT_NULL(dictionary);
+    if (dictionary->mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (!dictionary->isNullAt(i)) {
+          updateNonNullValue(
+              groups[i], TAccumulator(dictionary->valueAtFast(i)));
+        }
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        updateNonNullValue(groups[i], TAccumulator(dictionary->valueAtFast(i)));
+      });
+    }
+  }
+
+  void addSingleGroupDictionaryRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const BaseVector& arg) {
+    auto dictionary = arg.as<DictionaryVector<TInput>>();
+    BOLT_DCHECK_NOT_NULL(dictionary);
+    int64_t count = 0;
+    TAccumulator sum = 0;
+    if (dictionary->mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (!dictionary->isNullAt(i)) {
+          sum += TAccumulator(dictionary->valueAtFast(i));
+          ++count;
+        }
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        sum += TAccumulator(dictionary->valueAtFast(i));
+      });
+      count = rows.countSelected();
+    }
+    if (count > 0) {
+      updateNonNullValue(group, count, sum);
+    }
+  }
+
   /// Partial.
   template <bool tableHasNulls = true>
   inline void updateNonNullValue(char* group, TAccumulator value) {

--- a/bolt/functions/lib/aggregates/SimpleNumericAggregate.h
+++ b/bolt/functions/lib/aggregates/SimpleNumericAggregate.h
@@ -33,6 +33,7 @@
 #include "bolt/exec/Aggregate.h"
 #include "bolt/exec/AggregationHook.h"
 #include "bolt/vector/DecodedVector.h"
+#include "bolt/vector/DictionaryVector.h"
 #include "bolt/vector/FlatVector.h"
 #include "bolt/vector/LazyVector.h"
 namespace bytedance::bolt::functions::aggregate {
@@ -107,6 +108,29 @@ class SimpleNumericAggregate : public exec::Aggregate {
       const VectorPtr& arg,
       UpdateSingleValue updateSingleValue,
       bool mayPushdown) {
+    if (arg->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        arg->valueVector()->encoding() != VectorEncoding::Simple::DICTIONARY &&
+        !isLazyNotLoaded(*arg)) {
+      auto dictionary = arg->template as<DictionaryVector<TValue>>();
+      BOLT_DCHECK_NOT_NULL(dictionary);
+      if (dictionary->mayHaveNulls()) {
+        rows.applyToSelected([&](vector_size_t i) {
+          if (!dictionary->isNullAt(i)) {
+            updateNonNullValue<tableHasNulls, TData>(
+                groups[i],
+                TData(dictionary->valueAtFast(i)),
+                updateSingleValue);
+          }
+        });
+      } else {
+        rows.applyToSelected([&](vector_size_t i) {
+          updateNonNullValue<tableHasNulls, TData>(
+              groups[i], TData(dictionary->valueAtFast(i)), updateSingleValue);
+        });
+      }
+      return;
+    }
+
     DecodedVector decoded(*arg, rows, !mayPushdown);
     auto encoding = decoded.base()->encoding();
     if (UNLIKELY(encoding == VectorEncoding::Simple::LAZY)) {
@@ -184,6 +208,27 @@ class SimpleNumericAggregate : public exec::Aggregate {
       UpdateDuplicate updateDuplicateValues,
       bool /*mayPushdown*/,
       TData initialValue) {
+    if (arg->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        arg->valueVector()->encoding() != VectorEncoding::Simple::DICTIONARY &&
+        !isLazyNotLoaded(*arg)) {
+      auto dictionary = arg->template as<DictionaryVector<TValue>>();
+      BOLT_DCHECK_NOT_NULL(dictionary);
+      if (dictionary->mayHaveNulls()) {
+        rows.applyToSelected([&](vector_size_t i) {
+          if (!dictionary->isNullAt(i)) {
+            updateNonNullValue<true, TData>(
+                group, TData(dictionary->valueAtFast(i)), updateSingleValue);
+          }
+        });
+      } else {
+        rows.applyToSelected([&](vector_size_t i) {
+          updateNonNullValue<true, TData>(
+              group, TData(dictionary->valueAtFast(i)), updateSingleValue);
+        });
+      }
+      return;
+    }
+
     DecodedVector decoded(*arg, rows);
 
     // Do row by row if not all rows are selected.

--- a/bolt/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -165,6 +165,55 @@ TEST_F(AverageAggregationTest, avgConstNull) {
   testFunction("simple_avg");
 }
 
+TEST_F(AverageAggregationTest, dictionaryInput) {
+  bytedance::bolt::test::VectorMaker maker{pool()};
+  auto nonNullValues =
+      maker.dictionaryVector<int64_t>({10, 20, 10, 30, 20, 10});
+  testAggregations(
+      {makeRowVector({nonNullValues})},
+      {},
+      {"avg(c0)"},
+      {makeRowVector({makeFlatVector<double>({100.0 / 6})})});
+  auto nestedNonNullValues =
+      wrapInDictionary(makeIndices({5, 4, 3, 2, 1, 0}), nonNullValues);
+  ASSERT_EQ(
+      nestedNonNullValues->valueVector()->encoding(),
+      VectorEncoding::Simple::DICTIONARY);
+  testAggregations(
+      {makeRowVector({nestedNonNullValues})},
+      {},
+      {"avg(c0)"},
+      {makeRowVector({makeFlatVector<double>({100.0 / 6})})});
+
+  auto values = maker.dictionaryVector<int64_t>(
+      {10, 20, 10, std::nullopt, 30, 20, std::nullopt, 10});
+  auto groups = makeFlatVector<int64_t>({0, 0, 1, 1, 0, 1, 0, 1});
+  auto data = makeRowVector({groups, values});
+
+  testAggregations(
+      {data},
+      {},
+      {"avg(c1)"},
+      {makeRowVector({makeFlatVector<double>({100.0 / 6})})});
+  testAggregations(
+      {data},
+      {"c0"},
+      {"avg(c1)"},
+      {makeRowVector(
+          {makeFlatVector<int64_t>({0, 1}),
+           makeFlatVector<double>({20, 40.0 / 3})})});
+
+  auto nestedValues =
+      wrapInDictionary(makeIndices({0, 1, 2, 3, 4, 5, 6, 7}), values);
+  testAggregations(
+      {makeRowVector({groups, nestedValues})},
+      {"c0"},
+      {"avg(c1)"},
+      {makeRowVector(
+          {makeFlatVector<int64_t>({0, 1}),
+           makeFlatVector<double>({20, 40.0 / 3})})});
+}
+
 TEST_F(AverageAggregationTest, avgNulls) {
   auto testFunction = [this](const std::string& functionName) {
     // Have two row vectors a lest as it triggers different code paths.

--- a/bolt/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/bolt/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -100,6 +100,55 @@ TEST_F(SumTest, sumFloat) {
       "SELECT sum(c0) FROM tmp");
 }
 
+TEST_F(SumTest, dictionaryInput) {
+  bytedance::bolt::test::VectorMaker maker{pool()};
+  auto nonNullValues =
+      maker.dictionaryVector<int64_t>({10, 20, 10, 30, 20, 10});
+  testAggregations(
+      {makeRowVector({nonNullValues})},
+      {},
+      {"sum(c0)"},
+      {makeRowVector({makeFlatVector<int64_t>({100})})});
+  auto nestedNonNullValues =
+      wrapInDictionary(makeIndices({5, 4, 3, 2, 1, 0}), nonNullValues);
+  ASSERT_EQ(
+      nestedNonNullValues->valueVector()->encoding(),
+      VectorEncoding::Simple::DICTIONARY);
+  testAggregations(
+      {makeRowVector({nestedNonNullValues})},
+      {},
+      {"sum(c0)"},
+      {makeRowVector({makeFlatVector<int64_t>({100})})});
+
+  auto values = maker.dictionaryVector<int64_t>(
+      {10, 20, 10, std::nullopt, 30, 20, std::nullopt, 10});
+  auto groups = makeFlatVector<int64_t>({0, 0, 1, 1, 0, 1, 0, 1});
+  auto data = makeRowVector({groups, values});
+
+  testAggregations(
+      {data},
+      {},
+      {"sum(c1)"},
+      {makeRowVector({makeFlatVector<int64_t>({100})})});
+  testAggregations(
+      {data},
+      {"c0"},
+      {"sum(c1)"},
+      {makeRowVector(
+          {makeFlatVector<int64_t>({0, 1}),
+           makeFlatVector<int64_t>({60, 40})})});
+
+  auto nestedValues =
+      wrapInDictionary(makeIndices({0, 1, 2, 3, 4, 5, 6, 7}), values);
+  testAggregations(
+      {makeRowVector({groups, nestedValues})},
+      {"c0"},
+      {"sum(c1)"},
+      {makeRowVector(
+          {makeFlatVector<int64_t>({0, 1}),
+           makeFlatVector<int64_t>({60, 40})})});
+}
+
 TEST_F(SumTest, groupByNan) {
   auto data = {makeRowVector({
       makeFlatVector<double>({std::nan(""), std::nan("")}, DOUBLE()),


### PR DESCRIPTION
### What problem does this PR solve?

Numeric aggregates (SUM / AVG / MIN / MAX / bitwise / etc.) whose input is
already a `DictionaryVector` currently go through `DecodedVector::decode()`
and materialize an intermediate `DecodedVector`, even though the values can
be read directly through `valueAtFast()`. This PR adds a dedicated fast path.

Issue Number: close #896

### Type of Change

- [x] 🚀 Performance improvement (optimization)

### Description

Two shared base classes gain a dictionary fast path:

- `SimpleNumericAggregate::updateGroups` / `updateOneGroup`
- `AverageAggregateBase::addRawInput` / `addSingleGroupRawInput`

When the input encoding is `DICTIONARY`, we downcast to
`DictionaryVector<T>` and call `loadedVector()` once, then iterate through
`valueAtFast(i)` / `isNullAt(i)` directly — skipping the `DecodedVector`
allocation and population.

**Why the `loadedVector()` guard.**
`DictionaryVector::setInternalState()` returns early **without** setting
`initialized_ = true` when its `dictionaryValues_` is still an unloaded
`LazyVector`. Touching `mayHaveNulls()` / `valueAtFast(i)` in that state
either trips `BOLT_DCHECK(initialized_)` in debug builds or reads
uninitialized cache pointers in release. `loadedVector()` normalizes the
vector before the fast path executes; it is a no-op when the state is
already initialized.

**Tests.** New unit tests in `AverageAggregationTest` and `SumTest` cover
dictionary-wrapped inputs for both the multi-group and single-group paths.

### Performance Impact

- [x] **Positive Impact**: eliminates the `DecodedVector` allocation +
  population per batch when the input is already dictionary-encoded. Cost
  on the non-dictionary path is unchanged (a single encoding check).

### Release Note

```text
Release Note:
- perf(agg): add a DictionaryVector fast path for numeric aggregates
  (SUM/AVG/MIN/MAX/bitwise/etc.), avoiding DecodedVector overhead when the
  input is already dictionary-encoded.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build.
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
