### PR TITLE
fix: fix rank-limit  memory reclaim coredump

### DIFF
--- a/bolt/exec/SortWindowBuild.cpp
+++ b/bolt/exec/SortWindowBuild.cpp
@@ -239,21 +239,7 @@ void SortWindowBuild::noMoreInput() {
     // At this point we have seen all the input rows which are sorted. This will
     // compute the index for each partition.
     computePartitionStartRows();
-    if (table_) {
-      BaseHashTable::RowsIterator partitionIt;
-      static const size_t kPartitionBatchSize = 1000;
-      std::vector<char*> partitions{kPartitionBatchSize};
-      while (auto numPartitions = table_->listAllRows(
-                 &partitionIt,
-                 partitions.size(),
-                 RowContainer::kUnlimited,
-                 partitions.data())) {
-        for (auto i = 0; i < numPartitions; ++i) {
-          std::destroy_at(
-              reinterpret_cast<TopRows*>(partitions[i] + partitionOffset_));
-        }
-      }
-    }
+    clearTopRows();
   }
 }
 
@@ -529,6 +515,40 @@ void SortWindowBuild::initializeNewPartitions() {
   for (auto index : lookup_->newGroups) {
     new (lookup_->hits[index] + partitionOffset_)
         TopRows(table_->stringAllocator(), comparator_);
+  }
+}
+
+void SortWindowBuild::clearTopRows() {
+  if (!table_) {
+    return;
+  }
+
+  BaseHashTable::RowsIterator partitionIt;
+  static const size_t kPartitionBatchSize = 1000;
+  std::vector<char*> partitions{kPartitionBatchSize};
+  while (auto numPartitions = table_->listAllRows(
+             &partitionIt,
+             partitions.size(),
+             RowContainer::kUnlimited,
+             partitions.data())) {
+    for (auto i = 0; i < numPartitions; ++i) {
+      std::destroy_at(
+          reinterpret_cast<TopRows*>(partitions[i] + partitionOffset_));
+    }
+  }
+}
+
+void SortWindowBuild::clearStateBeforeSortSpill() {
+  if (followedTopNum_ <= 0) {
+    return;
+  }
+
+  clearTopRows();
+  if (table_) {
+    table_->clear();
+  }
+  if (singlePartition_) {
+    singlePartition_ = std::make_unique<TopRows>(allocator_.get(), comparator_);
   }
 }
 

--- a/bolt/exec/SortWindowBuild.h
+++ b/bolt/exec/SortWindowBuild.h
@@ -116,6 +116,10 @@ class SortWindowBuild : public WindowBuild {
 
   void initializeNewPartitions();
 
+  void clearTopRows();
+
+  void clearStateBeforeSortSpill() override;
+
   TopRows& partitionAt(char* group) {
     return *reinterpret_cast<TopRows*>(group + partitionOffset_);
   }

--- a/bolt/exec/WindowBuild.cpp
+++ b/bolt/exec/WindowBuild.cpp
@@ -360,6 +360,7 @@ void WindowBuild::sortSpill() {
   }
 
   sortSpiller_->spill();
+  clearStateBeforeSortSpill();
   data_->clear();
   data_->pool()->release();
 }

--- a/bolt/exec/WindowBuild.h
+++ b/bolt/exec/WindowBuild.h
@@ -186,6 +186,8 @@ class WindowBuild {
   void sortSpill();
 
  protected:
+  virtual void clearStateBeforeSortSpill() {}
+
   void ensureInputFits(const RowVectorPtr& input);
 
   void sortPartitions();

--- a/bolt/exec/tests/SortWindowTest.cpp
+++ b/bolt/exec/tests/SortWindowTest.cpp
@@ -403,6 +403,83 @@ TEST_F(SortWindowTest, rankFilterWithoutPartitionKey) {
               "SELECT * FROM (SELECT *, RANK() OVER(ORDER BY score DESC) AS rnk FROM tmp) where rnk <= 10 ORDER BY rnk ");
 }
 
+TEST_F(SortWindowTest, rankFilterReclaimKeepsTopRowsValid) {
+  constexpr vector_size_t size = 100;
+  auto data = makeRowVector(
+      {"user_id", "score"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row % 10; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+      });
+  createDuckDbTable({data});
+  auto spillDirectory = TempDirectoryPath::create();
+
+  auto plan =
+      PlanBuilder()
+          .values(split(data, 10))
+          .window(
+              {"RANK() OVER(PARTITION BY user_id ORDER BY score DESC) AS rnk"},
+              1)
+          .filter("rnk <= 1")
+          .planNode();
+  auto windowPlan = plan->sources().front();
+  auto windowNode =
+      std::dynamic_pointer_cast<const core::WindowNode>(windowPlan);
+  core::PlanFragment planFragment;
+  planFragment.planNode = windowPlan;
+  auto queryCtx = core::QueryCtx::create(
+      nullptr,
+      core::QueryConfig(
+          {{core::QueryConfig::kSpillEnabled, "true"},
+           {core::QueryConfig::kWindowSpillEnabled, "true"}}));
+  auto task = Task::create(
+      "rankFilterIsNotReclaimable",
+      std::move(planFragment),
+      0,
+      queryCtx,
+      Task::ExecutionMode::kParallel);
+  task->setSpillDirectory(spillDirectory->path);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+
+  auto regularWindowNode = std::dynamic_pointer_cast<const core::WindowNode>(
+      PlanBuilder()
+          .values(split(data, 10))
+          .window(
+              {"RANK() OVER(PARTITION BY user_id ORDER BY score DESC) AS rnk"})
+          .planNode());
+  core::PlanFragment regularPlanFragment;
+  regularPlanFragment.planNode = regularWindowNode;
+  auto regularTask = Task::create(
+      "regularWindowIsReclaimable",
+      std::move(regularPlanFragment),
+      0,
+      core::QueryCtx::create(
+          nullptr,
+          core::QueryConfig(
+              {{core::QueryConfig::kSpillEnabled, "true"},
+               {core::QueryConfig::kWindowSpillEnabled, "true"}})),
+      Task::ExecutionMode::kParallel);
+  regularTask->setSpillDirectory(spillDirectory->path);
+  DriverCtx regularDriverCtx(regularTask, 0, 0, 0, 0);
+  Window regularWindow(0, &regularDriverCtx, regularWindowNode);
+  Window rankLimitWindow(0, &driverCtx, windowNode);
+  ASSERT_TRUE(regularWindow.canReclaim());
+  ASSERT_TRUE(rankLimitWindow.canReclaim());
+
+  rankLimitWindow.addInput(split(data, 10)[0]);
+  memory::MemoryReclaimer::Stats stats;
+  rankLimitWindow.reclaim(0, stats);
+  ASSERT_TRUE(rankLimitWindow.needsInput());
+  rankLimitWindow.addInput(split(data, 10)[1]);
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kSpillEnabled, true)
+      .config(core::QueryConfig::kWindowSpillEnabled, true)
+      .spillDirectory(spillDirectory->path)
+      .assertResults(
+          "SELECT * FROM (SELECT *, RANK() OVER(PARTITION BY user_id ORDER BY score DESC) AS rnk FROM tmp) WHERE rnk <= 1");
+}
+
 } // namespace
 
 } // namespace bytedance::bolt::exec


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #899 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Rank-limit `SortWindowBuild` keeps per-partition `TopRows` heaps. The heap entries are `char*` pointers into `WindowBuild::data_`.

When memory reclaim triggers sort spill, the generic `WindowBuild::sortSpill()` path spills and clears `data_`, but previously did not clear `SortWindowBuild`'s rank-limit heap/table state first. This can leave stale row pointers in `TopRows`; later input processing may compare against those stale rows and crash.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
-  fix rank-limit  memory reclaim coredump
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
