### PR TITLE
fix(shuffle): avoid memcpy in splitFixedType

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -487,8 +487,14 @@ class BoltShuffleWriter : public ShuffleWriter {
       auto end = partition2RowOffsetBase_[pid + 1];
       for (; pos < end; ++pos) {
         auto rowId = rowOffset2RowId_[pos];
-        memcpy(
-            dstPidBase, &reinterpret_cast<const T*>(srcAddr)[rowId], sizeof(T));
+        if constexpr (alignof(T) > 8) {
+          memcpy(
+              dstPidBase,
+              &reinterpret_cast<const T*>(srcAddr)[rowId],
+              sizeof(T));
+        } else {
+          *dstPidBase = reinterpret_cast<const T*>(srcAddr)[rowId];
+        }
         dstPidBase++;
       }
     }
@@ -507,8 +513,14 @@ class BoltShuffleWriter : public ShuffleWriter {
       auto end = partition2RowOffsetBase_[pid + 1];
       for (; pos < end; ++pos) {
         auto rowId = rowOffset2RowId_[pos];
-        memcpy(
-            dstPidBase, &reinterpret_cast<const T*>(srcAddr)[rowId], sizeof(T));
+        if constexpr (alignof(T) > 8) {
+          memcpy(
+              dstPidBase,
+              &reinterpret_cast<const T*>(srcAddr)[rowId],
+              sizeof(T));
+        } else {
+          *dstPidBase = reinterpret_cast<const T*>(srcAddr)[rowId];
+        }
         dstPidBase++;
       }
     }


### PR DESCRIPTION
### What problem does this PR solve?

`splitFixedType` copies one fixed-width value per row with
`memcpy(dst, &src[rowId], sizeof(T))`. use plain typed assignment to replace memcpy here.
Issue Number: close #xxx

### Type of Change
- [x] 🚀 Performance improvement (optimization)

### Description

Use a plain typed assignment instead, which is not opaque to the aliasing
analysis, so the base pointer is hoisted out of the loop.

int128 (long decimal) deliberately keeps `memcpy`: plain assignment there
compiles to the aligned `vmovdqa`, which faults on a misaligned buffer rather
than merely running slower, and it measures no faster anyway. The dispatch keys
on `alignof(T) > 8`, exactly the condition under which the compiler may emit an
alignment-requiring instruction.

### Performance Impact

- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Microbenchmark of the split gather loop, 32k-row batches, gcc 12.4
    -O3 -march=native, interleaved A/B.

    type        200 partitions    4096 partitions
    uint16          -33%                 -
    uint32          -27%               -26%
    uint64          -22%                -6%
    Timestamp        -9%                 -
    uint8             0%                  -
    int128            0% (keeps memcpy)   0% (keeps memcpy)

    Caveats: this is the gather loop in isolation, not an end-to-end
    shuffle-write number. Measured with GCC on x86-64 only; the aliasing
    reload is a GCC behaviour, so the gain on clang is unverified, and ARM
    was not measured.
    ```
    </details>

### Release Note

```text
Release Note:
- Optimized Spark shuffle writer fixed-width column split by removing a
  redundant per-row pointer reload (one fewer load per row for 16/32/64-bit
  columns).
```

### Checklist (For Author)

- [x] I have verified the code with local build (Release).
- [x] I have run clang-format / linters.
- [x] No need to test or manual test.

Existing shuffle tests cover this path unchanged: `bolt_shuffle_spark_matrix_test`
(2040) and `bolt_shuffle_spark_large_partition_test` (280) both pass, including
shuffle mode V2 over the `kDecimal` group which covers `DECIMAL(38,18)`, i.e. the
int128 path.

### Breaking Changes

- [x] No
