### PR TITLE
fix(paimon): skip filtered empty batches

### DIFF
--- a/bolt/connectors/hive/PaimonSplitReader.cpp
+++ b/bolt/connectors/hive/PaimonSplitReader.cpp
@@ -111,7 +111,11 @@ PaimonRowIteratorPtr PaimonSplitReader::getIterator(SplitReader* rowReader) {
   VectorPtr result =
       BaseVector::create(readerOutputType_, 0, rowReader->pool());
 
-  if (rowReader->next(paimon::kMAX_BATCH_SIZE, result)) {
+  while (rowReader->next(paimon::kMAX_BATCH_SIZE, result)) {
+    // next() reports scanned rows, even if all rows are filtered out.
+    if (result->size() == 0) {
+      continue;
+    }
     RowVectorPtr resultAsRowVect = std::static_pointer_cast<RowVector>(result);
     resultAsRowVect->loadedVector();
     auto primaryKeys = projectVector(resultAsRowVect, primaryKeyIndices_);
@@ -148,9 +152,8 @@ PaimonRowIteratorPtr PaimonSplitReader::getIterator(SplitReader* rowReader) {
         values,
         sequenceGroups,
         rowReader);
-  } else {
-    return nullptr;
   }
+  return nullptr;
 }
 
 PaimonMergeEngineType PaimonSplitReader::getMergeEngineType() {


### PR DESCRIPTION
### What problem does this PR solve?

`RowReader::next()` returns the number of rows scanned, including rows removed
by pushed-down filters. As a result, it can return a non-zero value while
producing an empty output vector.

`PaimonSplitReader::getIterator()` previously treated any non-zero return value
as a non-empty batch and attempted to create an iterator from the empty result.

Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Update `PaimonSplitReader::getIterator()` to continue reading when
`SplitReader::next()` reports scanned rows but the filtered output batch is
empty.

The reader now:

1. Continues past empty filtered batches.
2. Returns an iterator for the first non-empty batch.
3. Returns `nullptr` only after reaching the end of the split.

The original Velox patch was adapted to Bolt paths and namespaces, while
preserving Bolt-specific sequence-group handling.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed Paimon reads stopping prematurely when pushed-down filters produce an empty output batch.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
