### PR TITLE
fix(flinksql): align json_str_to_map non-object JSON handling

### DIFF
--- a/bolt/functions/flinksql/JsonFunctions.cpp
+++ b/bolt/functions/flinksql/JsonFunctions.cpp
@@ -25,6 +25,10 @@ bool isDigit(char c) {
   return c >= '0' && c <= '9';
 }
 
+// Validate JSON numbers syntactically here because json_str_to_map only needs
+// to distinguish valid non-object JSON from malformed input. simdjson's DOM
+// parser materializes numbers and may reject out-of-range literals like 1e400,
+// even though they are valid JSON values for this purpose.
 bool isValidJsonNumber(std::string_view number) {
   size_t pos = number[0] == '-';
   if (pos == number.size()) {

--- a/bolt/functions/flinksql/JsonFunctions.cpp
+++ b/bolt/functions/flinksql/JsonFunctions.cpp
@@ -15,10 +15,13 @@
  */
 
 #include "bolt/expression/VectorFunction.h"
-#include "bolt/functions/prestosql/json/SIMDJsonWrapper.h"
+#include "bolt/functions/prestosql/json/SIMDJsonUtil.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
 #include "bolt/vector/ConstantVector.h"
 #include "bolt/vector/FlatVector.h"
+
+#include <cstring>
+
 namespace bytedance::bolt::functions::flinksql {
 namespace {
 bool isDigit(char c) {
@@ -64,6 +67,67 @@ bool isValidJsonNumber(std::string_view number) {
     }
   }
   return pos == number.size();
+}
+
+simdjson::padded_string_view paddedJsonView(
+    std::string_view input,
+    BufferPtr& buffer,
+    memory::MemoryPool* pool) {
+  const auto paddedSize = input.size() + simdjson::SIMDJSON_PADDING;
+  if (buffer == nullptr) {
+    buffer = AlignedBuffer::allocate<char>(paddedSize, pool);
+  } else if (UNLIKELY(paddedSize > buffer->capacity())) {
+    AlignedBuffer::reallocate<char>(&buffer, paddedSize);
+  } else {
+    buffer->setSize(paddedSize);
+  }
+  auto* data = buffer->asMutable<char>();
+  std::memcpy(data, input.data(), input.size());
+  return simdjson::padded_string_view(data, input.size(), buffer->size());
+}
+
+template <typename T>
+simdjson::error_code validateJson(
+    T& value,
+    simdjson::ondemand::json_type type) {
+  switch (type) {
+    case simdjson::ondemand::json_type::array: {
+      SIMDJSON_ASSIGN_OR_RAISE(auto array, value.get_array());
+      for (auto elementOrError : array) {
+        SIMDJSON_ASSIGN_OR_RAISE(auto element, elementOrError);
+        SIMDJSON_ASSIGN_OR_RAISE(auto elementType, element.type());
+        SIMDJSON_TRY(validateJson(element, elementType));
+      }
+      return simdjson::SUCCESS;
+    }
+    case simdjson::ondemand::json_type::object: {
+      SIMDJSON_ASSIGN_OR_RAISE(auto object, value.get_object());
+      for (auto fieldOrError : object) {
+        SIMDJSON_ASSIGN_OR_RAISE(auto field, fieldOrError);
+        // On-Demand validates object keys lazily. Explicitly unescape the key
+        // so malformed escapes in nested object field names are rejected before
+        // moving on to the value.
+        SIMDJSON_ASSIGN_OR_RAISE(auto fieldName, field.unescaped_key(true));
+        (void)fieldName;
+        auto fieldValue = field.value();
+        SIMDJSON_ASSIGN_OR_RAISE(auto fieldType, fieldValue.type());
+        SIMDJSON_TRY(validateJson(fieldValue, fieldType));
+      }
+      return simdjson::SUCCESS;
+    }
+    case simdjson::ondemand::json_type::number:
+      return isValidJsonNumber(value.raw_json_token()) ? simdjson::SUCCESS
+                                                       : simdjson::NUMBER_ERROR;
+    case simdjson::ondemand::json_type::string:
+      return value.get_string(true).error();
+    case simdjson::ondemand::json_type::boolean:
+      return value.get_bool().error();
+    case simdjson::ondemand::json_type::null: {
+      SIMDJSON_ASSIGN_OR_RAISE(auto isNull, value.is_null());
+      return isNull ? simdjson::SUCCESS : simdjson::N_ATOM_ERROR;
+    }
+  }
+  BOLT_UNREACHABLE();
 }
 
 template <typename NativeType>
@@ -127,6 +191,7 @@ class JsonStrToMapFunction : public bytedance::bolt::exec::VectorFunction {
     exec::VectorWriter<Any> writer;
     exec::LocalSelectivityVector remainingRowsHolder(context);
     SelectivityVector* remainingRows = nullptr;
+    BufferPtr paddedBuffer;
 
     auto ensureWritable = [&]() {
       if (remainingRows == nullptr) {
@@ -145,7 +210,8 @@ class JsonStrToMapFunction : public bytedance::bolt::exec::VectorFunction {
       if (trimmedValue.empty() || trimmedValue.front() == '{') {
         return;
       }
-      if (auto error = validateNonObjectJson(trimmedValue)) {
+      if (auto error = validateNonObjectJson(
+              trimmedValue, paddedBuffer, context.pool())) {
         ensureWritable();
         writer.setOffset(row);
         writer.commitNull();
@@ -203,18 +269,27 @@ class JsonStrToMapFunction : public bytedance::bolt::exec::VectorFunction {
 
  private:
   static simdjson::error_code validateNonObjectJson(
-      std::string_view trimmedInput) {
+      std::string_view trimmedInput,
+      BufferPtr& paddedBuffer,
+      memory::MemoryPool* pool) {
     if (trimmedInput == "true" || trimmedInput == "false" ||
-        trimmedInput == "null" || isValidJsonNumber(trimmedInput)) {
+        trimmedInput == "null" || trimmedInput == "[]" ||
+        isValidJsonNumber(trimmedInput)) {
       return simdjson::SUCCESS;
     }
 
-    thread_local simdjson::dom::parser parser;
-    simdjson::dom::element doc;
-    if (auto error = parser.parse(trimmedInput).get(doc)) {
+    simdjson::ondemand::document doc;
+    if (auto error =
+            simdjsonParse(paddedJsonView(trimmedInput, paddedBuffer, pool))
+                .get(doc)) {
       return error;
     }
-    return doc.type() == simdjson::dom::element_type::OBJECT
+    SIMDJSON_ASSIGN_OR_RAISE(auto type, doc.type());
+    SIMDJSON_TRY(validateJson(doc, type));
+    if (!doc.at_end()) {
+      return simdjson::TRAILING_CONTENT;
+    }
+    return type == simdjson::ondemand::json_type::object
         ? simdjson::INCORRECT_TYPE
         : simdjson::SUCCESS;
   }

--- a/bolt/functions/flinksql/JsonFunctions.cpp
+++ b/bolt/functions/flinksql/JsonFunctions.cpp
@@ -15,11 +15,53 @@
  */
 
 #include "bolt/expression/VectorFunction.h"
+#include "bolt/functions/prestosql/json/SIMDJsonWrapper.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
 #include "bolt/vector/ConstantVector.h"
 #include "bolt/vector/FlatVector.h"
 namespace bytedance::bolt::functions::flinksql {
 namespace {
+bool isDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+bool isValidJsonNumber(std::string_view number) {
+  size_t pos = number[0] == '-';
+  if (pos == number.size()) {
+    return false;
+  }
+  if (number[pos] == '0') {
+    ++pos;
+    if (pos < number.size() && isDigit(number[pos])) {
+      return false;
+    }
+  } else if (number[pos] >= '1' && number[pos] <= '9') {
+    while (++pos < number.size() && isDigit(number[pos])) {
+    }
+  } else {
+    return false;
+  }
+  if (pos < number.size() && number[pos] == '.') {
+    if (++pos == number.size() || !isDigit(number[pos])) {
+      return false;
+    }
+    while (++pos < number.size() && isDigit(number[pos])) {
+    }
+  }
+  if (pos < number.size() && (number[pos] == 'e' || number[pos] == 'E')) {
+    ++pos;
+    if (pos < number.size() && (number[pos] == '+' || number[pos] == '-')) {
+      ++pos;
+    }
+    if (pos == number.size() || !isDigit(number[pos])) {
+      return false;
+    }
+    while (++pos < number.size() && isDigit(number[pos])) {
+    }
+  }
+  return pos == number.size();
+}
+
 template <typename NativeType>
 VectorPtr checkAndFlatten(const SelectivityVector& rows, VectorPtr& input) {
   BOLT_CHECK_NOT_NULL(input);
@@ -68,18 +110,78 @@ class JsonStrToMapFunction : public bytedance::bolt::exec::VectorFunction {
       VectorPtr& result) const override {
     auto castFactory =
         dynamic_cast<const JsonCastOperator*>(JsonCastOperator::get().get());
+
+    auto input = checkAndFlatten<StringView>(rows, args[0]);
+    auto* inputVector = input->as<SimpleVector<StringView>>();
     VectorPtr logFailuresOnly;
+    SimpleVector<bool>* logFailuresOnlyVector{nullptr};
     if (args.size() == 2) {
       logFailuresOnly = checkAndFlatten<bool>(rows, args[1]);
+      logFailuresOnlyVector = logFailuresOnly->as<SimpleVector<bool>>();
     }
-    castFactory->castFrom(
-        *checkAndFlatten<StringView>(rows, args[0]),
-        context,
-        rows,
-        outputType,
-        result,
-        false,
-        std::move(logFailuresOnly));
+
+    exec::VectorWriter<Any> writer;
+    exec::LocalSelectivityVector remainingRowsHolder(context);
+    SelectivityVector* remainingRows = nullptr;
+
+    auto ensureWritable = [&]() {
+      if (remainingRows == nullptr) {
+        context.ensureWritable(rows, outputType, result);
+        writer.init(*result);
+        remainingRows = remainingRowsHolder.get(rows);
+      }
+    };
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (inputVector->isNullAt(row)) {
+        return;
+      }
+      auto value = inputVector->valueAt(row);
+      auto trimmedValue = folly::trimWhitespace(value);
+      if (trimmedValue.empty() || trimmedValue.front() == '{') {
+        return;
+      }
+      if (auto error = validateNonObjectJson(trimmedValue)) {
+        ensureWritable();
+        writer.setOffset(row);
+        writer.commitNull();
+        remainingRows->setValid(row, false);
+        if (logFailuresOnlyVector && logFailuresOnlyVector->valueAt(row)) {
+          LOG(WARNING) << "Failed to parse "
+                       << std::string_view(value.data(), value.size());
+        } else {
+          folly::call_once(initializeErrors_, [this] {
+            simdjsonErrorsToExceptions(errors_);
+          });
+          context.setBoltExceptionError(row, errors_[error]);
+        }
+      } else {
+        ensureWritable();
+        writer.setOffset(row);
+        writer.current().castTo<Map<Any, Any>>();
+        writer.commit(true);
+        remainingRows->setValid(row, false);
+      }
+    });
+
+    if (remainingRows == nullptr) {
+      castFactory->castFrom(
+          *input, context, rows, outputType, result, false, logFailuresOnly);
+      return;
+    }
+
+    writer.finish();
+    remainingRows->updateBounds();
+    if (remainingRows->hasSelections()) {
+      castFactory->castFrom(
+          *input,
+          context,
+          *remainingRows,
+          outputType,
+          result,
+          false,
+          logFailuresOnly);
+    }
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -94,6 +196,27 @@ class JsonStrToMapFunction : public bytedance::bolt::exec::VectorFunction {
             .argumentType("boolean")
             .build()};
   }
+
+ private:
+  static simdjson::error_code validateNonObjectJson(
+      std::string_view trimmedInput) {
+    if (trimmedInput == "true" || trimmedInput == "false" ||
+        trimmedInput == "null" || isValidJsonNumber(trimmedInput)) {
+      return simdjson::SUCCESS;
+    }
+
+    thread_local simdjson::dom::parser parser;
+    simdjson::dom::element doc;
+    if (auto error = parser.parse(trimmedInput).get(doc)) {
+      return error;
+    }
+    return doc.type() == simdjson::dom::element_type::OBJECT
+        ? simdjson::INCORRECT_TYPE
+        : simdjson::SUCCESS;
+  }
+
+  mutable folly::once_flag initializeErrors_;
+  mutable std::exception_ptr errors_[simdjson::NUM_ERROR_CODES];
 };
 
 class JsonStrToArrayFunction : public bytedance::bolt::exec::VectorFunction {

--- a/bolt/functions/flinksql/tests/JsonFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/JsonFunctionsTest.cpp
@@ -65,10 +65,19 @@ TEST_F(JsonFunctionsTest, jsonStrToMap) {
       {{{"a", "1"}, {"b", "{\"c\":\"2\"}"}, {"d", "[\"3\",\"4\"]"}}});
   testJsonStrToMap(evaluateExpr("{}"), emptyArray);
   testJsonStrToMap(evaluateExpr("{\"a\": null}"), {{{"a", std::nullopt}}});
+  testJsonStrToMap(evaluateExpr("44"), emptyArray);
+  testJsonStrToMap(evaluateExpr("0"), emptyArray);
+  testJsonStrToMap(evaluateExpr("9223372036854775808"), emptyArray);
+  testJsonStrToMap(evaluateExpr("1e400"), emptyArray);
+  testJsonStrToMap(evaluateExpr("true"), emptyArray);
+  testJsonStrToMap(evaluateExpr("null"), emptyArray);
+  testJsonStrToMap(evaluateExpr("[]"), emptyArray);
+  BOLT_ASSERT_THROW(evaluateExpr("[1e400, {\"a\": \"b\"}]"), "NUMBER_ERROR");
+  testJsonStrToMap(evaluateExpr("\"abc\""), emptyArray);
   BOLT_ASSERT_THROW(
       evaluateExpr("{\"a\": \"1}"), "A string is opened, but never closed");
-  BOLT_ASSERT_THROW(
-      evaluateExpr("abc"), "The JSON element does not have the requested type");
+  BOLT_ASSERT_THROW(evaluateExpr("[1,"), "improper structure");
+  BOLT_ASSERT_THROW(evaluateExpr("abc"), "improper structure");
   testJsonStrToMap(evaluateExpr("  "), std::nullopt);
   BOLT_ASSERT_THROW(evaluateExpr(std::nullopt), "input is null");
 
@@ -81,16 +90,40 @@ TEST_F(JsonFunctionsTest, jsonStrToMap) {
   testJsonStrToMap(evaluateExpr("{}", true), emptyArray);
   testJsonStrToMap(
       evaluateExpr("{\"a\": null}", true), {{{"a", std::nullopt}}});
+  testJsonStrToMap(evaluateExpr("44", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("0", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("9223372036854775808", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("1e400", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("true", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("null", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("[]", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("[1e400, {\"a\": \"b\"}]", true), std::nullopt);
+  testJsonStrToMap(evaluateExpr("\"abc\"", true), emptyArray);
   testJsonStrToMap(evaluateExpr("{\"a\": \"1}", true), std::nullopt);
-  BOLT_ASSERT_THROW(
-      evaluateExpr("abc", false),
-      "The JSON element does not have the requested type");
+  testJsonStrToMap(evaluateExpr("[1,", true), std::nullopt);
+  BOLT_ASSERT_THROW(evaluateExpr("abc", false), "improper structure");
   testJsonStrToMap(evaluateExpr("abc", true), std::nullopt);
   testJsonStrToMap(evaluateExpr("  ", false), std::nullopt);
   testJsonStrToMap(evaluateExpr("  ", true), std::nullopt);
   testJsonStrToMap(evaluateExpr("", false), std::nullopt);
   BOLT_ASSERT_THROW(evaluateExpr(std::nullopt, false), "input is null");
   testJsonStrToMap(evaluateExpr(std::nullopt, true), std::nullopt);
+}
+
+TEST_F(JsonFunctionsTest, jsonStrToMapNonObjectDoesNotReusePreviousValue) {
+  setFlinkCompatible(true);
+  auto jsonVector = makeNullableFlatVector<StringView>(
+      {"{\"a\": \"1\"}", "44", "[]", "{\"b\": \"2\"}"});
+  auto actual = evaluate<MapVector>(
+      "json_str_to_map(c0)",
+      makeRowVector({jsonVector}),
+      SelectivityVector{jsonVector->size()},
+      MAP(VARCHAR(), VARCHAR()));
+  auto expected = makeNullableMapVector(
+      std::vector<std::optional<
+          std::vector<std::pair<StringView, std::optional<StringView>>>>>(
+          {{{{"a", "1"}}}, emptyArray, emptyArray, {{{"b", "2"}}}}));
+  ::bytedance::bolt::test::assertEqualVectors(expected, actual);
 }
 
 TEST_F(JsonFunctionsTest, jsonStrToMapNestedEncoding) {

--- a/bolt/functions/flinksql/tests/JsonFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/JsonFunctionsTest.cpp
@@ -72,11 +72,13 @@ TEST_F(JsonFunctionsTest, jsonStrToMap) {
   testJsonStrToMap(evaluateExpr("true"), emptyArray);
   testJsonStrToMap(evaluateExpr("null"), emptyArray);
   testJsonStrToMap(evaluateExpr("[]"), emptyArray);
-  BOLT_ASSERT_THROW(evaluateExpr("[1e400, {\"a\": \"b\"}]"), "NUMBER_ERROR");
+  testJsonStrToMap(evaluateExpr("[1e400, {\"a\": \"b\"}]"), emptyArray);
+  BOLT_ASSERT_THROW(evaluateExpr("[{\"bad\\q\": 1}]"), "STRING_ERROR");
+  BOLT_ASSERT_THROW(evaluateExpr("[1e, {\"a\": \"b\"}]"), "NUMBER_ERROR");
   testJsonStrToMap(evaluateExpr("\"abc\""), emptyArray);
   BOLT_ASSERT_THROW(
       evaluateExpr("{\"a\": \"1}"), "A string is opened, but never closed");
-  BOLT_ASSERT_THROW(evaluateExpr("[1,"), "improper structure");
+  BOLT_ASSERT_THROW(evaluateExpr("[1,"), "INCOMPLETE_ARRAY_OR_OBJECT");
   BOLT_ASSERT_THROW(evaluateExpr("abc"), "improper structure");
   testJsonStrToMap(evaluateExpr("  "), std::nullopt);
   BOLT_ASSERT_THROW(evaluateExpr(std::nullopt), "input is null");
@@ -97,7 +99,9 @@ TEST_F(JsonFunctionsTest, jsonStrToMap) {
   testJsonStrToMap(evaluateExpr("true", true), emptyArray);
   testJsonStrToMap(evaluateExpr("null", true), emptyArray);
   testJsonStrToMap(evaluateExpr("[]", true), emptyArray);
-  testJsonStrToMap(evaluateExpr("[1e400, {\"a\": \"b\"}]", true), std::nullopt);
+  testJsonStrToMap(evaluateExpr("[1e400, {\"a\": \"b\"}]", true), emptyArray);
+  testJsonStrToMap(evaluateExpr("[{\"bad\\q\": 1}]", true), std::nullopt);
+  testJsonStrToMap(evaluateExpr("[1e, {\"a\": \"b\"}]", true), std::nullopt);
   testJsonStrToMap(evaluateExpr("\"abc\"", true), emptyArray);
   testJsonStrToMap(evaluateExpr("{\"a\": \"1}", true), std::nullopt);
   testJsonStrToMap(evaluateExpr("[1,", true), std::nullopt);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
`json_str_to_map` in Flink-compatible mode did not fully align with Flink behavior for valid JSON values that are not
  JSON objects. For inputs such as numbers, booleans, `null`, arrays, or strings, Flink returns an empty map instead of throwing an  error. Before this change, `json_str_to_map` could throw type errors for these non-object JSON values.

Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR aligns `json_str_to_map` behavior with Flink for non-object JSON inputs.

Changes include:
  - When casting JSON to MAP in Flink-compatible mode:
  - empty or whitespace-only input still returns null;
  - valid non-object JSON values such as `44`, `0`, `true`, `null`, `[]`, and `"abc"` now return an empty map;
  - invalid JSON input still follows existing error/log-failure behavior.
  - Added unit tests for both normal mode and `logFailuresOnly=true` mode to cover valid non-object JSON inputs.

The implementation only applies this special handling for MAP casts under Flink-compatible mode, preserving existing
  behavior for object JSON and invalid JSON parsing.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed `json_str_to_map` in Flink-compatible mode to return an empty map for valid non-object JSON inputs.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
