### PR TITLE
fix(memory): don't crash when an async preload outlives its MemoryManager

### DIFF
--- a/bolt/common/memory/Memory.cpp
+++ b/bolt/common/memory/Memory.cpp
@@ -234,6 +234,16 @@ MemoryManager::~MemoryManager() {
   arbitrator_->shutdown();
 
   if (pools_.size() != 0) {
+    // These pools outlive us, so detach the destruction callback first: it
+    // would otherwise run dropPool() -> arbitrator_->removePool() on a
+    // destroyed manager and arbitrator. Do this before reporting, which may
+    // throw. See issue #931.
+    for (const auto& pool : getAlivePools()) {
+      if (auto* impl = dynamic_cast<MemoryPoolImpl*>(pool.get())) {
+        impl->clearDestructionCallback();
+      }
+    }
+
     const auto errMsg = fmt::format(
         "pools_.size() != 0 ({} vs {}). There are unexpected alive memory "
         "pools allocated by user on memory manager destruction:\n{}",

--- a/bolt/common/memory/Memory.h
+++ b/bolt/common/memory/Memory.h
@@ -285,6 +285,13 @@ class MemoryManager {
 
   MemoryAllocator* allocator();
 
+  /// Returns the owning reference to the allocator. Memory pools hold one so
+  /// that a pool which outlives this manager cannot free through a dangling
+  /// allocator.
+  const std::shared_ptr<MemoryAllocator>& sharedAllocator() const {
+    return allocator_;
+  }
+
   MemoryArbitrator* arbitrator();
 
   /// Returns debug string of this memory manager. If 'detail' is true, it

--- a/bolt/common/memory/MemoryPool.cpp
+++ b/bolt/common/memory/MemoryPool.cpp
@@ -498,6 +498,7 @@ MemoryPoolImpl::MemoryPoolImpl(
     const Options& options)
     : MemoryPool{name, kind, parent, options},
       manager_{memoryManager},
+      allocatorHolder_{manager_->sharedAllocator()},
       allocator_{manager_->allocator()},
       arbitrator_{manager_->arbitrator()},
       reclaimer_(std::move(reclaimer)),
@@ -547,8 +548,16 @@ MemoryPoolImpl::~MemoryPoolImpl() {
         kMetricMemoryPoolCapacityGrowCount, numCapacityGrowths_);
   }
 
-  if (destructionCb_ != nullptr) {
-    destructionCb_(this);
+  // Read under the lock: the owning MemoryManager may be concurrently
+  // detaching the callback because it is being destroyed while 'this' is still
+  // alive. See MemoryPoolImpl::clearDestructionCallback().
+  DestructionCallback destructionCb;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    destructionCb = std::move(destructionCb_);
+  }
+  if (destructionCb != nullptr) {
+    destructionCb(this);
   }
 }
 
@@ -1443,6 +1452,11 @@ void MemoryPoolImpl::setDestructionCallback(
   std::lock_guard<std::mutex> l(mutex_);
   BOLT_CHECK_NULL(destructionCb_);
   destructionCb_ = callback;
+}
+
+void MemoryPoolImpl::clearDestructionCallback() {
+  std::lock_guard<std::mutex> l(mutex_);
+  destructionCb_ = nullptr;
 }
 
 void MemoryPoolImpl::testingSetCapacity(int64_t bytes) {

--- a/bolt/common/memory/MemoryPool.h
+++ b/bolt/common/memory/MemoryPool.h
@@ -730,6 +730,12 @@ class MemoryPoolImpl : public MemoryPool {
 
   void setDestructionCallback(const DestructionCallback& callback);
 
+  /// Detaches the destruction callback, if one was set. The callback points
+  /// back at the owning MemoryManager, so it must be dropped whenever this
+  /// pool is about to outlive that manager - otherwise ~MemoryPoolImpl calls
+  /// MemoryManager::dropPool() on freed memory.
+  void clearDestructionCallback();
+
   std::string toString(bool detail = false) const override;
 
   /// Detailed debug pool state printout by traversing the pool structure from
@@ -1015,6 +1021,12 @@ class MemoryPoolImpl : public MemoryPool {
   }
 
   MemoryManager* const manager_;
+  // Keeps the manager's allocator alive for as long as this pool is. A pool
+  // can outlive its MemoryManager - a straggling async IO thread holding the
+  // last reference is enough - and freeing its buffers through a dangling
+  // MemoryAllocator* is how such a straggler turns into
+  // "pure virtual method called".
+  const std::shared_ptr<MemoryAllocator> allocatorHolder_;
   MemoryAllocator* const allocator_;
   MemoryArbitrator* const arbitrator_;
 

--- a/bolt/common/memory/tests/MemoryManagerTest.cpp
+++ b/bolt/common/memory/tests/MemoryManagerTest.cpp
@@ -744,4 +744,22 @@ TEST_F(MemoryManagerTest, disableMemoryPoolTracking) {
     ASSERT_NO_THROW(root1.reset());
   }
 }
+
+// A pool can outlive its manager - a scan preload parked in a hung read holds
+// one while AsyncThreadCtx::wait() gives up and teardown proceeds. Releasing it
+// afterwards must not call back into the destroyed manager, which would run
+// dropPool() -> arbitrator_->removePool() on freed memory. See issue #931.
+TEST_F(MemoryManagerTest, poolOutlivingManagerIsSurvivable) {
+  MemoryManager::Options options;
+  options.allocatorCapacity = 1LL << 20;
+  options.checkUsageLeak = false;
+
+  auto manager = std::make_unique<MemoryManager>(options);
+  auto root = manager->addRootPool("straggler_root");
+  auto leaf = root->addLeafChild("straggler_leaf");
+
+  manager.reset();
+  ASSERT_NO_THROW(leaf.reset());
+  ASSERT_NO_THROW(root.reset());
+}
 } // namespace bytedance::bolt::memory

--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -432,14 +432,35 @@ class AsyncThreadCtx {
     cv_.notify_one();
   }
 
+  /// Waits for every async preload to leave this context, up to kMaxWait.
+  ///
+  /// Giving up is survivable but not free: an in-flight preload owns the scan
+  /// memory pool, so it will outlive the manager that owns that pool. See
+  /// ~MemoryManager, which detaches such pools so their late release is a
+  /// deferred cleanup rather than a use-after-free (issue #931).
   void wait() {
-    // check timeout and output warninglogs
+    constexpr auto kMaxWait = std::chrono::seconds(600);
+    constexpr auto kLogInterval = std::chrono::seconds(60);
     std::unique_lock lock(mutex_);
     state_ = State::kClosed;
-    cv_.wait_until(
-        lock,
-        std::chrono::steady_clock::now() + std::chrono::seconds(600),
-        [this] { return numIn_ == 0; });
+    // Wake holders backing off in AsyncLoadHolder::canPreload(), which would
+    // otherwise keep this wait going for their full retry budget.
+    allowPreload_ = false;
+    cv_.notify_all();
+
+    auto waited = std::chrono::seconds(0);
+    while (waited < kMaxWait) {
+      if (cv_.wait_for(lock, kLogInterval, [this] { return numIn_ == 0; })) {
+        return;
+      }
+      waited += kLogInterval;
+      LOG(WARNING) << "Waiting for " << numIn_
+                   << " in-flight async preload(s) after " << waited.count()
+                   << "s; the storage read is most likely stuck.";
+    }
+    LOG(ERROR) << "Giving up after " << kMaxWait.count() << "s with " << numIn_
+               << " async preload(s) still in flight. They hold scan memory "
+                  "that will only be reclaimed when the storage read returns.";
   }
 
   std::mutex& getMutex() {


### PR DESCRIPTION
### What problem does this PR solve?

Gluten/Spark executors abort with `pure virtual method called` /
`terminate called without an active exception` when HDFS stops responding. The
whole executor process dies, taking every task on it with it.

A scan preload parked in a hung read owns the scan memory pool, and teardown can
proceed while it still does — `AsyncThreadCtx::wait()` gives up after 600s, and
the preload closure is destroyed only after its guard is released. Either way the
pool outlives its `MemoryManager`, and releasing it then runs
`~MemoryPoolImpl` → `destructionCb_` → `dropPool` → `arbitrator_->removePool()`
— a pure virtual on a destroyed arbitrator.

Two things worth stating up front:

- **The crash did not fail the reported job.** That was a different symptom of
  the same HDFS outage — `HdfsBuilder.connect` errno=22 in
  `Executor.updateDependencies`, before task execution. This bug amplifies a
  survivable outage into lost executors; it would not have saved that job.
- **Which route fired in production is not established.** The evidence that
  pointed at the 600s timeout was a units bug in that log line (#935); the task
  runtimes on the surrounding lines rule the timeout out. The mechanism is
  verified and reproduced, but its production trigger is not pinned down.

<details>
<summary><b>Verified timeline</b> (Spark history server + executor stderr)</summary>

Executor stderr is UTC+8; normalised to GMT below. Only entries read directly
from those two sources are listed - nothing inferred.

| GMT | Source | Event |
|---|---|---|
| 11:26:35.981 | stages.json | Stage 2 submitted |
| 11:31:24.754 | stages.json | Stage 2 first task launched |
| **11:34:31.978** | stages.json | **Stage 2 aborted** - task 1735 failed 8x, last failure `HdfsBuilder.connect` errno=22 inside `Executor.updateDependencies`, i.e. fetching task dependencies before execution |
| 11:34:31.991 | stages.json | Stage 1 cancelled (`Job 1 cancelled`) |
| 11:34:32.002 | stages.json | Stage 3 cancelled |
| 11:34:32.010 | stages.json | Stage 4 cancelled |
| 11:34:32.393 | stderr | `ShuffleWriterNode.cpp:98` ShuffleWriter stop failed, INVALID_STATE |
| 11:34:32.617 | stderr | `AsyncLoadThr7` preload fails to load |
| 11:34:32.618 | stderr | `TableScan close wait async thread ctx cost` (task 6233, state = Failed) |
| 11:34:32.618 | stderr | `All drivers (1) finished ... after running for 8541 ms` (task 6233) |
| 11:34:32.642 | stderr | `AsyncLoadThr16` preload failed: `java.io.IOException: FileSystem: not connected` |
| 11:34:32.642 | stderr | `Disallow scan preload due to limited memory` |
| 11:34:32.645 | stderr | `AsyncLoadThr1` - same `FileSystem: not connected` |
| 11:34:32.663 | stderr | `AsyncLoadThr0` - same `FileSystem: not connected` |
| 11:34:32.663 | stderr | `TableScan close wait ...` (task 6202, state = Failed) |
| 11:34:32.664 | stderr | `All drivers (1) finished ... after running for 9623 ms` (task 6202) |
| 11:34:32.704-.708 | stderr | `WholeStageResultIterator` HDFS trace collection, `JniWrapper.cc:630` |
| immediately after | stderr | `pure virtual method called` / `terminate called without an active exception` |

What this establishes:

- **The job was failed by HDFS, not by this crash.** The abort at 11:34:31.978
  is an HDFS connect failure during dependency fetch, before any engine code
  runs. Stages 1, 3 and 4 record `Job N cancelled`, and all four completion
  times fall within 32ms - a cascade from that one abort.
- **Everything on the executor happens after that abort**, inside a ~320ms
  window (+415ms to +730ms), ending in the crash. The crash is at the end of a
  mass task teardown, not at its start.
- **The 600s `wait()` timeout was not reached.** Both tasks report total
  runtimes of 8541ms and 9623ms from an independent, correctly computed log
  line, which bounds their `close()` wait well under the timeout. (The wait
  values printed on those lines - `223652ms`, `147449ms` - are not durations at
  all: see #935.)
- **The parked preloads were released by the filesystem being closed**, not by
  a timeout - three `AsyncLoadThrN` threads report `FileSystem: not connected`
  within 21ms of each other, immediately before teardown completes.

What it does **not** establish: which holder kept a memory pool alive past the
manager on that executor. The timeout route is ruled out; the
closure-destruction window and other holders are not distinguished by this data.

</details>

Full diagnosis and logs: #931

Issue Number: close #931

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Waiting indefinitely was rejected: the task runs serially on the Spark task
thread, and a native thread parked in a JNI read cannot be interrupted, so the
job would become uncancellable. A crash is retried; a hang is not.

So the timeout stays and giving up is made survivable:

| File | Change |
|---|---|
| `memory/Memory.cpp` | `~MemoryManager` detaches `destructionCb_` from pools that outlive it, before reporting (which may throw) |
| `memory/MemoryPool.{h,cpp}` | Pools hold a `shared_ptr` to the allocator; `~MemoryPoolImpl` reads the callback under the lock; new `clearDestructionCallback()` |
| `connectors/Connector.h` | `wait()` logs every 60s and on giving up; clears `allowPreload_` on entry so a holder backing off in `canPreload()` (up to 500s) stops extending the wait |

**What detaching gives up.** `dropPool()` does `pools_.erase()` — moot, the map is
being destroyed — and `arbitrator_->removePool()`, which under Gluten notifies
Spark's accounting. That notification is skipped, and cannot be preserved:
`removePool()` starts with `BOLT_CHECK_EQ(pool->reservedBytes(), 0)` and the
straggler still holds that memory. It is only releasable once the read completes,
by which point the arbitrator is gone regardless. Today the same path crashes, so
nothing that currently works is lost.

The normal path is untouched — Gluten settles accounting when `tryDestructSafe()`
resets `boltAggregatePool_`, while the arbitrator is alive.

**Two points for reviewers who know the Gluten side:**

1. A release landing *inside* `~MemoryManager`, arbitrator still alive, used to
   run `dropPool()` and now does not. Microsecond window on a dying task.
2. Spark's off-heap accounting for that task may therefore not see the release,
   likely a leaked-memory warning at task end.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

    <details>
    <summary>Notes</summary>

    ```text
    One shared_ptr copy per pool construction, one mutex-guarded read per pool
    destruction; neither on an allocation or scan hot path. Timeout unchanged at
    600s. Clearing allowPreload_ shortens the common teardown case.
    ```
    </details>

### Release Note

```text
Release Note:
- Fixed an executor crash ("pure virtual method called") during task teardown
  when an asynchronous scan preload was still blocked on an unresponsive
  filesystem.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

| Suite | Result |
| --- | --- |
| `MemoryManagerTest.poolOutlivingManagerIsSurvivable` (new) | PASSED — segfaults in `dropPool` without the fix |
| `bolt_exec_scan_test` (TableScanTest, 99 tests) | 99/99 PASSED |

Release, `spark_compatible=True`. The new test is deterministic and runs in 0ms.
The rest of `bolt_memory_test` has pre-existing failures that reproduce
identically on an unmodified checkout.

An end-to-end reproduction (filesystem hanging `AsyncLoadThrN` reads, per-task
`MemoryManager`) is in #931 rather than here: it runs ~11 minutes and measurement
showed it does not actually reach the dangerous state, because
`TableScan::preload`'s closure captures the `Task`.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

No API or ABI change, and no change to the 600s timeout. A pool outliving its
manager is now leaked-then-reclaimed rather than fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Lrun1uiPmNbVmVqLv4mW8
