### PR TITLE
docs: fix devcontainer Docker CLI examples

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -15,7 +15,10 @@ This guide explains how to build and configure the Bolt devcontainer.
 
 ```bash
 # From the project root directory
-cd .github/runners && docker build -f .github/runners/Dockerfile.ci -t bolt-devcontainer:latest .
+docker build \
+  -f .github/runners/Dockerfile.ci \
+  -t bolt-devcontainer:latest \
+  .github/runners
 ```
 
 ## Building Worldwide and in Corporate Networks
@@ -47,12 +50,16 @@ download of debian packages is too slow.
 
 **Usage with Docker CLI:**
 ```bash
-docker build -f .github/runners/Dockerfile.ci --build-arg DEB_REGION="us" -t bolt-devcontainer:latest .
+docker build \
+  -f .github/runners/Dockerfile.ci \
+  --build-arg DEB_REGION="us" \
+  -t bolt-devcontainer:latest \
+  .github/runners
 ```
 
-### HTTPS_PROXY
+### `https_proxy`
 
-The `HTTPS_PROXY` argument allows you to specify an HTTPS proxy for
+The `https_proxy` argument allows you to specify an HTTPS proxy for
 network connections if you're behind a firewall.
 
 **Example value:**
@@ -64,12 +71,16 @@ network connections if you're behind a firewall.
    ```json
    "build": {
      "args": {
-       "HTTPS_PROXY": "http://proxy.company.com:8080"
+       "https_proxy": "http://proxy.company.com:8080"
      }
    }
    ```
 
 **Usage with Docker CLI:**
 ```bash
-docker build -f .github/runners/Dockerfile.ci --build-arg HTTPS_PROXY="http://proxy.company.com:8080" -t bolt-devcontainer:latest .
+docker build \
+  -f .github/runners/Dockerfile.ci \
+  --build-arg https_proxy="http://proxy.company.com:8080" \
+  -t bolt-devcontainer:latest \
+  .github/runners
 ```


### PR DESCRIPTION
### What problem does this PR solve?

The devcontainer Docker CLI quick start changes into `.github/runners` and then references the Dockerfile using the repository-root path, so the documented command resolves a nonexistent nested path. The other CLI examples also use a different build context from the checked-in devcontainer configuration, and the proxy examples use a different argument spelling from the Dockerfile and `devcontainer.json`.

Issue Number: close #911

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [x] 📝 Documentation only

### Description

- Keep all three Docker CLI examples runnable from the repository root.
- Use `.github/runners` as the build context, matching `.devcontainer/devcontainer.json` and the Dockerfile's `COPY requirements.txt` expectation.
- Use the declared lowercase `https_proxy` spelling in the heading, prose, VS Code example, and Docker CLI example.
- Split the commands across lines so the Dockerfile, arguments, tag, and context are easier to verify.

Docker treats predefined proxy arguments case-insensitively, so the spelling change is about keeping the repository's CLI and VS Code instructions aligned with its declared configuration; the path/context correction is what fixes the broken quick-start command.

Validation performed:

- A Python static check parsed all three documented `docker build` commands and verified that each `-f` path exists, each context directory exists, the Dockerfile is inside that context, and `https_proxy` matches both the Dockerfile and devcontainer configuration.
- `git diff --check` passed.
- `pre-commit 4.5.0 run --files .devcontainer/README.md` passed all applicable hooks, including gitleaks, line-ending/whitespace checks, license headers, and codespell.
- The README's only external link returned HTTP 200.
- `markdownlint-cli2@0.17.2` reports the same eight pre-existing blank-line diagnostics before and after this change; this PR adds no new markdownlint diagnostic.

A full Docker image build was not run because this documentation-only change does not alter the image and a build would download the complete toolchain and dependency set.

### Performance Impact

- [x] **No Impact**: This change only corrects documentation examples.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Corrected the devcontainer Docker CLI commands and proxy argument examples.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [x] No need to test or manual test.

Documentation-specific static validation is listed above; C++ unit tests, builds, clang-format, and sanitizers are not applicable to this README-only change.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)