### PR TITLE
test(shuffle): add spill pool lifetime regression test for #691

### DIFF
--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+#include <arrow/buffer.h>
 #include <vector/ComplexVector.h>
 #include <filesystem>
+#include <memory>
 #include "bolt/common/caching/AsyncDataCache.h"
 #include "bolt/common/memory/sparksql/tests/MemoryTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
@@ -23,6 +25,8 @@
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/exec/tests/utils/MemoryHogOperator.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/shuffle/sparksql/BoltArrowMemoryPool.h"
+#include "bolt/shuffle/sparksql/BoltShuffleWriter.h"
 #include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
 #include "bolt/shuffle/sparksql/partitioner/Partitioning.h"
 #include "bolt/shuffle/sparksql/tests/ShuffleTestBase.h"
@@ -33,6 +37,99 @@ using namespace bytedance::bolt::memory::sparksql::test;
 namespace bytedance::bolt::shuffle::sparksql::test {
 
 using bytedance::bolt::exec::test::MemoryHogNode;
+
+namespace {
+
+struct SpillPoolDestructionState {
+  bool partitionWriterDestructorRan{false};
+  bool poolAliveBeforeBufferRelease{false};
+  bool poolAliveAfterBufferRelease{false};
+  int64_t bytesBeforeBufferRelease{0};
+  int64_t bytesAfterBufferRelease{-1};
+};
+
+class SpillPoolLifetimePartitionWriter final : public PartitionWriter {
+ public:
+  SpillPoolLifetimePartitionWriter(
+      PartitionWriterOptions options,
+      arrow::MemoryPool* pool,
+      std::weak_ptr<BoltArrowMemoryPool> spillPool,
+      SpillPoolDestructionState* state)
+      : PartitionWriter(options.numPartitions, std::move(options), pool),
+        spillPool_(std::move(spillPool)),
+        state_(state),
+        buffer_(arrow::AllocateResizableBuffer(64, pool).ValueOrDie()) {
+    BOLT_CHECK(buffer_->Resize(4096).ok());
+  }
+
+  ~SpillPoolLifetimePartitionWriter() override {
+    auto spillPool = spillPool_.lock();
+    state_->poolAliveBeforeBufferRelease = spillPool != nullptr;
+    if (spillPool == nullptr) {
+      // Avoid dereferencing the dangling raw pool in a broken implementation;
+      // the state assertion below will report the ownership regression.
+      buffer_.release();
+      state_->partitionWriterDestructorRan = true;
+      return;
+    }
+    state_->bytesBeforeBufferRelease = spillPool->bytes_allocated();
+    spillPool.reset();
+
+    // ResizableBuffer retains only the raw MemoryPool pointer. Its release
+    // must therefore happen while ShuffleWriter still owns the spill pool.
+    buffer_.reset();
+
+    state_->poolAliveAfterBufferRelease = !spillPool_.expired();
+    if (auto pool = spillPool_.lock()) {
+      state_->bytesAfterBufferRelease = pool->bytes_allocated();
+    }
+    state_->partitionWriterDestructorRan = true;
+  }
+
+  arrow::Status reclaimFixedSize(int64_t, int64_t*) override {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status stop(ShuffleWriterMetrics*) override {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status evict(
+      uint32_t,
+      std::unique_ptr<InMemoryPayload>,
+      Evict::type,
+      bool,
+      bool) override {
+    return arrow::Status::OK();
+  }
+
+ private:
+  std::weak_ptr<BoltArrowMemoryPool> spillPool_;
+  SpillPoolDestructionState* state_;
+  std::unique_ptr<arrow::ResizableBuffer> buffer_;
+};
+
+class SpillPoolLifetimeTestWriter final : public BoltShuffleWriter {
+ public:
+  using BoltShuffleWriter::BoltShuffleWriter;
+
+  std::weak_ptr<BoltArrowMemoryPool> spillPoolWeakPtr() const {
+    auto* spillPool = dynamic_cast<BoltArrowMemoryPool*>(spillArrowPool_);
+    BOLT_CHECK_NOT_NULL(spillPool);
+    return spillPool->weak_from_this();
+  }
+
+  void installLifetimeCheckingPartitionWriter(
+      SpillPoolDestructionState* state) {
+    partitionWriter_ = std::make_unique<SpillPoolLifetimePartitionWriter>(
+        options_.partitionWriterOptions,
+        spillArrowPool_,
+        spillPoolWeakPtr(),
+        state);
+  }
+};
+
+} // namespace
 
 // A test suite for shuffle memory related tests
 class ShuffleMemoryTest : public ShuffleTestBase {
@@ -68,6 +165,30 @@ class ShuffleMemoryTest : public ShuffleTestBase {
         << ":1); splits are too small, hurting compression (issue #662)";
   }
 };
+
+TEST_F(ShuffleMemoryTest, testSpillPoolOutlivesPartitionWriterBuffer) {
+  BoltArrowMemoryPool inputPool(pool());
+  ShuffleWriterOptions options;
+  options.partitionWriterOptions.numPartitions = 1;
+
+  SpillPoolDestructionState destructionState;
+  std::weak_ptr<BoltArrowMemoryPool> spillPool;
+  {
+    SpillPoolLifetimeTestWriter writer(options, pool(), &inputPool);
+    spillPool = writer.spillPoolWeakPtr();
+    writer.installLifetimeCheckingPartitionWriter(&destructionState);
+
+    ASSERT_FALSE(spillPool.expired());
+    EXPECT_NE(spillPool.lock().get(), &inputPool);
+  }
+
+  EXPECT_TRUE(destructionState.partitionWriterDestructorRan);
+  EXPECT_TRUE(destructionState.poolAliveBeforeBufferRelease);
+  EXPECT_TRUE(destructionState.poolAliveAfterBufferRelease);
+  EXPECT_GT(destructionState.bytesBeforeBufferRelease, 0);
+  EXPECT_EQ(destructionState.bytesAfterBufferRelease, 0);
+  EXPECT_TRUE(spillPool.expired());
+}
 
 TEST_F(ShuffleMemoryTest, testRowBasedShuffleEstimateLowerThanActual) {
   std::string str(10 * 1024, 'x');


### PR DESCRIPTION
### What problem does this PR solve?

Related to #691.

#691 fixed a shutdown-time use-after-free by making `ShuffleWriter` retain
ownership of the Arrow spill memory pool until dependent partition writers and
their buffers are destroyed.

The ownership and destruction-order invariant was not covered directly by a
unit test. A future change to member ordering or spill-pool ownership could
therefore reintroduce the bug without an immediate regression signal.

### Type of Change

- [x] 🐛 Bug fix (regression coverage for an existing fix)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add a focused regression test for the shuffle spill-pool lifetime fixed in
#691.

The test:

- Installs a test partition writer containing an Arrow `ResizableBuffer`
  allocated from the shuffle writer's spill pool.
- Uses a weak pointer to verify that the spill pool is alive when the partition
  writer destructor begins.
- Releases the buffer and verifies that the pool remains alive and its tracked
  allocation returns to zero.
- Verifies that the spill pool expires only after the enclosing shuffle writer
  has been destroyed.

This is a test-only change and does not modify production behavior.

### Performance Impact

- [x] **No Impact**: This change only adds a focused unit test.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below.

### Release Note

```text
Release Note:
- N/A (test-only regression coverage).
```

### Validation

- `git diff --check`
- `clang-format-14 --dry-run --Werror -style=file bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp`
  (`Debian clang-format version 14.0.6`)
- File-scoped pre-commit checks
- Strict A/B regression check: the focused test passes with #691 and fails on
  current main with only #691 reverted at the spill-pool lifetime assertion.
- Release ASAN exact-target build on the latest synchronized main.
- `bolt_shuffle_spark_memory_test
  --gtest_filter=ShuffleMemoryTest.testSpillPoolOutlivesPartitionWriterBuffer`
  passed (1/1); the test binary links `libasan.so.8`.

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [x] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
