### PR TITLE
refactor: remove deprecated memory APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,6 @@ CONAN_HOST_PROFILE_ARGS = \
 
 # Package-scoped settings only apply when the matching dependency is in the graph.
 CONAN_BUILD_SETTINGS = \
-	-s llvm-core/*:build_type=Release \
-	-s google-cloud-cpp/*:build_type=Release \
 	-s "&:build_type=${BUILD_TYPE}" \
 	-s build_type=${DEPENDENCY_BUILD_TYPE}
 

--- a/bolt/common/flags/BoltFlags.cpp
+++ b/bolt/common/flags/BoltFlags.cpp
@@ -16,11 +16,6 @@
 
 #include "bolt/common/flags/BoltFlags.h"
 
-DEFINE_int32(
-    bolt_memory_num_shared_leaf_pools,
-    32,
-    "Deprecated compatibility flag; no longer used");
-
 DEFINE_bool(
     bolt_time_allocations,
     true,

--- a/bolt/common/flags/BoltFlags.h
+++ b/bolt/common/flags/BoltFlags.h
@@ -39,7 +39,6 @@ DECLARE_bool(bolt_use_ws_vread);
 
 DECLARE_int32(bolt_exception_system_stacktrace_rate_limit_ms);
 DECLARE_int32(bolt_exception_user_stacktrace_rate_limit_ms);
-DECLARE_int32(bolt_memory_num_shared_leaf_pools);
 DECLARE_int32(cache_prefetch_min_pct);
 DECLARE_int32(bolt_shuffle_zstd_compression_level);
 

--- a/bolt/common/memory/Memory.h
+++ b/bolt/common/memory/Memory.h
@@ -298,12 +298,6 @@ class MemoryManager {
 
   std::string treeMemoryUsage() const;
 
-  /// Returns the memory manger's internal default root memory pool for testing
-  /// purpose and legacy use cases.
-  MemoryPool& deprecatedSysRootPool() const {
-    return *sysRoot_;
-  }
-
   /// Returns the process wide leaf memory pool used for disk spilling.
   MemoryPool* spillPool() {
     return spillPool_.get();

--- a/bolt/common/memory/tests/MemoryManagerTest.cpp
+++ b/bolt/common/memory/tests/MemoryManagerTest.cpp
@@ -46,6 +46,10 @@ namespace bytedance::bolt::memory {
 namespace {
 constexpr folly::StringPiece kSysRootName{"__sys_root__"};
 
+MemoryPool& systemRootPool(MemoryManager& manager) {
+  return *manager.spillPool()->parent();
+}
+
 } // namespace
 
 class MemoryManagerTest : public testing::Test {
@@ -64,18 +68,18 @@ TEST_F(MemoryManagerTest, ctor) {
     ASSERT_EQ(manager.capacity(), kMaxMemory);
     ASSERT_EQ(0, manager.getTotalBytes());
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMaxAlignment);
-    ASSERT_EQ(manager.deprecatedSysRootPool().alignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedSysRootPool().capacity(), kMaxMemory);
-    ASSERT_EQ(manager.deprecatedSysRootPool().maxCapacity(), kMaxMemory);
+    ASSERT_EQ(systemRootPool(manager).alignment(), manager.alignment());
+    ASSERT_EQ(systemRootPool(manager).capacity(), kMaxMemory);
+    ASSERT_EQ(systemRootPool(manager).maxCapacity(), kMaxMemory);
     ASSERT_EQ(manager.arbitrator()->kind(), "NOOP");
-    auto sysPool = manager.deprecatedSysRootPool().shared_from_this();
+    auto sysPool = systemRootPool(manager).shared_from_this();
     ASSERT_NE(sysPool->reclaimer(), nullptr);
     try {
       BOLT_FAIL("Trigger Error");
     } catch (const bolt::BoltRuntimeError&) {
       BOLT_ASSERT_THROW(
           sysPool->reclaimer()->abort(
-              &manager.deprecatedSysRootPool(), std::current_exception()),
+              &systemRootPool(manager), std::current_exception()),
           "SysMemoryReclaimer::abort is not supported");
     }
     ASSERT_EQ(sysPool->reclaimer()->priority(), 0);
@@ -95,7 +99,7 @@ TEST_F(MemoryManagerTest, ctor) {
     MemoryManager manager{options};
     ASSERT_EQ(kCapacity, manager.capacity());
     ASSERT_EQ(manager.numPools(), 3);
-    ASSERT_EQ(manager.deprecatedSysRootPool().alignment(), manager.alignment());
+    ASSERT_EQ(systemRootPool(manager).alignment(), manager.alignment());
   }
   {
     const auto kCapacity = 8L * 1024 * 1024;
@@ -106,9 +110,9 @@ TEST_F(MemoryManagerTest, ctor) {
     MemoryManager manager{options};
 
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMinAlignment);
-    ASSERT_EQ(manager.deprecatedSysRootPool().alignment(), manager.alignment());
+    ASSERT_EQ(systemRootPool(manager).alignment(), manager.alignment());
     // TODO: replace with root pool memory tracker quota check.
-    ASSERT_EQ(3, manager.deprecatedSysRootPool().getChildCount());
+    ASSERT_EQ(3, systemRootPool(manager).getChildCount());
     ASSERT_EQ(kCapacity, manager.capacity());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
@@ -376,7 +380,7 @@ TEST_F(MemoryManagerTest, memoryPoolManagement) {
     if (i % 2) {
       ASSERT_EQ(pool->kind(), MemoryPool::Kind::kLeaf);
       userLeafPools.push_back(pool);
-      ASSERT_EQ(pool->parent()->name(), manager.deprecatedSysRootPool().name());
+      ASSERT_EQ(pool->parent()->name(), systemRootPool(manager).name());
     } else {
       ASSERT_EQ(pool->kind(), MemoryPool::Kind::kAggregate);
       ASSERT_EQ(pool->parent(), nullptr);
@@ -416,12 +420,12 @@ TEST_F(MemoryManagerTest, globalMemoryManager) {
   auto* managerII = memoryManager();
   constexpr int32_t kSystemPoolCount = 3;
   {
-    auto& rootI = manager->deprecatedSysRootPool();
+    auto& rootI = systemRootPool(*manager);
     const std::string childIName("some_child");
     auto childI = rootI.addLeafChild(childIName);
     ASSERT_EQ(rootI.getChildCount(), kSystemPoolCount + 1);
 
-    auto& rootII = managerII->deprecatedSysRootPool();
+    auto& rootII = systemRootPool(*managerII);
     ASSERT_EQ(kSystemPoolCount + 1, rootII.getChildCount());
     std::vector<MemoryPool*> pools{};
     rootII.visitChildren([&pools](MemoryPool* child) {
@@ -485,7 +489,7 @@ TEST_F(MemoryManagerTest, alignmentOptionCheck) {
         manager.alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     ASSERT_EQ(
-        manager.deprecatedSysRootPool().alignment(),
+        systemRootPool(manager).alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     auto leafPool = manager.addLeafPool("leafPool");
     ASSERT_EQ(

--- a/bolt/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/bolt/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -40,6 +40,12 @@ using namespace bytedance::bolt::memory;
 constexpr int64_t kMemoryFootprintIncrement = MemoryAllocator::kMaxAlignment;
 namespace bytedance::bolt::memory {
 
+namespace {
+MemoryPool& systemRootPool(MemoryManager& manager) {
+  return *manager.spillPool()->parent();
+}
+} // namespace
+
 class BenchmarkHelper {
  public:
   explicit BenchmarkHelper(MemoryManager& manager)
@@ -47,7 +53,7 @@ class BenchmarkHelper {
 
   std::vector<MemoryPool*> findLeaves() {
     std::vector<MemoryPool*> leaves;
-    findLeavesOf(manager_.testingDefaultRoot(), leaves);
+    findLeavesOf(systemRootPool(manager_), leaves);
     return leaves;
   }
 
@@ -170,7 +176,7 @@ void addNLeaves(MemoryPool& pool, size_t n) {
 BENCHMARK(FlatTree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  addNLeaves(manager.deprecatedSysRootPool(), 10 * 20);
+  addNLeaves(systemRootPool(manager), 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
   helper.runForEachPool([iters](MemoryPool& pool) {

--- a/bolt/common/memory/tests/MemoryPoolTest.cpp
+++ b/bolt/common/memory/tests/MemoryPoolTest.cpp
@@ -845,7 +845,7 @@ TEST_P(MemoryPoolTest, childUsageTest) {
 
 TEST_P(MemoryPoolTest, getPreferredSize) {
   MemoryManager& manager = *getMemoryManager();
-  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.deprecatedSysRootPool());
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(*manager.spillPool()->parent());
 
   // size < 8
   EXPECT_EQ(8, pool.preferredSize(1));
@@ -862,7 +862,7 @@ TEST_P(MemoryPoolTest, getPreferredSize) {
 
 TEST_P(MemoryPoolTest, getPreferredSizeOverflow) {
   MemoryManager& manager = *getMemoryManager();
-  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.deprecatedSysRootPool());
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(*manager.spillPool()->parent());
 
   EXPECT_EQ(1ULL << 32, pool.preferredSize((1ULL << 32) - 1));
   EXPECT_EQ(1ULL << 63, pool.preferredSize((1ULL << 62) - 1 + (1ULL << 62)));
@@ -870,7 +870,7 @@ TEST_P(MemoryPoolTest, getPreferredSizeOverflow) {
 
 TEST_P(MemoryPoolTest, allocatorOverflow) {
   MemoryManager& manager = *getMemoryManager();
-  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.deprecatedSysRootPool());
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(*manager.spillPool()->parent());
   StlAllocator<int64_t> alloc(pool);
   EXPECT_THROW(alloc.allocate(1ULL << 62), BoltException);
   EXPECT_THROW(alloc.deallocate(nullptr, 1ULL << 62), BoltException);


### PR DESCRIPTION
### What problem does this PR solve?

Gluten has removed its remaining uses of Bolt's deprecated memory interfaces. Bolt still carries the unused `bolt_memory_num_shared_leaf_pools` flag and exposes the internal system root pool through `MemoryManager::deprecatedSysRootPool()`.

The Makefile also repeats Release build type overrides for LLVM and Google Cloud C++, although all third-party dependencies already inherit `DEPENDENCY_BUILD_TYPE`.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Refactoring (no functional changes, no api changes)
- [x] 🔧 Build/CI related changes
- [ ] 📝 Documentation only

### Description

- Remove the unused `bolt_memory_num_shared_leaf_pools` declaration and definition.
- Remove `MemoryManager::deprecatedSysRootPool()`.
- Update Bolt memory tests and the memory pool benchmark to inspect the existing pool hierarchy without the deprecated accessor.
- Remove the redundant LLVM and Google Cloud C++ build type overrides from the Makefile. The Conan upload workflow keeps its LLVM Release override for Debug dependency uploads.

### Performance Impact

- [x] **No Impact**: This change does not affect performance
- [ ] **Positive Impact**: This change improves performance
  - Benchmark results:
  - Before:
  - After:
- [ ] **Negative Impact**: This change may reduce performance
  - Explanation:

### Release Note

Release Note:

```text
Release Note:
- Removed the deprecated MemoryManager::deprecatedSysRootPool() API and bolt_memory_num_shared_leaf_pools flag.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] Optional: I have tested with sanitizers.
- [ ] No need to test or manual test. (Explain below)

Release builds and focused tests passed. Debug validation is blocked because CMake cannot find `gflags_test_runtimeConfig.cmake`.

### Breaking Changes

- [ ] No
- [x] Yes (Description: Removed `MemoryManager::deprecatedSysRootPool()` and `bolt_memory_num_shared_leaf_pools`.)

Compatibility considerations:

- Downstream code that calls the accessor will no longer compile.
- Configurations that still set the removed flag must drop it.

Migration steps:

- Use `visitSystemRootChildren()` or `inspectManagedPoolState()` when only managed-pool state is needed.
- Remove `bolt_memory_num_shared_leaf_pools` from downstream configuration.

Rollback plan:

- Revert this commit to restore the compatibility interfaces temporarily.

Data backfill requirements: None.
