### PR TITLE
Make json_to_map control-character handling configurable

### DIFF
--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -750,6 +750,10 @@ class QueryConfig {
 
   static constexpr const char* kEnableSonicJsonToMap = "sonic.json_to_map";
 
+  /// Whether json_to_map escapes raw control chars and retries parse.
+  static constexpr const char* kJsonToMapEscapeControlChars =
+      "json_to_map_escape_control_chars";
+
   static constexpr const char* kEnableSonicIsJsonScalar =
       "sonic.is_json_scalar";
 
@@ -1688,6 +1692,10 @@ class QueryConfig {
 
   bool enableSonicJsonToMap() const {
     return get<bool>(kEnableSonicJsonToMap, true);
+  }
+
+  bool jsonToMapEscapeControlChars() const {
+    return get<bool>(kJsonToMapEscapeControlChars, true);
   }
 
   bool enableSonicIsJsonScalar() const {

--- a/bolt/functions/sparksql/JsonToMap.cpp
+++ b/bolt/functions/sparksql/JsonToMap.cpp
@@ -68,15 +68,17 @@ class JsonToMapFunction : public exec::VectorFunction {
       const TypePtr& outputType,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
-    folly::call_once(initUseSonic_, [&] {
-      useSonic_ =
-          context.execCtx()->queryCtx()->queryConfig().enableSonicJsonParse();
-    });
+    const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
+    folly::call_once(
+        initUseSonic_, [&] { useSonic_ = queryConfig.enableSonicJsonParse(); });
+
+    const auto escapeControlChars = queryConfig.jsonToMapEscapeControlChars();
 
     if (useSonic_) {
-      applySonic(rows, args, outputType, context, result);
+      applySonic(rows, args, outputType, escapeControlChars, context, result);
     } else {
-      applySimdJson(rows, args, outputType, context, result);
+      applySimdJson(
+          rows, args, outputType, escapeControlChars, context, result);
     }
   }
 
@@ -84,6 +86,7 @@ class JsonToMapFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
+      bool escapeControlChars,
       exec::EvalCtx& context,
       VectorPtr& result) const {
     BaseVector::ensureWritable(
@@ -141,7 +144,7 @@ class JsonToMapFunction : public exec::VectorFunction {
 
         padded_data = current;
         bool ok = parseInto(padded_data);
-        if (!ok) {
+        if (!ok && escapeControlChars) {
           // On failure, escape raw control chars and retry (only the rare
           // failure path; valid JSON is unaffected).
           padded_data = escapeUnescapedControlChars(current);
@@ -166,6 +169,7 @@ class JsonToMapFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
+      bool escapeControlChars,
       exec::EvalCtx& context,
       VectorPtr& result) const {
     BaseVector::ensureWritable(
@@ -191,7 +195,7 @@ class JsonToMapFunction : public exec::VectorFunction {
             kParseIntegerAsRaw | kParseOverflowNumAsNumStr;
         doc.Parse<kParseFlags>(current);
         std::string escaped;
-        if (doc.HasParseError()) {
+        if (doc.HasParseError() && escapeControlChars) {
           // On failure, escape raw control chars and retry (matching jsoniter);
           // `escaped` must outlive the member iteration below.
           escaped = escapeUnescapedControlChars(current);

--- a/bolt/functions/sparksql/tests/JsonToMapTest.cpp
+++ b/bolt/functions/sparksql/tests/JsonToMapTest.cpp
@@ -27,6 +27,13 @@ class JsonToMapTest : public SparkFunctionBaseTest {
         expr, makeRowVector({makeFlatVector<StringView>({inputs[0]})}));
   }
 
+  void setJsonToMapEscapeControlChars(bool escapeControlChars) {
+    auto config = queryCtx_->queryConfig().rawConfigsCopy();
+    config[core::QueryConfig::kJsonToMapEscapeControlChars] =
+        std::to_string(escapeControlChars);
+    queryCtx_->testingOverrideConfigUnsafe(std::move(config));
+  }
+
   void testJsonToMap(
       const std::vector<StringView>& inputs,
       const std::vector<std::pair<StringView, std::optional<StringView>>>&
@@ -147,6 +154,7 @@ TEST_F(JsonToMapTest, unescapedControlChars) {
   // escaped, but the reference Hive UDF (backed by com.jsoniter) accepts raw
   // control chars and keeps them verbatim in the values. json_to_map must
   // match that lenient behavior instead of returning SQL NULL.
+  setJsonToMapEscapeControlChars(true);
   {
     // Raw newlines embedded in several values; they must be preserved.
     StringView json =
@@ -176,6 +184,17 @@ TEST_F(JsonToMapTest, unescapedControlChars) {
     StringView json = StringView("{\"key\nname\":\"v\"}");
     testJsonToMap({json}, {{StringView("key\nname"), "v"}});
   }
+}
+
+TEST_F(JsonToMapTest, unescapedControlCharsRetryConfig) {
+  const StringView json = StringView("{\"k\":\"a\nb\"}");
+  setJsonToMapEscapeControlChars(false);
+  auto result = evaluateJsonToMap({json});
+  auto expected = makeNullableMapVector<StringView, StringView>({std::nullopt});
+  assertEqualVectors(expected, result);
+
+  setJsonToMapEscapeControlChars(true);
+  testJsonToMap({json}, {{"k", StringView("a\nb")}});
 }
 
 TEST_F(JsonToMapTest, numericValuesPreserveOriginalText) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
feature: https://github.com/bytedance/bolt/issues/921

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

in PR https://github.com/bytedance/bolt/pull/674, we align the behavior of unescaped control chars like '\n' in json with hive udf implement, however, this need an extra parse to handle the control chars. so we add a new json_to_map_escape_control_chars config to control whether we handle control chars.

when json_to_map_escape_control_chars is true, json_to_map would handle control chars and return valid map.

when json_to_map_escape_control_chars is false, json_to_map would return null when json contains unescaped control chars

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
