### PR TITLE
perf(nested-loop-join): collapse probe dictionary layers in output

### DIFF
--- a/bolt/exec/NestedLoopJoinProbe.cpp
+++ b/bolt/exec/NestedLoopJoinProbe.cpp
@@ -274,6 +274,7 @@ RowVectorPtr NestedLoopJoinProbe::generateOutput() {
   // If addToOutput() returns false, output_ is filled. Need to produce it.
   if (!addToOutput()) {
     BOLT_CHECK_GT(output_->size(), 0);
+    wrapProbeOutput();
     return std::move(output_);
   }
 
@@ -293,6 +294,7 @@ RowVectorPtr NestedLoopJoinProbe::generateOutput() {
   }
 
   output_->resize(numOutputRows_);
+  wrapProbeOutput();
   return std::move(output_);
 }
 
@@ -527,13 +529,9 @@ void NestedLoopJoinProbe::prepareOutput() {
   probeOutputIndices_ = allocateIndices(outputBatchSize_, pool());
   rawProbeOutputIndices_ = probeOutputIndices_->asMutable<vector_size_t>();
 
-  for (const auto& projection : identityProjections_) {
-    localColumns[projection.outputChannel] = BaseVector::wrapInDictionary(
-        {},
-        probeOutputIndices_,
-        outputBatchSize_,
-        input_->childAt(projection.inputChannel));
-  }
+  // Defer wrapping until all probe output indices are populated. This allows
+  // wrapIndirectChildren() to collapse dictionary-over-dictionary inputs.
+  outputProbeInput_ = input_;
 
   if (isLeftSemiProjectJoin(joinType_)) {
     // For LeftSemiProjectJoin, only add match column.
@@ -750,6 +748,28 @@ void NestedLoopJoinProbe::copyBuildValues(const RowVectorPtr& buildVector) {
     outputChild->copyRanges(buildChild.get(), buildCopyRanges_);
   }
   buildCopyRanges_.clear();
+}
+
+void NestedLoopJoinProbe::wrapProbeOutput() {
+  // Regular cross-product batches build probe columns directly without going
+  // through prepareOutput().
+  if (outputProbeInput_ == nullptr) {
+    return;
+  }
+  BOLT_CHECK_NOT_NULL(output_);
+
+  // wrapIndirectChildren() eagerly reads probeOutputIndices_ to collapse any
+  // dictionary layer already present on the probe input, producing a single
+  // dictionary layer over the probe base vectors. This is safe now because the
+  // batch is finalized: rawProbeOutputIndices_ holds the final row numbers for
+  // all output_->size() rows.
+  wrapIndirectChildren(
+      identityProjections_,
+      outputProbeInput_->children(),
+      output_->size(),
+      probeOutputIndices_,
+      output_->children());
+  outputProbeInput_.reset();
 }
 
 void NestedLoopJoinProbe::addProbeMismatchRow() {

--- a/bolt/exec/NestedLoopJoinProbe.h
+++ b/bolt/exec/NestedLoopJoinProbe.h
@@ -226,6 +226,9 @@ class NestedLoopJoinProbe : public Operator {
   // vector).
   void copyBuildValues(const RowVectorPtr& buildVector);
 
+  // Wraps probe projections after probeOutputIndices_ is fully populated.
+  void wrapProbeOutput();
+
   // Whether to use dictionary encoding for build columns in the output.
   // Enabled when there is a single build vector, avoiding deep copy of build
   // data. Not applicable to LeftSemiProject joins (which skip build
@@ -329,6 +332,9 @@ class NestedLoopJoinProbe : public Operator {
   // Dictionary indices for probe columns for output vector.
   BufferPtr probeOutputIndices_;
   vector_size_t* rawProbeOutputIndices_;
+
+  // Probe input backing the current output batch.
+  RowVectorPtr outputProbeInput_;
 
   // Dictionary indices for build columns.
   BufferPtr buildIndices_;

--- a/bolt/exec/OperatorUtils.cpp
+++ b/bolt/exec/OperatorUtils.cpp
@@ -295,13 +295,22 @@ std::vector<VectorPtr> wrapChildren(
     }
     if (nulls == nullptr &&
         children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
-        children[i]->rawNulls() == nullptr &&
         !children[i]->valueVector()->containingLazyAndWrapped()) {
       auto baseValues = children[i]->valueVector();
+      BufferPtr newNulls;
+      if (const auto* childNulls = children[i]->rawNulls()) {
+        newNulls = allocateNulls(size, mapping->pool());
+        auto* rawNewNulls = newNulls->asMutable<uint64_t>();
+        for (auto j = 0; j < size; ++j) {
+          if (bits::isBitNull(childNulls, curIndex[j])) {
+            bits::setNull(rawNewNulls, j);
+          }
+        }
+      }
       auto newMapping = old2newMappings.find(children[i]->wrapInfo());
       if (newMapping != old2newMappings.end()) {
         wrappedChildren[i] =
-            wrapChild(size, newMapping->second, baseValues, nullptr);
+            wrapChild(size, newMapping->second, baseValues, newNulls);
       } else {
         // generate new mapping and wrap child.value
         auto newBuffer =
@@ -311,7 +320,7 @@ std::vector<VectorPtr> wrapChildren(
         for (auto j = 0; j < size; ++j) {
           newIndex[j] = childIndex[curIndex[j]];
         }
-        wrappedChildren[i] = wrapChild(size, newBuffer, baseValues, nullptr);
+        wrappedChildren[i] = wrapChild(size, newBuffer, baseValues, newNulls);
         old2newMappings[children[i]->wrapInfo()] = newBuffer;
       }
     } else {

--- a/bolt/exec/tests/NestedLoopJoinTest.cpp
+++ b/bolt/exec/tests/NestedLoopJoinTest.cpp
@@ -805,6 +805,39 @@ TEST_F(NestedLoopJoinTest, dynamicBatchSizeWithWideBuildRows) {
   ASSERT_EQ(result->size(), kProbeRows);
 }
 
+TEST_F(NestedLoopJoinTest, collapseProbeDictionaryInOutput) {
+  auto probeBase = makeFlatVector<int32_t>({10, 20, 30, 40});
+  auto probeDictionary = BaseVector::wrapInDictionary(
+      nullptr, makeIndices({3, 1, 2}), 3, probeBase);
+  auto probeVector = makeRowVector({"t0"}, {probeDictionary});
+  auto buildVector =
+      makeRowVector({"u0"}, {makeFlatVector<int32_t>(std::vector<int32_t>{0})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  CursorParameters params;
+  params.planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVector})
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator).values({buildVector}).planNode(),
+              "t0 > u0",
+              {"t0", "u0"},
+              core::JoinType::kInner)
+          .planNode();
+  params.copyResult = false;
+
+  auto cursor = TaskCursor::create(params);
+  ASSERT_TRUE(cursor->moveNext());
+  const auto& result = cursor->current();
+  ASSERT_EQ(result->size(), 3);
+
+  const auto& probeOutput = result->childAt(0);
+  ASSERT_EQ(probeOutput->encoding(), VectorEncoding::Simple::DICTIONARY);
+  EXPECT_EQ(probeOutput->valueVector().get(), probeBase.get());
+  assertEqualVectors(makeFlatVector<int32_t>({40, 20, 30}), probeOutput);
+  ASSERT_FALSE(cursor->moveNext());
+}
+
 // Verifies filter path correctness when build side has a single row.
 // The optimization batches all probe rows into one filter evaluation.
 TEST_F(NestedLoopJoinTest, filterWithSingleBuildRow) {

--- a/bolt/exec/tests/OperatorUtilsTest.cpp
+++ b/bolt/exec/tests/OperatorUtilsTest.cpp
@@ -504,6 +504,30 @@ TEST_F(OperatorUtilsTest, projectDuplicateChildren) {
   }
 }
 
+TEST_F(OperatorUtilsTest, wrapDictionaryWithNulls) {
+  constexpr vector_size_t kInnerSize = 5;
+  auto flatVector = makeFlatVector<int64_t>(
+      kInnerSize, [](vector_size_t row) { return row; });
+  auto innerNulls = allocateNulls(kInnerSize, pool());
+  bits::setNull(innerNulls->asMutable<uint64_t>(), 1);
+  bits::setNull(innerNulls->asMutable<uint64_t>(), 3);
+  auto innerDictionary = BaseVector::wrapInDictionary(
+      innerNulls,
+      makeIndices(
+          kInnerSize, [](vector_size_t row) { return kInnerSize - row - 1; }),
+      kInnerSize,
+      flatVector);
+
+  auto wrapped =
+      wrapChildren(4, makeIndices({4, 3, 1, 0}), {innerDictionary}).front();
+
+  ASSERT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(wrapped->valueVector(), flatVector);
+  assertEqualVectors(
+      makeNullableFlatVector<int64_t>({0, std::nullopt, std::nullopt, 4}),
+      wrapped);
+}
+
 TEST_F(OperatorUtilsTest, projectDictionaryOverLazyKeepsExistingLazyWrapper) {
   auto flatVector =
       makeFlatVector<int64_t>(5, [](vector_size_t row) { return 10 + row; });


### PR DESCRIPTION
### What problem does this PR solve?

`NestedLoopJoinProbe::prepareOutput()` wrapped each probe identity projection
eagerly with `BaseVector::wrapInDictionary()` over `input_->childAt(...)`. When
a probe input column was already dictionary-encoded, the join output carried a
dictionary-over-dictionary chain, forcing every downstream operator to resolve
two indirection layers per row.

Issue Number: close #934

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Defer probe-side wrapping until the output batch is finalized and all probe
output indices are populated, then wrap once via `wrapIndirectChildren()`
(the same helper already used elsewhere in the engine). This collapses any
pre-existing dictionary layer on the probe input into a single dictionary over
the flat base vectors, so the output has at most one indirection layer.

Key points:

- `prepareOutput()` no longer builds the probe dictionaries inline. It records
  the current probe input in `outputProbeInput_` and lets `wrapProbeOutput()`
  finalize the projections in `generateOutput()`, after `rawProbeOutputIndices_`
  holds the final row numbers for all output rows.
- The deferral is keyed on `outputProbeInput_ != nullptr` rather than
  `isCrossJoin()`. Unconditional joins with an empty build side still emit probe
  mismatch rows through `prepareOutput()` and must be wrapped; regular
  cross-product batches build probe columns directly, leave `outputProbeInput_`
  null, and are correctly skipped. (This distinction was found and fixed after a
  full test run surfaced a crash in `emptyBuildOrProbeWithoutFilter`.)
- `outputProbeInput_` is reset right after wrapping so the operator does not
  retain the probe batch longer than necessary.

### Performance Impact
- [x] **Positive Impact**: Removes a dictionary indirection layer from the probe
  columns of nested-loop-join output when the probe input is dictionary-encoded.
  No extra allocations on the flat-probe path; the wrap now happens once per
  output batch instead of once per projection. No benchmark numbers are included
  in this PR.

### Release Note

```text
Release Note:
- Optimized NestedLoopJoin output to collapse dictionary-over-dictionary probe
  columns into a single dictionary layer.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation performed:

- Built `bolt_exec_merge_join_test` in Release and ran it: 64 tests passed
  (1 disabled). The new `collapseProbeDictionaryInOutput` test asserts the probe
  output is a single `DICTIONARY` layer whose `valueVector()` is the original
  flat base.
- `clang-format` (v14, repo-pinned) applied to the changed lines.
- `pre-commit run --files ...` was attempted; the Go-based
  `license-header-check` hook failed to bootstrap locally (`go install ./...` ->
  "error obtaining VCS status: exit status 128"), an environment issue unrelated
  to these files. License headers are present on all changed files.

### Breaking Changes
- [x] No
- [ ] Yes

