### PR TITLE
fix: report TableScan close wait in the unit it is measured in

### DIFF
--- a/bolt/exec/TableScan.cpp
+++ b/bolt/exec/TableScan.cpp
@@ -579,7 +579,7 @@ void TableScan::close() {
     asyncThreadCtx_->wait();
   }
 
-  LOG_IF(INFO, waitUs > 60'000'000)
+  LOG_IF(INFO, waitUs > 60'000)
       << "TableScan close wait async thread ctx cost: " << waitUs / 1000
       << "ms, task " << operatorCtx_->task()->taskId()
       << " state = " << operatorCtx_->task()->state();

--- a/bolt/exec/TableScan.cpp
+++ b/bolt/exec/TableScan.cpp
@@ -573,15 +573,15 @@ void TableScan::close() {
   }
 
   // wait all async threads to be finished
-  uint64_t waitMs;
+  uint64_t waitUs{0};
   {
-    MicrosecondTimer timer(&waitMs);
+    MicrosecondTimer timer(&waitUs);
     asyncThreadCtx_->wait();
   }
 
-  LOG_IF(INFO, waitMs > 60000)
-      << "TableScan close wait async thread ctx cost: " << waitMs << "ms, task "
-      << operatorCtx_->task()->taskId()
+  LOG_IF(INFO, waitUs > 60'000'000)
+      << "TableScan close wait async thread ctx cost: " << waitUs / 1000
+      << "ms, task " << operatorCtx_->task()->taskId()
       << " state = " << operatorCtx_->task()->state();
 
   SourceOperator::close();


### PR DESCRIPTION
### What problem does this PR solve?

`TableScan::close()` logs its wait time for async preload threads wrongly, in two ways:

```cpp
uint64_t waitMs;                     // never initialized, and the timer does +=
{
  MicrosecondTimer timer(&waitMs);   // writes MICROseconds
  asyncThreadCtx_->wait();
}
LOG_IF(INFO, waitMs > 60000)
    << "TableScan close wait async thread ctx cost: " << waitMs << "ms, ...
```

It matters because this is the only signal that a scan is stuck on unresponsive
storage. During a recent incident it reported a ~224ms wait as `223652ms`, on a
task whose next log line said it had run for 8541ms, and the "minutes" reading was
taken at face value.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Rename ms as us.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixed the "TableScan close wait async thread ctx cost" log line, which
  reported microseconds as milliseconds from an uninitialized counter.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

`bolt_exec_scan_test`: 99/99 PASSED, Release, `spark_compatible=True`.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

