### PR TITLE
fix: preserve complex types used by JIT modules

### DIFF
--- a/bolt/jit/CompiledModule.cpp
+++ b/bolt/jit/CompiledModule.cpp
@@ -45,15 +45,12 @@ void CompiledModule::setCodeSize(size_t codeSize) {
   codeSize_ = codeSize;
 }
 
-bool CompiledModule::compareExchangeUserData(
-    void* expected,
-    void* desired) noexcept {
-  return userData_.compare_exchange_strong(
-      expected, desired, std::memory_order_acq_rel, std::memory_order_acquire);
+void CompiledModule::setUserData(std::shared_ptr<void> userData) {
+  userData_ = std::move(userData);
 }
 
 void* CompiledModule::getUserData() const noexcept {
-  return userData_.load(std::memory_order_acquire);
+  return userData_.get();
 }
 
 void CompiledModule::appendCleanCallback(std::function<void()> cleanCallback) {

--- a/bolt/jit/CompiledModule.h
+++ b/bolt/jit/CompiledModule.h
@@ -18,7 +18,6 @@
 
 #ifdef ENABLE_BOLT_JIT
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -39,10 +38,9 @@ struct CompiledModule {
   void setCodeSize(size_t codeSize);
   void appendCleanCallback(std::function<void()> cleanCallback);
 
-  // type-erasured user data, CompiledModule does not own the data and won't
-  // manage its lifetime. The caller should make sure the data is valid during
-  // the module's lifetime.
-  bool compareExchangeUserData(void* expected, void* desired) noexcept;
+  /// Sets type-erased data owned by this module. This must be called before
+  /// the module is published to the JIT cache.
+  void setUserData(std::shared_ptr<void> userData);
   void* getUserData() const noexcept;
 
   ~CompiledModule();
@@ -53,7 +51,8 @@ struct CompiledModule {
   size_t codeSize_{0};
   std::vector<std::function<void()>> cleanCallbacks_;
 
-  std::atomic<void*> userData_{nullptr};
+  // It will hold the `deleter` of the typed user data.
+  std::shared_ptr<void> userData_;
 };
 
 using CompiledModuleSP = std::shared_ptr<CompiledModule>;

--- a/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
+++ b/bolt/jit/RowContainer/RowContainerCodeGenerator.cpp
@@ -123,9 +123,8 @@ CompiledModuleSP RowContainerCodeGenerator::codegen() {
     return this->GenCmpIR();
   };
 
-  auto module = jit->CompileModule(genIR, fn);
+  auto cacheTypes = std::make_shared<std::vector<bytedance::bolt::TypePtr>>();
   if (isEqualOp() || !flags.empty()) { // only for row cmp/= row
-    auto cacheTypes = std::make_unique<std::vector<bytedance::bolt::TypePtr>>();
     for (auto& t : keysTypes) {
       switch (t->kind()) {
         case bytedance::bolt::TypeKind::ARRAY:
@@ -137,22 +136,9 @@ CompiledModuleSP RowContainerCodeGenerator::codegen() {
           break;
       }
     }
-
-    if (cacheTypes->size() > 0) {
-      auto* userData = static_cast<void*>(cacheTypes.get());
-      if (module->compareExchangeUserData(nullptr, userData)) {
-        cacheTypes.release();
-        module->appendCleanCallback([mod = module.get()] {
-          auto* raw = mod->getUserData();
-          mod->compareExchangeUserData(raw, nullptr);
-          auto* cacheTypes =
-              static_cast<std::vector<bytedance::bolt::TypePtr>*>(raw);
-          delete cacheTypes;
-        });
-      }
-    }
   }
-  return module;
+  return jit->CompileModule(
+      genIR, fn, cacheTypes->empty() ? nullptr : std::move(cacheTypes));
 }
 
 /// util functions

--- a/bolt/jit/ThrustJITv2.cpp
+++ b/bolt/jit/ThrustJITv2.cpp
@@ -95,7 +95,8 @@ ThrustJITv2* ThrustJITv2::getInstance() {
 
 CompiledModuleSP ThrustJITv2::CompileModule(
     std::function<bool(llvm::Module&)> irGenerator,
-    const std::string& funcName) {
+    const std::string& funcName,
+    std::shared_ptr<void> userData) {
   {
     std::unique_lock lock(mutex_);
     if (auto cached = compiledModuleCache_.get(funcName); cached != nullptr) {
@@ -159,6 +160,7 @@ CompiledModuleSP ThrustJITv2::CompileModule(
 
   auto compiledModule = std::make_shared<CompiledModule>();
   compiledModule->setKey(funcName);
+  compiledModule->setUserData(std::move(userData));
   for (const auto& fn : funcNames) {
     auto symbol = jit_->lookup(fn);
     if (!symbol) {

--- a/bolt/jit/ThrustJITv2.h
+++ b/bolt/jit/ThrustJITv2.h
@@ -65,7 +65,8 @@ class ThrustJITv2 {
 
   CompiledModuleSP CompileModule(
       std::function<bool(llvm::Module&)> irGenerator,
-      const std::string& funcName);
+      const std::string& funcName,
+      std::shared_ptr<void> userData = nullptr);
 
   CompiledModuleSP LookupSymbolsInCache(const std::string& funcName);
 

--- a/bolt/jit/tests/RowContainerIRTest.cpp
+++ b/bolt/jit/tests/RowContainerIRTest.cpp
@@ -24,6 +24,7 @@
 #include "bolt/jit/ThrustJITv2.h"
 #include "bolt/jit/tests/JitTestBase.h"
 
+#include <algorithm>
 #include <atomic>
 #include <barrier>
 #include <cmath>
@@ -40,16 +41,49 @@ namespace {
 
 class TestRowContainerCodeGenerator : public RowContainerCodeGenerator {
  public:
-  explicit TestRowContainerCodeGenerator(std::string funcName)
-      : funcName_(std::move(funcName)) {}
+  explicit TestRowContainerCodeGenerator(
+      std::string funcName,
+      std::atomic<const Type*>* generatedType = nullptr)
+      : funcName_(std::move(funcName)), generatedType_(generatedType) {}
 
   std::string GetCmpFuncName() override {
     return funcName_;
   }
 
+  bool GenCmpIR() override {
+    if (generatedType_ != nullptr) {
+      generatedType_->store(keysTypes.front().get(), std::memory_order_release);
+    }
+    return RowContainerCodeGenerator::GenCmpIR();
+  }
+
  private:
   std::string funcName_;
+  std::atomic<const Type*>* generatedType_;
 };
+
+template <typename T>
+void appendSerializedValue(std::string& serialized, const T& value) {
+  serialized.append(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+std::string serializeNestedRow(std::string_view mapValue) {
+  std::string serialized;
+  appendSerializedValue(serialized, uint64_t{0});
+
+  appendSerializedValue(serialized, int32_t{1});
+  appendSerializedValue(serialized, uint64_t{0});
+  appendSerializedValue(serialized, int32_t{11});
+
+  appendSerializedValue(serialized, int32_t{1});
+  appendSerializedValue(serialized, uint64_t{0});
+  appendSerializedValue(serialized, int32_t{7});
+  appendSerializedValue(serialized, int32_t{1});
+  appendSerializedValue(serialized, uint64_t{0});
+  appendSerializedValue(serialized, static_cast<int32_t>(mapValue.size()));
+  serialized.append(mapValue);
+  return serialized;
+}
 
 } // namespace
 
@@ -522,32 +556,30 @@ TEST_F(RowContainerJitTest, stringview) {
   rows.clear();
 }
 
-TEST_F(RowContainerJitTest, complex_types_cache_in_user_data) {
+TEST_F(RowContainerJitTest, complex_type_lifetime_in_cached_module) {
   jit->ClearCacheForTest();
-
-  auto bigintType = BIGINT();
-  auto arrayType = ARRAY(INTEGER());
-  auto mapType = MAP(INTEGER(), VARCHAR());
-  auto rowType = ROW({{"nested", BIGINT()}});
-
-  auto codegenModule = [&]() {
-    TestRowContainerCodeGenerator gen("row_container_user_data_complex_types");
-    gen.setOpType(CmpType::EQUAL)
-        .setHasNullKeys(false)
-        .setKeyTypes({bigintType, arrayType, mapType, rowType})
-        .setKeyOffsets({0, 8, 16, 24});
-    return gen.codegen();
-  };
 
   constexpr size_t kConcurrentCodegenCount = 32;
   std::barrier syncPoint(kConcurrentCodegenCount);
+  std::atomic<const Type*> generatedType{nullptr};
   std::vector<CompiledModuleSP> modules(kConcurrentCodegenCount);
+  std::vector<std::weak_ptr<const Type>> inputTypes(kConcurrentCodegenCount);
   std::vector<std::thread> threads;
   threads.reserve(kConcurrentCodegenCount);
   for (size_t i = 0; i < kConcurrentCodegenCount; ++i) {
     threads.emplace_back([&, i]() {
+      auto type = ROW(
+          {{"array", ARRAY(INTEGER())}, {"map", MAP(INTEGER(), VARCHAR())}});
+      inputTypes[i] = type;
+      TestRowContainerCodeGenerator gen(
+          "row_container_complex_type_lifetime", &generatedType);
+      gen.setOpType(CmpType::CMP_SPILL)
+          .setHasNullKeys(false)
+          .setKeyTypes({std::move(type)})
+          .setCompareFlags({{.nullsFirst = true, .ascending = true}})
+          .setKeyOffsets({0});
       syncPoint.arrive_and_wait();
-      modules[i] = codegenModule();
+      modules[i] = gen.codegen();
     });
   }
   for (auto& thread : threads) {
@@ -559,6 +591,37 @@ TEST_F(RowContainerJitTest, complex_types_cache_in_user_data) {
   for (const auto& concurrentModule : modules) {
     ASSERT_EQ(concurrentModule.get(), module.get());
   }
+
+  auto* cachedTypes = static_cast<std::vector<TypePtr>*>(module->getUserData());
+  ASSERT_NE(cachedTypes, nullptr);
+  ASSERT_EQ(cachedTypes->size(), 1);
+  EXPECT_EQ(
+      cachedTypes->front().get(),
+      generatedType.load(std::memory_order_acquire));
+  EXPECT_EQ(
+      std::count_if(
+          inputTypes.begin(),
+          inputTypes.end(),
+          [](const auto& type) { return !type.expired(); }),
+      1);
+
+  auto leftSerialized = serializeNestedRow("a");
+  auto rightSerialized = serializeNestedRow("b");
+  std::string_view left{leftSerialized};
+  std::string_view right{rightSerialized};
+  using Compare = int8_t (*)(char*, char*);
+  auto compare = reinterpret_cast<Compare>(
+      module->getFuncPtr("row_container_complex_type_lifetime"));
+  ASSERT_NE(compare, nullptr);
+  EXPECT_LT(
+      compare(reinterpret_cast<char*>(&left), reinterpret_cast<char*>(&right)),
+      0);
+  EXPECT_GT(
+      compare(reinterpret_cast<char*>(&right), reinterpret_cast<char*>(&left)),
+      0);
+  EXPECT_EQ(
+      compare(reinterpret_cast<char*>(&left), reinterpret_cast<char*>(&left)),
+      0);
 }
 
 } // namespace bytedance::bolt::jit::test


### PR DESCRIPTION
Attach the complex type tree to the compiled module before publishing it to the shared JIT cache. This keeps the raw type pointers embedded in generated comparison code valid across concurrent code generation and caller teardown.

Add a concurrent regression test that releases caller-owned types and executes nested row, array, and map comparisons through the cached JIT function.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
