### PR TITLE
Fix OrderBy reclaim race during input allocation

### DIFF
--- a/bolt/exec/OrderBy.cpp
+++ b/bolt/exec/OrderBy.cpp
@@ -104,8 +104,15 @@ OrderBy::OrderBy(
 }
 
 void OrderBy::addInput(RowVectorPtr input) {
-  ReclaimableSectionGuard guard(this);
-  input->loadedVector();
+  {
+    // Loading lazy input may need to arbitrate for memory. It is safe to
+    // reclaim the existing sort buffer here because addInput hasn't started
+    // mutating it yet. Keep the actual SortBuffer::addInput call in the
+    // driver's non-reclaimable section: concurrent spill clears RowContainer
+    // state, including allocator-backed row pointers.
+    ReclaimableSectionGuard guard(this);
+    input->loadedVector();
+  }
   sortBuffer_->addInput(input);
 }
 

--- a/bolt/exec/tests/OrderByTest.cpp
+++ b/bolt/exec/tests/OrderByTest.cpp
@@ -1583,11 +1583,14 @@ DEBUG_ONLY_TEST_P(OrderByTest, reclaimDuringAllocation) {
               }
               // Allocating rows mutates SortBuffer's RowContainer and must not
               // race with reclaim(), which spills and clears the same state.
-              EXPECT_FALSE(op->canReclaim());
+              EXPECT_TRUE(op->testingNonReclaimable());
+              EXPECT_EQ(op->canReclaim(), enableSpilling);
               uint64_t reclaimableBytes{0};
               const bool reclaimable = op->reclaimableBytes(reclaimableBytes);
-              EXPECT_FALSE(reclaimable);
-              EXPECT_EQ(reclaimableBytes, 0);
+              EXPECT_EQ(reclaimable, enableSpilling);
+              if (!enableSpilling) {
+                EXPECT_EQ(reclaimableBytes, 0);
+              }
               auto* driver = op->testingOperatorCtx()->driver();
               SuspendedSection suspendedSection(driver);
               testWait.notify();
@@ -1635,11 +1638,14 @@ DEBUG_ONLY_TEST_P(OrderByTest, reclaimDuringAllocation) {
       ASSERT_EQ(reclaimableBytes, 0);
     }
 
-    BOLT_ASSERT_THROW(
-        op->reclaim(
-            folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
-            reclaimerStats_),
-        "");
+    reclaimerStats_.reset();
+    reclaimAndRestoreCapacity(
+        op,
+        folly::Random::oneIn(2) ? 0 : folly::Random::rand32(rng_),
+        reclaimerStats_);
+    ASSERT_EQ(reclaimerStats_.reclaimedBytes, 0);
+    ASSERT_EQ(
+        reclaimerStats_.numNonReclaimableAttempts, enableSpilling ? 1 : 0);
 
     driverWait.notify();
     Task::resume(task);
@@ -1651,7 +1657,6 @@ DEBUG_ONLY_TEST_P(OrderByTest, reclaimDuringAllocation) {
     ASSERT_EQ(stats[0].operatorStats[1].spilledPartitions, 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
-  ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{0});
 }
 
 DEBUG_ONLY_TEST_P(OrderByTest, reclaimDuringOutputProcessing) {

--- a/bolt/exec/tests/OrderByTest.cpp
+++ b/bolt/exec/tests/OrderByTest.cpp
@@ -1581,15 +1581,13 @@ DEBUG_ONLY_TEST_P(OrderByTest, reclaimDuringAllocation) {
               if (!injectOnce.exchange(false)) {
                 return;
               }
-              ASSERT_EQ(op->canReclaim(), enableSpilling);
+              // Allocating rows mutates SortBuffer's RowContainer and must not
+              // race with reclaim(), which spills and clears the same state.
+              EXPECT_FALSE(op->canReclaim());
               uint64_t reclaimableBytes{0};
               const bool reclaimable = op->reclaimableBytes(reclaimableBytes);
-              ASSERT_EQ(reclaimable, enableSpilling);
-              if (enableSpilling) {
-                ASSERT_GE(reclaimableBytes, 0);
-              } else {
-                ASSERT_EQ(reclaimableBytes, 0);
-              }
+              EXPECT_FALSE(reclaimable);
+              EXPECT_EQ(reclaimableBytes, 0);
               auto* driver = op->testingOperatorCtx()->driver();
               SuspendedSection suspendedSection(driver);
               testWait.notify();


### PR DESCRIPTION
### What problem does this PR solve?

Closes #938

`OrderBy::addInput()` marked both lazy input loading and `SortBuffer::addInput()` as reclaimable. During a memory arbitration triggered by row allocation, another thread could therefore reclaim the operator while `SortBuffer` was mutating its `RowContainer`. The concurrent spill clears allocator-backed row state and can lead to a native crash such as `HashStringAllocator::freeToPool` rejecting a block that no longer belongs to the allocator.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Limit `ReclaimableSectionGuard` to lazy vector materialization. `SortBuffer::addInput()` now runs in the driver's non-reclaimable section so row allocation cannot race with spill and clear.

Update `reclaimDuringAllocation` to verify that OrderBy is non-reclaimable while its `RowContainer` allocates rows.

### Performance Impact

- [x] **No Impact**: The change only narrows the interval in which OrderBy can be reclaimed to exclude an unsafe mutation window.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Fixed a native crash caused by concurrent OrderBy input allocation and memory reclaim.
```

### Validation

- Rebuilt `bolt_exec_test` successfully in Release mode.
- `git diff --check` passes.
- Reproduced the original crash with a main-based Gluten package.
- Ran the same Spark SQL workload with a package containing this fix: the application finished successfully, including all 80 tasks in the affected spill-heavy stage, with no JVM core dump or allocator corruption marker.
- The focused test is a `DEBUG_ONLY_TEST_P`; the available local build is Release, where test-value injection is compiled out, so its injected execution path was compile-checked but not executed locally.

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

The Release test target builds successfully; a Debug build was not available locally. The changed lines follow the repository style and `git diff --check` passes. The available clang-format is version 20, while the repository requires 14.0.6, so I did not reformat unrelated code with a mismatched version. The pre-commit run was blocked while installing the gitleaks hook by the local Go environment (`error obtaining VCS status: exit status 128`).

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

