### PR TITLE
fix(dwrf): support reading BIGINT columns as VARCHAR

### DIFF
--- a/bolt/dwio/common/ColumnLoader.cpp
+++ b/bolt/dwio/common/ColumnLoader.cpp
@@ -52,6 +52,28 @@ scatter(const RowSet& rows, vector_size_t resultSize, VectorPtr* result) {
   result->get()->disableMemo();
   *result = BaseVector::wrapInDictionary(nullptr, indices, resultSize, *result);
 }
+
+bool requiresReaderCastMaterialization(
+    const SelectiveColumnReader& reader,
+    const ValueHook* hook) {
+  return hook && reader.fileType().type()->kind() == TypeKind::BIGINT &&
+      !reader.fileType().type()->isDecimal() &&
+      reader.requestedType()->equivalent(*VARCHAR());
+}
+
+void applyStringHook(const BaseVector& values, ValueHook* hook) {
+  auto strings = values.as<SimpleVector<StringView>>();
+  for (vector_size_t i = 0; i < values.size(); ++i) {
+    if (values.isNullAt(i)) {
+      if (hook->acceptsNulls()) {
+        hook->addNull(i);
+      }
+    } else {
+      const auto value = strings->valueAt(i);
+      hook->addValue(i, &value);
+    }
+  }
+}
 } // namespace
 
 void ColumnLoader::loadInternal(
@@ -90,7 +112,9 @@ void ColumnLoader::loadInternal(
   }
 
   structReader_->advanceFieldReader(fieldReader_, offset);
-  fieldReader_->scanSpec()->setValueHook(hook);
+  const bool materializeForHook =
+      requiresReaderCastMaterialization(*fieldReader_, hook);
+  fieldReader_->scanSpec()->setValueHook(materializeForHook ? nullptr : hook);
   fieldReader_->read(offset, effectiveRows, incomingNulls);
   if (fieldReader_->fileType().type()->kind() == TypeKind::ROW) {
     // 'fieldReader_' may itself produce LazyVectors. For this it must have its
@@ -98,8 +122,14 @@ void ColumnLoader::loadInternal(
     static_cast<SelectiveStructColumnReaderBase*>(fieldReader_)
         ->setLoadableRows(effectiveRows);
   }
-  if (!hook) {
-    fieldReader_->getValues(effectiveRows, result);
+  if (!hook || materializeForHook) {
+    VectorPtr materialized;
+    auto* output = materializeForHook ? &materialized : result;
+    fieldReader_->getValues(effectiveRows, output);
+    if (materializeForHook) {
+      applyStringHook(*materialized, hook);
+      return;
+    }
     if (((rows.back() + 1) < resultSize) || rows.size() != outputRows.size()) {
       // We read sparsely. The values that were read should appear
       // at the indices in the result vector that were given by

--- a/bolt/dwio/common/SelectiveColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveColumnReader.cpp
@@ -209,6 +209,24 @@ void SelectiveColumnReader::getIntValues(
     RowSet rows,
     const TypePtr& requestedType,
     VectorPtr* result) {
+  if (requestedType->isVarchar()) {
+    VectorPtr integerResult;
+    getIntValues(rows, BIGINT(), &integerResult);
+    auto stringResult = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), integerResult->size(), &memoryPool_);
+    auto integers = integerResult->as<SimpleVector<int64_t>>();
+    for (vector_size_t i = 0; i < integerResult->size(); ++i) {
+      if (integerResult->isNullAt(i)) {
+        stringResult->setNull(i, true);
+      } else {
+        const auto value = folly::to<std::string>(integers->valueAt(i));
+        stringResult->set(i, StringView(value));
+      }
+    }
+    *result = std::move(stringResult);
+    return;
+  }
+
   switch (requestedType->kind()) {
     case TypeKind::SMALLINT:
       switch (valueSize_) {

--- a/bolt/dwio/common/SelectiveColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveColumnReader.cpp
@@ -78,8 +78,9 @@ SelectiveColumnReader::SelectiveColumnReader(
 void SelectiveColumnReader::validateReaderCastFilter() const {
   const auto* filter = scanSpec_->filter();
   if (fileType_->type()->kind() == TypeKind::BIGINT &&
-      !fileType_->type()->isDecimal() && requestedType_->isVarchar() &&
-      filter && !filter->isValueIndependent()) {
+      !fileType_->type()->isDecimal() &&
+      requestedType_->equivalent(*VARCHAR()) && filter &&
+      !filter->isValueIndependent()) {
     BOLT_USER_FAIL(
         "Cannot apply VARCHAR filter to physical BIGINT column {}",
         scanSpec_->fieldName());
@@ -222,7 +223,7 @@ void SelectiveColumnReader::getIntValues(
     RowSet rows,
     const TypePtr& requestedType,
     VectorPtr* result) {
-  if (requestedType->isVarchar()) {
+  if (requestedType->equivalent(*VARCHAR())) {
     VectorPtr integerResult;
     getIntValues(rows, BIGINT(), &integerResult);
     auto stringResult = BaseVector::create<FlatVector<StringView>>(

--- a/bolt/dwio/common/SelectiveColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveColumnReader.cpp
@@ -71,7 +71,20 @@ SelectiveColumnReader::SelectiveColumnReader(
       requestedType_(requestedType),
       fileType_(fileType),
       formatData_(params.toFormatData(fileType, scanSpec)),
-      scanSpec_(&scanSpec) {}
+      scanSpec_(&scanSpec) {
+  validateReaderCastFilter();
+}
+
+void SelectiveColumnReader::validateReaderCastFilter() const {
+  const auto* filter = scanSpec_->filter();
+  if (fileType_->type()->kind() == TypeKind::BIGINT &&
+      !fileType_->type()->isDecimal() && requestedType_->isVarchar() &&
+      filter && !filter->isValueIndependent()) {
+    BOLT_USER_FAIL(
+        "Cannot apply VARCHAR filter to physical BIGINT column {}",
+        scanSpec_->fieldName());
+  }
+}
 
 void SelectiveColumnReader::filterRowGroups(
     uint64_t rowGroupSize,
@@ -557,6 +570,7 @@ void SelectiveColumnReader::setNulls(BufferPtr resultNulls) {
 }
 
 void SelectiveColumnReader::resetFilterCaches() {
+  validateReaderCastFilter();
   if (scanState_.filterCache.empty() && scanSpec_->hasFilter()) {
     scanState_.filterCache.resize(std::max<int32_t>(
         1, scanState_.dictionary.numValues + scanState_.dictionary2.numValues));

--- a/bolt/dwio/common/SelectiveColumnReader.h
+++ b/bolt/dwio/common/SelectiveColumnReader.h
@@ -488,6 +488,8 @@ class SelectiveColumnReader {
   void doCastEvaluate(VectorPtr* result);
 
  protected:
+  void validateReaderCastFilter() const;
+
   // Filters 'rows' according to 'is_null'. Only applies to cases where
   // readsNullsOnly() is true.
   template <typename T>

--- a/bolt/dwio/common/TypeUtils.cpp
+++ b/bolt/dwio/common/TypeUtils.cpp
@@ -123,6 +123,7 @@ std::unordered_set<uint32_t> makeCompatibilityMap() {
   compat.insert(getKey(TypeKind::INTEGER, TypeKind::BIGINT));
   compat.insert(getKey(TypeKind::BIGINT, TypeKind::HUGEINT));
   compat.insert(getKey(TypeKind::REAL, TypeKind::DOUBLE));
+  compat.insert(getKey(TypeKind::BIGINT, TypeKind::VARCHAR));
   return compat;
 }
 

--- a/bolt/dwio/common/TypeUtils.cpp
+++ b/bolt/dwio/common/TypeUtils.cpp
@@ -140,12 +140,16 @@ void checkTypeCompatibility(
     const FKind& kind,
     const FShouldRead& shouldRead,
     const std::function<std::string()>& exceptionMessageCreator) {
-  if (shouldRead(to) && !isCompatible(from.kind(), kind(to))) {
+  const auto toKind = kind(to);
+  const bool unsupportedDecimalToVarchar =
+      from.isDecimal() && toKind == TypeKind::VARCHAR;
+  if (shouldRead(to) &&
+      (!isCompatible(from.kind(), toKind) || unsupportedDecimalToVarchar)) {
     BOLT_SCHEMA_MISMATCH_ERROR(fmt::format(
         "{}, From Kind: {}, To Kind: {}",
         exceptionMessageCreator ? exceptionMessageCreator() : "Schema mismatch",
         mapTypeKindToName(from.kind()),
-        mapTypeKindToName(kind(to))));
+        mapTypeKindToName(toKind)));
   }
 
   if (recurse) {

--- a/bolt/dwio/common/TypeUtils.cpp
+++ b/bolt/dwio/common/TypeUtils.cpp
@@ -132,6 +132,14 @@ bool isCompatible(TypeKind from, TypeKind to) {
   return from == to || compat.find(getKey(from, to)) != compat.end();
 }
 
+bool isConcreteVarchar(const Type& type) {
+  return type.equivalent(*VARCHAR());
+}
+
+bool isConcreteVarchar(const TypeWithId& type) {
+  return type.type()->equivalent(*VARCHAR());
+}
+
 template <typename T, typename FKind, typename FShouldRead>
 void checkTypeCompatibility(
     const Type& from,
@@ -143,8 +151,12 @@ void checkTypeCompatibility(
   const auto toKind = kind(to);
   const bool unsupportedDecimalToVarchar =
       from.isDecimal() && toKind == TypeKind::VARCHAR;
+  const bool unsupportedBigintToVarcharLogicalType =
+      from.kind() == TypeKind::BIGINT && !from.isDecimal() &&
+      toKind == TypeKind::VARCHAR && !isConcreteVarchar(to);
   if (shouldRead(to) &&
-      (!isCompatible(from.kind(), toKind) || unsupportedDecimalToVarchar)) {
+      (!isCompatible(from.kind(), toKind) || unsupportedDecimalToVarchar ||
+       unsupportedBigintToVarcharLogicalType)) {
     BOLT_SCHEMA_MISMATCH_ERROR(fmt::format(
         "{}, From Kind: {}, To Kind: {}",
         exceptionMessageCreator ? exceptionMessageCreator() : "Schema mismatch",

--- a/bolt/dwio/common/tests/ReaderTest.cpp
+++ b/bolt/dwio/common/tests/ReaderTest.cpp
@@ -33,6 +33,7 @@
 #include "bolt/dwio/common/FormatData.h"
 #include "bolt/dwio/common/SelectiveColumnReader.h"
 #include "bolt/type/Subfield.h"
+#include "bolt/type/filter/FilterUtil.h"
 #include "bolt/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -381,6 +382,50 @@ TEST_F(ReaderTest, prepareOutputNullsClearsReturnedReaderNulls) {
   EXPECT_FALSE(reader.returnReaderNullsForTest());
   EXPECT_EQ(nullptr, reader.storedResultNullsForTest().get());
   EXPECT_EQ(nullptr, reader.rawResultNullsForTest());
+}
+
+TEST_F(ReaderTest, bigintToVarcharReaderCastFilters) {
+  ColumnReaderStatistics stats;
+  TestFormatParams params(*pool(), stats);
+  auto fileTypeWithId = TypeWithId::create(BIGINT());
+
+  for (auto filter : {TestFilterKind::kIsNull, TestFilterKind::kIsNotNull}) {
+    common::ScanSpec scanSpec("c0");
+    scanSpec.setFilter(makeTestFilter(filter));
+    EXPECT_NO_THROW(
+        TestSelectiveColumnReader(VARCHAR(), fileTypeWithId, params, scanSpec));
+  }
+
+  // Reject a value filter pushed down before reader construction.
+  common::ScanSpec pushedDownSpec("c0");
+  pushedDownSpec.setProjectOut(true);
+  pushedDownSpec.setFilter(
+      common::createBytesRange("11", true, "11", true, false));
+  BOLT_ASSERT_THROW(
+      TestSelectiveColumnReader(
+          VARCHAR(), fileTypeWithId, params, pushedDownSpec),
+      "Cannot apply VARCHAR filter to physical BIGINT column c0");
+
+  // Extracted filters use the same ScanSpec filter path.
+  common::ScanSpec extractedSpec("c0");
+  extractedSpec.setExtractValues(true);
+  extractedSpec.setFilter(
+      common::createBytesRange("11", true, "11", true, false));
+  BOLT_ASSERT_THROW(
+      TestSelectiveColumnReader(
+          VARCHAR(), fileTypeWithId, params, extractedSpec),
+      "Cannot apply VARCHAR filter to physical BIGINT column c0");
+
+  // Runtime filters can be installed after construction. Validate these when
+  // the reader is notified to reset its filter caches.
+  common::ScanSpec runtimeSpec("c0");
+  TestSelectiveColumnReader reader(
+      VARCHAR(), fileTypeWithId, params, runtimeSpec);
+  runtimeSpec.setFilter(
+      common::createBytesRange("11", true, "11", true, false));
+  BOLT_ASSERT_THROW(
+      reader.resetFilterCaches(),
+      "Cannot apply VARCHAR filter to physical BIGINT column c0");
 }
 
 TEST_F(ReaderTest, projectColumnsFilterStruct) {

--- a/bolt/dwio/common/tests/TypeTests.cpp
+++ b/bolt/dwio/common/tests/TypeTests.cpp
@@ -208,6 +208,10 @@ TEST(TestType, typeCompatibility) {
   from = ROW({MAP(VARCHAR(), INTEGER())});
   to = ROW({MAP(VARCHAR(), DOUBLE())});
   EXPECT_THROW(checkTypeCompatibility(*from, *to, true), BoltUserError);
+
+  from = ROW({ROW({BIGINT(), BOOLEAN()})});
+  to = ROW({ROW({VARCHAR(), BOOLEAN()})});
+  checkTypeCompatibility(*from, *to, true);
 }
 
 TEST(TestType, typeCompatibilityWithErrorMessage) {

--- a/bolt/dwio/common/tests/TypeTests.cpp
+++ b/bolt/dwio/common/tests/TypeTests.cpp
@@ -212,6 +212,12 @@ TEST(TestType, typeCompatibility) {
   from = ROW({ROW({BIGINT(), BOOLEAN()})});
   to = ROW({ROW({VARCHAR(), BOOLEAN()})});
   checkTypeCompatibility(*from, *to, true);
+
+  // Short decimals use BIGINT as their physical kind, but must not be routed
+  // through the integer-to-string reader.
+  from = ROW({DECIMAL(10, 2)});
+  to = ROW({VARCHAR()});
+  EXPECT_THROW(checkTypeCompatibility(*from, *to, true), BoltUserError);
 }
 
 TEST(TestType, typeCompatibilityWithErrorMessage) {

--- a/bolt/dwio/common/tests/TypeTests.cpp
+++ b/bolt/dwio/common/tests/TypeTests.cpp
@@ -42,6 +42,24 @@ using namespace bytedance::bolt::dwio::common::typeutils;
 using bytedance::bolt::type::fbhive::HiveTypeParser;
 using bytedance::bolt::type::fbhive::HiveTypeSerializer;
 
+namespace {
+class JsonType : public VarcharType {
+ public:
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "JSON";
+  }
+};
+
+const TypePtr& jsonType() {
+  static const TypePtr type = std::make_shared<const JsonType>();
+  return type;
+}
+} // namespace
+
 TEST(TestType, selectedType) {
   auto type = HiveTypeParser().parse(
       "struct<col0:tinyint,col1:smallint,col2:array<string>,"
@@ -217,6 +235,10 @@ TEST(TestType, typeCompatibility) {
   // through the integer-to-string reader.
   from = ROW({DECIMAL(10, 2)});
   to = ROW({VARCHAR()});
+  EXPECT_THROW(checkTypeCompatibility(*from, *to, true), BoltUserError);
+
+  from = ROW({BIGINT()});
+  to = ROW({jsonType()});
   EXPECT_THROW(checkTypeCompatibility(*from, *to, true), BoltUserError);
 }
 

--- a/bolt/dwio/dwrf/reader/ColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/ColumnReader.cpp
@@ -2421,6 +2421,65 @@ std::unique_ptr<ColumnReader> buildTypedIntegerColumnReader(
   }
 }
 
+class IntegerToStringColumnReader : public ColumnReader {
+ public:
+  IntegerToStringColumnReader(
+      std::shared_ptr<const dwio::common::TypeWithId> fileType,
+      std::unique_ptr<ColumnReader> integerReader,
+      memory::MemoryPool& memoryPool)
+      : ColumnReader(memoryPool, fileType),
+        integerReader_(std::move(integerReader)) {}
+
+  uint64_t skip(uint64_t numValues) override {
+    return integerReader_->skip(numValues);
+  }
+
+  void next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* incomingNulls) override {
+    integerReader_->next(numValues, integerValues_, incomingNulls);
+    auto stringValues = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), numValues, &memoryPool_);
+    for (vector_size_t i = 0; i < numValues; ++i) {
+      if (integerValues_->isNullAt(i)) {
+        stringValues->setNull(i, true);
+      } else {
+        const auto value = integerValueToString(i);
+        stringValues->set(i, StringView(value));
+      }
+    }
+    result = std::move(stringValues);
+  }
+
+  void seekToRowGroup(uint32_t index) override {
+    integerReader_->seekToRowGroup(index);
+  }
+
+ private:
+  std::string integerValueToString(vector_size_t row) const {
+    switch (fileType_->type()->kind()) {
+      case TypeKind::TINYINT:
+        return folly::to<std::string>(
+            integerValues_->as<SimpleVector<int8_t>>()->valueAt(row));
+      case TypeKind::SMALLINT:
+        return folly::to<std::string>(
+            integerValues_->as<SimpleVector<int16_t>>()->valueAt(row));
+      case TypeKind::INTEGER:
+        return folly::to<std::string>(
+            integerValues_->as<SimpleVector<int32_t>>()->valueAt(row));
+      case TypeKind::BIGINT:
+        return folly::to<std::string>(
+            integerValues_->as<SimpleVector<int64_t>>()->valueAt(row));
+      default:
+        BOLT_UNREACHABLE();
+    }
+  }
+
+  std::unique_ptr<ColumnReader> integerReader_;
+  VectorPtr integerValues_;
+};
+
 std::unique_ptr<ColumnReader> buildIntegerReader(
     TypePtr requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
@@ -2428,6 +2487,18 @@ std::unique_ptr<ColumnReader> buildIntegerReader(
     FlatMapContext flatMapContext,
     StripeStreams& stripe,
     const StreamLabels& streamLabels) {
+  if (requestedType->isVarchar()) {
+    auto integerReader = buildIntegerReader(
+        fileType->type(),
+        fileType,
+        numBytes,
+        flatMapContext,
+        stripe,
+        streamLabels);
+    return std::make_unique<IntegerToStringColumnReader>(
+        fileType, std::move(integerReader), stripe.getMemoryPool());
+  }
+
   EncodingKey ek{fileType->id(), flatMapContext.sequence};
   switch (static_cast<int64_t>(stripe.getEncoding(ek).kind())) {
     case proto::ColumnEncoding_Kind_DICTIONARY:

--- a/bolt/dwio/dwrf/reader/ColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/ColumnReader.cpp
@@ -2472,7 +2472,7 @@ class IntegerToStringColumnReader : public ColumnReader {
         return folly::to<std::string>(
             integerValues_->as<SimpleVector<int64_t>>()->valueAt(row));
       default:
-        VELOX_UNREACHABLE();
+        BOLT_UNREACHABLE();
     }
   }
 

--- a/bolt/dwio/dwrf/reader/ColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/ColumnReader.cpp
@@ -2472,7 +2472,7 @@ class IntegerToStringColumnReader : public ColumnReader {
         return folly::to<std::string>(
             integerValues_->as<SimpleVector<int64_t>>()->valueAt(row));
       default:
-        BOLT_UNREACHABLE();
+        VELOX_UNREACHABLE();
     }
   }
 

--- a/bolt/dwio/dwrf/reader/ColumnReader.cpp
+++ b/bolt/dwio/dwrf/reader/ColumnReader.cpp
@@ -2487,7 +2487,7 @@ std::unique_ptr<ColumnReader> buildIntegerReader(
     FlatMapContext flatMapContext,
     StripeStreams& stripe,
     const StreamLabels& streamLabels) {
-  if (requestedType->isVarchar()) {
+  if (requestedType->equivalent(*VARCHAR())) {
     auto integerReader = buildIntegerReader(
         fileType->type(),
         fileType,

--- a/bolt/dwio/dwrf/test/ReaderTest.cpp
+++ b/bolt/dwio/dwrf/test/ReaderTest.cpp
@@ -2867,6 +2867,63 @@ TEST_F(TestReader, missingSubfieldsNoResultReusing) {
   assertEqualVectors(expected, actual);
 }
 
+TEST_F(TestReader, readNestedBigintAsVarcharWithIsNotNullFilter) {
+  auto fileSchema = ROW(
+      {"chat_id", "meta_details"},
+      {BIGINT(),
+       ROW({"chatter_id", "is_manual_set_nickname"}, {BIGINT(), BOOLEAN()})});
+  auto data = makeRowVector(
+      {"chat_id", "meta_details"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeRowVector(
+           {"chatter_id", "is_manual_set_nickname"},
+           {makeNullableFlatVector<int64_t>({11, std::nullopt, 33}),
+            makeFlatVector<bool>({true, false, true})})});
+  ASSERT_EQ(data->type()->toString(), fileSchema->toString());
+
+  auto [writer, reader] = createWriterReader({data}, pool());
+  auto requestedSchema = ROW(
+      {"chat_id", "meta_details"},
+      {BIGINT(),
+       ROW({"chatter_id", "is_manual_set_nickname"}, {VARCHAR(), BOOLEAN()})});
+
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedSchema));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  VectorPtr actual = BaseVector::create(requestedSchema, 0, pool());
+  ASSERT_EQ(rowReader->next(1024, actual), 3);
+  auto expected = makeRowVector(
+      {"chat_id", "meta_details"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeRowVector(
+           {"chatter_id", "is_manual_set_nickname"},
+           {makeNullableFlatVector<StringView>({"11", std::nullopt, "33"}),
+            makeFlatVector<bool>({true, false, true})})});
+  assertEqualVectors(expected, actual);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  scanSpec->addAllChildFields(*requestedSchema);
+  scanSpec->childByName("meta_details")
+      ->childByName("chatter_id")
+      ->setFilter(std::make_unique<common::IsNotNull>());
+
+  rowReaderOpts = RowReaderOptions();
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedSchema));
+  rowReaderOpts.setScanSpec(scanSpec);
+  rowReader = reader->createRowReader(rowReaderOpts);
+  actual = BaseVector::create(requestedSchema, 0, pool());
+  ASSERT_EQ(rowReader->next(1024, actual), 3);
+
+  expected = makeRowVector(
+      {"chat_id", "meta_details"},
+      {makeFlatVector<int64_t>({1, 3}),
+       makeRowVector(
+           {"chatter_id", "is_manual_set_nickname"},
+           {makeFlatVector<StringView>({"11", "33"}),
+            makeFlatVector<bool>({true, true})})});
+  assertEqualVectors(expected, actual);
+}
+
 // Ensure there is enough data before switching to fast path.
 TEST_F(TestReader, selectiveStringDirectFastPath) {
   auto genStr = [](auto i) {

--- a/bolt/dwio/dwrf/test/ReaderTest.cpp
+++ b/bolt/dwio/dwrf/test/ReaderTest.cpp
@@ -2977,8 +2977,13 @@ TEST_F(TestReader, readBigintAsVarcharWithValueHook) {
   auto [writer, reader] = createWriterReader({data}, pool());
   auto requestedSchema = ROW({VARCHAR()});
 
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  scanSpec->addAllChildFields(*requestedSchema);
+  scanSpec->childByName("c0")->setProjectOut(true);
+
   RowReaderOptions options;
   options.select(std::make_shared<ColumnSelector>(requestedSchema));
+  options.setScanSpec(scanSpec);
   auto rowReader = reader->createRowReader(options);
   VectorPtr result = BaseVector::create(requestedSchema, 0, pool());
   ASSERT_EQ(rowReader->next(1024, result), 3);

--- a/bolt/dwio/dwrf/test/ReaderTest.cpp
+++ b/bolt/dwio/dwrf/test/ReaderTest.cpp
@@ -39,6 +39,7 @@
 #include "bolt/dwio/dwrf/test/OrcTest.h"
 #include "bolt/dwio/dwrf/test/utils/E2EWriterTestUtil.h"
 #include "bolt/type/fbhive/HiveTypeParser.h"
+#include "bolt/type/filter/FilterUtil.h"
 #include "bolt/vector/ComplexVector.h"
 #include "bolt/vector/FlatVector.h"
 #include "bolt/vector/tests/utils/VectorTestBase.h"
@@ -2922,6 +2923,27 @@ TEST_F(TestReader, readNestedBigintAsVarcharWithIsNotNullFilter) {
            {makeFlatVector<StringView>({"11", "33"}),
             makeFlatVector<bool>({true, true})})});
   assertEqualVectors(expected, actual);
+
+  auto assertValueFilterRejected = [&](bool extractValues) {
+    auto valueFilterSpec = std::make_shared<common::ScanSpec>("<root>");
+    valueFilterSpec->addAllChildFields(*requestedSchema);
+    auto* chatterIdSpec =
+        valueFilterSpec->childByName("meta_details")->childByName("chatter_id");
+    chatterIdSpec->setProjectOut(!extractValues);
+    chatterIdSpec->setExtractValues(extractValues);
+    chatterIdSpec->setFilter(
+        common::createBytesRange("11", true, "11", true, false));
+
+    RowReaderOptions valueFilterOptions;
+    valueFilterOptions.select(
+        std::make_shared<ColumnSelector>(requestedSchema));
+    valueFilterOptions.setScanSpec(valueFilterSpec);
+    BOLT_ASSERT_THROW(
+        reader->createRowReader(valueFilterOptions),
+        "Cannot apply VARCHAR filter to physical BIGINT column chatter_id");
+  };
+  assertValueFilterRejected(false);
+  assertValueFilterRejected(true);
 }
 
 // Ensure there is enough data before switching to fast path.

--- a/bolt/dwio/dwrf/test/ReaderTest.cpp
+++ b/bolt/dwio/dwrf/test/ReaderTest.cpp
@@ -61,6 +61,31 @@ using namespace bytedance::bolt::dwrf;
 using namespace bytedance::bolt::test;
 
 namespace {
+class CollectStringHook : public ValueHook {
+ public:
+  explicit CollectStringHook(vector_size_t size) : values_(size) {}
+
+  bool acceptsNulls() const override {
+    return true;
+  }
+
+  void addNull(vector_size_t row) override {
+    values_[row] = std::nullopt;
+  }
+
+  void addValue(vector_size_t row, const void* value) override {
+    values_[row] =
+        std::string(*reinterpret_cast<const folly::StringPiece*>(value));
+  }
+
+  const std::vector<std::optional<std::string>>& values() const {
+    return values_;
+  }
+
+ private:
+  std::vector<std::optional<std::string>> values_;
+};
+
 const std::string& getStructFile() {
   static const std::string structFile_ = getExampleFilePath("struct.orc");
   return structFile_;
@@ -2944,6 +2969,30 @@ TEST_F(TestReader, readNestedBigintAsVarcharWithIsNotNullFilter) {
   };
   assertValueFilterRejected(false);
   assertValueFilterRejected(true);
+}
+
+TEST_F(TestReader, readBigintAsVarcharWithValueHook) {
+  auto data = makeRowVector({makeNullableFlatVector<int64_t>(
+      {-42, std::nullopt, 1234567890123456789})});
+  auto [writer, reader] = createWriterReader({data}, pool());
+  auto requestedSchema = ROW({VARCHAR()});
+
+  RowReaderOptions options;
+  options.select(std::make_shared<ColumnSelector>(requestedSchema));
+  auto rowReader = reader->createRowReader(options);
+  VectorPtr result = BaseVector::create(requestedSchema, 0, pool());
+  ASSERT_EQ(rowReader->next(1024, result), 3);
+
+  auto lazy = result->as<RowVector>()->childAt(0);
+  ASSERT_EQ(lazy->encoding(), VectorEncoding::Simple::LAZY);
+  CollectStringHook hook(3);
+  const std::array<vector_size_t, 3> rows = {0, 1, 2};
+  lazy->as<LazyVector>()->load(RowSet(rows), &hook);
+
+  EXPECT_EQ(
+      hook.values(),
+      (std::vector<std::optional<std::string>>{
+          "-42", std::nullopt, "1234567890123456789"}));
 }
 
 // Ensure there is enough data before switching to fast path.

--- a/bolt/dwio/parquet/reader/ParquetReaderCast.h
+++ b/bolt/dwio/parquet/reader/ParquetReaderCast.h
@@ -48,6 +48,10 @@ inline bool isReaderCastFilterMismatch(
       return requestedKind == TypeKind::DOUBLE ||
           (fileType->isDate() && requestedType->isVarchar());
     case TypeKind::BIGINT:
+      if (!fileType->isDecimal() && requestedType->isVarchar()) {
+        return true;
+      }
+      [[fallthrough]];
     case TypeKind::HUGEINT:
       return fileType->isDecimal() && requestedType->isDecimal() &&
           fileType->isShortDecimal() != requestedType->isShortDecimal();

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -2431,6 +2431,42 @@ TEST_F(ParquetTableScanTest, floatingPointToVarcharValueFilters) {
   EXPECT_EQ(alwaysFalseResult->size(), 0);
 }
 
+TEST_F(ParquetTableScanTest, bigintToVarcharValueFilters) {
+  auto data = makeRowVector(
+      {"c0"}, {makeNullableFlatVector<int64_t>({11, 22, std::nullopt})});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  auto declared = ROW({"c0"}, {VARCHAR()});
+  auto pushdownOnlyPlan = PlanBuilder(pool())
+                              .tableScan(declared, {"c0 = '11'"}, "", declared)
+                              .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(pushdownOnlyPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical BIGINT Parquet column c0");
+
+  auto extractedFilterPlan = PlanBuilder(pool())
+                                 .tableScan(declared, {}, "c0 = '11'", declared)
+                                 .planNode();
+  BOLT_ASSERT_THROW(
+      AssertQueryBuilder(extractedFilterPlan)
+          .split(makeSplit(file->getPath()))
+          .copyResults(pool()),
+      "Cannot apply VARCHAR filter to physical BIGINT Parquet column c0");
+
+  auto isNullPlan = PlanBuilder(pool())
+                        .tableScan(declared, {"c0 IS NULL"}, "", declared)
+                        .planNode();
+  auto isNullResult = AssertQueryBuilder(isNullPlan)
+                          .split(makeSplit(file->getPath()))
+                          .copyResults(pool());
+  auto expected = makeRowVector(
+      {"c0"}, {makeNullableFlatVector<StringView>({std::nullopt})});
+  EXPECT_TRUE(assertEqualResults({expected}, {isNullResult}));
+}
+
 TEST_F(ParquetTableScanTest, doubleToBigintValueChecks) {
   if (!::bytedance::bolt::kSparkCompatible) {
     GTEST_SKIP();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #941

The DWRF reader rejects schema evolution from `BIGINT` to `VARCHAR`, preventing Spark/Gluten queries from reading compatible data through the requested string schema.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Add DWRF compatibility for reading `BIGINT` columns as `VARCHAR`.
- Support the conversion in both regular and selective DWRF readers.
- Add nested-reader and filter regression coverage.
- Reject value-dependent filters before BIGINT-to-VARCHAR selective reader
  construction while preserving IS NULL / IS NOT NULL, including filters
  installed dynamically after construction.
- Keep short-decimal-to-`VARCHAR` compatibility rejected.
- Use Bolt's legacy/unreachable macros required by this codebase.

This PR intentionally does not include `VARCHAR -> BOOLEAN`, selective string reader, sparse projection mapping, or other unrelated schema-evolution changes.

### Performance Impact

- [x] **No Impact**: Existing same-type read paths are unchanged; conversion is only performed when `BIGINT` is requested as `VARCHAR`.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below.

### Release Note

```text
Support reading DWRF BIGINT columns as VARCHAR.
```

### Validation

- The five commits are patch-equivalent to internal Bolt MR !2523.
- Shared, DWRF, and Parquet regression coverage includes pushed-down,
  extracted, runtime, IS NULL, and IS NOT NULL filter paths.
- `pre-commit` passes for all changed files.
- Local compilation was attempted, but the reusable CMake cache points to a
  different checkout and has stale dependency include paths; GitHub Actions is
  the authoritative build validation.
- GitHub Actions were retriggered after syncing onto the latest `main`.

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have run clang-format / linters for the changed code.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
