### PR TITLE
perf: stream parquet repdef decoding by window

### DIFF
--- a/bolt/connectors/hive/HiveDataSource.cpp
+++ b/bolt/connectors/hive/HiveDataSource.cpp
@@ -75,6 +75,8 @@ HiveDataSource::HiveDataSource(
     reusableOutputPool_ =
         std::make_shared<ReusableOutputPool>(reusableOutputCount);
   }
+  parquetRepDefStreamingWindowSize_ =
+      queryConfig.parquetRepDefStreamingWindowSize();
   for (const auto& key : HiveConfig::hms_session_key) {
     std::optional<std::string> value = queryConfig.get<std::string>(key);
     if (value.has_value()) {
@@ -386,6 +388,8 @@ std::unique_ptr<SplitReader> HiveDataSource::createConfiguredSplitReader(
 
   splitReader->rowReaderOptions().setDecodeRepDefPageCount(
       decodeRepDefPageCount_);
+  splitReader->rowReaderOptions().setParquetRepDefStreamingWindowSize(
+      parquetRepDefStreamingWindowSize_);
   splitReader->rowReaderOptions().setParquetRepDefMemoryLimit(
       parquetRepDefMemoryLimit_);
   splitReader->rowReaderOptions().setParquetReaderImplicitCastMask(

--- a/bolt/connectors/hive/HiveDataSource.h
+++ b/bolt/connectors/hive/HiveDataSource.h
@@ -272,6 +272,7 @@ class HiveDataSource : public DataSource {
   int64_t ignoredFileSizes_{0};
 
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
+  int32_t parquetRepDefStreamingWindowSize_{2 * 1024};
   int32_t decodeRepDefPageCount_{10};
   int64_t parquetReaderImplicitCastMask_{0};
   int64_t parquetMaxBatchBytes_{0};

--- a/bolt/core/QueryConfig.h
+++ b/bolt/core/QueryConfig.h
@@ -631,6 +631,11 @@ class QueryConfig {
 
   static constexpr const char* kHybridJoinEnabled = "hybrid_join_enabled";
 
+  /// Number of levels per Parquet rep/def streaming window. Zero disables
+  /// streaming and uses the legacy preload path.
+  static constexpr const char* kParquetRepDefStreamingWindowSize =
+      "parquet_repdef_streaming_window_size";
+
   /// If true, reorder rows by containerId during hybrid join extraction for
   /// better cache locality. Can be disabled for testing to get deterministic
   /// output order.
@@ -1742,6 +1747,10 @@ class QueryConfig {
 
   int64_t parquetReaderImplicitCastMask() const {
     return get<int64_t>(kParquetReaderImplicitCastMask, 0);
+  }
+
+  int32_t parquetRepDefStreamingWindowSize() const {
+    return get<int32_t>(kParquetRepDefStreamingWindowSize, 2 * 1024);
   }
 
   bool enableDynamicConcurrencyAdjustment() const {

--- a/bolt/core/tests/QueryConfigTest.cpp
+++ b/bolt/core/tests/QueryConfigTest.cpp
@@ -67,6 +67,16 @@ TEST_F(QueryConfigTest, setConfig) {
   ASSERT_TRUE(config.isLegacyCast());
 }
 
+TEST_F(QueryConfigTest, parquetRepDefStreamingWindowSize) {
+  auto queryCtx = QueryCtx::create(nullptr, QueryConfig{{}});
+  EXPECT_EQ(queryCtx->queryConfig().parquetRepDefStreamingWindowSize(), 2'048);
+
+  std::unordered_map<std::string, std::string> configData(
+      {{QueryConfig::kParquetRepDefStreamingWindowSize, "0"}});
+  queryCtx = QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+  EXPECT_EQ(queryCtx->queryConfig().parquetRepDefStreamingWindowSize(), 0);
+}
+
 TEST_F(QueryConfigTest, hashBuildProbeAdmissionUnderMemoryPressureConfig) {
   auto queryCtx = QueryCtx::create(nullptr, QueryConfig{{}});
   ASSERT_TRUE(queryCtx->queryConfig()

--- a/bolt/dwio/common/BufferedInput.h
+++ b/bolt/dwio/common/BufferedInput.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "bolt/common/caching/ScanTracker.h"
 #include "bolt/common/flags/BoltFlags.h"
 #include "bolt/common/memory/AllocationPool.h"
@@ -37,6 +39,10 @@
 #include "bolt/dwio/common/StreamIdentifier.h"
 
 namespace bytedance::bolt::dwio::common {
+
+using SeekableInputStreamPair = std::pair<
+    std::unique_ptr<SeekableInputStream>,
+    std::unique_ptr<SeekableInputStream>>;
 
 class BufferedInput {
  public:
@@ -89,6 +95,16 @@ class BufferedInput {
   virtual std::unique_ptr<SeekableInputStream> enqueue(
       bolt::common::Region region,
       const StreamIdentifier* FOLLY_NULLABLE si = nullptr);
+
+  /// Returns two independently positioned streams for 'region'. Implementations
+  /// may share the underlying read.
+  virtual SeekableInputStreamPair enqueuePair(
+      bolt::common::Region region,
+      const StreamIdentifier* FOLLY_NULLABLE si = nullptr) {
+    auto first = enqueue(region, si);
+    auto second = enqueue(region, si);
+    return {std::move(first), std::move(second)};
+  }
 
   /// Returns true if load synchronously.
   virtual bool supportSyncLoad() const {

--- a/bolt/dwio/common/CachedBufferedInput.cpp
+++ b/bolt/dwio/common/CachedBufferedInput.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "bolt/dwio/common/CachedBufferedInput.h"
+#include <folly/executors/QueuedImmediateExecutor.h>
 #include "bolt/common/memory/Allocation.h"
 #include "bolt/common/process/ThreadNameHolder.h"
 #include "bolt/common/process/TraceContext.h"
@@ -78,6 +79,20 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
       options_.loadQuantum());
   requests_.back().stream = stream.get();
   return stream;
+}
+
+SeekableInputStreamPair CachedBufferedInput::enqueuePair(
+    Region region,
+    const StreamIdentifier* si) {
+  if (region.length == 0) {
+    return BufferedInput::enqueuePair(region, si);
+  }
+  auto first = enqueue(region, si);
+  auto* cacheStream = dynamic_cast<CacheInputStream*>(first.get());
+  BOLT_CHECK_NOT_NULL(cacheStream);
+  auto second = cacheStream->clone();
+  requests_.back().pairedStream = second.get();
+  return {std::move(first), std::move(second)};
 }
 
 bool CachedBufferedInput::isBuffered(uint64_t /*offset*/, uint64_t /*length*/)
@@ -147,6 +162,8 @@ std::vector<CacheRequest*> makeRequestParts(
         request.trackingId));
     parts.push_back(extraRequests.back().get());
     parts.back()->coalesces = prefetch;
+    parts.back()->stream = request.stream;
+    parts.back()->pairedStream = request.pairedStream;
     if (prefetchOne) {
       break;
     }
@@ -368,6 +385,54 @@ class DwioCoalescedLoadBase : public cache::CoalescedLoad {
   int64_t size_{0};
 };
 
+class CompositeCoalescedLoad final : public cache::CoalescedLoad {
+ public:
+  explicit CompositeCoalescedLoad(
+      std::vector<std::shared_ptr<cache::CoalescedLoad>> loads)
+      : cache::CoalescedLoad({}, {}), loads_(std::move(loads)) {}
+
+  int64_t size() const override {
+    int64_t size = 0;
+    for (const auto& load : loads_) {
+      size += load->size();
+    }
+    return size;
+  }
+
+  void cancel() override {
+    cache::CoalescedLoad::cancel();
+    for (const auto& load : loads_) {
+      load->cancel();
+    }
+  }
+
+ protected:
+  std::vector<cache::CachePin> loadData(bool /*isPrefetch*/) override {
+    for (const auto& load : loads_) {
+      for (;;) {
+        folly::SemiFuture<bool> wait(false);
+        if (!load->loadOrFuture(&wait)) {
+          auto& exec = folly::QueuedImmediateExecutor::instance();
+          std::move(wait).via(&exec).wait();
+        }
+        const auto state = load->state();
+        if (state == cache::CoalescedLoad::State::kLoaded ||
+            state == cache::CoalescedLoad::State::kCancelled) {
+          break;
+        }
+        if (isAsyncPreloadThread()) {
+          throw std::runtime_error(
+              "Child coalesced load failed during asynchronous preload");
+        }
+      }
+    }
+    return {};
+  }
+
+ private:
+  std::vector<std::shared_ptr<cache::CoalescedLoad>> loads_;
+};
+
 // Represents a CoalescedLoad from ReadFile, e.g. disagg disk.
 class DwioCoalescedLoad : public DwioCoalescedLoadBase {
  public:
@@ -475,7 +540,16 @@ void CachedBufferedInput::readRegion(
   allCoalescedLoads_.push_back(load);
   coalescedLoads_.withWLock([&](auto& loads) {
     for (auto& request : requests) {
-      loads[request->stream] = load;
+      auto addLoad = [&](const SeekableInputStream* stream) {
+        auto& streamLoads = loads[stream];
+        if (streamLoads.empty() || streamLoads.back() != load) {
+          streamLoads.push_back(load);
+        }
+      };
+      addLoad(request->stream);
+      if (request->pairedStream != nullptr) {
+        addLoad(request->pairedStream);
+      }
     }
   });
 }
@@ -527,12 +601,38 @@ std::shared_ptr<cache::CoalescedLoad> CachedBufferedInput::coalescedLoad(
         if (it == loads.end()) {
           return nullptr;
         }
-        auto load = std::move(it->second);
-        auto* dwioLoad = static_cast<DwioCoalescedLoadBase*>(load.get());
-        for (auto& request : dwioLoad->requests()) {
-          loads.erase(request.stream);
+        auto streamLoads = std::move(it->second);
+        loads.erase(it);
+        for (const auto& load : streamLoads) {
+          auto* dwioLoad = static_cast<DwioCoalescedLoadBase*>(load.get());
+          for (auto& request : dwioLoad->requests()) {
+            auto removeLoad = [&](const SeekableInputStream* requestStream) {
+              auto requestIt = loads.find(requestStream);
+              if (requestIt == loads.end()) {
+                return;
+              }
+              auto& loadsForRequest = requestIt->second;
+              loadsForRequest.erase(
+                  std::remove(
+                      loadsForRequest.begin(), loadsForRequest.end(), load),
+                  loadsForRequest.end());
+              if (loadsForRequest.empty()) {
+                loads.erase(requestIt);
+              }
+            };
+            if (request.stream != stream) {
+              removeLoad(request.stream);
+            }
+            if (request.pairedStream != nullptr &&
+                request.pairedStream != stream) {
+              removeLoad(request.pairedStream);
+            }
+          }
         }
-        return load;
+        if (streamLoads.size() == 1) {
+          return std::move(streamLoads.front());
+        }
+        return std::make_shared<CompositeCoalescedLoad>(std::move(streamLoads));
       });
 }
 

--- a/bolt/dwio/common/CachedBufferedInput.h
+++ b/bolt/dwio/common/CachedBufferedInput.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include <folly/Executor.h>
-
 #include "bolt/common/caching/FileGroupStats.h"
 #include "bolt/common/caching/ScanTracker.h"
 #include "bolt/common/caching/SsdCache.h"
@@ -62,6 +61,7 @@ struct CacheRequest {
   /// adjacent pieces.
   bool coalesces{true};
   const SeekableInputStream* FOLLY_NONNULL stream;
+  const SeekableInputStream* FOLLY_NULLABLE pairedStream{nullptr};
 };
 
 class CachedBufferedInput : public BufferedInput {
@@ -126,6 +126,10 @@ class CachedBufferedInput : public BufferedInput {
       bolt::common::Region region,
       const StreamIdentifier* FOLLY_NULLABLE si) override;
 
+  SeekableInputStreamPair enqueuePair(
+      bolt::common::Region region,
+      const StreamIdentifier* FOLLY_NULLABLE si) override;
+
   bool supportSyncLoad() const override {
     return false;
   }
@@ -173,9 +177,9 @@ class CachedBufferedInput : public BufferedInput {
   }
 
   // Returns the CoalescedLoad that contains the correlated loads for
-  // 'stream' or nullptr if none. Returns nullptr on all but first
-  // call for 'stream' since the load is to be triggered by the first
-  // access.
+  // 'stream' or nullptr if none. A stream can map to multiple loads when a
+  // large request is split. Returns nullptr after the first call for 'stream'
+  // since all mapped loads are triggered by the first access.
   std::shared_ptr<cache::CoalescedLoad> coalescedLoad(
       const SeekableInputStream* FOLLY_NONNULL stream);
 
@@ -234,7 +238,7 @@ class CachedBufferedInput : public BufferedInput {
   // Coalesced loads spanning multiple cache entries in one IO.
   folly::Synchronized<folly::F14FastMap<
       const SeekableInputStream*,
-      std::shared_ptr<cache::CoalescedLoad>>>
+      std::vector<std::shared_ptr<cache::CoalescedLoad>>>>
       coalescedLoads_;
 
   // Distinct coalesced loads in 'coalescedLoads_'.

--- a/bolt/dwio/common/DirectBufferedInput.cpp
+++ b/bolt/dwio/common/DirectBufferedInput.cpp
@@ -30,8 +30,11 @@
 
 #include <folly/GLog.h>
 #include <folly/ScopeGuard.h>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <exception>
+#include <limits>
 #include <stdexcept>
 
 #include "bolt/common/base/GlobalParameters.h"
@@ -51,6 +54,166 @@ namespace bytedance::bolt::dwio::common {
 using cache::CoalescedLoad;
 using cache::ScanTracker;
 using cache::TrackingId;
+
+namespace {
+
+struct SharedSeekableInputChunk {
+  uint64_t offset;
+  BufferPtr data;
+};
+
+class SharedSeekableInputData {
+ public:
+  SharedSeekableInputData(
+      std::unique_ptr<SeekableInputStream> input,
+      Region region,
+      std::shared_ptr<memory::MemoryPool> pool,
+      uint64_t loadQuantum)
+      : input_(std::move(input)),
+        region_(region),
+        pool_(std::move(pool)),
+        loadQuantum_(loadQuantum) {
+    BOLT_CHECK_GT(loadQuantum_, 0);
+  }
+
+  std::shared_ptr<const SharedSeekableInputChunk> load(uint64_t position) {
+    BOLT_CHECK_LT(position, region_.length);
+    const auto offset = position / loadQuantum_ * loadQuantum_;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (failure_) {
+      std::rethrow_exception(failure_);
+    }
+    for (auto i = 0; i < chunks_.size(); ++i) {
+      if (chunks_[i] && chunks_[i]->offset == offset) {
+        auto chunk = chunks_[i];
+        if (i == 0) {
+          std::swap(chunks_[0], chunks_[1]);
+        }
+        return chunk;
+      }
+    }
+
+    const auto size = std::min(loadQuantum_, region_.length - offset);
+    auto buffer = AlignedBuffer::allocate<char>(size, pool_.get());
+    const std::vector<uint64_t> positions{offset};
+    PositionProvider positionProvider(positions);
+    try {
+      input_->seekToPosition(positionProvider);
+      input_->readFully(buffer->asMutable<char>(), size);
+    } catch (...) {
+      failure_ = std::current_exception();
+      throw;
+    }
+
+    auto chunk = std::make_shared<SharedSeekableInputChunk>(
+        SharedSeekableInputChunk{offset, std::move(buffer)});
+    chunks_[0] = std::move(chunks_[1]);
+    chunks_[1] = chunk;
+    return chunk;
+  }
+
+ private:
+  const std::unique_ptr<SeekableInputStream> input_;
+  const Region region_;
+  const std::shared_ptr<memory::MemoryPool> pool_;
+  const uint64_t loadQuantum_;
+  std::mutex mutex_;
+  std::exception_ptr failure_;
+  std::array<std::shared_ptr<const SharedSeekableInputChunk>, 2> chunks_;
+};
+
+class SharedSeekableInputStream final : public SeekableInputStream {
+ public:
+  explicit SharedSeekableInputStream(
+      std::shared_ptr<SharedSeekableInputData> data,
+      uint64_t size)
+      : data_(std::move(data)), size_(size) {}
+
+  bool Next(const void** buffer, int32_t* size) override {
+    currentChunk_.reset();
+    lastNextSize_ = 0;
+    if (position_ >= size_) {
+      *size = 0;
+      return false;
+    }
+
+    currentChunk_ = data_->load(position_);
+    const auto offsetInChunk = position_ - currentChunk_->offset;
+    const auto available = currentChunk_->data->size() - offsetInChunk;
+    BOLT_CHECK_LE(available, std::numeric_limits<int32_t>::max());
+    *buffer = currentChunk_->data->as<char>() + offsetInChunk;
+    *size = static_cast<int32_t>(available);
+    position_ += available;
+    lastNextSize_ = *size;
+    return true;
+  }
+
+  void BackUp(int32_t count) override {
+    BOLT_CHECK_GE(count, 0, "can't backup negative distances");
+    BOLT_CHECK_LE(count, lastNextSize_, "Can't backup that much!");
+    currentChunk_.reset();
+    position_ -= count;
+    lastNextSize_ = 0;
+  }
+
+  bool SkipInt64(int64_t count) override {
+    currentChunk_.reset();
+    lastNextSize_ = 0;
+    if (count < 0) {
+      return false;
+    }
+    const auto unsignedCount = static_cast<uint64_t>(count);
+    if (unsignedCount <= size_ - position_) {
+      position_ += unsignedCount;
+      return true;
+    }
+    position_ = size_;
+    return false;
+  }
+
+  google::protobuf::int64 ByteCount() const override {
+    return static_cast<google::protobuf::int64>(position_);
+  }
+
+  void seekToPosition(PositionProvider& position) override {
+    const auto newPosition = position.next();
+    BOLT_CHECK_LE(newPosition, size_);
+    currentChunk_.reset();
+    lastNextSize_ = 0;
+    position_ = newPosition;
+  }
+
+  std::string getName() const override {
+    return fmt::format("SharedSeekableInputStream {} of {}", position_, size_);
+  }
+
+  size_t positionSize() override {
+    return 1;
+  }
+
+ private:
+  const std::shared_ptr<SharedSeekableInputData> data_;
+  const uint64_t size_;
+  uint64_t position_{0};
+  int32_t lastNextSize_{0};
+  std::shared_ptr<const SharedSeekableInputChunk> currentChunk_;
+};
+
+SeekableInputStreamPair makeSharedSeekableInputStreamPair(
+    std::unique_ptr<SeekableInputStream> input,
+    Region region,
+    std::shared_ptr<memory::MemoryPool> pool,
+    uint64_t loadQuantum) {
+  auto data = std::make_shared<SharedSeekableInputData>(
+      std::move(input), region, std::move(pool), loadQuantum);
+  auto makeStream = [&]() {
+    return std::make_unique<SharedSeekableInputStream>(data, region.length);
+  };
+  return {makeStream(), makeStream()};
+}
+
+} // namespace
 
 std::unique_ptr<SeekableInputStream> DirectBufferedInput::enqueue(
     Region region,
@@ -88,6 +251,29 @@ std::unique_ptr<SeekableInputStream> DirectBufferedInput::enqueue(
     requests_.back().stream = stream.get();
   }
   return stream;
+}
+
+SeekableInputStreamPair DirectBufferedInput::enqueuePair(
+    Region region,
+    const StreamIdentifier* sid) {
+  if (region.length == 0 || preloaded()) {
+    return BufferedInput::enqueuePair(region, sid);
+  }
+
+  BOLT_CHECK_LE(region.offset, fileSize_);
+  BOLT_CHECK_LE(region.length, fileSize_ - region.offset);
+  BOLT_CHECK_GT(options_.loadQuantum(), 0);
+  auto input = enqueue(region, sid);
+  BOLT_CHECK(!requests_.empty());
+  // Only preload the first quantum. Subsequent chunks are fetched on demand,
+  // keeping the shared pair bounded while retaining initial coalescing.
+  requests_.back().region.length =
+      std::min<uint64_t>(region.length, options_.loadQuantum());
+  return makeSharedSeekableInputStreamPair(
+      std::move(input),
+      region,
+      pool_.shared_from_this(),
+      options_.loadQuantum());
 }
 
 bool DirectBufferedInput::isBuffered(uint64_t /*offset*/, uint64_t /*length*/)

--- a/bolt/dwio/common/DirectBufferedInput.h
+++ b/bolt/dwio/common/DirectBufferedInput.h
@@ -196,6 +196,10 @@ class DirectBufferedInput : public BufferedInput {
       bolt::common::Region region,
       const StreamIdentifier* sid) override;
 
+  SeekableInputStreamPair enqueuePair(
+      bolt::common::Region region,
+      const StreamIdentifier* sid) override;
+
   bool supportSyncLoad() const override {
     return false;
   }

--- a/bolt/dwio/common/Options.h
+++ b/bolt/dwio/common/Options.h
@@ -185,6 +185,9 @@ class RowReaderOptions {
 
   int32_t decodeRepDefPageCount_{10};
   int32_t parquetRepDefMemoryLimit_{16UL << 20};
+  // Number of levels per Parquet rep/def streaming window. Zero disables
+  // streaming and uses the legacy preload path.
+  int32_t parquetRepDefStreamingWindowSize_{2 * 1024};
   bool useColumnNamesForColumnMapping_{false};
 
   // Hard upper bound on the in-memory bytes a single batch is allowed to
@@ -516,6 +519,14 @@ class RowReaderOptions {
     return parquetRepDefMemoryLimit_;
   }
 
+  void setParquetRepDefStreamingWindowSize(int32_t size) {
+    parquetRepDefStreamingWindowSize_ = size;
+  }
+
+  int32_t getParquetRepDefStreamingWindowSize() const {
+    return parquetRepDefStreamingWindowSize_;
+  }
+
   RowReaderOptions& setUseColumnNamesForColumnMapping(bool flag) {
     useColumnNamesForColumnMapping_ = flag;
     return *this;
@@ -586,8 +597,10 @@ class RowReaderOptions {
        << disableFloatingPointToVarcharMetadataFilter_ << ", ";
     ss << "parquetReaderImplicitCastMask_=" << parquetReaderImplicitCastMask_
        << ", ";
-    ss << "decodeRepDefPageCount_=" << decodeRepDefPageCount_;
+    ss << "decodeRepDefPageCount_=" << decodeRepDefPageCount_ << ", ";
     ss << "parquetRepDefMemoryLimit_=" << parquetRepDefMemoryLimit_ << ", ";
+    ss << "parquetRepDefStreamingWindowSize_="
+       << parquetRepDefStreamingWindowSize_ << ", ";
     ss << "maxBatchBytes_=" << maxBatchBytes_ << ", ";
     ss << "useColumnNamesForColumnMapping_="
        << (useColumnNamesForColumnMapping_ ? "true" : "false");

--- a/bolt/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/bolt/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -113,7 +113,15 @@ void SelectiveRepeatedColumnReader::makeNestedRowSet(
   // Reads the lengths, leaves an uninitialized gap for a null
   // map/list. Reading these checks the null mask.
   readLengths(allLengths_, maxRow + 1, nulls);
-  vector_size_t nestedLength = 0;
+  vector_size_t nestedLength;
+  if (nestedRowsAllSelected_) {
+    nestedLength = sumLengths(allLengths_, nulls, 0, maxRow + 1);
+    childTargetReadOffset_ += nestedLength;
+    nestedRows_ = RowSet(iota(nestedLength, nestedRowsHolder_), nestedLength);
+    return;
+  }
+
+  nestedLength = 0;
   for (auto row : rows) {
     if (!nulls || !bits::isBitNull(nulls, row)) {
       nestedLength +=
@@ -154,8 +162,24 @@ void SelectiveRepeatedColumnReader::makeOffsetsAndSizes(
       result.mutableOffsets(rows.size())->asMutable<vector_size_t>();
   auto* rawSizes = result.mutableSizes(rows.size())->asMutable<vector_size_t>();
   auto* nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
-  vector_size_t currentRow = 0;
+  numValues_ = rows.size();
   vector_size_t currentOffset = 0;
+  if (nestedRowsAllSelected_ && rows.size() == outputRows().size()) {
+    for (int i = 0; i < rows.size(); ++i) {
+      BOLT_DCHECK_EQ(i, rows[i]);
+      rawOffsets[i] = currentOffset;
+      if (nulls && bits::isBitNull(nulls, i)) {
+        rawSizes[i] = 0;
+        bits::setNull(rawResultNulls_, i);
+        anyNulls_ = true;
+      } else {
+        rawSizes[i] = allLengths_[i];
+        currentOffset += allLengths_[i];
+      }
+    }
+    return;
+  }
+  vector_size_t currentRow = 0;
   vector_size_t nestedRowIndex = 0;
   for (int i = 0; i < rows.size(); ++i) {
     auto row = rows[i];
@@ -176,7 +200,6 @@ void SelectiveRepeatedColumnReader::makeOffsetsAndSizes(
       nestedRowIndex = newNestedRowIndex;
     }
   }
-  numValues_ = rows.size();
 }
 
 RowSet SelectiveRepeatedColumnReader::applyFilter(const RowSet& rows) {
@@ -251,6 +274,9 @@ void SelectiveListColumnReader::read(
   child_->seekTo(childTargetReadOffset_, false);
   prepareRead<char>(offset, rows, incomingNulls);
   auto activeRows = applyFilter(rows);
+  nestedRowsAllSelected_ = activeRows.size() == rows.back() + 1 &&
+      scanSpec_->maxArrayElementsCount() ==
+          std::numeric_limits<vector_size_t>::max();
   makeNestedRowSet(activeRows, rows.back());
   if (child_ && !nestedRows_.empty()) {
     child_->read(child_->readOffset(), nestedRows_, nullptr);
@@ -329,10 +355,15 @@ void SelectiveMapColumnReader::read(
   }
 
   prepareRead<char>(offset, rows, incomingNulls);
-  auto activeRows = applyFilter(rows);
+  const auto activeRows = applyFilter(rows);
+  nestedRowsAllSelected_ = activeRows.size() == rows.back() + 1 &&
+      scanSpec_->maxArrayElementsCount() ==
+          std::numeric_limits<vector_size_t>::max();
   makeNestedRowSet(activeRows, rows.back());
   if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
     keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
+    nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
+        nestedRows_.size() == keyReader_->outputRows().size();
     nestedRows_ = keyReader_->outputRows();
     if (!nestedRows_.empty()) {
       elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);

--- a/bolt/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/bolt/dwio/common/SelectiveRepeatedColumnReader.h
@@ -105,6 +105,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   vector_size_t* allLengths_;
   RowSet nestedRows_;
   raw_vector<vector_size_t> nestedRowsHolder_;
+  bool nestedRowsAllSelected_{false};
 
   // The position in the child readers that corresponds to the position in the
   // length stream. The child readers can be behind if the last parents were

--- a/bolt/dwio/dwrf/test/CacheInputTest.cpp
+++ b/bolt/dwio/dwrf/test/CacheInputTest.cpp
@@ -411,6 +411,149 @@ class CacheTest : public testing::Test {
   bool testRandomSeek_{true};
 };
 
+TEST_F(CacheTest, enqueuePairReadsStorageOnce) {
+  constexpr int32_t kMB = 1 << 20;
+  constexpr int32_t kLength = 64 << 10;
+  initializeCache(16 * kMB);
+  auto tracker = std::make_shared<ScanTracker>(
+      "testTracker",
+      nullptr,
+      io::ReaderOptions::kDefaultLoadQuantum,
+      groupStats_);
+  uint64_t fileId;
+  uint64_t groupId;
+  auto file = inputByPath("shared_streams", fileId, groupId);
+  auto input = std::make_unique<CachedBufferedInput>(
+      file,
+      MetricsLog::voidLog(),
+      fileId,
+      cache_.get(),
+      tracker,
+      groupId,
+      ioStats_,
+      executor_.get(),
+      io::ReaderOptions(pool_.get()));
+  auto streamId = StreamIdentifier::sequentialFile();
+  auto [first, second] = input->enqueuePair({100, kLength}, &streamId);
+  const auto previous = file->numIos();
+  input->load(LogType::FILE);
+
+  auto readAll = [&](SeekableInputStream& stream) {
+    const void* data;
+    int32_t size;
+    int32_t bytesRead = 0;
+    while (stream.Next(&data, &size)) {
+      file->checkData(data, 100 + bytesRead, size);
+      bytesRead += size;
+    }
+    EXPECT_EQ(kLength, bytesRead);
+  };
+
+  readAll(*second);
+  readAll(*first);
+  EXPECT_EQ(1, file->numIos() - previous);
+}
+
+TEST_F(CacheTest, enqueuePairTriggersCoalescedLoad) {
+  constexpr int32_t kMB = 1 << 20;
+  constexpr int32_t kLength = 64 << 10;
+  constexpr int32_t kGap = 100;
+  gflags::FlagSaver flagSaver;
+  FLAGS_cache_prefetch_min_pct = 101;
+  initializeCache(16 * kMB);
+  auto tracker = std::make_shared<ScanTracker>(
+      "testTracker",
+      nullptr,
+      io::ReaderOptions::kDefaultLoadQuantum,
+      groupStats_);
+  uint64_t fileId;
+  uint64_t groupId;
+  auto file = inputByPath("shared_streams", fileId, groupId);
+  auto input = std::make_unique<CachedBufferedInput>(
+      file,
+      MetricsLog::voidLog(),
+      fileId,
+      cache_.get(),
+      tracker,
+      groupId,
+      ioStats_,
+      nullptr,
+      io::ReaderOptions(pool_.get()));
+  const Region pairRegion{100, kLength};
+  const Region adjacentRegion{
+      pairRegion.offset + pairRegion.length + kGap, kLength};
+  auto [first, second] = input->enqueuePair(pairRegion, streamIds_[0].get());
+  auto adjacent = input->enqueue(adjacentRegion, streamIds_[1].get());
+  first.reset();
+
+  const auto previous = file->numIos();
+  input->load(LogType::FILE);
+  EXPECT_EQ(previous, file->numIos());
+
+  auto readAll = [&](SeekableInputStream& stream, const Region& region) {
+    const void* data;
+    int32_t size;
+    int32_t bytesRead = 0;
+    while (stream.Next(&data, &size)) {
+      file->checkData(data, region.offset + bytesRead, size);
+      bytesRead += size;
+    }
+    EXPECT_EQ(region.length, bytesRead);
+  };
+
+  readAll(*second, pairRegion);
+  EXPECT_EQ(1, file->numIos() - previous);
+  readAll(*adjacent, adjacentRegion);
+  EXPECT_EQ(1, file->numIos() - previous);
+}
+
+TEST_F(CacheTest, enqueueLargePairTriggersAllSplitCoalescedLoads) {
+  constexpr int32_t kMB = 1 << 20;
+  constexpr int32_t kQuantum = 64 << 10;
+  constexpr int32_t kLength = 4 * kQuantum;
+  gflags::FlagSaver flagSaver;
+  FLAGS_cache_prefetch_min_pct = 50;
+  initializeCache(16 * kMB);
+  auto tracker = std::make_shared<ScanTracker>(
+      "testTracker", nullptr, kQuantum, groupStats_);
+  uint64_t fileId;
+  uint64_t groupId;
+  auto file = inputByPath("large_shared_streams", fileId, groupId);
+  io::ReaderOptions options(pool_.get());
+  options.setLoadQuantum(kQuantum).setMaxCoalesceBytes(2 * kQuantum);
+  auto input = std::make_unique<CachedBufferedInput>(
+      file,
+      MetricsLog::voidLog(),
+      fileId,
+      cache_.get(),
+      tracker,
+      groupId,
+      ioStats_,
+      nullptr,
+      options);
+
+  const auto trackingId = TrackingId(streamIds_[1]->getId());
+  tracker->recordReference(trackingId, 4 * kLength, fileId, groupId);
+  tracker->recordRead(trackingId, 5 * kLength, fileId, groupId);
+  const Region region{100, kLength};
+  auto [first, second] = input->enqueuePair(region, streamIds_[1].get());
+  first.reset();
+
+  const auto previous = file->numIos();
+  input->load(LogType::FILE);
+  EXPECT_EQ(previous, file->numIos());
+
+  const void* data;
+  int32_t size;
+  int32_t bytesRead = 0;
+  while (second->Next(&data, &size)) {
+    file->checkData(data, region.offset + bytesRead, size);
+    bytesRead += size;
+  }
+  EXPECT_EQ(region.length, bytesRead);
+  EXPECT_EQ(2, file->numIos() - previous);
+}
+
 TEST_F(CacheTest, window) {
   constexpr int32_t kMB = 1 << 20;
   initializeCache(64 * kMB);

--- a/bolt/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/bolt/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -40,7 +40,10 @@
 #include "bolt/dwio/dwrf/test/TestReadFile.h"
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <cstddef>
+#include <limits>
+#include <stdexcept>
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::dwio;
 using namespace bytedance::bolt::dwio::common;
@@ -56,6 +59,53 @@ struct TestRegion {
   int32_t length;
   bool read = true;
 };
+
+namespace {
+
+class FailOnceReadFile final : public TestReadFile {
+ public:
+  enum class FailureMode {
+    kThrow,
+    kShortRead,
+  };
+
+  FailOnceReadFile(
+      uint64_t seed,
+      uint64_t length,
+      std::shared_ptr<IoStatistics> ioStats,
+      FailureMode failureMode)
+      : TestReadFile(seed, length, std::move(ioStats)),
+        failureMode_(failureMode) {}
+
+  uint64_t preadv(
+      uint64_t offset,
+      const std::vector<folly::Range<char*>>& buffers) const override {
+    if (readAttempts_++ > 0) {
+      return TestReadFile::preadv(offset, buffers);
+    }
+
+    if (failureMode_ == FailureMode::kThrow) {
+      throw std::runtime_error("injected read failure");
+    }
+
+    auto shortBuffers = buffers;
+    BOLT_CHECK(!shortBuffers.empty());
+    auto& last = shortBuffers.back();
+    BOLT_CHECK_GT(last.size(), 0);
+    last = {last.data(), last.size() - 1};
+    return TestReadFile::preadv(offset, shortBuffers);
+  }
+
+  int32_t readAttempts() const {
+    return readAttempts_;
+  }
+
+ private:
+  const FailureMode failureMode_;
+  mutable std::atomic<int32_t> readAttempts_{0};
+};
+
+} // namespace
 
 class DirectBufferedInputTest : public testing::Test {
  protected:
@@ -216,6 +266,152 @@ TEST_F(DirectBufferedInputTest, noRedownloadCoalescedPrefetch) {
   testLoads({{100, 100}, {201, 1, true}, {202, 100}}, 1);
 }
 
+TEST_F(DirectBufferedInputTest, enqueuePairSharesLockstepReads) {
+  const int32_t quantum = 64 << 10;
+  const int32_t length = 3 * quantum + 123;
+  opts_->setLoadQuantum(quantum);
+  const Region region{100, static_cast<uint64_t>(length)};
+  auto previous = file_->numIos();
+  auto input = makeInput();
+  StreamIdentifier streamId(0);
+  auto [first, second] = input->enqueuePair(region, &streamId);
+  input->load(LogType::FILE);
+
+  int32_t offset = 0;
+  while (offset < length) {
+    const void* firstData;
+    const void* secondData;
+    int32_t firstSize;
+    int32_t secondSize;
+    ASSERT_TRUE(first->Next(&firstData, &firstSize));
+    ASSERT_TRUE(second->Next(&secondData, &secondSize));
+    EXPECT_EQ(firstSize, secondSize);
+    file_->checkData(firstData, region.offset + offset, firstSize);
+    file_->checkData(secondData, region.offset + offset, secondSize);
+    offset += firstSize;
+  }
+
+  EXPECT_EQ(4, file_->numIos() - previous);
+}
+
+TEST_F(DirectBufferedInputTest, enqueuePairSharesReadFailure) {
+  constexpr int32_t kQuantum = 4 << 10;
+  constexpr int32_t kLength = 2 * kQuantum;
+  opts_->setLoadQuantum(kQuantum);
+
+  for (const auto failureMode :
+       {FailOnceReadFile::FailureMode::kThrow,
+        FailOnceReadFile::FailureMode::kShortRead}) {
+    SCOPED_TRACE(static_cast<int32_t>(failureMode));
+    auto failOnceFile = std::make_shared<FailOnceReadFile>(
+        11, kLength, fileIoStats_, failureMode);
+    file_ = failOnceFile;
+    auto input = makeInput();
+    StreamIdentifier streamId(0);
+    auto [first, second] = input->enqueuePair({0, kLength}, &streamId);
+
+    const void* data;
+    int32_t size;
+    EXPECT_ANY_THROW(first->Next(&data, &size));
+    EXPECT_ANY_THROW(second->Next(&data, &size));
+    EXPECT_EQ(failOnceFile->readAttempts(), 1);
+  }
+}
+
+TEST_F(DirectBufferedInputTest, enqueuePairBoundsMemory) {
+  const int32_t quantum = 64 << 10;
+  const int32_t length = 32 * quantum;
+  opts_->setLoadQuantum(quantum);
+  file_ = std::make_shared<TestReadFile>(11, length, fileIoStats_);
+  auto pairPool = pool_;
+  const auto baseline = pairPool->currentBytes();
+  const auto chunkBytes =
+      pairPool->preferredSize(quantum + AlignedBuffer::kPaddedSize);
+  auto input = makeInput();
+  StreamIdentifier streamId(0);
+  auto [first, second] = input->enqueuePair({0, length}, &streamId);
+
+  const void* data;
+  int32_t size;
+  int32_t offset = 0;
+  while (first->Next(&data, &size)) {
+    file_->checkData(data, offset, size);
+    offset += size;
+    EXPECT_LE(pairPool->currentBytes() - baseline, 3 * chunkBytes);
+  }
+
+  checkRead(second.get(), {0, length});
+  EXPECT_LE(pairPool->currentBytes() - baseline, 3 * chunkBytes);
+  EXPECT_LE(pairPool->peakBytes() - baseline, 4 * chunkBytes);
+
+  first.reset();
+  second.reset();
+  input.reset();
+  EXPECT_EQ(baseline, pairPool->currentBytes());
+}
+
+TEST_F(DirectBufferedInputTest, enqueuePairInterleavesIndependentCursors) {
+  const int32_t quantum = 64 << 10;
+  const int32_t length = 5 * quantum;
+  opts_->setLoadQuantum(quantum);
+  file_ = std::make_shared<TestReadFile>(11, length, fileIoStats_);
+  auto input = makeInput();
+  StreamIdentifier streamId(0);
+  auto [first, second] = input->enqueuePair({0, length}, &streamId);
+
+  const void* firstData;
+  int32_t firstSize;
+  ASSERT_TRUE(first->Next(&firstData, &firstSize));
+  ASSERT_EQ(firstSize, quantum);
+  const auto* retained = static_cast<const char*>(firstData);
+
+  EXPECT_TRUE(second->SkipInt64(2 * quantum + 17));
+  const void* secondData;
+  int32_t secondSize;
+  ASSERT_TRUE(second->Next(&secondData, &secondSize));
+  file_->checkData(secondData, 2 * quantum + 17, secondSize);
+  EXPECT_EQ(second->ByteCount(), 3 * quantum);
+
+  EXPECT_TRUE(second->SkipInt64(quantum));
+  ASSERT_TRUE(second->Next(&secondData, &secondSize));
+  file_->checkData(secondData, 4 * quantum, secondSize);
+  file_->checkData(retained, 0, firstSize);
+
+  first->BackUp(23);
+  EXPECT_EQ(first->ByteCount(), quantum - 23);
+  ASSERT_TRUE(first->Next(&firstData, &firstSize));
+  file_->checkData(firstData, quantum - 23, firstSize);
+
+  const std::vector<uint64_t> positions{quantum + 11};
+  PositionProvider position(positions);
+  first->seekToPosition(position);
+  ASSERT_TRUE(first->Next(&firstData, &firstSize));
+  file_->checkData(firstData, quantum + 11, firstSize);
+  EXPECT_EQ(first->positionSize(), 1);
+  EXPECT_EQ(first->ByteCount(), 2 * quantum);
+  EXPECT_EQ(file_->numIos(), 5);
+}
+
+TEST_F(DirectBufferedInputTest, enqueuePairSupportsLargeRegion) {
+  constexpr uint64_t kLength =
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) + 1;
+  file_ = std::make_shared<TestReadFile>(11, kLength, fileIoStats_);
+  opts_->setLoadQuantum(64 << 10);
+  auto input = makeInput();
+  StreamIdentifier streamId(0);
+
+  auto [first, second] = input->enqueuePair({0, kLength}, &streamId);
+
+  EXPECT_TRUE(first->SkipInt64(kLength - 1));
+  const void* data;
+  int32_t size;
+  ASSERT_TRUE(first->Next(&data, &size));
+  ASSERT_EQ(size, 1);
+  file_->checkData(data, kLength - 1, size);
+  EXPECT_EQ(first->ByteCount(), kLength);
+  EXPECT_EQ(second->ByteCount(), 0);
+}
+
 TEST_F(DirectBufferedInputTest, coalesedPrefetchOverlap) {
   testLoads({{100, 100}, {201, 1, false}, {201, 2, false}, {203, 100}}, 2);
   testLoads({{100, 100}, {201, 1, true}, {201, 2, true}, {203, 100}}, 2);
@@ -263,6 +459,14 @@ TEST_F(DirectBufferedInputTest, preload) {
          static_cast<uint64_t>(testData.length)},
         nullptr);
     checkRead(stream.get(), {testData.offset, testData.length});
+    EXPECT_EQ(file_->numIos() - iosBeforePreload, 1);
+
+    auto [first, second] = input->enqueuePair(
+        {static_cast<uint64_t>(testData.offset),
+         static_cast<uint64_t>(testData.length)},
+        nullptr);
+    checkRead(first.get(), {testData.offset, testData.length});
+    checkRead(second.get(), {testData.offset, testData.length});
     EXPECT_EQ(file_->numIos() - iosBeforePreload, 1);
   }
 }

--- a/bolt/dwio/parquet/arrow/LevelConversion.cpp
+++ b/bolt/dwio/parquet/arrow/LevelConversion.cpp
@@ -54,14 +54,15 @@ using ::arrow::internal::CpuInfo;
 using ::std::optional;
 
 optional<::arrow::internal::FirstTimeBitmapWriter> makeBitmapWriter(
-    ValidityBitmapInputOutput* output) {
+    ValidityBitmapInputOutput* output,
+    int64_t values_to_skip = 0) {
   if (output->valid_bits == nullptr) {
     return std::nullopt;
   }
   return ::arrow::internal::FirstTimeBitmapWriter(
       output->valid_bits,
-      output->valid_bits_offset,
-      output->values_read_upper_bound);
+      output->valid_bits_offset + values_to_skip,
+      std::max<int64_t>(output->values_read_upper_bound - values_to_skip, 0));
 }
 
 void writeValidityBit(
@@ -86,13 +87,24 @@ int64_t countContinuationRun(
     int64_t num_def_levels,
     int64_t start,
     LevelInfo level_info) {
-  int64_t run = 1;
-  while (start + run < num_def_levels &&
-         rep_levels[start + run] == level_info.rep_level &&
-         def_levels[start + run] >= level_info.repeated_ancestor_def_level) {
-    ++run;
+  constexpr int64_t kBatch = xsimd::batch<int16_t>::size;
+  const auto repLevel = xsimd::broadcast<int16_t>(level_info.rep_level);
+  const auto ancestorDefLevel =
+      xsimd::broadcast<int16_t>(level_info.repeated_ancestor_def_level - 1);
+  auto runEnd = start + 1;
+  for (; runEnd + kBatch <= num_def_levels; runEnd += kBatch) {
+    const auto reps = xsimd::load_unaligned(rep_levels + runEnd);
+    const auto defs = xsimd::load_unaligned(def_levels + runEnd);
+    if (!xsimd::all((reps == repLevel) & (defs > ancestorDefLevel))) {
+      break;
+    }
   }
-  return run;
+  while (runEnd < num_def_levels &&
+         rep_levels[runEnd] == level_info.rep_level &&
+         def_levels[runEnd] >= level_info.repeated_ancestor_def_level) {
+    ++runEnd;
+  }
+  return runEnd - start;
 }
 
 bool isSupportedDirectStructList(
@@ -175,7 +187,15 @@ class OffsetListOutput {
 
 class LengthListOutput {
  public:
-  explicit LengthListOutput(int32_t* lengths) : lengths_(lengths) {}
+  explicit LengthListOutput(
+      int32_t* lengths,
+      ListLengthsState* state = nullptr,
+      bool finalize = true)
+      : lengths_(lengths),
+        state_(state),
+        finalize_(finalize),
+        currentLength_(state == nullptr ? 0 : state->current_length),
+        haveCurrentList_(state != nullptr && state->has_open_list) {}
 
   void OnContinuationRun(int64_t run) {
     if (ARROW_PREDICT_FALSE(
@@ -187,16 +207,18 @@ class LengthListOutput {
   }
 
   void OnNewList(int16_t def_level, const LevelInfo& level_info) {
-    Finish();
+    finishCurrentList();
     haveCurrentList_ = true;
     currentLength_ = def_level >= level_info.def_level ? 1 : 0;
   }
 
   void Finish() {
-    if (haveCurrentList_) {
-      lengths_[valuesRead_++] = currentLength_;
-      currentLength_ = 0;
-      haveCurrentList_ = false;
+    if (finalize_) {
+      finishCurrentList();
+    }
+    if (state_ != nullptr) {
+      state_->current_length = currentLength_;
+      state_->has_open_list = haveCurrentList_;
     }
   }
 
@@ -213,7 +235,17 @@ class LengthListOutput {
   }
 
  private:
+  void finishCurrentList() {
+    if (haveCurrentList_) {
+      lengths_[valuesRead_++] = currentLength_;
+      currentLength_ = 0;
+      haveCurrentList_ = false;
+    }
+  }
+
   int32_t* lengths_;
+  ListLengthsState* state_;
+  bool finalize_;
   int64_t valuesRead_{0};
   int32_t currentLength_{0};
   bool haveCurrentList_{false};
@@ -226,14 +258,10 @@ void DefRepLevelsToListInfo(
     int64_t num_def_levels,
     LevelInfo level_info,
     ValidityBitmapInputOutput* output,
-    ListOutput& list_output) {
-  optional<::arrow::internal::FirstTimeBitmapWriter> valid_bits_writer;
-  if (output->valid_bits) {
-    valid_bits_writer.emplace(
-        output->valid_bits,
-        output->valid_bits_offset,
-        output->values_read_upper_bound);
-  }
+    ListOutput& list_output,
+    int64_t validity_values_to_skip = 0,
+    bool finalize_open_list = true) {
+  auto valid_bits_writer = makeBitmapWriter(output, validity_values_to_skip);
   for (int64_t x = 0; x < num_def_levels; ++x) {
     // Skip items that belong to empty or null ancestor lists and further nested
     // lists.
@@ -252,7 +280,7 @@ void DefRepLevelsToListInfo(
     } else {
       if (ARROW_PREDICT_FALSE(
               (valid_bits_writer.has_value() &&
-               valid_bits_writer->position() >=
+               valid_bits_writer->position() + validity_values_to_skip >=
                    output->values_read_upper_bound) ||
               list_output.valuesReadForBounds() >=
                   output->values_read_upper_bound)) {
@@ -280,6 +308,15 @@ void DefRepLevelsToListInfo(
       }
     }
   }
+  if (ARROW_PREDICT_FALSE(
+          finalize_open_list &&
+          list_output.valuesReadForBounds() >
+              output->values_read_upper_bound)) {
+    std::stringstream ss;
+    ss << "Definition levels exceeded upper bound: "
+       << output->values_read_upper_bound;
+    throw ParquetException(ss.str());
+  }
   list_output.Finish();
   if (valid_bits_writer.has_value()) {
     valid_bits_writer->Finish();
@@ -294,6 +331,85 @@ void DefRepLevelsToListInfo(
         "Null values with null_slot_usage > 1 not supported."
         "(i.e. FixedSizeLists with null values are not supported)");
   }
+}
+
+bool defRepLevelsToListLengthsAndStructBitmap(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo list_level_info,
+    LevelInfo struct_level_info,
+    ValidityBitmapInputOutput* list_output,
+    int32_t* lengths,
+    ValidityBitmapInputOutput* struct_output,
+    ListLengthsState* state,
+    bool finalize) {
+  if (!isSupportedDirectStructList(list_level_info, struct_level_info)) {
+    return false;
+  }
+
+  const auto validityValuesToSkip =
+      static_cast<int64_t>(state != nullptr && state->has_open_list);
+  auto listValidWriter = makeBitmapWriter(list_output, validityValuesToSkip);
+  auto structValidWriter =
+      makeBitmapWriter(struct_output, validityValuesToSkip);
+  LengthListOutput listLengths(lengths, state, finalize);
+
+  for (int64_t x = 0; x < num_def_levels; ++x) {
+    if (def_levels[x] < list_level_info.repeated_ancestor_def_level ||
+        rep_levels[x] > list_level_info.rep_level) {
+      continue;
+    }
+
+    if (rep_levels[x] == list_level_info.rep_level) {
+      const auto run = countContinuationRun(
+          def_levels, rep_levels, num_def_levels, x, list_level_info);
+      listLengths.OnContinuationRun(run);
+      x += run - 1;
+      continue;
+    }
+
+    checkFusedValuesReadUpperBound(
+        listLengths.valuesReadForBounds(), list_output, struct_output);
+    listLengths.OnNewList(def_levels[x], list_level_info);
+    writeValidityBit(
+        listValidWriter,
+        list_output,
+        def_levels[x] >= list_level_info.def_level - 1);
+    writeValidityBit(
+        structValidWriter,
+        struct_output,
+        def_levels[x] >= struct_level_info.def_level);
+  }
+  if (ARROW_PREDICT_FALSE(
+          finalize &&
+          (listLengths.valuesReadForBounds() >
+               list_output->values_read_upper_bound ||
+           listLengths.valuesReadForBounds() >
+               struct_output->values_read_upper_bound))) {
+    std::stringstream ss;
+    ss << "Definition levels exceeded upper bound: "
+       << std::min(
+              list_output->values_read_upper_bound,
+              struct_output->values_read_upper_bound);
+    throw ParquetException(ss.str());
+  }
+  listLengths.Finish();
+
+  if (listValidWriter.has_value()) {
+    listValidWriter->Finish();
+  }
+  if (structValidWriter.has_value()) {
+    structValidWriter->Finish();
+  }
+  list_output->values_read = listLengths.valuesRead();
+  struct_output->values_read = listLengths.valuesRead();
+  if (list_output->null_count > 0 && list_level_info.null_slot_usage > 1) {
+    throw ParquetException(
+        "Null values with null_slot_usage > 1 not supported."
+        "(i.e. FixedSizeLists with null values are not supported)");
+  }
+  return true;
 }
 
 struct AllValidResult {
@@ -340,7 +456,7 @@ bool DefLevelsAreAllValidNoRepeatedParent(
   int64_t i = 0;
   for (; i + kBatch <= num_def_levels; i += kBatch) {
     const auto levels = xsimd::load_unaligned(def_levels + i);
-    allValid &= simd::toBitMask(levels > validLevel) == ((1 << kBatch) - 1);
+    allValid &= xsimd::all(levels > validLevel);
   }
   for (; i < num_def_levels; ++i) {
     allValid &= def_levels[i] >= level_info.def_level;
@@ -443,6 +559,28 @@ void DefRepLevelsToListLengths(
       def_levels, rep_levels, num_def_levels, level_info, output, listOutput);
 }
 
+void DefRepLevelsToListLengths(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info,
+    ValidityBitmapInputOutput* output,
+    int32_t* lengths,
+    ListLengthsState* state,
+    bool finalize) {
+  const auto validityValuesToSkip = static_cast<int64_t>(state->has_open_list);
+  LengthListOutput listOutput(lengths, state, finalize);
+  DefRepLevelsToListInfo(
+      def_levels,
+      rep_levels,
+      num_def_levels,
+      level_info,
+      output,
+      listOutput,
+      validityValuesToSkip,
+      finalize);
+}
+
 bool DefRepLevelsToListLengthsAndStructBitmap(
     const int16_t* def_levels,
     const int16_t* rep_levels,
@@ -452,60 +590,41 @@ bool DefRepLevelsToListLengthsAndStructBitmap(
     ValidityBitmapInputOutput* list_output,
     int32_t* lengths,
     ValidityBitmapInputOutput* struct_output) {
-  if (!isSupportedDirectStructList(list_level_info, struct_level_info)) {
-    return false;
-  }
+  return defRepLevelsToListLengthsAndStructBitmap(
+      def_levels,
+      rep_levels,
+      num_def_levels,
+      list_level_info,
+      struct_level_info,
+      list_output,
+      lengths,
+      struct_output,
+      nullptr,
+      true);
+}
 
-  auto list_valid_writer = makeBitmapWriter(list_output);
-  auto struct_valid_writer = makeBitmapWriter(struct_output);
-  LengthListOutput listLengths(lengths);
-
-  for (int64_t x = 0; x < num_def_levels; ++x) {
-    if (def_levels[x] < list_level_info.repeated_ancestor_def_level ||
-        rep_levels[x] > list_level_info.rep_level) {
-      continue;
-    }
-
-    if (rep_levels[x] == list_level_info.rep_level) {
-      const auto run = countContinuationRun(
-          def_levels, rep_levels, num_def_levels, x, list_level_info);
-      listLengths.OnContinuationRun(run);
-      x += run - 1;
-      continue;
-    }
-
-    checkFusedValuesReadUpperBound(
-        listLengths.valuesReadForBounds(), list_output, struct_output);
-    listLengths.OnNewList(def_levels[x], list_level_info);
-    writeValidityBit(
-        list_valid_writer,
-        list_output,
-        def_levels[x] >= list_level_info.def_level - 1);
-    writeValidityBit(
-        struct_valid_writer,
-        struct_output,
-        def_levels[x] >= struct_level_info.def_level);
-  }
-  listLengths.Finish();
-
-  if (list_valid_writer.has_value()) {
-    list_valid_writer->Finish();
-    list_output->values_read = list_valid_writer->position();
-  } else {
-    list_output->values_read = listLengths.valuesRead();
-  }
-  if (struct_valid_writer.has_value()) {
-    struct_valid_writer->Finish();
-    struct_output->values_read = struct_valid_writer->position();
-  } else {
-    struct_output->values_read = listLengths.valuesRead();
-  }
-  if (list_output->null_count > 0 && list_level_info.null_slot_usage > 1) {
-    throw ParquetException(
-        "Null values with null_slot_usage > 1 not supported."
-        "(i.e. FixedSizeLists with null values are not supported)");
-  }
-  return true;
+bool DefRepLevelsToListLengthsAndStructBitmap(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo list_level_info,
+    LevelInfo struct_level_info,
+    ValidityBitmapInputOutput* list_output,
+    int32_t* lengths,
+    ValidityBitmapInputOutput* struct_output,
+    ListLengthsState* state,
+    bool finalize) {
+  return defRepLevelsToListLengthsAndStructBitmap(
+      def_levels,
+      rep_levels,
+      num_def_levels,
+      list_level_info,
+      struct_level_info,
+      list_output,
+      lengths,
+      struct_output,
+      state,
+      finalize);
 }
 
 void DefRepLevelsToBitmap(

--- a/bolt/dwio/parquet/arrow/LevelConversion.h
+++ b/bolt/dwio/parquet/arrow/LevelConversion.h
@@ -181,6 +181,11 @@ struct PARQUET_EXPORT ValidityBitmapInputOutput {
   int64_t valid_bits_offset = 0;
 };
 
+struct PARQUET_EXPORT ListLengthsState {
+  int32_t current_length = 0;
+  bool has_open_list = false;
+};
+
 //  Converts def_levels to validity bitmaps for non-list arrays and structs that
 //  have at least one member that is not a list and has no list descendents. For
 //  lists use DefRepLevelsToList and structs where all descendants contain a
@@ -236,6 +241,20 @@ void PARQUET_EXPORT DefRepLevelsToListLengths(
     ValidityBitmapInputOutput* output,
     int32_t* lengths);
 
+// Incremental variant of DefRepLevelsToListLengths. Keeps the current list
+// open across calls unless finalize is true. output->values_read reports only
+// finalized lengths produced by this call. A validity bit for the open list
+// may be written at valid_bits_offset + values_read.
+void PARQUET_EXPORT DefRepLevelsToListLengths(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo level_info,
+    ValidityBitmapInputOutput* output,
+    int32_t* lengths,
+    ListLengthsState* state,
+    bool finalize);
+
 // Reconstructs list lengths/list validity and the validity bitmap of a direct
 // nullable struct parent in one pass over the same def/rep levels. Returns
 // false if the two LevelInfo values do not describe a supported direct
@@ -249,6 +268,20 @@ bool PARQUET_EXPORT DefRepLevelsToListLengthsAndStructBitmap(
     ValidityBitmapInputOutput* list_output,
     int32_t* lengths,
     ValidityBitmapInputOutput* struct_output);
+
+// Incremental variant for a direct struct -> list relationship. Keeps the
+// current list open across calls unless finalize is true.
+bool PARQUET_EXPORT DefRepLevelsToListLengthsAndStructBitmap(
+    const int16_t* def_levels,
+    const int16_t* rep_levels,
+    int64_t num_def_levels,
+    LevelInfo list_level_info,
+    LevelInfo struct_level_info,
+    ValidityBitmapInputOutput* list_output,
+    int32_t* lengths,
+    ValidityBitmapInputOutput* struct_output,
+    ListLengthsState* state,
+    bool finalize);
 
 // Reconstructs a validity bitmap for a struct every member is a list or has
 // a list descendant.  See documentation on DefLevelsToBitmap for when more

--- a/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/LevelConversionTest.cpp
@@ -520,6 +520,133 @@ TEST(NestedListTest, DirectLengthsExactUpperBound) {
   EXPECT_THAT(lengths, testing::ElementsAre(1, 1));
 }
 
+TEST(NestedListTest, DirectLengthsCountNullableContinuationRun) {
+  LevelInfo levelInfo;
+  levelInfo.rep_level = 1;
+  levelInfo.def_level = 3;
+  levelInfo.repeated_ancestor_def_level = 1;
+
+  constexpr int32_t kNumContinuations = 65;
+  std::vector<int16_t> defLevels(kNumContinuations + 1, 1);
+  std::vector<int16_t> repLevels(kNumContinuations + 1, 1);
+  defLevels.front() = levelInfo.def_level;
+  repLevels.front() = 0;
+
+  ValidityBitmapInputOutput output;
+  output.values_read_upper_bound = 1;
+  std::vector<int32_t> lengths(1, -1);
+  DefRepLevelsToListLengths(
+      defLevels.data(),
+      repLevels.data(),
+      defLevels.size(),
+      levelInfo,
+      &output,
+      lengths.data());
+
+  EXPECT_EQ(output.values_read, 1);
+  EXPECT_EQ(lengths.front(), kNumContinuations + 1);
+}
+
+TEST(NestedListTest, IncrementalLengthsMatchOneShot) {
+  const auto testData = TriplyNestedList();
+  const auto check = [&](LevelInfo levelInfo, int32_t chunkSize) {
+    const auto maxValues = testData.def_levels.size();
+
+    std::vector<uint8_t> expectedValidity(maxValues, 0);
+    ValidityBitmapInputOutput expectedIo;
+    expectedIo.valid_bits = expectedValidity.data();
+    expectedIo.values_read_upper_bound = maxValues;
+    std::vector<int32_t> expectedLengths(maxValues, -1);
+    DefRepLevelsToListLengths(
+        testData.def_levels.data(),
+        testData.rep_levels.data(),
+        maxValues,
+        levelInfo,
+        &expectedIo,
+        expectedLengths.data());
+
+    std::vector<uint8_t> actualValidity(maxValues, 0);
+    std::vector<int32_t> actualLengths(maxValues, -1);
+    ListLengthsState state;
+    int64_t valuesRead = 0;
+    int64_t nullCount = 0;
+    for (int32_t begin = 0; begin < maxValues; begin += chunkSize) {
+      const auto size = std::min<int32_t>(chunkSize, maxValues - begin);
+      ValidityBitmapInputOutput io;
+      io.valid_bits = actualValidity.data();
+      io.valid_bits_offset = valuesRead;
+      io.values_read_upper_bound = maxValues - valuesRead;
+      io.null_count = nullCount;
+      DefRepLevelsToListLengths(
+          testData.def_levels.data() + begin,
+          testData.rep_levels.data() + begin,
+          size,
+          levelInfo,
+          &io,
+          actualLengths.data() + valuesRead,
+          &state,
+          false);
+      valuesRead += io.values_read;
+      nullCount = io.null_count;
+    }
+
+    ValidityBitmapInputOutput finalIo;
+    finalIo.valid_bits = actualValidity.data();
+    finalIo.valid_bits_offset = valuesRead;
+    finalIo.values_read_upper_bound = maxValues - valuesRead;
+    finalIo.null_count = nullCount;
+    DefRepLevelsToListLengths(
+        testData.def_levels.data() + maxValues,
+        testData.rep_levels.data() + maxValues,
+        0,
+        levelInfo,
+        &finalIo,
+        actualLengths.data() + valuesRead,
+        &state,
+        true);
+    valuesRead += finalIo.values_read;
+    nullCount = finalIo.null_count;
+
+    SCOPED_TRACE(
+        testing::Message() << "def=" << levelInfo.def_level << ", rep="
+                           << levelInfo.rep_level << ", ancestorDef="
+                           << levelInfo.repeated_ancestor_def_level
+                           << ", chunk=" << chunkSize);
+    ASSERT_EQ(valuesRead, expectedIo.values_read);
+    EXPECT_EQ(nullCount, expectedIo.null_count);
+    EXPECT_FALSE(state.has_open_list);
+    EXPECT_THAT(
+        std::vector<int32_t>(
+            actualLengths.begin(), actualLengths.begin() + valuesRead),
+        testing::ElementsAreArray(
+            expectedLengths.begin(),
+            expectedLengths.begin() + expectedIo.values_read));
+    EXPECT_EQ(
+        BitmapToString(actualValidity, expectedIo.values_read),
+        BitmapToString(expectedValidity, expectedIo.values_read));
+  };
+
+  LevelInfo outer;
+  outer.rep_level = 1;
+  outer.def_level = 2;
+
+  LevelInfo middle;
+  middle.rep_level = 2;
+  middle.def_level = 4;
+  middle.repeated_ancestor_def_level = 2;
+
+  LevelInfo inner;
+  inner.rep_level = 3;
+  inner.def_level = 6;
+  inner.repeated_ancestor_def_level = 4;
+
+  for (const auto chunkSize : {1, 2, 3, 7, 16, 64}) {
+    check(outer, chunkSize);
+    check(middle, chunkSize);
+    check(inner, chunkSize);
+  }
+}
+
 TEST(NestedListTest, FusedDirectStructListMatchesSeparateConversions) {
   MultiLevelTestData test_data;
   test_data.def_levels = std::vector<int16_t>{
@@ -870,6 +997,126 @@ TEST(NestedListTest, FusedDirectStructListUpperBound) {
           &structOutput),
       ParquetException);
   EXPECT_EQ(lengths[1], -1);
+}
+
+TEST(NestedListTest, IncrementalFusedDirectStructListMatchesOneShot) {
+  MultiLevelTestData testData;
+  testData.def_levels = std::vector<int16_t>{0, 1, 2, 3, 4, 4, 2, 0};
+  testData.rep_levels = std::vector<int16_t>{0, 0, 0, 0, 0, 1, 0, 0};
+
+  LevelInfo structInfo;
+  structInfo.rep_level = 0;
+  structInfo.def_level = 1;
+  structInfo.repeated_ancestor_def_level = 0;
+
+  LevelInfo listInfo;
+  listInfo.rep_level = 1;
+  listInfo.def_level = 3;
+  listInfo.repeated_ancestor_def_level = 0;
+
+  const auto maxValues = testData.def_levels.size();
+  std::vector<uint8_t> expectedListValidity(maxValues, 0);
+  ValidityBitmapInputOutput expectedListIo;
+  expectedListIo.valid_bits = expectedListValidity.data();
+  expectedListIo.values_read_upper_bound = maxValues;
+  std::vector<int32_t> expectedLengths(maxValues, -1);
+  std::vector<uint8_t> expectedStructValidity(maxValues, 0);
+  ValidityBitmapInputOutput expectedStructIo;
+  expectedStructIo.valid_bits = expectedStructValidity.data();
+  expectedStructIo.values_read_upper_bound = maxValues;
+  ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+      testData.def_levels.data(),
+      testData.rep_levels.data(),
+      maxValues,
+      listInfo,
+      structInfo,
+      &expectedListIo,
+      expectedLengths.data(),
+      &expectedStructIo));
+
+  for (const auto chunkSize : {1, 2, 3, 7, 16}) {
+    std::vector<uint8_t> actualListValidity(maxValues, 0);
+    std::vector<uint8_t> actualStructValidity(maxValues, 0);
+    std::vector<int32_t> actualLengths(maxValues, -1);
+    ListLengthsState state;
+    int64_t valuesRead = 0;
+    int64_t listNullCount = 0;
+    int64_t structNullCount = 0;
+
+    for (int32_t begin = 0; begin < maxValues; begin += chunkSize) {
+      const auto size = std::min<int32_t>(chunkSize, maxValues - begin);
+      ValidityBitmapInputOutput listIo;
+      listIo.valid_bits = actualListValidity.data();
+      listIo.valid_bits_offset = valuesRead;
+      listIo.values_read_upper_bound = maxValues - valuesRead;
+      listIo.null_count = listNullCount;
+      ValidityBitmapInputOutput structIo;
+      structIo.valid_bits = actualStructValidity.data();
+      structIo.valid_bits_offset = valuesRead;
+      structIo.values_read_upper_bound = maxValues - valuesRead;
+      structIo.null_count = structNullCount;
+      ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+          testData.def_levels.data() + begin,
+          testData.rep_levels.data() + begin,
+          size,
+          listInfo,
+          structInfo,
+          &listIo,
+          actualLengths.data() + valuesRead,
+          &structIo,
+          &state,
+          false));
+      ASSERT_EQ(listIo.values_read, structIo.values_read);
+      valuesRead += listIo.values_read;
+      listNullCount = listIo.null_count;
+      structNullCount = structIo.null_count;
+    }
+
+    ValidityBitmapInputOutput finalListIo;
+    finalListIo.valid_bits = actualListValidity.data();
+    finalListIo.valid_bits_offset = valuesRead;
+    finalListIo.values_read_upper_bound = maxValues - valuesRead;
+    finalListIo.null_count = listNullCount;
+    ValidityBitmapInputOutput finalStructIo;
+    finalStructIo.valid_bits = actualStructValidity.data();
+    finalStructIo.valid_bits_offset = valuesRead;
+    finalStructIo.values_read_upper_bound = maxValues - valuesRead;
+    finalStructIo.null_count = structNullCount;
+    ASSERT_TRUE(DefRepLevelsToListLengthsAndStructBitmap(
+        testData.def_levels.data() + maxValues,
+        testData.rep_levels.data() + maxValues,
+        0,
+        listInfo,
+        structInfo,
+        &finalListIo,
+        actualLengths.data() + valuesRead,
+        &finalStructIo,
+        &state,
+        true));
+    ASSERT_EQ(finalListIo.values_read, finalStructIo.values_read);
+    valuesRead += finalListIo.values_read;
+    listNullCount = finalListIo.null_count;
+    structNullCount = finalStructIo.null_count;
+
+    SCOPED_TRACE(testing::Message() << "chunk=" << chunkSize);
+    ASSERT_EQ(valuesRead, expectedListIo.values_read);
+    EXPECT_EQ(valuesRead, expectedStructIo.values_read);
+    EXPECT_EQ(listNullCount, expectedListIo.null_count);
+    EXPECT_EQ(structNullCount, expectedStructIo.null_count);
+    EXPECT_FALSE(state.has_open_list);
+    EXPECT_THAT(
+        std::vector<int32_t>(
+            actualLengths.begin(), actualLengths.begin() + valuesRead),
+        testing::ElementsAreArray(
+            expectedLengths.begin(),
+            expectedLengths.begin() + expectedListIo.values_read));
+    EXPECT_EQ(
+        BitmapToString(actualListValidity, valuesRead),
+        BitmapToString(expectedListValidity, valuesRead));
+    EXPECT_EQ(
+        BitmapToString(actualStructValidity, valuesRead),
+        BitmapToString(expectedStructValidity, valuesRead));
+  }
 }
 
 TEST(LevelConversionTest, DefLevelsAreAllValid) {

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -32,6 +32,9 @@
 #include <lz4.h>
 #include <thrift/protocol/TCompactProtocol.h> // @manual
 #include <algorithm>
+#include <cstring>
+#include <limits>
+#include <vector>
 
 #include "bolt/common/base/SimdUtil.h"
 #include "bolt/common/time/Timer.h"
@@ -175,8 +178,8 @@ void copyRawDataPageV1RepDefs(
   auto offset = output.size();
   output.resize(offset + repDefs.size + kLenSize);
   BOLT_CHECK_GT(repDefs.size, 0);
-  *(reinterpret_cast<int32_t*>(output.data() + offset)) = numRepDefsInPage;
-  simd::memcpy(output.data() + offset + kLenSize, repDefs.data, repDefs.size);
+  folly::storeUnaligned<int32_t>(output.data() + offset, numRepDefsInPage);
+  std::memcpy(output.data() + offset + kLenSize, repDefs.data, repDefs.size);
 }
 
 void makeDataPageV1RepDefDecoders(
@@ -206,7 +209,173 @@ void makeDataPageV1RepDefDecoders(
         ::arrow::bit_util::NumRequiredBits(maxDefine));
   }
 }
+
+int32_t findTopLevelBoundary(
+    const int16_t* repetitionLevels,
+    int32_t numLevels,
+    int32_t topLevelRowsNeeded,
+    int32_t& topLevelRowsSeen) {
+  constexpr int32_t kBatch = xsimd::batch<int16_t>::size;
+  const auto zero = xsimd::broadcast<int16_t>(0);
+  int32_t i = 0;
+  for (; i + kBatch <= numLevels; i += kBatch) {
+    const auto levels = xsimd::load_unaligned(repetitionLevels + i);
+    auto mask = simd::toBitMask(levels == zero);
+    const auto topLevelRows = __builtin_popcount(mask);
+    const auto rowsBeforeBoundary = topLevelRowsNeeded - topLevelRowsSeen;
+    if (topLevelRows <= rowsBeforeBoundary) {
+      topLevelRowsSeen += topLevelRows;
+      continue;
+    }
+    for (int32_t row = 0; row < rowsBeforeBoundary; ++row) {
+      mask &= mask - 1;
+    }
+    topLevelRowsSeen = topLevelRowsNeeded;
+    return i + __builtin_ctz(mask);
+  }
+  for (; i < numLevels; ++i) {
+    if (repetitionLevels[i] == 0) {
+      if (topLevelRowsSeen == topLevelRowsNeeded) {
+        return i;
+      }
+      ++topLevelRowsSeen;
+    }
+  }
+  return numLevels;
+}
+
+int32_t countPresentLevels(
+    ::arrow::bit_util::BitReader& bitReader,
+    int32_t bitWidth,
+    int32_t numLevels,
+    int16_t presentLevel) {
+  constexpr int32_t kBatchSize = 64;
+  constexpr int32_t kSimdSize = xsimd::batch<int16_t>::size;
+  alignas(xsimd::default_arch::alignment()) int16_t levels[kBatchSize];
+  const auto present = xsimd::broadcast<int16_t>(presentLevel - 1);
+  int32_t count = 0;
+  while (numLevels > 0) {
+    const auto batchSize = std::min(numLevels, kBatchSize);
+    BOLT_CHECK_EQ(bitReader.GetBatch(bitWidth, levels, batchSize), batchSize);
+    int32_t i = 0;
+    for (; i + kSimdSize <= batchSize; i += kSimdSize) {
+      const auto values = xsimd::load_aligned(levels + i);
+      count += __builtin_popcount(simd::toBitMask(values > present));
+    }
+    for (; i < batchSize; ++i) {
+      count += levels[i] >= presentLevel ? 1 : 0;
+    }
+    numLevels -= batchSize;
+  }
+  return count;
+}
+
 } // namespace
+
+struct PageReader::StreamingRepDefState {
+  struct CachedDataPageV1 {
+    BufferPtr data;
+    uint64_t start;
+    int32_t compressedSize;
+    uint64_t retainedBytes;
+    bool containsDecompressedData;
+  };
+
+  struct Output {
+    LevelMode mode;
+    arrow::LevelInfo info;
+    arrow::ListLengthsState listState;
+    raw_vector<int32_t> lengths;
+    raw_vector<uint64_t> nulls;
+    int32_t size{0};
+    int32_t nullCount{0};
+
+    Output(
+        LevelMode outputMode,
+        const arrow::LevelInfo& levelInfo,
+        memory::MemoryPool* pool)
+        : mode(outputMode), info(levelInfo), lengths(pool), nulls(pool) {}
+
+    void reset() {
+      listState = {};
+      lengths.clear();
+      nulls.clear();
+      size = 0;
+      nullCount = 0;
+    }
+
+    void resizeLengths(int32_t capacity) {
+      lengths.resize(size + capacity);
+    }
+
+    arrow::ValidityBitmapInputOutput prepareValidity(int32_t capacity) {
+      const auto oldSize = nulls.size();
+      nulls.resize(bits::nwords(size + capacity));
+      if (nulls.size() > oldSize) {
+        std::memset(
+            nulls.data() + oldSize,
+            0,
+            (nulls.size() - oldSize) * sizeof(uint64_t));
+      }
+
+      arrow::ValidityBitmapInputOutput output;
+      output.values_read_upper_bound = capacity;
+      output.null_count = nullCount;
+      output.valid_bits = reinterpret_cast<uint8_t*>(nulls.data());
+      output.valid_bits_offset = size;
+      return output;
+    }
+
+    void commit(const arrow::ValidityBitmapInputOutput& output) {
+      size += output.values_read;
+      nullCount = output.null_count;
+    }
+
+    void finishLengths() {
+      lengths.resize(size);
+    }
+  };
+
+  explicit StreamingRepDefState(memory::MemoryPool* pool)
+      : definitionScratch(pool), repetitionScratch(pool) {}
+
+  void evictCachedDataPagesV1(uint64_t pageDataStart, bool includeCurrent) {
+    while (!cachedDataPagesV1.empty() &&
+           (cachedDataPagesV1.front().start < pageDataStart ||
+            (includeCurrent &&
+             cachedDataPagesV1.front().start == pageDataStart))) {
+      cachedDataPagesV1Bytes -= cachedDataPagesV1.front().retainedBytes;
+      cachedDataPagesV1.pop_front();
+    }
+  }
+
+  uint64_t pageStart{0};
+  uint64_t pageDataStart{0};
+  const char* FOLLY_NULLABLE bufferStart{nullptr};
+  const char* FOLLY_NULLABLE bufferEnd{nullptr};
+  BufferPtr pageBuffer;
+  BufferPtr decompressedData;
+  // V1 page bodies already materialized by the rep/def cursor and waiting for
+  // the value cursor. Account actual pool allocations against the existing
+  // per-column rep/def memory limit.
+  std::deque<CachedDataPageV1> cachedDataPagesV1;
+  uint64_t cachedDataPagesV1Bytes{0};
+  std::unique_ptr<::arrow::util::RleDecoder> repeatDecoder;
+  std::unique_ptr<::arrow::util::RleDecoder> defineDecoder;
+  raw_vector<int16_t> definitionScratch;
+  raw_vector<int16_t> repetitionScratch;
+  int32_t scratchBegin{0};
+  std::vector<Output> outputs;
+  int32_t levelsRemainingInPage{0};
+  int32_t bytesRemainingInPage{0};
+};
+
+void PageReader::StreamingRepDefStateDeleter::operator()(
+    StreamingRepDefState* state) const {
+  delete state;
+}
+
+PageReader::~PageReader() = default;
 
 void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
   defineDecoder_.reset();
@@ -243,7 +412,7 @@ void PageReader::seekToPage(int64_t row, bool keepRepDefRawData) {
     // the exit of 'decodeRepDefs'.
     if (hasChunkRepDefs_ && !isTopLevel_ && maxRepeat_ > 0) {
       while (pageIndex_ + 1 >= static_cast<int32_t>(numLeavesInPage_.size()) &&
-             !preloadedRepDefs_.empty()) {
+             !usesStreamingRepDefs() && !preloadedRepDefs_.empty()) {
         loadMoreRepDefs();
       }
     }
@@ -458,13 +627,31 @@ void PageReader::setPageRowInfo(bool forRepDef) {
     numRowsInPage_ = numRepDefsInPage_;
   } else if (hasChunkRepDefs_) {
     ++pageIndex_;
+    if (usesStreamingRepDefs()) {
+      const auto relativePageIndex = pageIndex_ - numLeavesInPageBase_;
+      while (relativePageIndex >= numLeavesInPage_.size() &&
+             loadNextStreamingRepDefPage()) {
+      }
+    }
+    const auto relativePageIndex = pageIndex_ - numLeavesInPageBase_;
+    BOLT_CHECK_GE(
+        relativePageIndex,
+        0,
+        "Missing leaf count for already consumed non top level page {}",
+        pageIndex_);
     BOLT_CHECK_LT(
-        pageIndex_,
+        relativePageIndex,
         numLeavesInPage_.size(),
 
         "Seeking past known repdefs for non top level column page {}",
         pageIndex_);
-    numRowsInPage_ = numLeavesInPage_[pageIndex_];
+    numRowsInPage_ = numLeavesInPage_[relativePageIndex];
+    if (usesStreamingRepDefs() && relativePageIndex > 0) {
+      for (int32_t i = 0; i < relativePageIndex; ++i) {
+        numLeavesInPage_.pop_front();
+        ++numLeavesInPageBase_;
+      }
+    }
   } else {
     numRowsInPage_ = kRowsUnknown;
   }
@@ -472,14 +659,31 @@ void PageReader::setPageRowInfo(bool forRepDef) {
 
 void PageReader::readPageDefLevels() {
   BOLT_CHECK(kRowsUnknown == numRowsInPage_ || maxDefine_ > 1);
-  definitionLevels_.resize(numRepDefsInPage_);
   BOLT_CHECK_NOT_NULL(
       wideDefineDecoder_, "parquet read error with maxDefine = {}", maxDefine_);
-  wideDefineDecoder_->GetBatch(definitionLevels_.data(), numRepDefsInPage_);
   leafNullsSize_ = 0;
   leafNullsAllValidPrefix_ = true;
   numLeafNullsConsumed_ = 0;
   erasedLeafNullWords_ = 0;
+  if (usesStreamingRepDefs()) {
+    definitionLevels_.resize(
+        std::min(numRepDefsInPage_, repDefStreamingWindowSize_));
+    int32_t decoded = 0;
+    while (decoded < numRepDefsInPage_) {
+      const auto batchSize =
+          std::min(numRepDefsInPage_ - decoded, repDefStreamingWindowSize_);
+      BOLT_CHECK_EQ(
+          wideDefineDecoder_->GetBatch(definitionLevels_.data(), batchSize),
+          batchSize);
+      leafNullsSize_ += appendLeafNulls(definitionLevels_.data(), batchSize);
+      decoded += batchSize;
+    }
+    numRowsInPage_ = leafNullsSize_;
+    return;
+  }
+
+  definitionLevels_.resize(numRepDefsInPage_);
+  wideDefineDecoder_->GetBatch(definitionLevels_.data(), numRepDefsInPage_);
   numRowsInPage_ = appendLeafNullsFromLevels(0, numRepDefsInPage_);
   leafNullsSize_ = numRowsInPage_;
 }
@@ -502,8 +706,13 @@ void PageReader::prepareDataPageV1(
   ++pageOrdinal_;
   numRepDefsInPage_ = pageHeader.data_page_header.num_values;
   setPageRowInfo(row == kRepDefOnly);
+  int32_t compressedLen = pageHeader.compressed_page_size;
   if (row != kRepDefOnly && numRowsInPage_ != kRowsUnknown &&
       numRowsInPage_ + rowOfPage_ <= row) {
+    if (streamingRepDef_) {
+      auto& state = *streamingRepDef_;
+      state.evictCachedDataPagesV1(pageDataStart_, true);
+    }
     dwio::common::skipBytes(
         pageHeader.compressed_page_size,
         inputStream_.get(),
@@ -513,8 +722,37 @@ void PageReader::prepareDataPageV1(
     return;
   }
 
-  int32_t compressedLen = pageHeader.compressed_page_size;
-  pageData_ = readBytes(compressedLen, pageBuffer_);
+  BufferPtr cachedPage;
+  bool cachedPageIsDecompressed = false;
+  if (streamingRepDef_) {
+    BOLT_CHECK_NULL(cryptoCtx_.dataDecryptor);
+    auto& state = *streamingRepDef_;
+    state.evictCachedDataPagesV1(pageDataStart_, false);
+    if (!state.cachedDataPagesV1.empty() &&
+        state.cachedDataPagesV1.front().start == pageDataStart_) {
+      auto page = std::move(state.cachedDataPagesV1.front());
+      state.cachedDataPagesV1.pop_front();
+      state.cachedDataPagesV1Bytes -= page.retainedBytes;
+      BOLT_CHECK_EQ(page.compressedSize, compressedLen);
+      cachedPage = std::move(page.data);
+      cachedPageIsDecompressed = page.containsDecompressedData;
+    }
+  }
+  if (cachedPage) {
+    std::vector<uint64_t> positions{pageDataStart_ + compressedLen};
+    dwio::common::PositionProvider position(positions);
+    inputStream_->seekToPosition(position);
+    bufferStart_ = bufferEnd_ = nullptr;
+    if (cachedPageIsDecompressed) {
+      decompressedData_ = std::move(cachedPage);
+      pageData_ = decompressedData_->as<char>();
+    } else {
+      pageBuffer_ = std::move(cachedPage);
+      pageData_ = pageBuffer_->as<char>();
+    }
+  } else {
+    pageData_ = readBytes(compressedLen, pageBuffer_);
+  }
   if (cryptoCtx_.dataDecryptor != nullptr) {
     decryptPageData(compressedLen);
   }
@@ -523,8 +761,10 @@ void PageReader::prepareDataPageV1(
           pageHeader, compressedLen, keepRepDefRawData)) {
     return;
   }
-  pageData_ = decompressData(
-      pageData_, compressedLen, pageHeader.uncompressed_page_size);
+  if (!cachedPageIsDecompressed) {
+    pageData_ = decompressData(
+        pageData_, compressedLen, pageHeader.uncompressed_page_size);
+  }
   auto pageEnd = pageData_ + pageHeader.uncompressed_page_size;
 
   const auto repDefs = readDataPageV1RepDefs(
@@ -674,16 +914,15 @@ void PageReader::prepareDataPageV2(
     auto offset = refDefData.size();
     auto totalSize = offset + defineLength + repeatLength + 3 * kLenSize;
     refDefData.resize(totalSize);
-    *(reinterpret_cast<int32_t*>(refDefData.data() + offset)) =
-        numRepDefsInPage_;
-    *(reinterpret_cast<int32_t*>(refDefData.data() + offset + kLenSize)) =
-        repeatLength;
-    simd::memcpy(
+    folly::storeUnaligned<int32_t>(
+        refDefData.data() + offset, numRepDefsInPage_);
+    folly::storeUnaligned<int32_t>(
+        refDefData.data() + offset + kLenSize, repeatLength);
+    std::memcpy(
         refDefData.data() + offset + 2 * kLenSize, pageData_, repeatLength);
-    *(reinterpret_cast<int32_t*>(
-        refDefData.data() + offset + 2 * kLenSize + repeatLength)) =
-        defineLength;
-    simd::memcpy(
+    folly::storeUnaligned<int32_t>(
+        refDefData.data() + offset + 2 * kLenSize + repeatLength, defineLength);
+    std::memcpy(
         refDefData.data() + offset + 3 * kLenSize + repeatLength,
         pageData_ + repeatLength,
         defineLength);
@@ -708,6 +947,10 @@ void PageReader::prepareDataPageV2(
         defineLength,
         ::arrow::bit_util::NumRequiredBits(maxDefine_));
   }
+  if (row == kRepDefOnly) {
+    return;
+  }
+
   auto levelsSize = repeatLength + defineLength;
   pageData_ += levelsSize;
   if (pageHeader.data_page_header_v2.__isset.is_compressed ||
@@ -716,9 +959,6 @@ void PageReader::prepareDataPageV2(
         pageData_,
         pageHeader.compressed_page_size - levelsSize,
         pageHeader.uncompressed_page_size - levelsSize);
-  }
-  if (row == kRepDefOnly) {
-    return;
   }
 
   encodedDataSize_ = pageHeader.uncompressed_page_size - levelsSize;
@@ -1003,6 +1243,555 @@ int32_t parquetTypeBytes(thrift::Type::type type) {
 }
 } // namespace
 
+PageHeader PageReader::readStreamingPageHeader() {
+  auto& state = *streamingRepDef_;
+  if (state.bufferEnd == state.bufferStart) {
+    const void* buffer = nullptr;
+    int32_t size = 0;
+    BOLT_CHECK(
+        repDefInputStream_->Next(&buffer, &size),
+        "Reading past the end of the rep/def stream");
+    state.bufferStart = reinterpret_cast<const char*>(buffer);
+    state.bufferEnd = state.bufferStart + size;
+  }
+
+  auto transport = std::make_shared<thrift::ThriftStreamingTransport>(
+      repDefInputStream_.get(), state.bufferStart, state.bufferEnd);
+  apache::thrift::protocol::TCompactProtocolT<thrift::ThriftTransport> protocol(
+      transport);
+  PageHeader pageHeader;
+  const auto readBytes = pageHeader.read(&protocol);
+  state.pageDataStart = state.pageStart + readBytes;
+  return pageHeader;
+}
+
+const char* PageReader::readStreamingBytes(int32_t size, BufferPtr& copy) {
+  auto& state = *streamingRepDef_;
+  if (state.bufferEnd == state.bufferStart) {
+    const void* buffer = nullptr;
+    int32_t bufferSize = 0;
+    BOLT_CHECK(
+        repDefInputStream_->Next(&buffer, &bufferSize),
+        "Read past end of rep/def stream");
+    state.bufferStart = reinterpret_cast<const char*>(buffer);
+    state.bufferEnd = state.bufferStart + bufferSize;
+  }
+  if (state.bufferEnd - state.bufferStart >= size) {
+    state.bufferStart += size;
+    return state.bufferStart - size;
+  }
+  dwio::common::ensureCapacity<char>(copy, size, &pool_);
+  dwio::common::readBytes(
+      size,
+      repDefInputStream_.get(),
+      copy->asMutable<char>(),
+      state.bufferStart,
+      state.bufferEnd);
+  return copy->as<char>();
+}
+
+void PageReader::skipStreamingBytes(uint64_t size) {
+  if (size == 0) {
+    return;
+  }
+  auto& state = *streamingRepDef_;
+  const auto bufferedBytes = state.bufferStart == nullptr
+      ? 0
+      : static_cast<uint64_t>(state.bufferEnd - state.bufferStart);
+  if (bufferedBytes >= size) {
+    state.bufferStart += size;
+    return;
+  }
+
+  const auto bytesToSkip = size - bufferedBytes;
+  state.bufferStart = state.bufferEnd;
+  const auto beforeSkip = repDefInputStream_->ByteCount();
+  repDefInputStream_->SkipInt64(bytesToSkip);
+  BOLT_CHECK_EQ(
+      repDefInputStream_->ByteCount() - beforeSkip,
+      bytesToSkip,
+      "Reading past the end of the rep/def stream");
+}
+
+void PageReader::initializeStreamingOutputs() {
+  auto& state = *streamingRepDef_;
+  if (!state.outputs.empty()) {
+    return;
+  }
+
+  std::vector<std::pair<LevelMode, arrow::LevelInfo>> outputs;
+  bool hasRepeatedDescendant = false;
+  for (auto* node = type_.get(); node != nullptr;
+       node = node->parquetParent()) {
+    if (node->parquetParent() == nullptr) {
+      break;
+    }
+    const auto kind = node->type()->kind();
+    if (kind != TypeKind::ARRAY && kind != TypeKind::MAP &&
+        kind != TypeKind::ROW) {
+      continue;
+    }
+    if (kind == TypeKind::ARRAY || kind == TypeKind::MAP) {
+      hasRepeatedDescendant = true;
+    }
+    arrow::LevelInfo info;
+    auto mode = node->makeLevelInfo(info);
+    if (kind == TypeKind::ROW) {
+      mode = hasRepeatedDescendant ? LevelMode::kStructOverLists
+                                   : LevelMode::kNulls;
+    }
+    if (info.rep_level == 0 && info.def_level == 0) {
+      continue;
+    }
+    const auto duplicate =
+        std::find_if(outputs.begin(), outputs.end(), [&](const auto& output) {
+          return output.first == mode && output.second == info;
+        });
+    if (duplicate == outputs.end()) {
+      outputs.emplace_back(mode, info);
+    }
+  }
+  std::reverse(outputs.begin(), outputs.end());
+  for (const auto& [mode, info] : outputs) {
+    state.outputs.emplace_back(mode, info, &pool_);
+  }
+}
+
+void PageReader::resetStreamingOutputs() {
+  auto& state = *streamingRepDef_;
+  for (auto& output : state.outputs) {
+    output.reset();
+  }
+}
+
+void PageReader::appendStreamingLevels(
+    const int16_t* definitionLevels,
+    const int16_t* repetitionLevels,
+    int32_t numLevels) {
+  auto& state = *streamingRepDef_;
+  for (int32_t outputIndex = 0; outputIndex < state.outputs.size();
+       ++outputIndex) {
+    auto& output = state.outputs[outputIndex];
+    if (output.mode != LevelMode::kList &&
+        outputIndex + 1 < state.outputs.size()) {
+      auto& listOutput = state.outputs[outputIndex + 1];
+      if (listOutput.mode == LevelMode::kList) {
+        const auto maxNewValues = numLevels + 1;
+        listOutput.resizeLengths(maxNewValues);
+        auto listBits = listOutput.prepareValidity(maxNewValues);
+        auto structBits = output.prepareValidity(maxNewValues);
+        if (arrow::DefRepLevelsToListLengthsAndStructBitmap(
+                definitionLevels,
+                repetitionLevels,
+                numLevels,
+                listOutput.info,
+                output.info,
+                &listBits,
+                listOutput.lengths.data() + listOutput.size,
+                &structBits,
+                &listOutput.listState,
+                false)) {
+          BOLT_CHECK_EQ(listBits.values_read, structBits.values_read);
+          listOutput.commit(listBits);
+          listOutput.finishLengths();
+          output.commit(structBits);
+          ++outputIndex;
+          continue;
+        }
+      }
+    }
+
+    if (output.mode == LevelMode::kList) {
+      const auto maxNewValues = numLevels + 1;
+      output.resizeLengths(maxNewValues);
+      auto bits = output.prepareValidity(maxNewValues);
+      arrow::DefRepLevelsToListLengths(
+          definitionLevels,
+          repetitionLevels,
+          numLevels,
+          output.info,
+          &bits,
+          output.lengths.data() + output.size,
+          &output.listState,
+          false);
+      output.commit(bits);
+      output.finishLengths();
+      continue;
+    }
+
+    auto bits = output.prepareValidity(numLevels);
+    if (output.mode == LevelMode::kNulls) {
+      DefLevelsToBitmap(definitionLevels, numLevels, output.info, &bits);
+    } else {
+      DefRepLevelsToBitmap(
+          definitionLevels, repetitionLevels, numLevels, output.info, &bits);
+    }
+    output.commit(bits);
+  }
+}
+
+void PageReader::finishStreamingOutputs() {
+  auto& outputs = streamingRepDef_->outputs;
+  for (int32_t outputIndex = 0; outputIndex < outputs.size(); ++outputIndex) {
+    auto& output = outputs[outputIndex];
+    if (output.mode != LevelMode::kList && outputIndex + 1 < outputs.size()) {
+      auto& listOutput = outputs[outputIndex + 1];
+      if (listOutput.mode == LevelMode::kList &&
+          listOutput.listState.has_open_list) {
+        listOutput.resizeLengths(1);
+        arrow::ValidityBitmapInputOutput listBits;
+        listBits.values_read_upper_bound = 1;
+        listBits.null_count = listOutput.nullCount;
+        arrow::ValidityBitmapInputOutput structBits;
+        structBits.values_read_upper_bound = 1;
+        structBits.null_count = output.nullCount;
+        if (arrow::DefRepLevelsToListLengthsAndStructBitmap(
+                nullptr,
+                nullptr,
+                0,
+                listOutput.info,
+                output.info,
+                &listBits,
+                listOutput.lengths.data() + listOutput.size,
+                &structBits,
+                &listOutput.listState,
+                true)) {
+          BOLT_CHECK_EQ(listBits.values_read, structBits.values_read);
+          listOutput.commit(listBits);
+          listOutput.finishLengths();
+          output.commit(structBits);
+          ++outputIndex;
+          continue;
+        }
+      }
+    }
+
+    if (output.mode == LevelMode::kList && output.listState.has_open_list) {
+      output.resizeLengths(1);
+      arrow::ValidityBitmapInputOutput bits;
+      bits.values_read_upper_bound = 1;
+      bits.null_count = output.nullCount;
+      arrow::DefRepLevelsToListLengths(
+          nullptr,
+          nullptr,
+          0,
+          output.info,
+          &bits,
+          output.lengths.data() + output.size,
+          &output.listState,
+          true);
+      output.commit(bits);
+      output.finishLengths();
+    }
+  }
+}
+
+int32_t PageReader::streamingOutputIndex(
+    LevelMode mode,
+    const arrow::LevelInfo& info) const {
+  BOLT_CHECK_NOT_NULL(streamingRepDef_);
+  for (int32_t i = 0; i < streamingRepDef_->outputs.size(); ++i) {
+    const auto& output = streamingRepDef_->outputs[i];
+    if (output.mode == mode && output.info == info) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+int32_t PageReader::repDefOutputSize(
+    LevelMode mode,
+    const arrow::LevelInfo& info) const {
+  if (!usesStreamingRepDefs()) {
+    return repDefEnd_ - repDefBegin_;
+  }
+  const auto index = streamingOutputIndex(mode, info);
+  BOLT_CHECK_GE(
+      index,
+      0,
+      "No streaming rep/def output for mode {}, def {}, rep {}, ancestor def {}",
+      static_cast<int32_t>(mode),
+      info.def_level,
+      info.rep_level,
+      info.repeated_ancestor_def_level);
+  return streamingRepDef_->outputs[index].size;
+}
+
+bool PageReader::loadNextStreamingRepDefPage() {
+  auto& state = *streamingRepDef_;
+  BOLT_CHECK_EQ(
+      state.levelsRemainingInPage,
+      0,
+      "Cannot advance rep/def page with {} levels remaining",
+      state.levelsRemainingInPage);
+  state.repeatDecoder.reset();
+  state.defineDecoder.reset();
+  if (state.bytesRemainingInPage > 0) {
+    skipStreamingBytes(state.bytesRemainingInPage);
+    state.bytesRemainingInPage = 0;
+  }
+  state.pageBuffer.reset();
+  state.decompressedData.reset();
+  while (state.pageStart < chunkSize_) {
+    auto pageHeader = readStreamingPageHeader();
+    BOLT_CHECK_GE(pageHeader.compressed_page_size, 0);
+    BOLT_CHECK_GE(pageHeader.uncompressed_page_size, 0);
+    BOLT_CHECK_LE(state.pageDataStart, static_cast<uint64_t>(chunkSize_));
+    BOLT_CHECK_LE(
+        static_cast<uint64_t>(pageHeader.compressed_page_size),
+        static_cast<uint64_t>(chunkSize_) - state.pageDataStart,
+        "Page body extends past the end of the rep/def stream");
+    state.pageStart = state.pageDataStart + pageHeader.compressed_page_size;
+
+    if (pageHeader.type == thrift::PageType::DICTIONARY_PAGE ||
+        (pageHeader.type != thrift::PageType::DATA_PAGE &&
+         pageHeader.type != thrift::PageType::DATA_PAGE_V2)) {
+      skipStreamingBytes(pageHeader.compressed_page_size);
+      continue;
+    }
+
+    const auto isDataPageV1 = pageHeader.type == thrift::PageType::DATA_PAGE;
+    if (isDataPageV1) {
+      BOLT_CHECK(pageHeader.__isset.data_page_header);
+    } else {
+      BOLT_CHECK(pageHeader.__isset.data_page_header_v2);
+    }
+    const auto numValues = isDataPageV1
+        ? pageHeader.data_page_header.num_values
+        : pageHeader.data_page_header_v2.num_values;
+    BOLT_CHECK_GE(numValues, 0);
+    state.levelsRemainingInPage = numValues;
+    if (numValues == 0) {
+      skipStreamingBytes(pageHeader.compressed_page_size);
+      numLeavesInPage_.push_back(0);
+      continue;
+    }
+
+    const char* repDefData = nullptr;
+    const char* definitionData = nullptr;
+    uint32_t repeatLength = 0;
+    uint32_t defineLength = 0;
+    if (isDataPageV1) {
+      const auto compressedData =
+          readStreamingBytes(pageHeader.compressed_page_size, state.pageBuffer);
+      DataPageV1RepDefs repDefPrefix;
+      const auto uncompressedSize =
+          static_cast<uint32_t>(pageHeader.uncompressed_page_size);
+      bool hasFullyDecompressedPage =
+          codec_ == thrift::CompressionCodec::UNCOMPRESSED;
+      if (codec_ == thrift::CompressionCodec::UNCOMPRESSED) {
+        if (hasDataPageV1RepDefPrefix(
+                compressedData,
+                pageHeader.compressed_page_size,
+                uncompressedSize,
+                maxRepeat_,
+                maxDefine_,
+                repDefPrefix)) {
+          repDefData = compressedData;
+        }
+      } else if (codec_ == thrift::CompressionCodec::ZSTD) {
+        const auto startNs =
+            FOLLY_LIKELY(statis_ != nullptr) ? getCurrentTimeNano() : 0;
+        if (tryDecompressZstdPrefix(
+                compressedData,
+                state.decompressedData,
+                pageHeader.compressed_page_size,
+                uncompressedSize,
+                kRepDefPrefixOutputQuantum,
+                pool_,
+                [&](const char* data, uint32_t availableSize) {
+                  return hasDataPageV1RepDefPrefix(
+                      data,
+                      availableSize,
+                      uncompressedSize,
+                      maxRepeat_,
+                      maxDefine_,
+                      repDefPrefix);
+                },
+                repDefData) &&
+            FOLLY_LIKELY(statis_ != nullptr)) {
+          statis_->decompressDataTimeNs += getCurrentTimeNano() - startNs;
+        }
+      }
+      if (repDefData == nullptr) {
+        dwio::common::ensureCapacity<char>(
+            state.decompressedData, pageHeader.uncompressed_page_size, &pool_);
+        if (codec_ == thrift::CompressionCodec::LZ4 ||
+            codec_ == thrift::CompressionCodec::LZO) {
+          repDefData = decompressLz4AndLzo(
+              compressedData,
+              state.decompressedData,
+              pageHeader.compressed_page_size,
+              pageHeader.uncompressed_page_size,
+              pool_,
+              codec_);
+        } else if (codec_ == thrift::CompressionCodec::ZSTD) {
+          repDefData = bdZstdDecompression(
+              compressedData,
+              state.decompressedData,
+              pageHeader.compressed_page_size,
+              pageHeader.uncompressed_page_size,
+              pool_,
+              codec_);
+        } else {
+          repDefData = bdCodecDecompression(
+              compressedData,
+              state.decompressedData,
+              pageHeader.compressed_page_size,
+              pageHeader.uncompressed_page_size,
+              pool_,
+              codec_);
+        }
+        hasFullyDecompressedPage = true;
+      }
+      BufferPtr cachedPage;
+      if (hasFullyDecompressedPage && state.decompressedData) {
+        cachedPage = state.decompressedData;
+      } else {
+        cachedPage = state.pageBuffer;
+      }
+      if (cachedPage) {
+        const auto pageBytes = pool_.preferredSize(
+            cachedPage->capacity() + AlignedBuffer::kPaddedSize);
+        const auto cacheLimit =
+            static_cast<uint64_t>(std::max(repDefMemoryLimit_, 0));
+        if (pageBytes <= cacheLimit &&
+            state.cachedDataPagesV1Bytes <= cacheLimit - pageBytes) {
+          state.cachedDataPagesV1.push_back(
+              {std::move(cachedPage),
+               state.pageDataStart,
+               pageHeader.compressed_page_size,
+               pageBytes,
+               hasFullyDecompressedPage});
+          state.cachedDataPagesV1Bytes += pageBytes;
+        }
+      }
+      if (hasFullyDecompressedPage && state.decompressedData) {
+        state.pageBuffer.reset();
+      }
+      const auto repDefs = readDataPageV1RepDefs(
+          repDefData, uncompressedSize, maxRepeat_, maxDefine_);
+      repeatLength = repDefs.repeatSize;
+      state.repeatDecoder = std::make_unique<::arrow::util::RleDecoder>(
+          reinterpret_cast<const uint8_t*>(repDefs.repeatData),
+          repeatLength,
+          ::arrow::bit_util::NumRequiredBits(maxRepeat_));
+      defineLength = repDefs.defineSize;
+      definitionData = repDefs.defineData;
+      state.defineDecoder = std::make_unique<::arrow::util::RleDecoder>(
+          reinterpret_cast<const uint8_t*>(definitionData),
+          defineLength,
+          ::arrow::bit_util::NumRequiredBits(maxDefine_));
+    } else {
+      BOLT_CHECK_GE(
+          pageHeader.data_page_header_v2.repetition_levels_byte_length, 0);
+      BOLT_CHECK_GE(
+          pageHeader.data_page_header_v2.definition_levels_byte_length, 0);
+      repeatLength =
+          pageHeader.data_page_header_v2.repetition_levels_byte_length;
+      defineLength =
+          pageHeader.data_page_header_v2.definition_levels_byte_length;
+      const auto levelsSize = static_cast<int64_t>(repeatLength) + defineLength;
+      BOLT_CHECK_LE(levelsSize, pageHeader.compressed_page_size);
+      BOLT_CHECK_LE(levelsSize, pageHeader.uncompressed_page_size);
+      repDefData = readStreamingBytes(
+          static_cast<int32_t>(levelsSize), state.pageBuffer);
+      state.bytesRemainingInPage = pageHeader.compressed_page_size - levelsSize;
+      state.repeatDecoder = std::make_unique<::arrow::util::RleDecoder>(
+          reinterpret_cast<const uint8_t*>(repDefData),
+          repeatLength,
+          ::arrow::bit_util::NumRequiredBits(maxRepeat_));
+      definitionData = repDefData + repeatLength;
+      state.defineDecoder = std::make_unique<::arrow::util::RleDecoder>(
+          reinterpret_cast<const uint8_t*>(definitionData),
+          defineLength,
+          ::arrow::bit_util::NumRequiredBits(maxDefine_));
+    }
+
+    BOLT_CHECK_GT(state.levelsRemainingInPage, 0);
+    BOLT_CHECK_GT(repeatLength, 0);
+    BOLT_CHECK_GT(defineLength, 0);
+    numLeavesInPage_.push_back(countLeavesInDefinitionLevels(
+        reinterpret_cast<const uint8_t*>(definitionData),
+        defineLength,
+        state.levelsRemainingInPage));
+    return true;
+  }
+
+  state.pageBuffer.reset();
+  state.decompressedData.reset();
+  return false;
+}
+
+bool PageReader::consumeStreamingRepDefScratch(
+    int32_t topLevelRowsNeeded,
+    int32_t& topLevelRowsSeen) {
+  auto& state = *streamingRepDef_;
+  BOLT_CHECK_EQ(state.definitionScratch.size(), state.repetitionScratch.size());
+  BOLT_CHECK_LT(state.scratchBegin, state.repetitionScratch.size());
+  const auto scratchSize = state.repetitionScratch.size() - state.scratchBegin;
+  const auto* definitions = state.definitionScratch.data() + state.scratchBegin;
+  const auto* repetitions = state.repetitionScratch.data() + state.scratchBegin;
+  const auto boundary = findTopLevelBoundary(
+      repetitions, scratchSize, topLevelRowsNeeded, topLevelRowsSeen);
+  if (boundary > 0) {
+    leafNullsSize_ += appendLeafNulls(definitions, boundary);
+    appendStreamingLevels(definitions, repetitions, boundary);
+  }
+  state.scratchBegin += boundary;
+  if (boundary < scratchSize) {
+    return true;
+  }
+  state.definitionScratch.clear();
+  state.repetitionScratch.clear();
+  state.scratchBegin = 0;
+  return false;
+}
+
+void PageReader::decodeStreamingRepDefs(int32_t numTopLevelRows) {
+  hasChunkRepDefs_ = true;
+  if (!streamingRepDef_) {
+    streamingRepDef_.reset(new StreamingRepDefState(&pool_));
+  }
+  compactConsumedLeafNulls();
+
+  auto& state = *streamingRepDef_;
+  initializeStreamingOutputs();
+  resetStreamingOutputs();
+  int32_t topLevelRowsSeen = 0;
+  bool batchComplete = false;
+
+  if (!state.repetitionScratch.empty()) {
+    batchComplete =
+        consumeStreamingRepDefScratch(numTopLevelRows, topLevelRowsSeen);
+  }
+
+  while (!batchComplete) {
+    if (state.levelsRemainingInPage == 0 && !loadNextStreamingRepDefPage()) {
+      break;
+    }
+    const auto windowSize =
+        std::min(state.levelsRemainingInPage, repDefStreamingWindowSize_);
+    state.definitionScratch.resize(windowSize);
+    state.repetitionScratch.resize(windowSize);
+    state.scratchBegin = 0;
+    BOLT_CHECK_EQ(
+        state.defineDecoder->GetBatch(
+            state.definitionScratch.data(), windowSize),
+        windowSize);
+    BOLT_CHECK_EQ(
+        state.repeatDecoder->GetBatch(
+            state.repetitionScratch.data(), windowSize),
+        windowSize);
+    state.levelsRemainingInPage -= windowSize;
+    batchComplete =
+        consumeStreamingRepDefScratch(numTopLevelRows, topLevelRowsSeen);
+  }
+  finishStreamingOutputs();
+  repDefBegin_ = 0;
+  repDefEnd_ = 0;
+}
+
 void PageReader::preloadPageRepDefs(const bool keepRepDefRawData) {
   seekToPage(kRepDefOnly, keepRepDefRawData);
   if (!keepRepDefRawData) {
@@ -1098,47 +1887,150 @@ void PageReader::preloadRepDefs() {
   cryptoCtx_.startDecryptWithDictionaryPage = startWithDictinoaryPage;
 }
 
+int32_t PageReader::countLeavesInDefinitionLevels(
+    const uint8_t* definitionLevels,
+    int32_t definitionLevelsSize,
+    int32_t numLevels) const {
+  if (leafInfo_.rep_level == 0) {
+    return numLevels;
+  }
+  auto bitReader =
+      ::arrow::bit_util::BitReader(definitionLevels, definitionLevelsSize);
+  const auto bitWidth = ::arrow::bit_util::NumRequiredBits(maxDefine_);
+  const auto presentLevel = leafInfo_.repeated_ancestor_def_level;
+  int32_t remaining = numLevels;
+  int32_t numLeaves = 0;
+  while (remaining > 0) {
+    uint32_t indicator = 0;
+    BOLT_CHECK(bitReader.GetVlqInt(&indicator), "Invalid definition RLE run");
+    const bool isLiteral = indicator & 1;
+    const uint32_t count = indicator >> 1;
+
+    if (isLiteral) {
+      BOLT_CHECK_GT(count, 0);
+      BOLT_CHECK_LE(count, static_cast<uint32_t>(INT32_MAX) / 8);
+      const auto literalCount =
+          std::min<int32_t>(remaining, static_cast<int32_t>(count * 8));
+      numLeaves +=
+          countPresentLevels(bitReader, bitWidth, literalCount, presentLevel);
+      remaining -= literalCount;
+    } else {
+      BOLT_CHECK_GT(count, 0);
+      BOLT_CHECK_LE(count, static_cast<uint32_t>(INT32_MAX));
+      uint64_t value = 0;
+      BOLT_CHECK(
+          bitReader.GetAligned(
+              static_cast<int>(::arrow::bit_util::CeilDiv(bitWidth, 8)),
+              &value),
+          "Invalid definition repeated run");
+      const auto repeatCount =
+          std::min<int32_t>(remaining, static_cast<int32_t>(count));
+      if (value >= presentLevel) {
+        numLeaves += repeatCount;
+      }
+      remaining -= repeatCount;
+    }
+  }
+  return numLeaves;
+}
+
+void PageReader::compactConsumedLeafNulls() {
+  constexpr int32_t WordBits = 64;
+  const int64_t erasedBits = erasedLeafNullWords_ * WordBits;
+  BOLT_CHECK_LE(numLeafNullsConsumed_, leafNullsSize_ + erasedBits);
+  const auto relativeConsumed = numLeafNullsConsumed_ - erasedBits;
+  if (relativeConsumed <= WordBits) {
+    return;
+  }
+
+  const auto consumedWords = bits::nwords(relativeConsumed) - 1;
+  const auto consumedBits = static_cast<int64_t>(consumedWords) * WordBits;
+  BOLT_CHECK_LE(consumedBits, leafNullsSize_);
+
+  if (!leafNullsAllValidPrefix_) {
+    const auto totalNullWords = bits::nwords(leafNullsSize_);
+    const auto unConsumedNullWords = totalNullWords - consumedWords;
+    if (unConsumedNullWords > 0) {
+      uint64_t* rawData = leafNulls_.data();
+      size_t copyBytes = unConsumedNullWords * sizeof(uint64_t);
+
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GLIBC__) && \
+    (__GLIBC__ * 100 + __GLIBC_MINOR__ < 233)
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wrestrict"
+#endif
+      if (unConsumedNullWords < consumedWords) {
+        memcpy(rawData, rawData + consumedWords, copyBytes);
+      } else {
+        raw_vector<uint64_t> tmpBuffer;
+        tmpBuffer.resize(unConsumedNullWords);
+        uint64_t* tmpDest = tmpBuffer.data();
+        memcpy(tmpDest, rawData + consumedWords, copyBytes);
+        memcpy(rawData, tmpDest, copyBytes);
+      }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#else
+      memmove(rawData, rawData + consumedWords, copyBytes);
+#endif
+    }
+    leafNulls_.resize(unConsumedNullWords);
+  }
+
+  leafNullsSize_ -= consumedBits;
+  erasedLeafNullWords_ += consumedWords;
+  BOLT_CHECK(
+      leafNullsAllValidPrefix_ ||
+      leafNulls_.size() == bits::nwords(leafNullsSize_));
+}
+
 void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
-  if (definitionLevels_.empty() && maxDefine_ > 0) {
+  if (usesStreamingRepDefs()) {
+    decodeStreamingRepDefs(numTopLevelRows);
+    return;
+  }
+  if (!hasChunkRepDefs_ && maxDefine_ > 0) {
     preloadRepDefs();
   }
   repDefBegin_ = repDefEnd_;
   int32_t numLevels = definitionLevels_.size();
-  int32_t topFound = 0;
-  int32_t i = repDefBegin_;
-
-  auto foundTopLevel = [&]() {
-    for (; i < numLevels; ++i) {
-      if (repetitionLevels_[i] == 0) {
-        ++topFound;
-        if (topFound == numTopLevelRows + 1) {
-          break;
-        }
-      }
-    }
-    repDefEnd_ = i;
-  };
-
+  int32_t topLevelRowsSeen = 0;
+  bool boundaryFound = false;
   if (maxRepeat_ > 0) {
-    foundTopLevel();
-  } else {
-    repDefEnd_ = i + numTopLevelRows;
-  }
-  if (maxRepeat_ > 0 && maxDefine_ > 0) {
-    // definitionLevels_ has been consumed, decode more if any
-    while (repDefEnd_ == numLevels && topFound < numTopLevelRows + 1 &&
-           !preloadedRepDefs_.empty()) {
+    auto findBoundary = [&]() {
+      const auto numRemainingLevels = numLevels - repDefEnd_;
+      const auto boundary = findTopLevelBoundary(
+          repetitionLevels_.data() + repDefEnd_,
+          numRemainingLevels,
+          numTopLevelRows,
+          topLevelRowsSeen);
+      repDefEnd_ += boundary;
+      boundaryFound = boundary < numRemainingLevels;
+    };
+    findBoundary();
+    while (!boundaryFound && !preloadedRepDefs_.empty()) {
       loadMoreRepDefs();
       numLevels = definitionLevels_.size();
-      i = repDefEnd_;
-      foundTopLevel();
-      BOLT_CHECK(topFound == numTopLevelRows + 1 || repDefEnd_ == numLevels);
+      findBoundary();
+      BOLT_CHECK(boundaryFound || repDefEnd_ == numLevels);
     }
+  } else {
+    repDefEnd_ = repDefBegin_ + numTopLevelRows;
+  }
+  if (maxRepeat_ > 0 && maxDefine_ > 0) {
     // after topFound done, left decoded rep/def is less than 1 page, decode
     // more
     if (!numLeavesInPage_.empty() &&
-        numLevels - repDefEnd_ < numLeavesInPage_.back() &&
-        topFound == numTopLevelRows + 1 && !preloadedRepDefs_.empty()) {
+        numLevels - repDefEnd_ < numLeavesInPage_.back() && boundaryFound &&
+        !preloadedRepDefs_.empty()) {
       loadMoreRepDefs();
     }
   }
@@ -1286,34 +2178,33 @@ void PageReader::decodeRepDefsFromBuffer() {
 }
 
 int32_t PageReader::appendLeafNullsFromLevels(int32_t begin, int32_t end) {
+  return appendLeafNulls(definitionLevels_.data() + begin, end - begin);
+}
+
+int32_t PageReader::appendLeafNulls(
+    const int16_t* definitionLevels,
+    int32_t numLevels) {
   int64_t valuesRead = 0;
   if (leafNullsAllValidPrefix_ &&
       arrow::DefLevelsAreAllValid(
-          definitionLevels_.data() + begin,
-          end - begin,
-          leafInfo_,
-          end - begin,
-          &valuesRead)) {
+          definitionLevels, numLevels, leafInfo_, numLevels, &valuesRead)) {
     return static_cast<int32_t>(valuesRead);
   }
 
   const auto startOffset = leafNullsSize_;
-  leafNulls_.resize(bits::nwords(startOffset + end - begin));
+  leafNulls_.resize(bits::nwords(startOffset + numLevels));
   if (leafNullsAllValidPrefix_) {
     if (startOffset > 0) {
       bits::fillBits(leafNulls_.data(), 0, startOffset, bits::kNotNull);
     }
     leafNullsAllValidPrefix_ = false;
   }
-  return getLengthsAndNulls(
-      LevelMode::kNulls,
-      leafInfo_,
-      begin,
-      end,
-      end - begin,
-      nullptr,
-      leafNulls_.data(),
-      startOffset);
+  arrow::ValidityBitmapInputOutput bits;
+  bits.values_read_upper_bound = numLevels;
+  bits.valid_bits = reinterpret_cast<uint8_t*>(leafNulls_.data());
+  bits.valid_bits_offset = startOffset;
+  DefLevelsToBitmap(definitionLevels, numLevels, leafInfo_, &bits);
+  return static_cast<int32_t>(bits.values_read);
 }
 
 int32_t PageReader::getLengthsAndNulls(
@@ -1325,6 +2216,35 @@ int32_t PageReader::getLengthsAndNulls(
     int32_t* lengths,
     uint64_t* nulls,
     int64_t nullsStartIndex) const {
+  if (usesStreamingRepDefs()) {
+    const auto index = streamingOutputIndex(mode, info);
+    BOLT_CHECK_GE(
+        index,
+        0,
+        "No streaming rep/def output for mode {}, def {}, rep {}, ancestor def "
+        "{}",
+        static_cast<int32_t>(mode),
+        info.def_level,
+        info.rep_level,
+        info.repeated_ancestor_def_level);
+    const auto& output = streamingRepDef_->outputs[index];
+    BOLT_CHECK_GE(maxItems, output.size);
+    if (lengths != nullptr) {
+      BOLT_CHECK_EQ(
+          static_cast<int32_t>(mode), static_cast<int32_t>(LevelMode::kList));
+      BOLT_CHECK_EQ(output.lengths.size(), output.size);
+      memcpy(
+          lengths,
+          output.lengths.data(),
+          output.size * sizeof(output.lengths[0]));
+    }
+    if (nulls != nullptr) {
+      bits::copyBits(
+          output.nulls.data(), 0, nulls, nullsStartIndex, output.size);
+    }
+    return output.size;
+  }
+
   arrow::ValidityBitmapInputOutput bits;
   bits.values_read_upper_bound = maxItems;
   bits.values_read = 0;
@@ -1373,6 +2293,55 @@ bool PageReader::getListLengthsAndStructNulls(
     arrow::ValidityBitmapInputOutput* listBits,
     int32_t* lengths,
     arrow::ValidityBitmapInputOutput* structBits) const {
+  if (usesStreamingRepDefs()) {
+    const auto listIndex = streamingOutputIndex(LevelMode::kList, listInfo);
+    BOLT_CHECK_GE(
+        listIndex,
+        0,
+        "No streaming list output for def {}, rep {}, ancestor def {}",
+        listInfo.def_level,
+        listInfo.rep_level,
+        listInfo.repeated_ancestor_def_level);
+    const auto& listOutput = streamingRepDef_->outputs[listIndex];
+    auto structIndex =
+        streamingOutputIndex(LevelMode::kStructOverLists, structInfo);
+    if (structIndex < 0) {
+      structIndex = streamingOutputIndex(LevelMode::kNulls, structInfo);
+    }
+    BOLT_CHECK_GE(
+        structIndex,
+        0,
+        "No streaming struct output for def {}, rep {}, ancestor def {}",
+        structInfo.def_level,
+        structInfo.rep_level,
+        structInfo.repeated_ancestor_def_level);
+    const auto& structOutput = streamingRepDef_->outputs[structIndex];
+    BOLT_CHECK_EQ(listOutput.size, structOutput.size);
+    BOLT_CHECK_GE(listBits->values_read_upper_bound, listOutput.size);
+    BOLT_CHECK_GE(structBits->values_read_upper_bound, structOutput.size);
+    memcpy(
+        lengths,
+        listOutput.lengths.data(),
+        listOutput.size * sizeof(listOutput.lengths[0]));
+    bits::copyBits(
+        listOutput.nulls.data(),
+        0,
+        reinterpret_cast<uint64_t*>(listBits->valid_bits),
+        listBits->valid_bits_offset,
+        listOutput.size);
+    bits::copyBits(
+        structOutput.nulls.data(),
+        0,
+        reinterpret_cast<uint64_t*>(structBits->valid_bits),
+        structBits->valid_bits_offset,
+        structOutput.size);
+    listBits->values_read = listOutput.size;
+    listBits->null_count = listOutput.nullCount;
+    structBits->values_read = structOutput.size;
+    structBits->null_count = structOutput.nullCount;
+    return true;
+  }
+
   return arrow::DefRepLevelsToListLengthsAndStructBitmap(
       definitionLevels_.data() + begin,
       repetitionLevels_.data() + begin,
@@ -1456,8 +2425,15 @@ void PageReader::skip(int64_t numRows) {
     return;
   }
   auto toSkip = numRows;
-  if (firstUnvisited_ + numRows >= rowOfPage_ + numRowsInPage_) {
-    seekToPage(firstUnvisited_ + numRows);
+  const auto pageEnd = rowOfPage_ + numRowsInPage_;
+  const auto target = firstUnvisited_ + numRows;
+  // Rep/def levels after the last leaf can still describe empty or null
+  // parents. Leave a streaming reader at the exact page end so the next
+  // rep/def batch can consume these levels before advancing the data page.
+  const bool keepStreamingPage =
+      usesStreamingRepDefs() && numRows > 0 && target == pageEnd;
+  if (!keepStreamingPage && target >= pageEnd) {
+    seekToPage(target);
     if (hasChunkRepDefs_) {
       BOLT_CHECK_GE(rowOfPage_, 0);
       numLeafNullsConsumed_ = rowOfPage_;
@@ -1501,7 +2477,9 @@ int32_t PageReader::skipNulls(int32_t numValues) {
     return numValues;
   }
   if (!isTopLevel_ && leafNullsAllValidPrefix_) {
-    BOLT_CHECK_LE(numLeafNullsConsumed_ + numValues, leafNullsSize_);
+    BOLT_CHECK_LE(
+        numLeafNullsConsumed_ + numValues,
+        erasedLeafNullWords_ * 64 + leafNullsSize_);
     numLeafNullsConsumed_ += numValues;
     return numValues;
   }
@@ -1579,7 +2557,9 @@ PageReader::readNulls(int32_t numValues, BufferPtr& buffer) {
   }
 
   if (leafNullsAllValidPrefix_) {
-    BOLT_CHECK_LE(numLeafNullsConsumed_ + numValues, leafNullsSize_);
+    BOLT_CHECK_LE(
+        numLeafNullsConsumed_ + numValues,
+        erasedLeafNullWords_ * 64 + leafNullsSize_);
     numLeafNullsConsumed_ += numValues;
     buffer = nullptr;
     return nullptr;

--- a/bolt/dwio/parquet/reader/PageReader.h
+++ b/bolt/dwio/parquet/reader/PageReader.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include <folly/lang/Bits.h>
+#include <deque>
+
 #include "bolt/common/compression/Compression.h"
 #include "bolt/dwio/common/BitConcatenation.h"
 #include "bolt/dwio/common/DirectDecoder.h"
@@ -76,15 +79,19 @@ struct CryptoContext {
 /// continuous stream accessible via readWithVisitor().
 class PageReader {
  public:
+  ~PageReader();
+
   PageReader(
       std::unique_ptr<dwio::common::SeekableInputStream> stream,
       memory::MemoryPool& pool,
       ParquetTypeWithIdPtr fileType,
       thrift::CompressionCodec::type codec,
       int64_t chunkSize,
-      dwio::common::RuntimeStatistics* statis)
+      dwio::common::RuntimeStatistics* statis,
+      std::unique_ptr<dwio::common::SeekableInputStream> repDefStream = nullptr)
       : pool_(pool),
         inputStream_(std::move(stream)),
+        repDefInputStream_(std::move(repDefStream)),
         type_(std::move(fileType)),
         maxRepeat_(type_->maxRepeat_),
         maxDefine_(type_->maxDefine_),
@@ -195,6 +202,8 @@ class PageReader {
     return {repDefBegin_, repDefEnd_};
   }
 
+  int32_t repDefOutputSize(LevelMode mode, const arrow::LevelInfo& info) const;
+
   // Parses the PageHeader at 'inputStream_', and move the bufferStart_ and
   // bufferEnd_ to the corresponding positions.
   thrift::PageHeader readPageHeader();
@@ -261,6 +270,10 @@ class PageReader {
     repDefMemoryLimit_ = memlimit;
   }
 
+  void setParquetRepDefStreamingWindowSize(int32_t size) {
+    repDefStreamingWindowSize_ = size == 0 ? 0 : std::max(size, 1);
+  }
+
  private:
   // Indicates that we only want the repdefs for the next page. Used when
   // prereading repdefs with seekToPage.
@@ -311,6 +324,12 @@ class PageReader {
       const thrift::PageHeader& pageHeader,
       int32_t compressedLen,
       const bool keepRepDefRawData);
+  bool tryDecompressDataPageV1RepDefPrefix(
+      const char* FOLLY_NONNULL compressedData,
+      uint32_t compressedSize,
+      uint32_t uncompressedSize,
+      BufferPtr& decompressedData,
+      const char* FOLLY_NONNULL& pageData);
   void prepareDataPageV2(
       const thrift::PageHeader& pageHeader,
       int64_t row,
@@ -340,7 +359,7 @@ class PageReader {
 
   template <typename T>
   T readField(const char* FOLLY_NONNULL& ptr) {
-    T data = *reinterpret_cast<const T*>(ptr);
+    T data = folly::loadUnaligned<T>(ptr);
     ptr += sizeof(T);
     return data;
   }
@@ -489,11 +508,45 @@ class PageReader {
 
   void preloadPageRepDefs(const bool keepRepDefRawData);
   void loadMoreRepDefs();
+  void decodeStreamingRepDefs(int32_t numTopLevelRows);
+  bool loadNextStreamingRepDefPage();
+  bool consumeStreamingRepDefScratch(
+      int32_t topLevelRowsNeeded,
+      int32_t& topLevelRowsSeen);
+  thrift::PageHeader readStreamingPageHeader();
+  const char* FOLLY_NONNULL readStreamingBytes(int32_t size, BufferPtr& copy);
+  void skipStreamingBytes(uint64_t size);
+  void initializeStreamingOutputs();
+  void resetStreamingOutputs();
+  void appendStreamingLevels(
+      const int16_t* FOLLY_NONNULL definitionLevels,
+      const int16_t* FOLLY_NONNULL repetitionLevels,
+      int32_t numLevels);
+  void finishStreamingOutputs();
+  bool usesStreamingRepDefs() const {
+    return repDefStreamingWindowSize_ > 0 && repDefInputStream_ != nullptr;
+  }
+  int32_t streamingOutputIndex(LevelMode mode, const arrow::LevelInfo& info)
+      const;
+  int32_t countLeavesInDefinitionLevels(
+      const uint8_t* FOLLY_NONNULL definitionLevels,
+      int32_t definitionLevelsSize,
+      int32_t numLevels) const;
+  void compactConsumedLeafNulls();
   void decodeRepDefsFromBuffer();
+  int32_t appendLeafNulls(
+      const int16_t* FOLLY_NONNULL definitionLevels,
+      int32_t numLevels);
+
+  struct StreamingRepDefState;
+  struct StreamingRepDefStateDeleter {
+    void operator()(StreamingRepDefState* state) const;
+  };
 
   memory::MemoryPool& pool_;
 
   std::unique_ptr<dwio::common::SeekableInputStream> inputStream_;
+  std::unique_ptr<dwio::common::SeekableInputStream> repDefInputStream_;
   ParquetTypeWithIdPtr type_;
   const int32_t maxRepeat_;
   const int32_t maxDefine_;
@@ -522,7 +575,8 @@ class PageReader {
   int32_t pageIndex_{-1};
 
   // Number of leaf values in each data page of column chunk.
-  std::vector<int32_t> numLeavesInPage_;
+  std::deque<int32_t> numLeavesInPage_;
+  int32_t numLeavesInPageBase_{0};
 
   // First position in '*levels_' for the range of last decodeRepDefs().
   int32_t repDefBegin_{0};
@@ -646,11 +700,13 @@ class PageReader {
   BufferPtr decryptionBuffer_;
   int32_t pageOrdinal_;
 
-  // preload undecoded RepDefs
   std::list<raw_vector<char>> preloadedRepDefs_;
   int32_t repDefMemoryLimit_{16L << 20};
   int64_t totalRefDefBytes_{0};
   int32_t decodeRepDefPageCount_{10};
+  int32_t repDefStreamingWindowSize_{2 * 1024};
+  std::unique_ptr<StreamingRepDefState, StreamingRepDefStateDeleter>
+      streamingRepDef_;
 
   dwio::common::RuntimeStatistics* statis_{nullptr};
   // Tracks output count for the current physical page. -1 means there is no

--- a/bolt/dwio/parquet/reader/ParquetData.cpp
+++ b/bolt/dwio/parquet/reader/ParquetData.cpp
@@ -50,7 +50,8 @@ std::unique_ptr<dwio::common::FormatData> ParquetParams::toFormatData(
       enableMetadataFilter_,
       enableDictionaryFilter_,
       decodeRepDefPageCount_,
-      parquetRepDefMemoryLimit_);
+      parquetRepDefMemoryLimit_,
+      parquetRepDefStreamingWindowSize_);
 }
 
 void ParquetData::filterRowGroups(
@@ -357,6 +358,7 @@ void ParquetData::enqueueRowGroup(
     dwio::common::BufferedInput& input) {
   auto& chunk = rowGroups_[index].columns[type_->column()];
   streams_.resize(rowGroups_.size());
+  repDefStreams_.resize(rowGroups_.size());
   BOLT_CHECK(
       chunk.__isset.meta_data,
       "ColumnMetaData does not exist for schema Id ",
@@ -376,7 +378,16 @@ void ParquetData::enqueueRowGroup(
       : metaData.total_compressed_size;
 
   auto id = dwio::common::StreamIdentifier(type_->column());
-  streams_[index] = input.enqueue({chunkReadOffset, readSize}, &id);
+  const auto region = common::Region{chunkReadOffset, readSize};
+  const bool useStreamingRepDefs = parquetRepDefStreamingWindowSize_ != 0 &&
+      maxRepeat_ > 0 && maxDefine_ > 0 && !chunk.__isset.crypto_metadata;
+  if (useStreamingRepDefs) {
+    auto [dataStream, repDefStream] = input.enqueuePair(region, &id);
+    streams_[index] = std::move(dataStream);
+    repDefStreams_[index] = std::move(repDefStream);
+  } else {
+    streams_[index] = input.enqueue(region, &id);
+  }
 }
 
 dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
@@ -393,9 +404,12 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
       type_,
       metadata.codec,
       metadata.total_compressed_size,
-      statis_);
+      statis_,
+      std::move(repDefStreams_[index]));
   reader_->setDecodeRepDefPageCount(decodeRepDefPageCount_);
   reader_->setParquetRepDefMemoryLimit(parquetRepDefMemoryLimit_);
+  reader_->setParquetRepDefStreamingWindowSize(
+      parquetRepDefStreamingWindowSize_);
 
   if (columnChunkMeta.__isset.crypto_metadata) {
     std::shared_ptr<Decryptor> metaDecryptor;
@@ -443,20 +457,28 @@ void ParquetData::releaseRowGroupReader() {
 
 std::pair<int64_t, int64_t> ParquetData::getRowGroupRegion(
     uint32_t index) const {
-  auto& rowGroup = rowGroups_[index];
-
+  const auto& rowGroup = rowGroups_[index];
   BOLT_CHECK_GT(rowGroup.columns.size(), 0);
-  auto fileOffset = rowGroup.__isset.file_offset ? rowGroup.file_offset
-      : rowGroup.columns[0].meta_data.__isset.dictionary_page_offset
-      ? rowGroup.columns[0].meta_data.dictionary_page_offset
-      : rowGroup.columns[0].meta_data.data_page_offset;
-  BOLT_CHECK_GT(fileOffset, 0);
 
-  auto length = rowGroup.__isset.total_compressed_size
-      ? rowGroup.total_compressed_size
-      : rowGroup.total_byte_size;
-
-  return {fileOffset, length};
+  int64_t begin = std::numeric_limits<int64_t>::max();
+  int64_t end = 0;
+  for (const auto& column : rowGroup.columns) {
+    BOLT_CHECK(column.__isset.meta_data);
+    const auto& metadata = column.meta_data;
+    const auto offset = metadata.__isset.dictionary_page_offset
+        ? metadata.dictionary_page_offset
+        : metadata.data_page_offset;
+    BOLT_CHECK_GE(offset, 0);
+    BOLT_CHECK_GE(metadata.total_compressed_size, 0);
+    BOLT_CHECK_LE(
+        offset,
+        std::numeric_limits<int64_t>::max() - metadata.total_compressed_size,
+        "Column chunk region overflows int64_t");
+    begin = std::min(begin, offset);
+    end = std::max(end, offset + metadata.total_compressed_size);
+  }
+  BOLT_CHECK_GT(end, begin);
+  return {begin, end - begin};
 }
 
 bool ParquetData::checkColumnFilter(

--- a/bolt/dwio/parquet/reader/ParquetData.h
+++ b/bolt/dwio/parquet/reader/ParquetData.h
@@ -64,6 +64,7 @@ class ParquetParams : public dwio::common::FormatParams {
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
       int32_t parquetRepDefMemoryLimit,
+      int32_t parquetRepDefStreamingWindowSize,
       int64_t parquetReaderImplicitCastMask = 0)
       : FormatParams(pool, stats),
         parquetReaderImplicitCastMask(parquetReaderImplicitCastMask),
@@ -76,7 +77,8 @@ class ParquetParams : public dwio::common::FormatParams {
             disableFloatingPointToVarcharMetadataFilter),
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
-        parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {}
+        parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit),
+        parquetRepDefStreamingWindowSize_(parquetRepDefStreamingWindowSize) {}
 
   // ParquetReaderImplicitCastMask selecting implicit casts to block.
   int64_t parquetReaderImplicitCastMask{0};
@@ -107,6 +109,7 @@ class ParquetParams : public dwio::common::FormatParams {
   const bool enableDictionaryFilter_;
   const int32_t decodeRepDefPageCount_;
   const int32_t parquetRepDefMemoryLimit_;
+  const int32_t parquetRepDefStreamingWindowSize_;
 };
 
 /// Format-specific data created for each leaf column of a Parquet rowgroup.
@@ -122,7 +125,8 @@ class ParquetData : public dwio::common::FormatData {
       bool enableMetadataFilter,
       bool enableDictionaryFilter,
       int32_t decodeRepDefPageCount,
-      int32_t parquetRepDefMemoryLimit)
+      int32_t parquetRepDefMemoryLimit,
+      int32_t parquetRepDefStreamingWindowSize)
       : pool_(pool),
         type_(std::static_pointer_cast<const ParquetTypeWithId>(type)),
         rowGroups_(rowGroups),
@@ -135,7 +139,8 @@ class ParquetData : public dwio::common::FormatData {
         enableMetadataFilter_(enableMetadataFilter),
         enableDictionaryFilter_(enableDictionaryFilter),
         decodeRepDefPageCount_(decodeRepDefPageCount),
-        parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit) {
+        parquetRepDefMemoryLimit_(parquetRepDefMemoryLimit),
+        parquetRepDefStreamingWindowSize_(parquetRepDefStreamingWindowSize) {
     rowGroupOffsets_ = std::vector<int64_t>(rowGroups_.size());
     rowGroupOffsets_[0] = 0;
     for (int32_t i = 1; i < rowGroups_.size(); ++i) {
@@ -333,6 +338,8 @@ class ParquetData : public dwio::common::FormatData {
   // Streams for this column in each of 'rowGroups_'. Will be created on or
   // ahead of first use, not at construction.
   std::vector<std::unique_ptr<dwio::common::SeekableInputStream>> streams_;
+  std::vector<std::unique_ptr<dwio::common::SeekableInputStream>>
+      repDefStreams_;
   std::vector<int64_t> rowGroupOffsets_;
 
   const uint32_t maxDefine_;
@@ -358,6 +365,7 @@ class ParquetData : public dwio::common::FormatData {
   const bool enableDictionaryFilter_;
   const int32_t decodeRepDefPageCount_;
   const int32_t parquetRepDefMemoryLimit_;
+  const int32_t parquetRepDefStreamingWindowSize_;
 };
 
 } // namespace bytedance::bolt::parquet

--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1600,6 +1600,7 @@ class ParquetRowReader::Impl {
         options_.isDictionaryFilterEnabled(),
         options_.getDecodeRepDefPageCount(),
         options_.getParquetRepDefMemoryLimit(),
+        options_.getParquetRepDefStreamingWindowSize(),
         options_.parquetReaderImplicitCastMask());
 
     if (auto selector = options_.getSelector()) {

--- a/bolt/dwio/parquet/reader/ParquetTypeWithId.cpp
+++ b/bolt/dwio/parquet/reader/ParquetTypeWithId.cpp
@@ -31,13 +31,14 @@
 #include "bolt/dwio/parquet/reader/ParquetTypeWithId.h"
 namespace bytedance::bolt::parquet {
 namespace {
-bool containsList(const ParquetTypeWithId& type) {
-  if (type.type()->kind() == TypeKind::ARRAY) {
+bool containsRepeatedType(const ParquetTypeWithId& type) {
+  if (type.type()->kind() == TypeKind::ARRAY ||
+      type.type()->kind() == TypeKind::MAP) {
     return true;
   }
   if (type.type()->kind() == TypeKind::ROW) {
     for (auto i = 0; i < type.getChildren().size(); ++i) {
-      if (containsList(type.parquetChildAt(i))) {
+      if (containsRepeatedType(type.parquetChildAt(i))) {
         return true;
       }
     }
@@ -83,7 +84,7 @@ LevelMode ParquetTypeWithId::makeLevelInfo(LevelInfo& info) const {
       if (child.type()->kind() != TypeKind ::ARRAY) {
         isAllLists = false;
       }
-      hasList |= hasList || containsList(child);
+      hasList |= containsRepeatedType(child);
     }
   }
   if (isList) {

--- a/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -92,7 +92,8 @@ bool trySetFusedStructAndRepeatedRepDefs(
   }
 
   const auto repDefRange = pageReader.repDefRange();
-  const int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  const int32_t numRepDefs =
+      pageReader.repDefOutputSize(LevelMode::kList, repeatedReader.levelInfo());
   auto lengths = repeatedReader.prepareRepDefLengths(numRepDefs);
   auto repeatedBits = repeatedReader.prepareRepDefNulls(numRepDefs);
   auto structBits = structReader.prepareRepDefNulls(numRepDefs);
@@ -164,7 +165,9 @@ PageReader* FOLLY_NULLABLE readLeafRepDefs(
     if (repDefChild == nullptr) {
       return nullptr;
     }
-    const bool fuseStructAndRepeated = isArrayOrMap(*repDefChild);
+    const bool fuseStructAndRepeated =
+        structReader->fileType().type()->kind() == TypeKind::ROW &&
+        isArrayOrMap(*repDefChild);
     pageReader =
         readLeafRepDefs(repDefChild, numTop, true, !fuseStructAndRepeated);
     assert(pageReader);
@@ -349,7 +352,8 @@ void MapColumnReader::setLengthsFromRepDefOutput(
 
 void MapColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   auto repDefRange = pageReader.repDefRange();
-  int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  int32_t numRepDefs =
+      pageReader.repDefOutputSize(LevelMode::kList, levelInfo_);
   BufferPtr lengths = std::move(lengths_.lengths());
   dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs + 1, &memoryPool_);
   dwio::common::ensureCapacity<uint64_t>(
@@ -479,7 +483,8 @@ void ListColumnReader::setLengthsFromRepDefOutput(
 
 void ListColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   auto repDefRange = pageReader.repDefRange();
-  int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  int32_t numRepDefs =
+      pageReader.repDefOutputSize(LevelMode::kList, levelInfo_);
   BufferPtr lengths = std::move(lengths_.lengths());
   dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs + 1, &memoryPool_);
   dwio::common::ensureCapacity<uint64_t>(

--- a/bolt/dwio/parquet/reader/StructColumnReader.cpp
+++ b/bolt/dwio/parquet/reader/StructColumnReader.cpp
@@ -268,7 +268,7 @@ void StructColumnReader::setNullsFromRepDefs(PageReader& pageReader) {
     return;
   }
   auto repDefRange = pageReader.repDefRange();
-  int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  int32_t numRepDefs = pageReader.repDefOutputSize(levelMode_, levelInfo_);
   auto bits = prepareRepDefNulls(numRepDefs);
   bits.values_read = pageReader.getLengthsAndNulls(
       levelMode_,

--- a/bolt/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/bolt/dwio/parquet/tests/reader/CMakeLists.txt
@@ -76,6 +76,14 @@ target_link_libraries(
     ${FOLLY_BENCHMARK}
 )
 
+add_executable(bolt_dwio_parquet_complex_type_benchmark ParquetComplexTypeBenchmark.cpp)
+target_link_libraries(
+  bolt_dwio_parquet_complex_type_benchmark
+  PRIVATE
+    bolt_testutils
+    ${FOLLY_BENCHMARK}
+)
+
 add_executable(bolt_dwio_parquet_structure_decoder_benchmark NestedStructureDecoderBenchmark.cpp)
 target_link_libraries(
   bolt_dwio_parquet_structure_decoder_benchmark

--- a/bolt/dwio/parquet/tests/reader/ParquetComplexTypeBenchmark.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetComplexTypeBenchmark.cpp
@@ -1,0 +1,959 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-12.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/common/compression/Compression.h"
+#include "bolt/dwio/common/BufferedInput.h"
+#include "bolt/dwio/common/FileSink.h"
+#include "bolt/dwio/common/Options.h"
+#include "bolt/dwio/common/Statistics.h"
+#include "bolt/dwio/parquet/reader/ParquetReader.h"
+#include "bolt/dwio/parquet/writer/Writer.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/vector/tests/utils/VectorMaker.h"
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <sys/resource.h>
+
+#include <algorithm>
+#include <atomic>
+#include <fstream>
+#include <map>
+#include <random>
+#include <sstream>
+#include <string_view>
+
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::dwio;
+using namespace bytedance::bolt::dwio::common;
+using namespace bytedance::bolt::parquet;
+using namespace bytedance::bolt::test;
+
+DEFINE_int32(
+    parquet_complex_data_page_version,
+    1,
+    "Parquet data page version to write. Supported values: 1 and 2.");
+DEFINE_int32(
+    parquet_complex_repdef_streaming_window_size,
+    2 * 1024,
+    "Number of rep/def levels decoded per streaming window; 0 disables "
+    "streaming.");
+DEFINE_bool(
+    parquet_complex_print_runtime_stats,
+    false,
+    "Print Parquet reader runtime statistics for each scan.");
+DEFINE_bool(
+    parquet_complex_print_memory_stats,
+    false,
+    "Print scan-only RSS and MemoryPool statistics for each scan.");
+
+namespace {
+
+constexpr uint32_t kSeed = 20260812;
+constexpr vector_size_t kRowsPerBatch = 2'048;
+constexpr int32_t kNumBatches = 8;
+constexpr uint64_t kRowsPerRowGroup = 4'096;
+constexpr int64_t kBytesPerRowGroup = 128 * 1'024 * 1'024;
+constexpr int64_t kDataPageSize = 64 * 1'024;
+
+int64_t processRssKb() {
+  std::ifstream input("/proc/self/status");
+  std::string line;
+  while (std::getline(input, line)) {
+    if (line.rfind("VmRSS:", 0) != 0) {
+      continue;
+    }
+    std::istringstream stream(line.substr(6));
+    int64_t value = 0;
+    stream >> value;
+    return value;
+  }
+  return -1;
+}
+
+enum class DataSetKind {
+  kControl,
+  kList,
+  kMap,
+  kStringList,
+  kStringMap,
+  kNullable,
+  kLongList,
+  kNested,
+  kMapStruct,
+  kWideFeature,
+};
+
+enum class ProjectionKind {
+  kAll,
+  kRepresentative,
+  kLongOnly,
+  kNullHeavy,
+};
+
+enum class LengthShape {
+  kFixedOne,
+  kFixedSmall,
+  kFixedMedium,
+  kFixedLarge,
+  kSparse,
+  kBounded,
+  kLong2K,
+  kLongTail,
+};
+
+struct ColumnSpec {
+  std::string name;
+  TypePtr type;
+};
+
+struct DataSetSpec {
+  std::string name;
+  std::vector<ColumnSpec> columns;
+  bool disableDictionary{true};
+};
+
+std::string toString(DataSetKind kind) {
+  switch (kind) {
+    case DataSetKind::kControl:
+      return "control";
+    case DataSetKind::kList:
+      return "list";
+    case DataSetKind::kMap:
+      return "map";
+    case DataSetKind::kStringList:
+      return "stringList";
+    case DataSetKind::kStringMap:
+      return "stringMap";
+    case DataSetKind::kNullable:
+      return "nullable";
+    case DataSetKind::kLongList:
+      return "longList";
+    case DataSetKind::kNested:
+      return "nested";
+    case DataSetKind::kMapStruct:
+      return "mapStruct";
+    case DataSetKind::kWideFeature:
+      return "wideFeature";
+  }
+  return "unknown";
+}
+
+std::string toString(ProjectionKind kind) {
+  switch (kind) {
+    case ProjectionKind::kAll:
+      return "all";
+    case ProjectionKind::kRepresentative:
+      return "representative";
+    case ProjectionKind::kLongOnly:
+      return "longOnly";
+    case ProjectionKind::kNullHeavy:
+      return "nullHeavy";
+  }
+  return "unknown";
+}
+
+int32_t stableHash(uint64_t value) {
+  value ^= value >> 33;
+  value *= 0xff51afd7ed558ccdULL;
+  value ^= value >> 33;
+  value *= 0xc4ceb9fe1a85ec53ULL;
+  value ^= value >> 33;
+  return static_cast<int32_t>(value & 0x7fffffff);
+}
+
+bool periodicNull(vector_size_t row, int32_t percent, uint64_t salt = 0) {
+  if (percent <= 0) {
+    return false;
+  }
+  if (percent >= 100) {
+    return true;
+  }
+  return stableHash(static_cast<uint64_t>(row) * 1315423911ULL + salt) % 100 <
+      percent;
+}
+
+vector_size_t listSizeAt(vector_size_t row, LengthShape shape, uint64_t salt) {
+  const auto h = stableHash(static_cast<uint64_t>(row) * 2654435761ULL + salt);
+  switch (shape) {
+    case LengthShape::kFixedOne:
+      return 1;
+    case LengthShape::kFixedSmall:
+      return 4;
+    case LengthShape::kFixedMedium:
+      return 50;
+    case LengthShape::kFixedLarge:
+      return 256;
+    case LengthShape::kSparse:
+      if (h % 100 < 78) {
+        return 0;
+      }
+      return 1 + (h % 8);
+    case LengthShape::kBounded:
+      if (h % 100 < 8) {
+        return 0;
+      }
+      return 1 + (h % 20);
+    case LengthShape::kLong2K:
+      return 2'000;
+    case LengthShape::kLongTail:
+      if (h % 100 < 70) {
+        return h % 33;
+      }
+      if (h % 100 < 95) {
+        return 512 + (h % 1'536);
+      }
+      return 2'048 + (h % 4'096);
+  }
+  return 0;
+}
+
+template <typename T>
+T numericValue(vector_size_t row, vector_size_t index, uint64_t salt) {
+  const auto value = static_cast<int64_t>(
+      stableHash(static_cast<uint64_t>(row) * 1'000'003ULL + index + salt));
+  if constexpr (std::is_same_v<T, float>) {
+    return static_cast<float>(value % 10'000) / 100.0f;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return static_cast<double>(value % 1'000'000) / 1'000.0;
+  } else {
+    return static_cast<T>(value);
+  }
+}
+
+BufferPtr makeNullsBuffer(
+    memory::MemoryPool* pool,
+    vector_size_t size,
+    std::function<bool(vector_size_t)> isNullAt) {
+  BufferPtr nulls;
+  for (vector_size_t row = 0; row < size; ++row) {
+    if (isNullAt(row)) {
+      if (!nulls) {
+        nulls = AlignedBuffer::allocate<bool>(size, pool, bits::kNotNull);
+      }
+      bits::setNull(nulls->asMutable<uint64_t>(), row, true);
+    }
+  }
+  return nulls;
+}
+
+template <typename T>
+ArrayVectorPtr makeNumericList(
+    VectorMaker& maker,
+    vector_size_t size,
+    LengthShape shape,
+    int32_t listNullPct,
+    int32_t elementNullPct,
+    uint64_t salt,
+    const TypePtr& arrayType = ARRAY(CppToType<T>::create())) {
+  return maker.arrayVector<T>(
+      size,
+      [shape, salt](vector_size_t row) { return listSizeAt(row, shape, salt); },
+      [salt](vector_size_t index) {
+        return numericValue<T>(index / 4'096, index, salt);
+      },
+      [listNullPct, salt](vector_size_t row) {
+        return periodicNull(row, listNullPct, salt + 17);
+      },
+      [elementNullPct, salt](vector_size_t index) {
+        return periodicNull(index, elementNullPct, salt + 29);
+      },
+      arrayType);
+}
+
+ArrayVectorPtr makeStringList(
+    VectorMaker& maker,
+    vector_size_t size,
+    LengthShape shape,
+    int32_t listNullPct,
+    uint64_t salt) {
+  return maker.arrayVector<std::string>(
+      size,
+      [shape, salt](vector_size_t row) { return listSizeAt(row, shape, salt); },
+      [salt](vector_size_t row, vector_size_t index) {
+        return fmt::format("s{}_{}", row % 997, (index + salt) % 131);
+      },
+      [listNullPct, salt](vector_size_t row) {
+        return periodicNull(row, listNullPct, salt + 37);
+      },
+      ARRAY(VARCHAR()));
+}
+
+VectorPtr makeStructValue(
+    VectorMaker& maker,
+    const std::string& fieldName,
+    const VectorPtr& value,
+    int32_t structNullPct,
+    uint64_t salt) {
+  const auto size = value->size();
+  auto type = ROW({fieldName}, {value->type()});
+  auto nulls = makeNullsBuffer(
+      value->pool(), size, [structNullPct, salt](vector_size_t row) {
+        return periodicNull(row, structNullPct, salt);
+      });
+  if (nulls) {
+    auto clearCollectionSize =
+        [&](auto& self, const VectorPtr& vector, vector_size_t row) -> void {
+      if (auto array = vector->as<ArrayVector>()) {
+        array->setOffsetAndSize(row, array->offsetAt(row), 0);
+        return;
+      }
+      if (auto map = vector->as<MapVector>()) {
+        map->setOffsetAndSize(row, map->offsetAt(row), 0);
+        return;
+      }
+      if (auto rowVector = vector->as<RowVector>()) {
+        for (const auto& child : rowVector->children()) {
+          self(self, child, row);
+        }
+      }
+    };
+    for (vector_size_t row = 0; row < size; ++row) {
+      if (bits::isBitNull(nulls->as<uint64_t>(), row)) {
+        clearCollectionSize(clearCollectionSize, value, row);
+      }
+    }
+  }
+  return std::make_shared<RowVector>(
+      value->pool(), type, nulls, size, std::vector<VectorPtr>{value});
+}
+
+ArrayVectorPtr makeNestedList(
+    VectorMaker& maker,
+    vector_size_t size,
+    int32_t outerNullPct,
+    uint64_t salt) {
+  std::vector<vector_size_t> outerOffsets;
+  std::vector<vector_size_t> outerNulls;
+  std::vector<vector_size_t> innerOffsets;
+  std::vector<int64_t> values;
+  outerOffsets.reserve(size);
+  for (vector_size_t row = 0; row < size; ++row) {
+    outerOffsets.push_back(innerOffsets.size());
+    if (periodicNull(row, outerNullPct, salt)) {
+      outerNulls.push_back(row);
+      continue;
+    }
+    const auto outerSize =
+        listSizeAt(row, LengthShape::kSparse, salt + 3) == 0 ? 0 : 24;
+    for (vector_size_t outerIndex = 0; outerIndex < outerSize; ++outerIndex) {
+      innerOffsets.push_back(values.size());
+      for (vector_size_t innerIndex = 0; innerIndex < 11; ++innerIndex) {
+        values.push_back(
+            numericValue<int64_t>(row, outerIndex * 11 + innerIndex, salt));
+      }
+    }
+  }
+  auto elements = maker.flatVector<int64_t>(values);
+  auto innerArrays = maker.arrayVector(innerOffsets, elements);
+  return maker.arrayVector(outerOffsets, innerArrays, outerNulls);
+}
+
+ArrayVectorPtr
+makeListOfStruct(VectorMaker& maker, vector_size_t size, uint64_t salt) {
+  auto rowType = ROW({"id", "score"}, {BIGINT(), DOUBLE()});
+  std::vector<std::vector<std::optional<std::tuple<int64_t, double>>>> data;
+  data.reserve(size);
+  for (vector_size_t row = 0; row < size; ++row) {
+    const auto length = listSizeAt(row, LengthShape::kBounded, salt);
+    std::vector<std::optional<std::tuple<int64_t, double>>> values;
+    values.reserve(length);
+    for (vector_size_t i = 0; i < length; ++i) {
+      if (periodicNull(row * 1'024 + i, 7, salt + 41)) {
+        values.push_back(std::nullopt);
+      } else {
+        values.push_back(std::make_tuple(
+            numericValue<int64_t>(row, i, salt),
+            numericValue<double>(row, i, salt + 1)));
+      }
+    }
+    data.push_back(std::move(values));
+  }
+  return maker.arrayOfRowVector(data, rowType);
+}
+
+MapVectorPtr makeStringBigintMap(
+    VectorMaker& maker,
+    vector_size_t size,
+    uint64_t salt,
+    LengthShape shape,
+    int32_t mapNullPct,
+    int32_t valueNullPct) {
+  std::vector<std::optional<
+      std::vector<std::pair<std::string, std::optional<int64_t>>>>>
+      maps;
+  maps.reserve(size);
+  for (vector_size_t row = 0; row < size; ++row) {
+    if (periodicNull(row, mapNullPct, salt)) {
+      maps.push_back(std::nullopt);
+      continue;
+    }
+    const auto mapSize = listSizeAt(row, shape, salt + 5);
+    std::vector<std::pair<std::string, std::optional<int64_t>>> values;
+    values.reserve(mapSize);
+    for (vector_size_t i = 0; i < mapSize; ++i) {
+      std::optional<int64_t> value;
+      if (!periodicNull(row * 1'024 + i, valueNullPct, salt + 7)) {
+        value = numericValue<int64_t>(row, i, salt);
+      }
+      values.push_back({fmt::format("k{}", (row + i + salt) % 97), value});
+    }
+    maps.push_back(std::move(values));
+  }
+  return maker.mapVector<std::string, int64_t>(maps, MAP(VARCHAR(), BIGINT()));
+}
+
+MapVectorPtr
+makeStringStringMap(VectorMaker& maker, vector_size_t size, uint64_t salt) {
+  std::vector<std::vector<std::pair<std::string, std::optional<std::string>>>>
+      maps;
+  maps.reserve(size);
+  for (vector_size_t row = 0; row < size; ++row) {
+    std::vector<std::pair<std::string, std::optional<std::string>>> values;
+    const auto mapSize = listSizeAt(row, LengthShape::kFixedSmall, salt);
+    values.reserve(mapSize);
+    for (vector_size_t i = 0; i < mapSize; ++i) {
+      values.push_back(
+          {fmt::format("key_{}_{}", row % 997, i),
+           fmt::format("string_value_{}_{}", row % 997, (i + salt) % 131)});
+    }
+    maps.push_back(std::move(values));
+  }
+  return maker.mapVector<std::string, std::string>(
+      maps, MAP(VARCHAR(), VARCHAR()));
+}
+
+std::vector<std::string> allColumnNames(const DataSetSpec& spec) {
+  std::vector<std::string> names;
+  names.reserve(spec.columns.size());
+  for (const auto& column : spec.columns) {
+    names.push_back(column.name);
+  }
+  return names;
+}
+
+std::vector<std::string> projectedNames(
+    const DataSetSpec& spec,
+    ProjectionKind projection) {
+  if (projection == ProjectionKind::kAll) {
+    return allColumnNames(spec);
+  }
+
+  std::vector<std::string> names;
+  for (const auto& column : spec.columns) {
+    const auto& name = column.name;
+    if (projection == ProjectionKind::kRepresentative) {
+      if (name.find("fixed") != std::string::npos ||
+          name.find("sparse") != std::string::npos ||
+          name.find("nested") != std::string::npos ||
+          name.find("map") != std::string::npos ||
+          name.find("list_struct") != std::string::npos) {
+        names.push_back(name);
+      }
+    } else if (projection == ProjectionKind::kLongOnly) {
+      if (name.find("long") != std::string::npos ||
+          name.find("nested") != std::string::npos) {
+        names.push_back(name);
+      }
+    } else if (projection == ProjectionKind::kNullHeavy) {
+      if (name.find("all_null") != std::string::npos ||
+          name.find("top_null") != std::string::npos ||
+          name.find("sparse") != std::string::npos) {
+        names.push_back(name);
+      }
+    }
+  }
+
+  if (names.empty() && !spec.columns.empty()) {
+    names.push_back(spec.columns.front().name);
+  }
+  return names;
+}
+
+RowTypePtr rowTypeFor(const std::vector<ColumnSpec>& columns) {
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(columns.size());
+  types.reserve(columns.size());
+  for (const auto& column : columns) {
+    names.push_back(column.name);
+    types.push_back(column.type);
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+DataSetSpec makeDataSetSpec(DataSetKind kind) {
+  const auto bigintList = ROW({"value"}, {ARRAY(BIGINT())});
+  const auto floatList = ROW({"value"}, {ARRAY(REAL())});
+  const auto doubleList = ROW({"value"}, {ARRAY(DOUBLE())});
+  const auto varcharList = ROW({"value"}, {ARRAY(VARCHAR())});
+  const auto nestedList = ROW({"value"}, {ARRAY(ARRAY(BIGINT()))});
+  const auto nestedStructList =
+      ROW({"c0"}, {ROW({"value"}, {ARRAY(BIGINT())})});
+
+  DataSetSpec spec{toString(kind), {}, true};
+  auto add = [&](std::string name, TypePtr type) {
+    spec.columns.push_back({std::move(name), std::move(type)});
+  };
+
+  switch (kind) {
+    case DataSetKind::kControl:
+      add("id", BIGINT());
+      add("score", DOUBLE());
+      add("name", VARCHAR());
+      add("fixed_small_ids", ARRAY(BIGINT()));
+      add("struct_value_fixed", bigintList);
+      break;
+    case DataSetKind::kList:
+      add("list_values", ARRAY(BIGINT()));
+      break;
+    case DataSetKind::kMap:
+      add("map_values", MAP(VARCHAR(), BIGINT()));
+      break;
+    case DataSetKind::kStringList:
+      add("string_list_values", ARRAY(VARCHAR()));
+      break;
+    case DataSetKind::kStringMap:
+      add("string_map_values", MAP(VARCHAR(), VARCHAR()));
+      break;
+    case DataSetKind::kNullable:
+      add("all_null_ids", bigintList);
+      add("top_null_sparse_ids", bigintList);
+      add("element_null_ids", bigintList);
+      add("sparse_ids", bigintList);
+      add("fixed_label", floatList);
+      break;
+    case DataSetKind::kLongList:
+      add("fixed_2k_ids", bigintList);
+      add("long_tail_ids", nestedStructList);
+      add("fixed_3035_label", floatList);
+      add("sparse_ids", bigintList);
+      break;
+    case DataSetKind::kNested:
+      add("nested_short_seq", nestedList);
+      add("nested_sparse_seq", nestedList);
+      add("list_struct_events",
+          ARRAY(ROW({"id", "score"}, {BIGINT(), DOUBLE()})));
+      add("fixed_label", floatList);
+      break;
+    case DataSetKind::kMapStruct:
+      add("map_attrs", MAP(VARCHAR(), BIGINT()));
+      add("list_struct_events",
+          ARRAY(ROW({"id", "score"}, {BIGINT(), DOUBLE()})));
+      add("binary_tags", varcharList);
+      add("double_dense", doubleList);
+      break;
+    case DataSetKind::kWideFeature:
+      add("id", BIGINT());
+      for (int32_t i = 0; i < 48; ++i) {
+        add(fmt::format("feature_ids_{:02d}", i), bigintList);
+      }
+      for (int32_t i = 0; i < 8; ++i) {
+        add(fmt::format("feature_float_{:02d}", i), floatList);
+      }
+      for (int32_t i = 0; i < 4; ++i) {
+        add(fmt::format("feature_nested_{:02d}", i), nestedList);
+      }
+      for (int32_t i = 0; i < 4; ++i) {
+        add(fmt::format("feature_binary_{:02d}", i), varcharList);
+      }
+      add("all_null_ids", bigintList);
+      add("long_tail_ids", nestedStructList);
+      break;
+  }
+  return spec;
+}
+
+VectorPtr makeColumn(
+    VectorMaker& maker,
+    const std::string& name,
+    const TypePtr& type,
+    vector_size_t size,
+    uint64_t salt) {
+  if (type->kind() == TypeKind::BIGINT) {
+    return maker.flatVector<int64_t>(size, [salt](vector_size_t row) {
+      return numericValue<int64_t>(row, 0, salt);
+    });
+  }
+  if (type->kind() == TypeKind::DOUBLE) {
+    return maker.flatVector<double>(size, [salt](vector_size_t row) {
+      return numericValue<double>(row, 0, salt);
+    });
+  }
+  if (type->kind() == TypeKind::VARCHAR) {
+    return maker.flatVector<std::string>(size, [salt](vector_size_t row) {
+      return fmt::format("name_{}", (row + salt) % 1'003);
+    });
+  }
+  if (type->kind() == TypeKind::ARRAY) {
+    if (type->childAt(0)->kind() == TypeKind::ARRAY) {
+      return makeNestedList(maker, size, 0, salt);
+    }
+    if (type->childAt(0)->kind() == TypeKind::BIGINT) {
+      return makeNumericList<int64_t>(
+          maker, size, LengthShape::kFixedSmall, 0, 0, salt, type);
+    }
+    if (type->childAt(0)->kind() == TypeKind::VARCHAR) {
+      return makeStringList(maker, size, LengthShape::kFixedSmall, 0, salt);
+    }
+    if (type->childAt(0)->kind() == TypeKind::ROW) {
+      return makeListOfStruct(maker, size, salt);
+    }
+  }
+  if (type->kind() == TypeKind::MAP) {
+    if (type->childAt(1)->kind() == TypeKind::VARCHAR) {
+      return makeStringStringMap(maker, size, salt);
+    }
+    if (name == "map_values") {
+      return makeStringBigintMap(
+          maker, size, salt, LengthShape::kFixedSmall, 0, 0);
+    }
+    return makeStringBigintMap(
+        maker, size, salt, LengthShape::kBounded, 15, 10);
+  }
+
+  BOLT_CHECK_EQ(type->kind(), TypeKind::ROW);
+  const auto child = type->childAt(0);
+  const auto& fieldName = type->asRow().nameOf(0);
+  if (fieldName == "c0") {
+    auto innerList = makeNumericList<int64_t>(
+        maker, size, LengthShape::kLongTail, 87, 0, salt, child->childAt(0));
+    auto innerStruct = makeStructValue(maker, "value", innerList, 87, salt + 3);
+    return makeStructValue(maker, "c0", innerStruct, 87, salt + 5);
+  }
+  if (child->childAt(0)->kind() == TypeKind::ARRAY) {
+    auto list = makeNestedList(maker, size, 0, salt);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+
+  if (name.find("all_null") != std::string::npos) {
+    auto list = makeNumericList<int64_t>(
+        maker, size, LengthShape::kFixedOne, 100, 0, salt, child);
+    return makeStructValue(maker, "value", list, 100, salt);
+  }
+  if (name.find("top_null") != std::string::npos) {
+    auto list = makeNumericList<int64_t>(
+        maker, size, LengthShape::kSparse, 87, 0, salt, child);
+    return makeStructValue(maker, "value", list, 87, salt);
+  }
+  if (name.find("element_null") != std::string::npos) {
+    auto list = makeNumericList<int64_t>(
+        maker, size, LengthShape::kBounded, 0, 20, salt, child);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+  if (name.find("sparse") != std::string::npos) {
+    auto list = makeNumericList<int64_t>(
+        maker, size, LengthShape::kSparse, 0, 0, salt, child);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+  if (name.find("fixed_2k") != std::string::npos) {
+    auto list = makeNumericList<int64_t>(
+        maker, size, LengthShape::kLong2K, 87, 0, salt, child);
+    return makeStructValue(maker, "value", list, 87, salt);
+  }
+  if (name.find("3035") != std::string::npos) {
+    auto list = makeNumericList<float>(
+        maker, size, LengthShape::kFixedLarge, 0, 0, salt, child);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+  if (name.find("label") != std::string::npos || child->childAt(0)->isReal()) {
+    auto list = makeNumericList<float>(
+        maker, size, LengthShape::kFixedMedium, 0, 0, salt, child);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+  if (child->childAt(0)->isDouble()) {
+    auto list = makeNumericList<double>(
+        maker, size, LengthShape::kFixedMedium, 0, 0, salt, child);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+  if (child->childAt(0)->isVarchar()) {
+    auto list = makeStringList(maker, size, LengthShape::kFixedOne, 0, salt);
+    return makeStructValue(maker, "value", list, 0, salt);
+  }
+  auto list = makeNumericList<int64_t>(
+      maker, size, LengthShape::kBounded, 0, 0, salt, child);
+  return makeStructValue(maker, "value", list, 0, salt);
+}
+
+RowVectorPtr makeBatch(
+    memory::MemoryPool* pool,
+    const DataSetSpec& spec,
+    vector_size_t size,
+    int32_t batchIndex) {
+  VectorMaker maker(pool);
+  std::vector<std::string> names;
+  std::vector<VectorPtr> children;
+  names.reserve(spec.columns.size());
+  children.reserve(spec.columns.size());
+  for (int32_t i = 0; i < spec.columns.size(); ++i) {
+    const auto& column = spec.columns[i];
+    names.push_back(column.name);
+    children.push_back(makeColumn(
+        maker,
+        column.name,
+        column.type,
+        size,
+        kSeed + batchIndex * 997 + i * 67));
+  }
+  return maker.rowVector(std::move(names), children);
+}
+
+RowTypePtr projectedRowType(
+    const RowTypePtr& fullType,
+    const std::vector<std::string>& names) {
+  std::vector<TypePtr> types;
+  types.reserve(names.size());
+  for (const auto& name : names) {
+    types.push_back(fullType->findChild(name));
+  }
+  return ROW(std::vector<std::string>(names), std::move(types));
+}
+
+std::shared_ptr<bytedance::bolt::common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType,
+    dwio::common::RuntimeStatistics* stats = nullptr) {
+  auto scanSpec = std::make_shared<bytedance::bolt::common::ScanSpec>("");
+  scanSpec->setRuntimeStatistics(stats);
+  scanSpec->addAllChildFields(*rowType);
+  return scanSpec;
+}
+
+class ComplexTypeBenchmark {
+ public:
+  explicit ComplexTypeBenchmark(DataSetKind kind)
+      : spec_(makeDataSetSpec(kind)),
+        rootPool_(memory::memoryManager()->addRootPool(
+            fmt::format("ParquetComplexTypeBenchmark.{}", spec_.name))),
+        leafPool_(rootPool_->addLeafChild("leaf")),
+        fileFolder_(bytedance::bolt::exec::test::TempDirectoryPath::create()),
+        filePath_(fileFolder_->path + "/" + spec_.name + ".parquet"),
+        rowType_(rowTypeFor(spec_.columns)) {
+    writeFile();
+  }
+
+  int64_t read(ProjectionKind projection, vector_size_t batchSize) {
+    auto names = projectedNames(spec_, projection);
+    auto projectedType = projectedRowType(rowType_, names);
+
+    static std::atomic<uint64_t> scanId{0};
+    auto scanRootPool = memory::memoryManager()->addRootPool(fmt::format(
+        "ParquetComplexTypeBenchmark.{}.scan.{}",
+        spec_.name,
+        scanId.fetch_add(1)));
+    auto scanLeafPool = scanRootPool->addLeafChild("leaf");
+    dwio::common::ReaderOptions readerOptions{scanLeafPool.get()};
+    auto input = std::make_unique<BufferedInput>(
+        std::make_shared<LocalReadFile>(filePath_),
+        readerOptions.getMemoryPool());
+    auto reader =
+        std::make_unique<ParquetReader>(std::move(input), readerOptions);
+
+    dwio::common::RowReaderOptions rowReaderOptions;
+    rowReaderOptions.select(
+        std::make_shared<ColumnSelector>(projectedType, names));
+    dwio::common::RuntimeStatistics stats;
+    rowReaderOptions.setScanSpec(makeScanSpec(projectedType, &stats));
+    rowReaderOptions.setParquetRepDefStreamingWindowSize(
+        FLAGS_parquet_complex_repdef_streaming_window_size);
+    auto rowReader = reader->createRowReader(rowReaderOptions);
+
+    const auto collectMemoryStats = FLAGS_parquet_complex_print_memory_stats;
+    const auto rssBeforeKb = collectMemoryStats ? processRssKb() : 0;
+    auto rssPeakKb = rssBeforeKb;
+    VectorPtr result = BaseVector::create(projectedType, 0, scanLeafPool.get());
+    int64_t rows = 0;
+    while (true) {
+      const auto read = rowReader->next(batchSize, result);
+      if (read == 0) {
+        break;
+      }
+      rows += result->size();
+      folly::doNotOptimizeAway(result->hashValueAt(0));
+      if (collectMemoryStats) {
+        rssPeakKb = std::max(rssPeakKb, processRssKb());
+      }
+    }
+
+    rowReader->updateRuntimeStats(stats);
+    if (FLAGS_parquet_complex_print_runtime_stats) {
+      fmt::print(
+          "PARQUET_COMPLEX_STATS dataset={} projection={} batch_size={} "
+          "page_version={} streaming={} decompress_time_ns={} "
+          "value_decode_time_ns={}\n",
+          spec_.name,
+          toString(projection),
+          batchSize,
+          FLAGS_parquet_complex_data_page_version,
+          FLAGS_parquet_complex_repdef_streaming_window_size != 0,
+          stats.decompressDataTimeNs,
+          stats.decodeTimeNs);
+    }
+    if (FLAGS_parquet_complex_print_memory_stats) {
+      fmt::print(
+          "PARQUET_COMPLEX_MEMORY dataset={} projection={} batch_size={} "
+          "page_version={} streaming={} rss_before_kb={} rss_peak_kb={} "
+          "rss_delta_kb={} root_peak_bytes={} leaf_peak_bytes={}\n",
+          spec_.name,
+          toString(projection),
+          batchSize,
+          FLAGS_parquet_complex_data_page_version,
+          FLAGS_parquet_complex_repdef_streaming_window_size != 0,
+          rssBeforeKb,
+          rssPeakKb,
+          rssPeakKb - rssBeforeKb,
+          scanRootPool->peakBytes(),
+          scanLeafPool->peakBytes());
+    }
+    folly::doNotOptimizeAway(stats);
+    BOLT_CHECK_GT(rows, 0, "Complex type benchmark read no rows");
+    return rows;
+  }
+
+ private:
+  void writeFile() {
+    auto localWriteFile =
+        std::make_unique<LocalWriteFile>(filePath_, true, false);
+    auto sink =
+        std::make_unique<WriteFileSink>(std::move(localWriteFile), filePath_);
+
+    bytedance::bolt::parquet::WriterOptions options;
+    options.enableDictionary = !spec_.disableDictionary;
+    options.memoryPool = rootPool_.get();
+    options.compression = bytedance::bolt::common::CompressionKind_ZSTD;
+    BOLT_CHECK(
+        FLAGS_parquet_complex_data_page_version == 1 ||
+            FLAGS_parquet_complex_data_page_version == 2,
+        "Unsupported Parquet data page version {}",
+        FLAGS_parquet_complex_data_page_version);
+    options.dataPageVersion = FLAGS_parquet_complex_data_page_version == 1
+        ? bytedance::bolt::parquet::arrow::ParquetDataPageVersion::V1
+        : bytedance::bolt::parquet::arrow::ParquetDataPageVersion::V2;
+    options.dataPageSize = kDataPageSize;
+    options.flushPolicyFactory = [] {
+      return std::make_unique<DefaultFlushPolicy>(
+          kRowsPerRowGroup, kBytesPerRowGroup);
+    };
+
+    bytedance::bolt::parquet::Writer writer(std::move(sink), options, rowType_);
+    for (int32_t batch = 0; batch < kNumBatches; ++batch) {
+      writer.write(makeBatch(leafPool_.get(), spec_, kRowsPerBatch, batch));
+    }
+    writer.flush();
+    writer.close();
+  }
+
+  DataSetSpec spec_;
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> leafPool_;
+  std::shared_ptr<bytedance::bolt::exec::test::TempDirectoryPath> fileFolder_;
+  std::string filePath_;
+  RowTypePtr rowType_;
+};
+
+ComplexTypeBenchmark& benchmark(DataSetKind kind) {
+  static std::map<DataSetKind, std::unique_ptr<ComplexTypeBenchmark>>
+      benchmarks;
+  auto& instance = benchmarks[kind];
+  if (!instance) {
+    instance = std::make_unique<ComplexTypeBenchmark>(kind);
+  }
+  return *instance;
+}
+
+void runComplexTypeBenchmark(
+    uint32_t iters,
+    DataSetKind kind,
+    ProjectionKind projection,
+    vector_size_t batchSize) {
+  folly::BenchmarkSuspender suspender;
+  auto& instance = benchmark(kind);
+  suspender.dismiss();
+  while (iters--) {
+    folly::doNotOptimizeAway(instance.read(projection, batchSize));
+  }
+}
+
+#define COMPLEX_BENCHMARK(name, kind, projection, batchSize)              \
+  BENCHMARK(name##_##projection##_##batchSize, iters) {                   \
+    runComplexTypeBenchmark(                                              \
+        iters, DataSetKind::kind, ProjectionKind::projection, batchSize); \
+  }
+
+COMPLEX_BENCHMARK(control, kControl, kAll, 128);
+COMPLEX_BENCHMARK(control, kControl, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(list, kList, kAll, 128);
+COMPLEX_BENCHMARK(list, kList, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(map, kMap, kAll, 128);
+COMPLEX_BENCHMARK(map, kMap, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(stringList, kStringList, kAll, 128);
+COMPLEX_BENCHMARK(stringList, kStringList, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(stringMap, kStringMap, kAll, 128);
+COMPLEX_BENCHMARK(stringMap, kStringMap, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(nullable, kNullable, kAll, 128);
+COMPLEX_BENCHMARK(nullable, kNullable, kNullHeavy, 128);
+COMPLEX_BENCHMARK(nullable, kNullable, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(longList, kLongList, kAll, 128);
+COMPLEX_BENCHMARK(longList, kLongList, kLongOnly, 128);
+COMPLEX_BENCHMARK(longList, kLongList, kAll, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(nested, kNested, kAll, 128);
+COMPLEX_BENCHMARK(nested, kNested, kRepresentative, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(mapStruct, kMapStruct, kAll, 128);
+COMPLEX_BENCHMARK(mapStruct, kMapStruct, kRepresentative, 4096);
+BENCHMARK_DRAW_LINE();
+
+COMPLEX_BENCHMARK(wideFeature, kWideFeature, kRepresentative, 128);
+COMPLEX_BENCHMARK(wideFeature, kWideFeature, kAll, 1024);
+COMPLEX_BENCHMARK(wideFeature, kWideFeature, kNullHeavy, 1024);
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -29,12 +29,21 @@
  */
 
 #include "bolt/dwio/parquet/reader/PageReader.h"
+#include "bolt/dwio/parquet/reader/ParquetData.h"
+#include "bolt/dwio/parquet/reader/ParquetTypeWithId.h"
 #include "bolt/dwio/parquet/tests/ParquetTestBase.h"
 
 #include <arrow/util/rle_encoding.h>
+#include <snappy.h>
 #include <thrift/protocol/TCompactProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <zstd.h>
+#include <atomic>
+#include <limits>
+#include <random>
+
+#include "bolt/common/base/tests/GTestUtils.h"
+#include "bolt/dwio/common/DirectBufferedInput.h"
 
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::common;
@@ -49,7 +58,10 @@ void appendInt32(std::string& out, int32_t value) {
 }
 
 std::string encodeLevels(const std::vector<int16_t>& levels, int bitWidth) {
-  std::string encoded(levels.size() * sizeof(int16_t) + 64, '\0');
+  std::string encoded(
+      ::arrow::util::RleEncoder::MaxBufferSize(bitWidth, levels.size()) +
+          ::arrow::util::RleEncoder::MinBufferSize(bitWidth),
+      '\0');
   ::arrow::util::RleEncoder encoder(
       reinterpret_cast<uint8_t*>(encoded.data()), encoded.size(), bitWidth);
   for (auto level : levels) {
@@ -86,11 +98,18 @@ std::string zstdCompress(const std::string& data) {
   return compressed;
 }
 
+std::string snappyCompress(const std::string& data) {
+  std::string compressed;
+  snappy::Compress(data.data(), data.size(), &compressed);
+  return compressed;
+}
+
 thrift::PageHeader makePageHeader(
     int32_t compressedSize,
-    int32_t uncompressedSize) {
+    int32_t uncompressedSize,
+    int32_t numValues = 8) {
   thrift::DataPageHeader dataPageHeader;
-  dataPageHeader.__set_num_values(8);
+  dataPageHeader.__set_num_values(numValues);
   dataPageHeader.__set_encoding(thrift::Encoding::PLAIN);
   dataPageHeader.__set_definition_level_encoding(thrift::Encoding::RLE);
   dataPageHeader.__set_repetition_level_encoding(thrift::Encoding::RLE);
@@ -116,26 +135,283 @@ std::string serializePageHeader(const thrift::PageHeader& pageHeader) {
   return std::string(reinterpret_cast<const char*>(data), size);
 }
 
-ParquetTypeWithIdPtr makeNestedInt64Type() {
-  return std::make_shared<ParquetTypeWithId>(
+std::string makeDataPageV2(
+    int32_t numValues,
+    const std::string& repetitionLevels,
+    const std::string& definitionLevels,
+    const std::string& values,
+    int32_t compressedValueSize,
+    int32_t uncompressedValueSize) {
+  thrift::DataPageHeaderV2 dataPageHeader;
+  dataPageHeader.__set_num_values(numValues);
+  dataPageHeader.__set_num_nulls(0);
+  dataPageHeader.__set_num_rows(numValues);
+  dataPageHeader.__set_encoding(thrift::Encoding::PLAIN);
+  dataPageHeader.__set_definition_levels_byte_length(definitionLevels.size());
+  dataPageHeader.__set_repetition_levels_byte_length(repetitionLevels.size());
+  dataPageHeader.__set_is_compressed(true);
+
+  thrift::PageHeader pageHeader;
+  pageHeader.__set_type(thrift::PageType::DATA_PAGE_V2);
+  pageHeader.__set_data_page_header_v2(dataPageHeader);
+  pageHeader.__set_compressed_page_size(
+      repetitionLevels.size() + definitionLevels.size() + compressedValueSize);
+  pageHeader.__set_uncompressed_page_size(
+      repetitionLevels.size() + definitionLevels.size() +
+      uncompressedValueSize);
+  return serializePageHeader(pageHeader) + repetitionLevels + definitionLevels +
+      values;
+}
+
+struct NestedInt64Type {
+  ParquetTypeWithIdPtr root;
+  ParquetTypeWithIdPtr list;
+  ParquetTypeWithIdPtr leaf;
+};
+
+NestedInt64Type makeNestedInt64Type() {
+  auto leaf = std::make_shared<ParquetTypeWithId>(
       BIGINT(),
       std::vector<std::shared_ptr<const dwio::common::TypeWithId>>{},
+      2,
+      2,
       0,
-      0,
-      0,
-      "value",
+      "element",
       thrift::Type::INT64,
       std::nullopt,
       std::nullopt,
       1,
       2,
+      false,
+      false);
+  auto list = std::make_shared<ParquetTypeWithId>(
+      ARRAY(BIGINT()),
+      std::vector<std::shared_ptr<const TypeWithId>>{leaf},
+      1,
+      2,
+      ParquetTypeWithId::kNonLeaf,
+      "list",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      1,
+      1,
       true,
       true);
+  auto root = std::make_shared<ParquetTypeWithId>(
+      ROW({"list"}, {ARRAY(BIGINT())}),
+      std::vector<std::shared_ptr<const TypeWithId>>{list},
+      0,
+      2,
+      ParquetTypeWithId::kNonLeaf,
+      "schema",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      0,
+      0,
+      false,
+      false);
+  return {std::move(root), std::move(list), std::move(leaf)};
+}
+
+class CountingInMemoryReadFile final : public InMemoryReadFile {
+ public:
+  explicit CountingInMemoryReadFile(std::string data)
+      : InMemoryReadFile(std::move(data)) {}
+
+  std::string_view pread(uint64_t offset, uint64_t length, void* buffer)
+      const override {
+    ++readCalls_;
+    readBytes_ += length;
+    return InMemoryReadFile::pread(offset, length, buffer);
+  }
+
+  uint64_t readCalls() const {
+    return readCalls_;
+  }
+
+  uint64_t readBytes() const {
+    return readBytes_;
+  }
+
+ private:
+  mutable std::atomic<uint64_t> readCalls_{0};
+  mutable std::atomic<uint64_t> readBytes_{0};
+};
+
+struct DataPageV1TestData {
+  std::string body;
+  std::string encoded;
+  size_t encodedBodySize;
+};
+
+DataPageV1TestData makeDataPageV1(
+    thrift::CompressionCodec::type codec,
+    int32_t numRows,
+    int32_t valuesPerRow,
+    uint64_t seed,
+    bool emptyLastRow = false) {
+  const auto fullRows = numRows - (emptyLastRow ? 1 : 0);
+  const auto numPresentValues = fullRows * valuesPerRow;
+  const auto numLevels = numPresentValues + (emptyLastRow ? 1 : 0);
+  std::vector<int16_t> repetitionLevels(numLevels, 1);
+  for (int32_t i = 0; i < numPresentValues; i += valuesPerRow) {
+    repetitionLevels[i] = 0;
+  }
+  std::vector<int16_t> definitionLevels(numLevels, 2);
+  if (emptyLastRow) {
+    repetitionLevels.back() = 0;
+    definitionLevels.back() = 1;
+  }
+
+  std::string body;
+  const auto encodedRepetitionLevels = encodeLevels(repetitionLevels, 1);
+  appendInt32(body, encodedRepetitionLevels.size());
+  body.append(encodedRepetitionLevels);
+  const auto encodedDefinitionLevels = encodeLevels(definitionLevels, 2);
+  appendInt32(body, encodedDefinitionLevels.size());
+  body.append(encodedDefinitionLevels);
+
+  std::mt19937_64 rng(seed);
+  for (int32_t i = 0; i < numPresentValues; ++i) {
+    const auto value = rng();
+    body.append(reinterpret_cast<const char*>(&value), sizeof(value));
+  }
+
+  std::string encodedBody;
+  if (codec == thrift::CompressionCodec::UNCOMPRESSED) {
+    encodedBody = body;
+  } else if (codec == thrift::CompressionCodec::ZSTD) {
+    encodedBody = zstdCompress(body);
+  } else {
+    BOLT_CHECK_EQ(codec, thrift::CompressionCodec::SNAPPY);
+    encodedBody = snappyCompress(body);
+  }
+  const auto encodedBodySize = encodedBody.size();
+  auto encoded = serializePageHeader(
+                     makePageHeader(encodedBodySize, body.size(), numLevels)) +
+      encodedBody;
+  return {std::move(body), std::move(encoded), encodedBodySize};
+}
+
+struct StreamingV1Reader {
+  std::shared_ptr<memory::MemoryPool> pool;
+  std::shared_ptr<CountingInMemoryReadFile> file;
+  std::unique_ptr<DirectBufferedInput> input;
+  NestedInt64Type nestedType;
+  std::unique_ptr<PageReader> reader;
+};
+
+StreamingV1Reader makeStreamingV1Reader(
+    const std::shared_ptr<memory::MemoryPool>& rootPool,
+    const std::string& columnChunk,
+    int32_t loadQuantum,
+    int32_t memoryLimit,
+    const std::string& poolName) {
+  auto pool = rootPool->addLeafChild(poolName);
+  auto file = std::make_shared<CountingInMemoryReadFile>(columnChunk);
+  auto ioStats = std::make_shared<io::IoStatistics>();
+  dwio::common::ReaderOptions options{pool.get()};
+  options.setLoadQuantum(loadQuantum);
+  auto input = std::make_unique<DirectBufferedInput>(
+      file,
+      MetricsLog::voidLog(),
+      1,
+      nullptr,
+      1,
+      ioStats,
+      nullptr,
+      options,
+      nullptr);
+
+  StreamIdentifier streamId(0);
+  auto streams = input->enqueuePair(Region{0, columnChunk.size()}, &streamId);
+  input->load(LogType::FILE);
+
+  auto nestedType = makeNestedInt64Type();
+  auto reader = std::make_unique<PageReader>(
+      std::move(streams.first),
+      *pool,
+      nestedType.leaf,
+      thrift::CompressionCodec::UNCOMPRESSED,
+      columnChunk.size(),
+      nullptr,
+      std::move(streams.second));
+  reader->setParquetRepDefMemoryLimit(memoryLimit);
+  reader->setParquetRepDefStreamingWindowSize(2'048);
+
+  return {
+      std::move(pool),
+      std::move(file),
+      std::move(input),
+      std::move(nestedType),
+      std::move(reader)};
+}
+
+std::vector<int32_t> readListLengths(
+    StreamingV1Reader& input,
+    int32_t numRows) {
+  arrow::LevelInfo listInfo;
+  EXPECT_EQ(input.nestedType.list->makeLevelInfo(listInfo), LevelMode::kList);
+  std::vector<int32_t> lengths(numRows);
+  std::vector<uint64_t> nulls(bits::nwords(numRows));
+  const auto [repDefBegin, repDefEnd] = input.reader->repDefRange();
+  EXPECT_EQ(
+      input.reader->getLengthsAndNulls(
+          LevelMode::kList,
+          listInfo,
+          repDefBegin,
+          repDefEnd,
+          numRows,
+          lengths.data(),
+          nulls.data(),
+          0),
+      numRows);
+  EXPECT_TRUE(bits::isAllSet(nulls.data(), 0, numRows, bits::kNotNull));
+  return lengths;
 }
 
 } // namespace
 
 class ParquetPageReaderTest : public ParquetTestBase {};
+
+TEST_F(ParquetPageReaderTest, rowGroupRegionRejectsOverflow) {
+  thrift::ColumnMetaData metadata;
+  metadata.__set_data_page_offset(std::numeric_limits<int64_t>::max() - 4);
+  metadata.__set_total_compressed_size(16);
+
+  thrift::ColumnChunk column;
+  column.__set_meta_data(metadata);
+  thrift::RowGroup rowGroup;
+  rowGroup.__set_columns({column});
+  std::vector<thrift::RowGroup> rowGroups{rowGroup};
+
+  std::vector<thrift::SchemaElement> schema;
+  SchemaHelper schemaHelper(schema);
+  auto nestedType = makeNestedInt64Type();
+  ParquetData parquetData(
+      nestedType.leaf,
+      rowGroups,
+      *leafPool_,
+      nullptr,
+      nullptr,
+      schemaHelper,
+      false,
+      false,
+      0,
+      0,
+      0);
+
+  BOLT_ASSERT_THROW(
+      parquetData.getRowGroupRegion(0),
+      "Column chunk region overflows int64_t");
+
+  rowGroups[0].columns[0].meta_data.__set_total_compressed_size(4);
+  EXPECT_EQ(
+      parquetData.getRowGroupRegion(0),
+      std::make_pair(std::numeric_limits<int64_t>::max() - 4, int64_t{4}));
+}
 
 TEST_F(ParquetPageReaderTest, smallPage) {
   auto readFile =
@@ -214,6 +490,140 @@ TEST_F(ParquetPageReaderTest, corruptedPageHeader) {
   EXPECT_THROW(pageReader->readPageHeader(), BoltException);
 }
 
+TEST_F(
+    ParquetPageReaderTest,
+    streamingDataPageV2RepDefReadSkipsValueDecompression) {
+  constexpr int32_t kNumValues = 4;
+  const auto repetitionLevels = encodeLevels({0, 0, 0, 0}, 1);
+  const auto definitionLevels = encodeLevels({2, 2, 2, 2}, 2);
+
+  std::string invalidCompressedValues;
+  const uint32_t zstdMagic = ZSTD_MAGICNUMBER;
+  invalidCompressedValues.append(
+      reinterpret_cast<const char*>(&zstdMagic), sizeof(zstdMagic));
+  invalidCompressedValues.append(4, '\0');
+
+  const std::string page = makeDataPageV2(
+      kNumValues,
+      repetitionLevels,
+      definitionLevels,
+      invalidCompressedValues,
+      invalidCompressedValues.size(),
+      1'024);
+  const std::string pages = page + page;
+  auto input =
+      std::make_unique<SeekableArrayInputStream>(pages.data(), pages.size());
+  auto repDefInput =
+      std::make_unique<SeekableArrayInputStream>(pages.data(), pages.size());
+  auto nestedType = makeNestedInt64Type();
+
+  dwio::common::RuntimeStatistics stats;
+  PageReader pageReader(
+      std::move(input),
+      *leafPool_,
+      nestedType.leaf,
+      thrift::CompressionCodec::ZSTD,
+      pages.size(),
+      &stats,
+      std::move(repDefInput));
+
+  EXPECT_NO_THROW(pageReader.decodeRepDefs(kNumValues - 1));
+  arrow::LevelInfo listInfo;
+  EXPECT_EQ(nestedType.list->makeLevelInfo(listInfo), LevelMode::kList);
+  EXPECT_EQ(pageReader.repDefOutputSize(LevelMode::kList, listInfo), 3);
+  EXPECT_NO_THROW(pageReader.decodeRepDefs(1));
+  EXPECT_EQ(pageReader.repDefOutputSize(LevelMode::kList, listInfo), 1);
+  EXPECT_NO_THROW(pageReader.decodeRepDefs(1));
+  EXPECT_EQ(pageReader.repDefOutputSize(LevelMode::kList, listInfo), 1);
+  EXPECT_EQ(stats.decompressDataTimeNs, 0);
+}
+
+TEST_F(ParquetPageReaderTest, zeroStreamingWindowUsesLegacyRepDefPath) {
+  constexpr int32_t kNumValues = 4;
+  const auto repetitionLevels = encodeLevels({0, 0, 0, 0}, 1);
+  const auto definitionLevels = encodeLevels({2, 2, 2, 2}, 2);
+  const auto page =
+      makeDataPageV2(kNumValues, repetitionLevels, definitionLevels, "", 0, 0);
+  auto nestedType = makeNestedInt64Type();
+
+  dwio::common::RuntimeStatistics stats;
+  PageReader pageReader(
+      std::make_unique<SeekableArrayInputStream>(page.data(), page.size()),
+      *leafPool_,
+      nestedType.leaf,
+      thrift::CompressionCodec::UNCOMPRESSED,
+      page.size(),
+      &stats,
+      std::make_unique<SeekableArrayInputStream>(
+          static_cast<const char*>(nullptr), 0));
+  pageReader.setParquetRepDefStreamingWindowSize(0);
+
+  EXPECT_NO_THROW(pageReader.decodeRepDefs(kNumValues));
+  arrow::LevelInfo listInfo;
+  EXPECT_EQ(nestedType.list->makeLevelInfo(listInfo), LevelMode::kList);
+  EXPECT_EQ(
+      pageReader.repDefOutputSize(LevelMode::kList, listInfo), kNumValues);
+}
+
+TEST_F(ParquetPageReaderTest, streamingRepDefsSkipEmptyDataPages) {
+  auto emptyV1Header = makePageHeader(0, 0);
+  emptyV1Header.data_page_header.__set_num_values(0);
+  const auto emptyV1 = serializePageHeader(emptyV1Header);
+  const auto emptyV2 = makeDataPageV2(0, "", "", "", 0, 0);
+  const auto repetitionLevels = encodeLevels({0, 0}, 1);
+  const auto definitionLevels = encodeLevels({1, 1}, 1);
+  const auto dataV2 =
+      makeDataPageV2(2, repetitionLevels, definitionLevels, "", 0, 0);
+  const auto pages = emptyV1 + emptyV2 + dataV2;
+
+  auto nestedType = makeNestedInt64Type();
+  dwio::common::RuntimeStatistics stats;
+  PageReader pageReader(
+      std::make_unique<SeekableArrayInputStream>(pages.data(), pages.size()),
+      *leafPool_,
+      nestedType.leaf,
+      thrift::CompressionCodec::UNCOMPRESSED,
+      pages.size(),
+      &stats,
+      std::make_unique<SeekableArrayInputStream>(pages.data(), pages.size()));
+
+  EXPECT_NO_THROW(pageReader.decodeRepDefs(1));
+  arrow::LevelInfo listInfo;
+  EXPECT_EQ(nestedType.list->makeLevelInfo(listInfo), LevelMode::kList);
+  EXPECT_EQ(pageReader.repDefOutputSize(LevelMode::kList, listInfo), 1);
+}
+
+TEST_F(ParquetPageReaderTest, streamingDataPageV2RejectsTruncatedValueBody) {
+  constexpr int32_t kNumValues = 4;
+  constexpr int32_t kMissingValueBytes = 8;
+  const auto repetitionLevels = encodeLevels({0, 0, 0, 0}, 1);
+  const auto definitionLevels = encodeLevels({1, 1, 1, 1}, 1);
+  const auto truncatedPage = makeDataPageV2(
+      kNumValues,
+      repetitionLevels,
+      definitionLevels,
+      "",
+      kMissingValueBytes,
+      kMissingValueBytes);
+  const auto declaredChunkSize = truncatedPage.size() + kMissingValueBytes;
+
+  auto nestedType = makeNestedInt64Type();
+  dwio::common::RuntimeStatistics stats;
+  PageReader pageReader(
+      std::make_unique<SeekableArrayInputStream>(
+          truncatedPage.data(), truncatedPage.size()),
+      *leafPool_,
+      nestedType.leaf,
+      thrift::CompressionCodec::ZSTD,
+      declaredChunkSize,
+      &stats,
+      std::make_unique<SeekableArrayInputStream>(
+          truncatedPage.data(), truncatedPage.size()));
+
+  EXPECT_NO_THROW(pageReader.decodeRepDefs(kNumValues - 1));
+  EXPECT_THROW(pageReader.decodeRepDefs(1), BoltException);
+}
+
 TEST(CompressionOptionsTest, testCompressionOptions) {
   auto options = getParquetDecompressionOptions(
       bytedance::bolt::common::CompressionKind_ZLIB);
@@ -239,10 +649,11 @@ TEST_F(ParquetPageReaderTest, zstdDataPageV1RepDefPrefix) {
 
   auto stream = std::make_unique<SeekableArrayInputStream>(
       columnChunk.data(), columnChunk.size());
+  auto nestedType = makeNestedInt64Type();
   PageReader reader(
       std::move(stream),
       *leafPool_,
-      makeNestedInt64Type(),
+      nestedType.leaf,
       thrift::CompressionCodec::ZSTD,
       columnChunk.size(),
       nullptr);
@@ -250,6 +661,330 @@ TEST_F(ParquetPageReaderTest, zstdDataPageV1RepDefPrefix) {
 
   reader.decodeRepDefs(5);
   EXPECT_GT(reader.repDefRange().second, 8);
+}
+
+TEST_F(ParquetPageReaderTest, largeDataPageV1DirectInputSharesPhysicalReads) {
+  constexpr int32_t kLoadQuantum = 8 << 10;
+  constexpr int32_t kRows = 256;
+  constexpr int32_t kValuesPerRow = 64;
+
+  struct ScanStats {
+    uint64_t readCalls;
+    uint64_t readBytes;
+    int64_t peakBytes;
+    int64_t currentBytes;
+    int32_t outputSize;
+  };
+  auto scan = [&](const std::string& columnChunk,
+                  thrift::CompressionCodec::type codec,
+                  int32_t streamingWindowSize) {
+    auto readPool = rootPool_->addLeafChild(
+        fmt::format("v1-direct-input-{}", streamingWindowSize));
+    auto file = std::make_shared<CountingInMemoryReadFile>(columnChunk);
+    auto ioStats = std::make_shared<io::IoStatistics>();
+    dwio::common::ReaderOptions options{readPool.get()};
+    options.setLoadQuantum(kLoadQuantum);
+    auto input = std::make_unique<DirectBufferedInput>(
+        file,
+        MetricsLog::voidLog(),
+        1,
+        nullptr,
+        1,
+        ioStats,
+        nullptr,
+        options,
+        nullptr);
+
+    StreamIdentifier streamId(0);
+    std::unique_ptr<SeekableInputStream> dataStream;
+    std::unique_ptr<SeekableInputStream> repDefStream;
+    const Region region{0, columnChunk.size()};
+    if (streamingWindowSize == 0) {
+      dataStream = input->enqueue(region, &streamId);
+    } else {
+      auto streams = input->enqueuePair(region, &streamId);
+      dataStream = std::move(streams.first);
+      repDefStream = std::move(streams.second);
+    }
+    input->load(LogType::FILE);
+
+    auto nestedType = makeNestedInt64Type();
+    PageReader reader(
+        std::move(dataStream),
+        *readPool,
+        nestedType.leaf,
+        codec,
+        columnChunk.size(),
+        nullptr,
+        std::move(repDefStream));
+    reader.setParquetRepDefStreamingWindowSize(streamingWindowSize);
+
+    reader.decodeRepDefs(kRows);
+    arrow::LevelInfo listInfo;
+    EXPECT_EQ(nestedType.list->makeLevelInfo(listInfo), LevelMode::kList);
+    std::vector<int32_t> lengths(kRows);
+    std::vector<uint64_t> nulls(bits::nwords(kRows));
+    const auto [repDefBegin, repDefEnd] = reader.repDefRange();
+    const auto outputSize = reader.getLengthsAndNulls(
+        LevelMode::kList,
+        listInfo,
+        repDefBegin,
+        repDefEnd,
+        kRows,
+        lengths.data(),
+        nulls.data(),
+        0);
+    EXPECT_TRUE(std::all_of(lengths.begin(), lengths.end(), [](auto length) {
+      return length == kValuesPerRow;
+    }));
+    reader.seekToPage(0);
+    reader.skip(1);
+    return ScanStats{
+        file->readCalls(),
+        file->readBytes(),
+        readPool->peakBytes(),
+        readPool->currentBytes(),
+        outputSize};
+  };
+
+  for (const auto codec :
+       {thrift::CompressionCodec::ZSTD, thrift::CompressionCodec::SNAPPY}) {
+    SCOPED_TRACE(fmt::format("codec={}", static_cast<int32_t>(codec)));
+    const auto page = makeDataPageV1(codec, kRows, kValuesPerRow, 20260831);
+    const auto& columnChunk = page.encoded;
+    ASSERT_GE(columnChunk.size(), 4 * kLoadQuantum);
+
+    const auto legacy = scan(columnChunk, codec, 0);
+    const auto streaming = scan(columnChunk, codec, 2'048);
+
+    EXPECT_EQ(legacy.outputSize, kRows);
+    EXPECT_LT(streaming.readBytes, legacy.readBytes);
+    EXPECT_LT(streaming.readCalls, legacy.readCalls);
+    EXPECT_EQ(streaming.outputSize, kRows);
+    EXPECT_LT(streaming.peakBytes, legacy.peakBytes);
+    if (codec == thrift::CompressionCodec::SNAPPY) {
+      const auto compressedAllocation = leafPool_->preferredSize(
+          page.encodedBodySize + AlignedBuffer::kPaddedSize);
+      EXPECT_LT(
+          streaming.currentBytes + compressedAllocation, legacy.currentBytes);
+    }
+  }
+}
+
+TEST_F(
+    ParquetPageReaderTest,
+    streamingDataPageV1MultiPageHandoffReusesPhysicalReads) {
+  constexpr int32_t kLoadQuantum = 8 << 10;
+  constexpr int32_t kRowsPerPage = 128;
+  constexpr int32_t kFirstPageValuesPerRow = 64;
+  constexpr int32_t kSecondPageValuesPerRow = 96;
+
+  for (const auto codec :
+       {thrift::CompressionCodec::UNCOMPRESSED,
+        thrift::CompressionCodec::ZSTD,
+        thrift::CompressionCodec::SNAPPY}) {
+    SCOPED_TRACE(fmt::format("codec={}", static_cast<int32_t>(codec)));
+    const auto firstPage =
+        makeDataPageV1(codec, kRowsPerPage, kFirstPageValuesPerRow, 2026083101);
+    const auto secondPage = makeDataPageV1(
+        codec, kRowsPerPage, kSecondPageValuesPerRow, 2026083102);
+    EXPECT_GT(firstPage.encodedBodySize, 4 * kLoadQuantum);
+    EXPECT_GT(secondPage.encodedBodySize, 4 * kLoadQuantum);
+    const auto columnChunk = firstPage.encoded + secondPage.encoded;
+
+    auto readPool = rootPool_->addLeafChild("v1-multi-page-handoff");
+    auto file = std::make_shared<CountingInMemoryReadFile>(columnChunk);
+    auto ioStats = std::make_shared<io::IoStatistics>();
+    dwio::common::ReaderOptions options{readPool.get()};
+    options.setLoadQuantum(kLoadQuantum);
+    auto input = std::make_unique<DirectBufferedInput>(
+        file,
+        MetricsLog::voidLog(),
+        1,
+        nullptr,
+        1,
+        ioStats,
+        nullptr,
+        options,
+        nullptr);
+
+    StreamIdentifier streamId(0);
+    auto streams = input->enqueuePair(Region{0, columnChunk.size()}, &streamId);
+    input->load(LogType::FILE);
+
+    auto nestedType = makeNestedInt64Type();
+    PageReader reader(
+        std::move(streams.first),
+        *readPool,
+        nestedType.leaf,
+        codec,
+        columnChunk.size(),
+        nullptr,
+        std::move(streams.second));
+    reader.setParquetRepDefMemoryLimit(1 << 20);
+    reader.setParquetRepDefStreamingWindowSize(2'048);
+
+    const auto currentBytesBeforeRepDefs = readPool->currentBytes();
+    reader.decodeRepDefs(2 * kRowsPerPage);
+    EXPECT_LE(
+        readPool->currentBytes() - currentBytesBeforeRepDefs,
+        (1 << 20) + 2 * kLoadQuantum);
+    arrow::LevelInfo listInfo;
+    ASSERT_EQ(nestedType.list->makeLevelInfo(listInfo), LevelMode::kList);
+    std::vector<int32_t> lengths(2 * kRowsPerPage);
+    std::vector<uint64_t> nulls(bits::nwords(2 * kRowsPerPage));
+    const auto [repDefBegin, repDefEnd] = reader.repDefRange();
+    ASSERT_EQ(
+        reader.getLengthsAndNulls(
+            LevelMode::kList,
+            listInfo,
+            repDefBegin,
+            repDefEnd,
+            lengths.size(),
+            lengths.data(),
+            nulls.data(),
+            0),
+        lengths.size());
+    EXPECT_TRUE(std::all_of(
+        lengths.begin(), lengths.begin() + kRowsPerPage, [](auto length) {
+          return length == kFirstPageValuesPerRow;
+        }));
+    EXPECT_TRUE(std::all_of(
+        lengths.begin() + kRowsPerPage, lengths.end(), [](auto length) {
+          return length == kSecondPageValuesPerRow;
+        }));
+    const auto readCallsAfterRepDefs = file->readCalls();
+    const auto readBytesAfterRepDefs = file->readBytes();
+    reader.seekToPage(0);
+    reader.skip(kRowsPerPage * kFirstPageValuesPerRow);
+    reader.skip(1);
+
+    EXPECT_LE(file->readCalls() - readCallsAfterRepDefs, 2);
+    EXPECT_LE(file->readBytes() - readBytesAfterRepDefs, 2 * kLoadQuantum);
+  }
+}
+
+TEST_F(
+    ParquetPageReaderTest,
+    streamingDataPageV1HandoffBudgetUsesRetainedAllocationBytes) {
+  constexpr int32_t kLoadQuantum = 8 << 10;
+  constexpr int32_t kRowsPerPage = 128;
+  constexpr int32_t kFirstPageValuesPerRow = 64;
+  constexpr int32_t kSecondPageValuesPerRow = 96;
+  const auto firstPage = makeDataPageV1(
+      thrift::CompressionCodec::UNCOMPRESSED,
+      kRowsPerPage,
+      kFirstPageValuesPerRow,
+      2026083103);
+  const auto secondPage = makeDataPageV1(
+      thrift::CompressionCodec::UNCOMPRESSED,
+      kRowsPerPage,
+      kSecondPageValuesPerRow,
+      2026083104);
+  const auto columnChunk = firstPage.encoded + secondPage.encoded;
+  ASSERT_GT(firstPage.body.size(), 4 * kLoadQuantum);
+  ASSERT_GT(secondPage.body.size(), 4 * kLoadQuantum);
+
+  const auto logicalBudget = firstPage.body.size() + secondPage.body.size();
+  const auto firstAllocation = leafPool_->preferredSize(
+      firstPage.body.size() + AlignedBuffer::kPaddedSize);
+  const auto secondAllocation = leafPool_->preferredSize(
+      secondPage.body.size() + AlignedBuffer::kPaddedSize);
+  ASSERT_LE(firstAllocation, logicalBudget);
+  ASSERT_LT(logicalBudget, firstAllocation + secondAllocation);
+  ASSERT_LE(
+      firstAllocation + secondAllocation,
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
+
+  auto scan = [&](int32_t memoryLimit, const std::string& poolName) {
+    auto input = makeStreamingV1Reader(
+        rootPool_, columnChunk, kLoadQuantum, memoryLimit, poolName);
+    input.reader->decodeRepDefs(2 * kRowsPerPage);
+    const auto lengths = readListLengths(input, 2 * kRowsPerPage);
+    EXPECT_TRUE(std::all_of(
+        lengths.begin(), lengths.begin() + kRowsPerPage, [](auto length) {
+          return length == kFirstPageValuesPerRow;
+        }));
+    EXPECT_TRUE(std::all_of(
+        lengths.begin() + kRowsPerPage, lengths.end(), [](auto length) {
+          return length == kSecondPageValuesPerRow;
+        }));
+
+    const auto readsBeforeValues = input.file->readBytes();
+    input.reader->seekToPage(0);
+    input.reader->skip(kRowsPerPage * kFirstPageValuesPerRow);
+    const auto readsBeforeSecondPage = input.file->readBytes();
+    input.reader->skip(1);
+    return std::make_pair(
+        readsBeforeSecondPage - readsBeforeValues,
+        input.file->readBytes() - readsBeforeSecondPage);
+  };
+
+  const auto boundaryBudgetReads =
+      scan(logicalBudget, "v1-logical-byte-budget");
+  const auto fullBudgetReads =
+      scan(firstAllocation + secondAllocation, "v1-allocation-byte-budget");
+
+  EXPECT_LE(boundaryBudgetReads.first, 2 * kLoadQuantum);
+  EXPECT_LE(fullBudgetReads.first, 2 * kLoadQuantum);
+  EXPECT_GT(boundaryBudgetReads.second, 4 * kLoadQuantum);
+  EXPECT_LE(fullBudgetReads.second, 2 * kLoadQuantum);
+}
+
+TEST_F(
+    ParquetPageReaderTest,
+    streamingDataPageV1SeekEvictsStaleHandoffBeforeCachingNextPage) {
+  constexpr int32_t kLoadQuantum = 8 << 10;
+  constexpr int32_t kRowsPerPage = 128;
+  constexpr int32_t kValuesPerRow = 96;
+  const auto firstPage = makeDataPageV1(
+      thrift::CompressionCodec::UNCOMPRESSED,
+      kRowsPerPage,
+      kValuesPerRow,
+      2026083105,
+      true);
+  const auto secondPage = makeDataPageV1(
+      thrift::CompressionCodec::UNCOMPRESSED,
+      kRowsPerPage,
+      kValuesPerRow,
+      2026083106);
+  const auto columnChunk = firstPage.encoded + secondPage.encoded;
+  ASSERT_GT(firstPage.body.size(), 8 * kLoadQuantum);
+  const auto firstPageAllocation = leafPool_->preferredSize(
+      firstPage.body.size() + AlignedBuffer::kPaddedSize);
+  const auto secondPageAllocation = leafPool_->preferredSize(
+      secondPage.body.size() + AlignedBuffer::kPaddedSize);
+  const auto onePageBudget =
+      std::max(firstPageAllocation, secondPageAllocation);
+  ASSERT_LT(onePageBudget, firstPageAllocation + secondPageAllocation);
+  ASSERT_LE(
+      onePageBudget,
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
+
+  auto scan = [&](int32_t memoryLimit, const std::string& poolName) {
+    auto input = makeStreamingV1Reader(
+        rootPool_, columnChunk, kLoadQuantum, memoryLimit, poolName);
+    input.reader->decodeRepDefs(kRowsPerPage - 1);
+    const auto lengths = readListLengths(input, kRowsPerPage - 1);
+    EXPECT_TRUE(std::all_of(lengths.begin(), lengths.end(), [](auto length) {
+      return length == kValuesPerRow;
+    }));
+
+    const auto readsBeforeSeek = input.file->readBytes();
+    input.reader->seekToPage((kRowsPerPage - 1) * kValuesPerRow);
+    input.reader->decodeRepDefs(2);
+    EXPECT_EQ(
+        readListLengths(input, 2), (std::vector<int32_t>{0, kValuesPerRow}));
+    input.reader->skip(1);
+    return input.file->readBytes() - readsBeforeSeek;
+  };
+
+  const auto noHandoffReads = scan(0, "v1-stale-page-no-handoff");
+  const auto onePageHandoffReads =
+      scan(onePageBudget, "v1-stale-page-one-page-handoff");
+
+  EXPECT_GT(noHandoffReads, onePageHandoffReads);
+  EXPECT_GT(noHandoffReads - onePageHandoffReads, 4 * kLoadQuantum);
 }
 
 } // namespace bytedance::bolt::parquet

--- a/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -32,6 +32,7 @@
 
 #include <type/HugeInt.h>
 #include <type/Type.h>
+#include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <random>
@@ -136,6 +137,7 @@ template <typename T>
 FlatVector<T>* loadedFlatChildAt(RowVector* row, vector_size_t index) {
   return loadedChildAt(row, index)->asFlatVector<T>();
 }
+
 } // namespace
 
 namespace bytedance::bolt::parquet {
@@ -179,6 +181,111 @@ struct PageReaderTestPeer {
   }
 };
 } // namespace bytedance::bolt::parquet
+
+namespace {
+class CountingReadFile final : public ReadFile {
+ public:
+  explicit CountingReadFile(std::shared_ptr<ReadFile> file)
+      : file_(std::move(file)) {}
+
+  std::string_view pread(uint64_t offset, uint64_t length, void* buffer)
+      const override {
+    ++readCalls_;
+    readBytes_ += length;
+    return file_->pread(offset, length, buffer);
+  }
+
+  uint64_t preadv(
+      uint64_t offset,
+      const std::vector<folly::Range<char*>>& buffers) const override {
+    ++readCalls_;
+    for (const auto& buffer : buffers) {
+      readBytes_ += buffer.size();
+    }
+    return file_->preadv(offset, buffers);
+  }
+
+  void preadv(
+      folly::Range<const common::Region*> regions,
+      folly::Range<folly::IOBuf*> iobufs) const override {
+    ++readCalls_;
+    for (const auto& region : regions) {
+      readBytes_ += region.length;
+    }
+    file_->preadv(regions, iobufs);
+  }
+
+  uint64_t size() const override {
+    return file_->size();
+  }
+
+  uint64_t memoryUsage() const override {
+    return file_->memoryUsage();
+  }
+
+  bool shouldCoalesce() const override {
+    return file_->shouldCoalesce();
+  }
+
+  std::string getName() const override {
+    return file_->getName();
+  }
+
+  uint64_t getNaturalReadSize() const override {
+    return file_->getNaturalReadSize();
+  }
+
+  void resetCounts() {
+    readCalls_ = 0;
+    readBytes_ = 0;
+  }
+
+  uint64_t readCalls() const {
+    return readCalls_;
+  }
+
+  uint64_t readBytes() const {
+    return readBytes_;
+  }
+
+ private:
+  const std::shared_ptr<ReadFile> file_;
+  mutable std::atomic<uint64_t> readCalls_{0};
+  mutable std::atomic<uint64_t> readBytes_{0};
+};
+
+class CountingBufferedInput final : public BufferedInput {
+ public:
+  CountingBufferedInput(
+      std::shared_ptr<ReadFile> file,
+      memory::MemoryPool& pool,
+      std::shared_ptr<std::atomic<uint64_t>> pairCalls)
+      : BufferedInput(std::move(file), pool),
+        pairCalls_(std::move(pairCalls)) {}
+
+  CountingBufferedInput(
+      std::shared_ptr<ReadFileInputStream> input,
+      memory::MemoryPool& pool,
+      std::shared_ptr<std::atomic<uint64_t>> pairCalls)
+      : BufferedInput(std::move(input), pool),
+        pairCalls_(std::move(pairCalls)) {}
+
+  SeekableInputStreamPair enqueuePair(
+      Region region,
+      const StreamIdentifier* streamId = nullptr) override {
+    ++*pairCalls_;
+    return BufferedInput::enqueuePair(region, streamId);
+  }
+
+  std::unique_ptr<BufferedInput> clone() const override {
+    return std::make_unique<CountingBufferedInput>(input_, pool_, pairCalls_);
+  }
+
+ private:
+  const std::shared_ptr<std::atomic<uint64_t>> pairCalls_;
+};
+
+} // namespace
 
 class ParquetReaderTest : public ParquetTestBase {
  public:
@@ -323,6 +430,49 @@ class ParquetReaderTest : public ParquetTestBase {
     rowReaderOptions.setScanSpec(
         scanSpec ? std::move(scanSpec) : makeScanSpec(asRowType(data->type())));
     return reader->createRowReader(rowReaderOptions);
+  }
+
+  void testNestedRowsOverMap(int32_t streamingWindowSize) {
+    constexpr vector_size_t kSize = 5;
+    auto maps = vectorMaker_.mapVector<int32_t, int64_t>(
+        kSize,
+        [](auto row) {
+          if (row == 3) {
+            return 0;
+          }
+          return row == 4 ? 2 : 1;
+        },
+        [](auto row, auto index) { return row * 10 + index; },
+        [](auto row, auto index) { return row * 100 + index; },
+        [](auto row) { return row == 2; });
+    auto inner =
+        makeRowVector({"entries"}, {maps}, [](auto row) { return row == 1; });
+    auto outer =
+        makeRowVector({"inner"}, {inner}, [](auto row) { return row == 0; });
+    auto data = makeRowVector({"outer"}, {outer});
+    auto rowType = asRowType(data->type());
+
+    for (const auto pageVersion :
+         {bytedance::bolt::parquet::arrow::ParquetDataPageVersion::V1,
+          bytedance::bolt::parquet::arrow::ParquetDataPageVersion::V2}) {
+      SCOPED_TRACE(fmt::format(
+          "windowSize={} pageVersion={}",
+          streamingWindowSize,
+          static_cast<int32_t>(pageVersion)));
+      bytedance::bolt::parquet::WriterOptions writerOptions;
+      writerOptions.enableDictionary = false;
+      writerOptions.dataPageVersion = pageVersion;
+      auto file = writeTempParquet({data}, writerOptions);
+
+      dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+      auto reader = createReader(file->getPath(), readerOptions);
+      auto rowReaderOptions = getReaderOpts(rowType);
+      rowReaderOptions.setScanSpec(makeScanSpec(rowType));
+      rowReaderOptions.setParquetRepDefStreamingWindowSize(streamingWindowSize);
+      auto rowReader = reader->createRowReader(rowReaderOptions);
+
+      assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
+    }
   }
 };
 
@@ -3808,6 +3958,126 @@ TEST_F(ParquetReaderTest, readNestedMap) {
   EXPECT_FALSE(rowReader->next(100, result));
 }
 
+TEST_F(ParquetReaderTest, projectedChunkDataAndRepDefsShareRead) {
+  const auto path = getExampleFilePath("row_map_array.parquet");
+  const auto fullStructType =
+      ROW({"c0", "c1"}, {BIGINT(), MAP(VARCHAR(), ARRAY(INTEGER()))});
+  const auto fullType = ROW({"c"}, {fullStructType});
+  const auto primitiveProjection = ROW({"c"}, {ROW({"c0"}, {BIGINT()})});
+  const auto complexProjection =
+      ROW({"c"}, {ROW({"c1"}, {MAP(VARCHAR(), ARRAY(INTEGER()))})});
+
+  auto scan = [&](const RowTypePtr& rowType) {
+    auto file = std::make_shared<CountingReadFile>(
+        std::make_shared<LocalReadFile>(path));
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    readerOptions.setFilePreloadThreshold(0);
+    readerOptions.setFooterEstimatedSize(8);
+    auto input = std::make_unique<DirectBufferedInput>(
+        file,
+        MetricsLog::voidLog(),
+        1,
+        nullptr,
+        1,
+        std::make_shared<io::IoStatistics>(),
+        nullptr,
+        readerOptions,
+        nullptr);
+    auto reader =
+        std::make_unique<ParquetReader>(std::move(input), readerOptions);
+    EXPECT_EQ(reader->fileMetaData().numRowGroups(), 1);
+    file->resetCounts();
+
+    auto rowReaderOptions = getReaderOpts(rowType);
+    rowReaderOptions.setScanSpec(makeScanSpec(rowType));
+    auto rowReader = reader->createRowReader(rowReaderOptions);
+    VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+    uint64_t rows = 0;
+    while (rowReader->next(1024, result) > 0) {
+      rows += result->size();
+      EXPECT_FALSE(result->toString(0).empty());
+    }
+    EXPECT_EQ(rows, 1);
+    return std::pair{file->readCalls(), file->readBytes()};
+  };
+
+  const auto fullScan = scan(fullType);
+  const auto primitiveScan = scan(primitiveProjection);
+  const auto complexScan = scan(complexProjection);
+  EXPECT_EQ(fullScan.first, 1);
+  EXPECT_EQ(primitiveScan.first, 1);
+  EXPECT_EQ(complexScan.first, 1);
+  EXPECT_LT(primitiveScan.second, fullScan.second);
+  EXPECT_LT(complexScan.second, fullScan.second);
+}
+
+TEST_F(ParquetReaderTest, streamingWindowControlsRepDefPath) {
+  constexpr vector_size_t kSize = 32;
+  auto arrays = makeArrayVector<int64_t>(
+      kSize,
+      [](auto row) { return row % 5; },
+      [](auto row, auto index) { return row * 100 + index; });
+  auto maps = vectorMaker_.mapVector<int32_t, int64_t>(
+      kSize,
+      [](auto row) { return row % 4; },
+      [](auto row, auto index) { return index; },
+      [](auto row, auto index) { return row * 1'000 + index; });
+  auto data = makeRowVector(
+      {"id", "array_values", "map_values"},
+      {makeFlatVector<int64_t>(kSize, [](auto row) { return row; }),
+       arrays,
+       maps});
+  auto file = writeTempParquet({data});
+  auto rowType = asRowType(data->type());
+
+  for (const auto& [windowSize, expectedPairCalls] :
+       std::vector<std::pair<int32_t, uint64_t>>{{0, 0}, {2'048, 3}}) {
+    SCOPED_TRACE(windowSize);
+    auto pairCalls = std::make_shared<std::atomic<uint64_t>>(0);
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    auto input = std::make_unique<CountingBufferedInput>(
+        std::make_shared<LocalReadFile>(file->getPath()),
+        readerOptions.getMemoryPool(),
+        pairCalls);
+    auto reader =
+        std::make_unique<ParquetReader>(std::move(input), readerOptions);
+
+    auto rowReaderOptions = getReaderOpts(rowType);
+    rowReaderOptions.setParquetRepDefStreamingWindowSize(windowSize);
+    auto scanSpec = makeScanSpec(rowType);
+    scanSpec->getOrCreateChild("id")->setFilter(
+        exec::bigintOr(exec::between(3, 7), exec::between(20, 23)));
+    rowReaderOptions.setScanSpec(scanSpec);
+    auto rowReader = reader->createRowReader(rowReaderOptions);
+
+    VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+    vector_size_t outputRows = 0;
+    while (rowReader->next(7, result)) {
+      auto* rows = result->as<RowVector>();
+      auto* ids = rows->childAt(0)->as<FlatVector<int64_t>>();
+      for (vector_size_t row = 0; row < rows->size(); ++row) {
+        const auto originalRow = static_cast<vector_size_t>(ids->valueAt(row));
+        EXPECT_TRUE(
+            (originalRow >= 3 && originalRow <= 7) ||
+            (originalRow >= 20 && originalRow <= 23));
+        EXPECT_TRUE(data->equalValueAt(result.get(), originalRow, row))
+            << "original row " << originalRow;
+      }
+      outputRows += rows->size();
+    }
+    EXPECT_EQ(outputRows, 9);
+    EXPECT_EQ(pairCalls->load(), expectedPairCalls);
+  }
+}
+
+TEST_F(ParquetReaderTest, nestedRowsOverMapLegacyRepDefs) {
+  testNestedRowsOverMap(0);
+}
+
+TEST_F(ParquetReaderTest, nestedRowsOverMapStreamingRepDefs) {
+  testNestedRowsOverMap(1);
+}
+
 // Regression test for the parquet writer-defect tolerance fix in
 // RepeatedLengths::readLengths. When the underlying lengths buffer holds
 // fewer entries than the parent reader requests (which can happen if a
@@ -4206,6 +4476,8 @@ TEST_F(ParquetReaderTest, lazyRepDefSanitizedCustomTagRepro) {
   VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
   uint64_t totalRows = 0;
   uint64_t totalCustomTagEntries = 0;
+  uint64_t totalNullMaps = 0;
+  uint64_t totalEmptyMaps = 0;
   for (;;) {
     const auto got = rowReader->next(kBatchRows, result);
     if (got == 0) {
@@ -4220,13 +4492,19 @@ TEST_F(ParquetReaderTest, lazyRepDefSanitizedCustomTagRepro) {
     auto* map = customTag->as<MapVector>();
     ASSERT_NE(map, nullptr);
     for (vector_size_t i = 0; i < map->size(); ++i) {
-      if (!map->isNullAt(i)) {
-        totalCustomTagEntries += map->sizeAt(i);
+      if (map->isNullAt(i)) {
+        ++totalNullMaps;
+      } else {
+        const auto size = map->sizeAt(i);
+        totalCustomTagEntries += size;
+        totalEmptyMaps += size == 0;
       }
     }
     totalRows += result->size();
   }
 
-  EXPECT_GT(totalRows, 0);
-  EXPECT_GT(totalCustomTagEntries, 0);
+  EXPECT_EQ(totalRows, 248'349);
+  EXPECT_EQ(totalCustomTagEntries, 199'598);
+  EXPECT_EQ(totalNullMaps, 144'426);
+  EXPECT_EQ(totalEmptyMaps, 28'521);
 }

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -42,6 +42,7 @@
 #include "bolt/common/testutil/TestValue.h"
 #include "bolt/connectors/Connector.h"
 #include "bolt/connectors/hive/HiveConnector.h"
+#include "bolt/dwio/common/DirectBufferedInput.h"
 #include "bolt/dwio/common/tests/utils/BatchMaker.h"
 #include "bolt/dwio/parquet/RegisterParquetWriter.h"
 #include "bolt/dwio/parquet/arrow/ColumnPage.h"
@@ -383,6 +384,255 @@ TEST_F(ParquetWriterTest, comparison) {
   vp::WriterOptions writerOptions{};
   assertWrite(parquetPath, kRows, schema, data, writerOptions);
 };
+
+TEST_F(ParquetWriterTest, streamingRepDefsAcrossPages) {
+  constexpr vector_size_t kRows = 257;
+  constexpr vector_size_t kLongSize = 32 * 1024;
+  auto arrays = makeArrayVector<int32_t>(
+      kRows,
+      [](vector_size_t row) {
+        return row == 0 ? kLongSize : row % 11 == 0 ? 0 : row % 7 + 1;
+      },
+      [](vector_size_t index) { return index; },
+      [](vector_size_t row) { return row % 29 == 0 && row != 0; },
+      [](vector_size_t index) { return index % 37 == 0; });
+  auto maps = makeMapVector<int32_t, int64_t>(
+      kRows,
+      [](vector_size_t row) {
+        return row == 0 ? kLongSize : row % 13 == 0 ? 0 : row % 5 + 1;
+      },
+      [](vector_size_t index) { return index; },
+      [](vector_size_t index) { return index * 17; },
+      [](vector_size_t row) { return row % 31 == 0 && row != 0; },
+      [](vector_size_t index) { return index % 41 == 0; });
+  auto structArrayItems = makeArrayVector<int32_t>(
+      kRows,
+      [](vector_size_t row) {
+        return row == 0 ? kLongSize : row % 23 == 0 ? 0 : row % 7 + 1;
+      },
+      [](vector_size_t index) { return index * 3; },
+      nullptr,
+      [](vector_size_t index) { return index % 43 == 0; });
+  auto structArrays = makeRowVector({"items"}, {structArrayItems});
+  using InnerArray = std::vector<std::optional<int32_t>>;
+  using OuterArray = std::vector<std::optional<InnerArray>>;
+  std::vector<std::optional<OuterArray>> nestedData;
+  nestedData.reserve(kRows);
+  for (vector_size_t row = 0; row < kRows; ++row) {
+    if (row == 0) {
+      InnerArray first(kLongSize / 2);
+      InnerArray second(kLongSize / 2);
+      for (vector_size_t i = 0; i < first.size(); ++i) {
+        first[i] = i % 47 == 0 ? std::nullopt : std::optional<int32_t>(i);
+        second[i] = i % 53 == 0 ? std::nullopt
+                                : std::optional<int32_t>(i + first.size());
+      }
+      nestedData.emplace_back(
+          OuterArray{{std::move(first)}, {std::move(second)}});
+    } else if (row % 17 == 0) {
+      nestedData.emplace_back(OuterArray{});
+    } else {
+      nestedData.emplace_back(
+          OuterArray{{InnerArray{row, std::nullopt, row + 1}}, std::nullopt});
+    }
+  }
+  auto nestedArrays = makeNullableNestedArrayVector<int32_t>(nestedData);
+  auto expected = makeRowVector(
+      {"arrays", "maps", "struct_arrays", "nested_arrays"},
+      {arrays, maps, structArrays, nestedArrays});
+  auto schema = asRowType(expected->type());
+
+  for (const auto pageVersion :
+       {vp::arrow::ParquetDataPageVersion::V1,
+        vp::arrow::ParquetDataPageVersion::V2}) {
+    for (const int64_t pageSize : {int64_t{1024}, int64_t{64} << 20}) {
+      const auto parquetPath = fmt::format(
+          "{}/streamingRepDefs-{}-{}.parquet",
+          tempPath_->path,
+          static_cast<int32_t>(pageVersion),
+          pageSize);
+      vp::WriterOptions writerOptions;
+      writerOptions.enableDictionary = false;
+      writerOptions.dataPageSize = pageSize;
+      writerOptions.dataPageVersion = pageVersion;
+      writerOptions.compression = CompressionKind::CompressionKind_ZSTD;
+      auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+      writer->write(expected);
+      writer->close();
+
+      for (const vector_size_t batchSize : {1, 17, 128}) {
+        SCOPED_TRACE(fmt::format(
+            "pageVersion={} pageSize={} batchSize={}",
+            static_cast<int32_t>(pageVersion),
+            pageSize,
+            batchSize));
+        dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+        auto reader = std::make_unique<vp::ParquetReader>(
+            std::make_unique<dwio::common::DirectBufferedInput>(
+                std::make_shared<LocalReadFile>(parquetPath),
+                MetricsLog::voidLog(),
+                1,
+                nullptr,
+                1,
+                std::make_shared<io::IoStatistics>(),
+                nullptr,
+                readerOptions,
+                nullptr),
+            readerOptions);
+        auto rowReaderOptions = getReaderOpts(schema);
+        rowReaderOptions.setScanSpec(makeScanSpec(schema));
+        rowReaderOptions.setParquetRepDefMemoryLimit(64 << 10);
+        rowReaderOptions.setParquetRepDefStreamingWindowSize(7);
+        auto rowReader = reader->createRowReader(rowReaderOptions);
+
+        vector_size_t offset = 0;
+        VectorPtr result = BaseVector::create(schema, 0, leafPool_.get());
+        while (rowReader->next(batchSize, result) > 0) {
+          assertEqualVectorPart(expected, result, offset);
+          offset += result->size();
+        }
+        EXPECT_EQ(offset, kRows);
+      }
+    }
+  }
+}
+
+TEST_F(ParquetWriterTest, streamingRepDefsV1CompressionCodecs) {
+  constexpr vector_size_t kRows = 64;
+  auto arrays = makeArrayVector<int32_t>(
+      kRows,
+      [](vector_size_t row) { return row % 9 == 0 ? 0 : row % 7 + 1; },
+      [](vector_size_t index) { return index % 13; },
+      [](vector_size_t row) { return row % 17 == 0; });
+  auto maps = makeMapVector<int32_t, int64_t>(
+      kRows,
+      [](vector_size_t row) { return row % 11 == 0 ? 0 : row % 5 + 1; },
+      [](vector_size_t index) { return index % 11; },
+      [](vector_size_t index) { return index % 17; },
+      [](vector_size_t row) { return row % 19 == 0; });
+  auto expected = makeRowVector({"arrays", "maps"}, {arrays, maps});
+  auto schema = asRowType(expected->type());
+
+  for (const auto compression : params) {
+    SCOPED_TRACE(fmt::format("compression={}", compression));
+    const auto parquetPath = fmt::format(
+        "{}/streamingRepDefsV1-{}.parquet",
+        tempPath_->path,
+        static_cast<int32_t>(compression));
+    vp::WriterOptions writerOptions;
+    writerOptions.enableDictionary = true;
+    writerOptions.dataPageSize = 1'024;
+    writerOptions.maxRowsPerDataPage = 16;
+    writerOptions.dataPageVersion = vp::arrow::ParquetDataPageVersion::V1;
+    writerOptions.compression = compression;
+    auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+    writer->write(expected);
+    writer->close();
+
+    auto metadataReader = createLocalParquetReader(parquetPath);
+    const auto rowGroup = metadataReader->fileMetaData().rowGroup(0);
+    for (int32_t column = 0; column < rowGroup.numColumns(); ++column) {
+      EXPECT_EQ(rowGroup.columnChunk(column).compression(), compression);
+      const auto& encodingStats =
+          rowGroup.columnChunk(column).pageEncodingStats();
+      EXPECT_NE(
+          std::find_if(
+              encodingStats.begin(),
+              encodingStats.end(),
+              [](const auto& stats) {
+                return stats.page_type == thrift::PageType::DICTIONARY_PAGE &&
+                    stats.count > 0;
+              }),
+          encodingStats.end());
+      EXPECT_GT(
+          forEachDataPage(
+              parquetPath,
+              column,
+              [](const auto& page) {
+                EXPECT_EQ(page->type(), vp::arrow::PageType::DATA_PAGE);
+              }),
+          1);
+    }
+
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    auto reader = std::make_unique<vp::ParquetReader>(
+        std::make_unique<dwio::common::DirectBufferedInput>(
+            std::make_shared<LocalReadFile>(parquetPath),
+            MetricsLog::voidLog(),
+            1,
+            nullptr,
+            1,
+            std::make_shared<io::IoStatistics>(),
+            nullptr,
+            readerOptions,
+            nullptr),
+        readerOptions);
+    auto rowReaderOptions = getReaderOpts(schema);
+    rowReaderOptions.setScanSpec(makeScanSpec(schema));
+    rowReaderOptions.setParquetRepDefMemoryLimit(0);
+    rowReaderOptions.setParquetRepDefStreamingWindowSize(7);
+    auto rowReader = reader->createRowReader(rowReaderOptions);
+
+    vector_size_t offset = 0;
+    VectorPtr result = BaseVector::create(schema, 0, leafPool_.get());
+    while (rowReader->next(5, result) > 0) {
+      assertEqualVectorPart(expected, result, offset);
+      offset += result->size();
+    }
+    EXPECT_EQ(offset, kRows);
+  }
+}
+
+TEST_F(ParquetWriterTest, streamingRepDefsSkipAtLeafPageEnd) {
+  using NullableArray = std::optional<std::vector<std::optional<int32_t>>>;
+  const std::vector<NullableArray> data{
+      std::vector<std::optional<int32_t>>{10},
+      std::vector<std::optional<int32_t>>{},
+      std::nullopt,
+      std::vector<std::optional<int32_t>>{40},
+  };
+  auto arrays = makeNullableArrayVector<int32_t>(data);
+  auto expected = makeRowVector({"arrays"}, {arrays});
+  auto schema = asRowType(expected->type());
+  const auto parquetPath = fmt::format(
+      "{}/streamingRepDefsSkipAtLeafPageEnd.parquet", tempPath_->path);
+
+  vp::WriterOptions writerOptions;
+  writerOptions.enableDictionary = false;
+  writerOptions.compression = CompressionKind::CompressionKind_NONE;
+  writerOptions.dataPageSize = 64 << 20;
+  writerOptions.maxRowsPerDataPage = 3;
+  writerOptions.dataPageVersion = vp::arrow::ParquetDataPageVersion::V2;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(expected);
+  writer->close();
+
+  std::vector<int64_t> levelsPerPage;
+  EXPECT_EQ(
+      forEachDataPage(
+          parquetPath,
+          0,
+          [&](const auto& page) {
+            levelsPerPage.push_back(
+                std::static_pointer_cast<vp::arrow::DataPage>(page)
+                    ->num_values());
+          }),
+      2);
+  EXPECT_EQ(levelsPerPage, (std::vector<int64_t>{3, 1}));
+
+  auto reader = createLocalParquetReader(parquetPath);
+  auto rowReaderOptions = getReaderOpts(schema);
+  rowReaderOptions.setScanSpec(makeScanSpec(schema));
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+  EXPECT_EQ(rowReader->skip(1), 1);
+
+  VectorPtr result = BaseVector::create(schema, 0, leafPool_.get());
+  EXPECT_EQ(rowReader->next(2, result), 2);
+  assertEqualVectorPart(expected, result, 1);
+  EXPECT_EQ(rowReader->next(1, result), 1);
+  assertEqualVectorPart(expected, result, 3);
+  EXPECT_EQ(rowReader->next(1, result), 0);
+}
 
 TEST_F(ParquetWriterTest, dictToArrow) {
   const size_t kRows = 1100;


### PR DESCRIPTION
### What problem does this PR solve?

Parquet nested columns encode structure in repetition and definition levels.
The existing reader preloads level data across multiple pages before serving a
batch, so peak reader memory can scale with the prefetched level stream instead
of the requested batch.

This PR decodes repetition and definition levels incrementally through a
bounded window. It reduces peak memory for nested-column scans while preserving
page, row, list, map, struct, filter, and projection semantics.

Issue Number: N/A

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds bounded repetition/definition-level streaming for non-encrypted
repeated Parquet columns.

- `PageReader` decodes levels in configurable windows and preserves conversion
  state across window, batch, and physical-page boundaries.
- List lengths, list validity, struct validity, and leaf nulls are produced
  incrementally, including continuation runs that cross windows.
- Value data and level data use independent cursors over paired input streams.
  Cached input clones the cache-backed stream; direct input uses a bounded
  two-chunk cache and shares resident chunks between both cursors.
- Streaming page parsing validates declared page and level lengths, rejects
  truncated deferred bodies, handles empty V1 and V2 data pages, and uses
  unaligned-safe handoff serialization.
- Encrypted column chunks keep the existing single-stream path.
- `parquet_repdef_streaming_window_size` defaults to 2,048 levels. Setting it
  to `0` disables the feature and selects the legacy preload path.

Correctness coverage includes incremental conversion equivalence, V1/V2 page
boundaries, nullable and nested collections, ordinary LIST and MAP projections
with filters, empty and malformed pages, dictionary input, supported V1
compression codecs, independent paired cursors, bounded direct-input storage,
large regions, row-group boundary checks, and explicit window-size-zero
fallback.

Local verification on the final source tree:

- Release `bolt_dwio_parquet_reader_test`: 151/151 passed.
- Release `bolt_dwio_parquet_table_scan_test`: 56/56 passed.
- Release `bolt_parquet_filter_test`: 79/79 passed.
- Release `bolt_parquet_writer_sink_test`: 33/33 passed.
- Release `bolt_dwio_parquet_arrow_test`: 614/614 passed.
- Release `QueryConfigTest.parquetRepDefStreamingWindowSize`: passed.
- The PageReader, paired-input, level-conversion, nested-list, map-filter, and
  writer paths were also exercised under ASAN and UBSAN.
- Benchmark and test targets were built with `--parallel 32`.
- `clang-format-14` and `git diff --check` passed.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path.
- [x] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below.

<details>
<summary>Benchmark methodology</summary>

- Release/O3 build pinned to one CPU.
- Each scan reads 16,384 rows from ZSTD-compressed Parquet data with 64 KiB
  data pages and dictionary encoding disabled.
- Data Page V1 and V2 were measured separately.
- Both modes use the same final source tree, generated data, projections, and
  scan configuration. A window size of `0` selects the legacy preload path;
  `2048` selects bounded streaming.
- Each returned batch is consumed before advancing the reader, so projected
  value and level decoding is included without changing the scan extraction
  policy.
- The core 19-case suite uses three independent processes per mode and reports
  medians.
- The string LIST/MAP suite uses seven independent processes per mode and
  reports medians. Memory is measured in a separate seven-process run so RSS
  sampling does not affect latency.
- `Delta = streaming / legacy - 1`; negative latency is faster and negative
  memory is lower.

</details>

<details>
<summary>Core complex-type benchmark (19 cases)</summary>

All values are milliseconds per complete scan.

| Dataset / projection | Batch | V1 legacy | V1 streaming | V1 delta | V2 legacy | V2 streaming | V2 delta |
|---|---:|---:|---:|---:|---:|---:|---:|
| control / all | 128 | 11.616 | 8.648 | -25.56% | 6.220 | 6.323 | +1.66% |
| control / all | 4096 | 9.151 | 7.263 | -20.63% | 4.985 | 4.990 | +0.10% |
| list / all | 128 | 2.614 | 1.959 | -25.05% | 1.199 | 1.204 | +0.36% |
| list / all | 4096 | 2.386 | 1.679 | -29.65% | 0.944 | 0.930 | -1.40% |
| map / all | 128 | 3.307 | 2.351 | -28.92% | 2.237 | 2.290 | +2.38% |
| map / all | 4096 | 2.729 | 1.936 | -29.05% | 1.901 | 1.910 | +0.47% |
| nullable / all | 128 | 25.338 | 18.187 | -28.22% | 12.270 | 12.435 | +1.35% |
| nullable / null-heavy | 128 | 4.270 | 3.170 | -25.77% | 2.688 | 2.837 | +5.55% |
| nullable / all | 4096 | 22.102 | 16.418 | -25.72% | 11.060 | 10.769 | -2.63% |
| long-list / all | 128 | 84.772 | 62.791 | -25.93% | 39.051 | 37.155 | -4.85% |
| long-list / long-only | 128 | 2.196 | 1.575 | -28.28% | 1.137 | 1.193 | +4.90% |
| long-list / all | 4096 | 91.465 | 61.947 | -32.27% | 41.120 | 36.274 | -11.78% |
| nested / all | 128 | 112.604 | 73.702 | -34.55% | 48.272 | 48.101 | -0.36% |
| nested / representative | 4096 | 105.738 | 72.435 | -31.50% | 47.607 | 46.276 | -2.80% |
| map-struct / all | 128 | 62.860 | 40.914 | -34.91% | 27.851 | 27.824 | -0.10% |
| map-struct / representative | 4096 | 26.691 | 18.381 | -31.13% | 14.174 | 14.341 | +1.17% |
| wide-feature / representative | 128 | 173.086 | 108.144 | -37.52% | 71.390 | 70.996 | -0.55% |
| wide-feature / all | 1024 | 676.312 | 444.554 | -34.27% | 295.762 | 287.530 | -2.78% |
| wide-feature / null-heavy | 1024 | 1.372 | 1.016 | -25.95% | 0.962 | 0.960 | -0.24% |

The equal-weight geometric mean across all 19 cases is `-29.32%` for V1 and
`-0.57%` for V2. V1 benefits most because bounded level decoding avoids the
legacy full rep/def preload cost on repeated data pages. V2 remains effectively
neutral overall, with the 4,096-row long-list scan improving by `-11.78%`.

</details>

<details>
<summary>Seven-run string LIST/MAP latency and memory</summary>

`ARRAY<VARCHAR>` and `MAP<VARCHAR, VARCHAR>` contain four elements per row and
no nulls. Leaf-pool peak is the primary memory metric. RSS delta is included as
a secondary signal and is subject to allocator reuse and OS page granularity.

| Page | Type | Batch | Latency legacy to streaming | Latency delta | Leaf pool peak legacy to streaming | Memory delta | RSS delta legacy to streaming |
|---|---|---:|---:|---:|---:|---:|---:|
| V1 | `ARRAY<VARCHAR>` | 128 | 2.623 to 2.676 ms | +2.02% | 285.9 to 181.9 KiB | -36.37% | 0 to 0 KiB |
| V1 | `ARRAY<VARCHAR>` | 4096 | 2.338 to 2.329 ms | -0.35% | 1204.8 to 1053.8 KiB | -12.53% | 3252 to 2484 KiB |
| V1 | `MAP<VARCHAR, VARCHAR>` | 128 | 4.785 to 4.853 ms | +1.43% | 829.8 to 725.8 KiB | -12.53% | 0 to 0 KiB |
| V1 | `MAP<VARCHAR, VARCHAR>` | 4096 | 4.325 to 4.328 ms | +0.06% | 2876.4 to 2725.4 KiB | -5.25% | 528 to 264 KiB |
| V2 | `ARRAY<VARCHAR>` | 128 | 1.881 to 1.928 ms | +2.48% | 285.9 to 175.9 KiB | -38.47% | 2424 to 0 KiB |
| V2 | `ARRAY<VARCHAR>` | 4096 | 1.590 to 1.595 ms | +0.33% | 1204.8 to 1053.8 KiB | -12.53% | 528 to 528 KiB |
| V2 | `MAP<VARCHAR, VARCHAR>` | 128 | 4.061 to 4.084 ms | +0.55% | 813.8 to 703.8 KiB | -13.52% | 0 to 0 KiB |
| V2 | `MAP<VARCHAR, VARCHAR>` | 4096 | 3.596 to 3.552 ms | -1.23% | 2860.4 to 2709.4 KiB | -5.28% | 792 to 524 KiB |

String-collection latency changes by `-1.23%` to `+2.48%`. Peak leaf-pool
memory decreases in every case: `12.53%` to `38.47%` for string arrays and
`5.25%` to `13.52%` for string maps.

</details>

### Release Note

```text
Release Note:
- Reduced peak memory usage when reading nested Parquet columns by decoding
  repetition and definition levels through bounded windows.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [x] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [ ] No
- [x] Yes (C++ ABI only; no user-facing source or configuration migration)

<details>
<summary>Click to view Breaking Changes</summary>

```text
Breaking Changes:
- BufferedInput adds a virtual enqueuePair() method. Out-of-tree subclasses are
  source compatible through the default implementation, but prebuilt C++
  binaries should be rebuilt because the virtual interface changed.
```

</details>
