### PR TITLE
feat: add writer phase metrics

### DIFF
--- a/bolt/connectors/Connector.cpp
+++ b/bolt/connectors/Connector.cpp
@@ -45,7 +45,10 @@ std::unordered_map<std::string, std::shared_ptr<Connector>>& connectors() {
 } // namespace
 
 bool DataSink::Stats::empty() const {
-  return numWrittenBytes == 0 && numWrittenFiles == 0 && spillStats.empty();
+  return numWrittenBytes == 0 && numWrittenFiles == 0 &&
+      writeRecodeWallNanos == 0 && writeEncodeWallNanos == 0 &&
+      writeCompressionWallNanos == 0 && writeIOWallNanos == 0 &&
+      writeFinalizeWallNanos == 0 && spillStats.empty();
 }
 
 std::string DataSink::Stats::toString() const {

--- a/bolt/connectors/Connector.h
+++ b/bolt/connectors/Connector.h
@@ -222,6 +222,11 @@ class DataSink {
   struct Stats {
     uint64_t numWrittenBytes{0};
     uint32_t numWrittenFiles{0};
+    uint64_t writeRecodeWallNanos{0};
+    uint64_t writeEncodeWallNanos{0};
+    uint64_t writeCompressionWallNanos{0};
+    uint64_t writeIOWallNanos{0};
+    uint64_t writeFinalizeWallNanos{0};
     common::SpillStats spillStats;
 
     bool empty() const;

--- a/bolt/connectors/hive/HiveDataSink.cpp
+++ b/bolt/connectors/hive/HiveDataSink.cpp
@@ -532,6 +532,13 @@ DataSink::Stats HiveDataSink::stats() const {
 
   stats.numWrittenFiles = writers_.size();
   for (int i = 0; i < writerInfo_.size(); ++i) {
+    const auto writerMetrics = writers_.at(i)->metrics();
+    stats.writeRecodeWallNanos += writerMetrics.writeRecodeWallNanos;
+    stats.writeEncodeWallNanos += writerMetrics.writeEncodeWallNanos;
+    stats.writeCompressionWallNanos += writerMetrics.writeCompressionWallNanos;
+    stats.writeIOWallNanos += writerMetrics.writeIOWallNanos;
+    stats.writeFinalizeWallNanos += writerMetrics.writeFinalizeWallNanos;
+
     const auto& info = writerInfo_.at(i);
     BOLT_CHECK_NOT_NULL(info);
     if (!info->spillStats->empty()) {

--- a/bolt/dwio/common/Writer.h
+++ b/bolt/dwio/common/Writer.h
@@ -35,6 +35,7 @@
 #include <optional>
 #include <string>
 
+#include "bolt/dwio/common/WriterMetrics.h"
 #include "bolt/vector/ComplexVector.h"
 namespace bytedance::bolt::dwio::common {
 
@@ -86,6 +87,10 @@ class Writer {
    *  Data can no longer be written.
    */
   virtual void abort() = 0;
+
+  virtual WriterMetrics metrics() const {
+    return {};
+  }
 
  protected:
   bool isRunning() const;

--- a/bolt/dwio/common/WriterMetrics.h
+++ b/bolt/dwio/common/WriterMetrics.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace bytedance::bolt::dwio::common {
+
+struct WriterMetrics {
+  uint64_t writeRecodeWallNanos{0};
+  uint64_t writeEncodeWallNanos{0};
+  uint64_t writeCompressionWallNanos{0};
+  uint64_t writeIOWallNanos{0};
+  uint64_t writeFinalizeWallNanos{0};
+};
+
+} // namespace bytedance::bolt::dwio::common

--- a/bolt/dwio/parquet/arrow/ColumnWriter.cpp
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.cpp
@@ -410,7 +410,8 @@ class SerializedPageWriter : public PageWriter {
       std::shared_ptr<Encryptor> data_encryptor = nullptr,
       ColumnIndexBuilder* column_index_builder = nullptr,
       OffsetIndexBuilder* offset_index_builder = nullptr,
-      const CodecOptions& codec_options = CodecOptions{})
+      const CodecOptions& codec_options = CodecOptions{},
+      std::shared_ptr<WriterMetricsCollector> writerMetrics = nullptr)
       : sink_(std::move(sink)),
         metadata_(metadata),
         pool_(pool),
@@ -427,7 +428,8 @@ class SerializedPageWriter : public PageWriter {
         data_encryptor_(std::move(data_encryptor)),
         encryption_buffer_(AllocateBuffer(pool, 0)),
         column_index_builder_(column_index_builder),
-        offset_index_builder_(offset_index_builder) {
+        offset_index_builder_(offset_index_builder),
+        writerMetrics_(std::move(writerMetrics)) {
     if (data_encryptor_ != nullptr || meta_encryptor_ != nullptr) {
       InitEncryption();
     }
@@ -549,13 +551,19 @@ class SerializedPageWriter : public PageWriter {
     // reallocate.
     PARQUET_THROW_NOT_OK(dest_buffer->Resize(max_compressed_size, false));
 
-    PARQUET_ASSIGN_OR_THROW(
-        int64_t compressed_size,
-        compressor_->Compress(
-            src_buffer.size(),
-            src_buffer.data(),
-            max_compressed_size,
-            dest_buffer->mutable_data()));
+    int64_t compressed_size;
+    {
+      WriterMetricTimer timer(
+          writerMetrics_ ? &writerMetrics_->writeCompressionWallNanos : nullptr,
+          true);
+      PARQUET_ASSIGN_OR_THROW(
+          compressed_size,
+          compressor_->Compress(
+              src_buffer.size(),
+              src_buffer.data(),
+              max_compressed_size,
+              dest_buffer->mutable_data()));
+    }
     PARQUET_THROW_NOT_OK(dest_buffer->Resize(compressed_size, false));
   }
 
@@ -846,6 +854,7 @@ class SerializedPageWriter : public PageWriter {
 
   ColumnIndexBuilder* column_index_builder_;
   OffsetIndexBuilder* offset_index_builder_;
+  const std::shared_ptr<WriterMetricsCollector> writerMetrics_;
 };
 
 // This implementation of the PageWriter writes to the final sink on Close .
@@ -864,7 +873,8 @@ class BufferedPageWriter : public PageWriter {
       std::shared_ptr<Encryptor> data_encryptor = nullptr,
       ColumnIndexBuilder* column_index_builder = nullptr,
       OffsetIndexBuilder* offset_index_builder = nullptr,
-      const CodecOptions& codec_options = CodecOptions{})
+      const CodecOptions& codec_options = CodecOptions{},
+      std::shared_ptr<WriterMetricsCollector> writerMetrics = nullptr)
       : final_sink_(std::move(sink)),
         metadata_(metadata),
         has_dictionary_pages_(false),
@@ -881,7 +891,8 @@ class BufferedPageWriter : public PageWriter {
         std::move(data_encryptor),
         column_index_builder,
         offset_index_builder,
-        codec_options);
+        codec_options,
+        std::move(writerMetrics));
   }
 
   int64_t WriteDictionaryPage(std::unique_ptr<DictionaryPage> page) override {
@@ -1018,7 +1029,8 @@ std::unique_ptr<PageWriter> PageWriter::Open(
     ColumnIndexBuilder* column_index_builder,
     OffsetIndexBuilder* offset_index_builder,
     const CodecOptions& codec_options,
-    std::shared_ptr<PageBufferArena> page_buffer_arena) {
+    std::shared_ptr<PageBufferArena> page_buffer_arena,
+    std::shared_ptr<WriterMetricsCollector> writer_metrics) {
   if (buffered_row_group) {
     return std::unique_ptr<PageWriter>(new BufferedPageWriter(
         std::move(sink),
@@ -1033,7 +1045,8 @@ std::unique_ptr<PageWriter> PageWriter::Open(
         std::move(data_encryptor),
         column_index_builder,
         offset_index_builder,
-        codec_options));
+        codec_options,
+        std::move(writer_metrics)));
   } else {
     return std::unique_ptr<PageWriter>(new SerializedPageWriter(
         std::move(sink),
@@ -1047,7 +1060,8 @@ std::unique_ptr<PageWriter> PageWriter::Open(
         std::move(data_encryptor),
         column_index_builder,
         offset_index_builder,
-        codec_options));
+        codec_options,
+        std::move(writer_metrics)));
   }
 }
 
@@ -1065,7 +1079,8 @@ std::unique_ptr<PageWriter> PageWriter::Open(
     bool page_write_checksum_enabled,
     ColumnIndexBuilder* column_index_builder,
     OffsetIndexBuilder* offset_index_builder,
-    std::shared_ptr<PageBufferArena> page_buffer_arena) {
+    std::shared_ptr<PageBufferArena> page_buffer_arena,
+    std::shared_ptr<WriterMetricsCollector> writer_metrics) {
   return PageWriter::Open(
       sink,
       codec,
@@ -1080,7 +1095,8 @@ std::unique_ptr<PageWriter> PageWriter::Open(
       column_index_builder,
       offset_index_builder,
       CodecOptions{compression_level},
-      std::move(page_buffer_arena));
+      std::move(page_buffer_arena),
+      std::move(writer_metrics));
 }
 // ----------------------------------------------------------------------
 // ColumnWriter
@@ -1573,6 +1589,9 @@ void ColumnWriterImpl::BuildDataPageV2(
 
 int64_t ColumnWriterImpl::Close() {
   if (!closed_) {
+    const auto& writerMetrics = properties_->writer_metrics();
+    WriterEncodeMetricTimer timer(
+        writerMetrics ? &writerMetrics->writeEncodeWallNanos : nullptr);
     closed_ = true;
     if (has_dictionary_ && !fallback_) {
       WriteDictionaryPage();

--- a/bolt/dwio/parquet/arrow/ColumnWriter.h
+++ b/bolt/dwio/parquet/arrow/ColumnWriter.h
@@ -41,6 +41,7 @@
 #include "bolt/dwio/parquet/arrow/Types.h"
 #include "bolt/dwio/parquet/arrow/WriterMemoryStats.h"
 #include "bolt/dwio/parquet/arrow/util/Compression.h"
+#include "bolt/dwio/parquet/writer/WriterMetrics.h"
 
 namespace arrow {
 
@@ -164,7 +165,8 @@ class PARQUET_EXPORT PageWriter {
       // offset_index_builder MUST outlive the PageWriter
       OffsetIndexBuilder* offset_index_builder = NULLPTR,
       const util::CodecOptions& codec_options = util::CodecOptions{},
-      std::shared_ptr<PageBufferArena> page_buffer_arena = nullptr);
+      std::shared_ptr<PageBufferArena> page_buffer_arena = nullptr,
+      std::shared_ptr<WriterMetricsCollector> writer_metrics = nullptr);
 
   // TODO: remove this and port to new signature.
   // ARROW_DEPRECATED(
@@ -185,7 +187,8 @@ class PARQUET_EXPORT PageWriter {
       ColumnIndexBuilder* column_index_builder = NULLPTR,
       // offset_index_builder MUST outlive the PageWriter
       OffsetIndexBuilder* offset_index_builder = NULLPTR,
-      std::shared_ptr<PageBufferArena> page_buffer_arena = nullptr);
+      std::shared_ptr<PageBufferArena> page_buffer_arena = nullptr,
+      std::shared_ptr<WriterMetricsCollector> writer_metrics = nullptr);
 
   // The Column Writer decides if dictionary encoding is used if set and
   // if the dictionary encoding has fallen back to default encoding on reaching

--- a/bolt/dwio/parquet/arrow/FileWriter.cpp
+++ b/bolt/dwio/parquet/arrow/FileWriter.cpp
@@ -240,7 +240,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
           CodecOptions(),
           buffered_resources_ != nullptr
               ? buffered_resources_->page_buffer_arena()
-              : nullptr);
+              : nullptr,
+          properties_->writer_metrics());
     } else {
       pager = PageWriter::Open(
           sink_,
@@ -258,7 +259,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
           *codec_options,
           buffered_resources_ != nullptr
               ? buffered_resources_->page_buffer_arena()
-              : nullptr);
+              : nullptr,
+          properties_->writer_metrics());
     }
     column_writers_[0] = ColumnWriter::Make(
         col_meta, std::move(pager), properties_, buffered_resources_);
@@ -474,7 +476,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
             CodecOptions(),
             buffered_resources_ != nullptr
                 ? buffered_resources_->page_buffer_arena()
-                : nullptr);
+                : nullptr,
+            properties_->writer_metrics());
       } else {
         pager = PageWriter::Open(
             sink_,
@@ -492,7 +495,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
             *codec_options,
             buffered_resources_ != nullptr
                 ? buffered_resources_->page_buffer_arena()
-                : nullptr);
+                : nullptr,
+            properties_->writer_metrics());
       }
       column_writers_.push_back(ColumnWriter::Make(
           col_meta, std::move(pager), properties_, buffered_resources_));

--- a/bolt/dwio/parquet/arrow/Properties.h
+++ b/bolt/dwio/parquet/arrow/Properties.h
@@ -49,6 +49,7 @@
 #include "bolt/dwio/parquet/arrow/Schema.h"
 #include "bolt/dwio/parquet/arrow/Types.h"
 #include "bolt/dwio/parquet/arrow/util/Compression.h"
+#include "bolt/dwio/parquet/writer/WriterMetrics.h"
 #include "bolt/version/version.h"
 
 // Define the parquet created_by value. Keep this compatible with parquet-mr's
@@ -852,6 +853,12 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
+    Builder* writer_metrics(
+        std::shared_ptr<WriterMetricsCollector> writerMetrics) {
+      writerMetrics_ = std::move(writerMetrics);
+      return this;
+    }
+
     /// \brief Build the WriterProperties with the builder parameters.
     /// \return The WriterProperties defined by the builder.
     std::shared_ptr<WriterProperties> build() {
@@ -895,7 +902,8 @@ class PARQUET_EXPORT WriterProperties {
           column_properties,
           data_page_version_,
           store_decimal_as_integer_,
-          std::move(sorting_columns_)));
+          std::move(sorting_columns_),
+          std::move(writerMetrics_)));
     }
 
    private:
@@ -926,6 +934,7 @@ class PARQUET_EXPORT WriterProperties {
     std::unordered_map<std::string, bool> page_index_enabled_;
     std::unordered_map<std::string, int64_t> dictionary_pagesize_limit_;
     std::unordered_map<std::string, int64_t> pagesize_;
+    std::shared_ptr<WriterMetricsCollector> writerMetrics_;
   };
 
   inline MemoryPool* memory_pool() const {
@@ -1068,6 +1077,10 @@ class PARQUET_EXPORT WriterProperties {
     return file_encryption_properties_.get();
   }
 
+  const std::shared_ptr<WriterMetricsCollector>& writer_metrics() const {
+    return writerMetrics_;
+  }
+
   std::shared_ptr<ColumnEncryptionProperties> column_encryption_properties(
       const std::string& path) const {
     if (file_encryption_properties_) {
@@ -1093,7 +1106,8 @@ class PARQUET_EXPORT WriterProperties {
           column_properties,
       ParquetDataPageVersion data_page_version,
       bool store_short_decimal_as_integer,
-      std::vector<SortingColumn> sorting_columns)
+      std::vector<SortingColumn> sorting_columns,
+      std::shared_ptr<WriterMetricsCollector> writerMetrics)
       : pool_(pool),
         write_batch_size_(write_batch_size),
         max_row_group_length_(max_row_group_length),
@@ -1107,7 +1121,8 @@ class PARQUET_EXPORT WriterProperties {
         file_encryption_properties_(file_encryption_properties),
         sorting_columns_(std::move(sorting_columns)),
         default_column_properties_(default_column_properties),
-        column_properties_(column_properties) {}
+        column_properties_(column_properties),
+        writerMetrics_(std::move(writerMetrics)) {}
 
   MemoryPool* pool_;
   int64_t dictionary_pagesize_limit_;
@@ -1128,6 +1143,7 @@ class PARQUET_EXPORT WriterProperties {
 
   ColumnProperties default_column_properties_;
   std::unordered_map<std::string, ColumnProperties> column_properties_;
+  std::shared_ptr<WriterMetricsCollector> writerMetrics_;
 };
 
 PARQUET_EXPORT const std::shared_ptr<WriterProperties>&

--- a/bolt/dwio/parquet/arrow/Writer.cpp
+++ b/bolt/dwio/parquet/arrow/Writer.cpp
@@ -328,6 +328,7 @@ class FileWriterImpl : public FileWriter {
       std::shared_ptr<ArrowWriterProperties> arrow_properties)
       : schema_(std::move(schema)),
         writer_(std::move(writer)),
+        writerMetrics_(writer_->properties()->writer_metrics()),
         row_group_writer_(nullptr),
         column_write_context_(pool, arrow_properties.get()),
         arrow_properties_(std::move(arrow_properties)),
@@ -394,6 +395,8 @@ class FileWriterImpl : public FileWriter {
         return Status::Invalid(
             "Cannot write column chunk into the buffered row group.");
       }
+      WriterEncodeMetricTimer timer(
+          writerMetrics_ ? &writerMetrics_->writeEncodeWallNanos : nullptr);
       ARROW_ASSIGN_OR_RAISE(
           std::unique_ptr<ArrowColumnWriterV2> writer,
           ArrowColumnWriterV2::Make(
@@ -493,19 +496,26 @@ class FileWriterImpl : public FileWriter {
 
       for (int i = 0; i < batch.num_columns(); i++) {
         ChunkedArray chunked_array{batch.column(i)};
-        ARROW_ASSIGN_OR_RAISE(
-            std::unique_ptr<ArrowColumnWriterV2> writer,
-            ArrowColumnWriterV2::Make(
-                chunked_array,
-                offset,
-                size,
-                schema_manifest_,
-                row_group_writer_,
-                column_index_start));
+        std::unique_ptr<ArrowColumnWriterV2> writer;
+        {
+          WriterEncodeMetricTimer timer(
+              writerMetrics_ ? &writerMetrics_->writeEncodeWallNanos : nullptr);
+          ARROW_ASSIGN_OR_RAISE(
+              writer,
+              ArrowColumnWriterV2::Make(
+                  chunked_array,
+                  offset,
+                  size,
+                  schema_manifest_,
+                  row_group_writer_,
+                  column_index_start));
+        }
         column_index_start += writer->leaf_count();
         if (arrow_properties_->use_threads()) {
           writers.emplace_back(std::move(writer));
         } else {
+          WriterEncodeMetricTimer timer(
+              writerMetrics_ ? &writerMetrics_->writeEncodeWallNanos : nullptr);
           RETURN_NOT_OK(writer->Write(&column_write_context_));
         }
       }
@@ -515,6 +525,9 @@ class FileWriterImpl : public FileWriter {
         RETURN_NOT_OK(::arrow::internal::ParallelFor(
             static_cast<int>(writers.size()),
             [&](int i) {
+              WriterEncodeMetricTimer timer(
+                  writerMetrics_ ? &writerMetrics_->writeEncodeWallNanos
+                                 : nullptr);
               return writers[i]->Write(&parallel_column_write_contexts_[i]);
             },
             arrow_properties_->executor()));
@@ -615,6 +628,7 @@ class FileWriterImpl : public FileWriter {
   SchemaManifest schema_manifest_;
 
   std::unique_ptr<ParquetFileWriter> writer_;
+  const std::shared_ptr<WriterMetricsCollector> writerMetrics_;
   RowGroupWriter* row_group_writer_;
   ArrowWriteContext column_write_context_;
   std::shared_ptr<ArrowWriterProperties> arrow_properties_;

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -295,6 +295,13 @@ TEST_F(ParquetWriterTest, compression) {
   writer->write(data);
   writer->close();
 
+  const auto metrics = writer->metrics();
+  EXPECT_GT(metrics.writeRecodeWallNanos, 0);
+  EXPECT_GT(metrics.writeEncodeWallNanos, 0);
+  EXPECT_GT(metrics.writeCompressionWallNanos, 0);
+  EXPECT_GT(metrics.writeIOWallNanos, 0);
+  EXPECT_GT(metrics.writeFinalizeWallNanos, 0);
+
   dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 

--- a/bolt/dwio/parquet/writer/ArrowDataBufferSink.cpp
+++ b/bolt/dwio/parquet/writer/ArrowDataBufferSink.cpp
@@ -25,11 +25,13 @@ ArrowDataBufferSink::ArrowDataBufferSink(
     std::unique_ptr<dwio::common::FileSink> sink,
     memory::MemoryPool& pool,
     int64_t flushThresholdBytes,
-    double growRatio)
+    double growRatio,
+    std::shared_ptr<WriterMetricsCollector> metrics)
     : pool_(&pool),
       sink_(std::move(sink)),
       flushThresholdBytes_(flushThresholdBytes),
-      growRatio_(growRatio) {}
+      growRatio_(growRatio),
+      metrics_(std::move(metrics)) {}
 
 ::arrow::Status ArrowDataBufferSink::Write(
     const std::shared_ptr<::arrow::Buffer>& data) {
@@ -90,6 +92,7 @@ struct BufferReleaser {
     dwio::common::DataBuffer<char>& buffer) {
   if (buffer.size() > 0) {
     bytesFlushed_ += buffer.size();
+    WriterMetricTimer timer(&metrics_->writeIOWallNanos, true);
     sink_->write(std::move(buffer));
   }
   return ::arrow::Status::OK();
@@ -101,6 +104,7 @@ struct BufferReleaser {
 
 ::arrow::Status ArrowDataBufferSink::Close() {
   ARROW_RETURN_NOT_OK(Flush());
+  WriterMetricTimer timer(&metrics_->writeIOWallNanos, true);
   sink_->close();
   return ::arrow::Status::OK();
 }

--- a/bolt/dwio/parquet/writer/ArrowDataBufferSink.h
+++ b/bolt/dwio/parquet/writer/ArrowDataBufferSink.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "bolt/dwio/common/DataBuffer.h"
+#include "bolt/dwio/parquet/writer/WriterMetrics.h"
 namespace bytedance::bolt {
 namespace memory {
 class MemoryPool;
@@ -38,7 +39,8 @@ class ArrowDataBufferSink : public ::arrow::io::OutputStream {
       std::unique_ptr<dwio::common::FileSink> sink,
       memory::MemoryPool& pool,
       int64_t flushThresholdBytes,
-      double growRatio);
+      double growRatio,
+      std::shared_ptr<WriterMetricsCollector> metrics);
 
   ::arrow::Status Write(const std::shared_ptr<::arrow::Buffer>& data) override;
 
@@ -67,6 +69,7 @@ class ArrowDataBufferSink : public ::arrow::io::OutputStream {
   const double growRatio_;
   BufferPtr buffer_;
   int64_t bytesFlushed_ = 0;
+  const std::shared_ptr<WriterMetricsCollector> metrics_;
 };
 } // namespace parquet
 } // namespace bytedance::bolt

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -447,11 +447,13 @@ Writer::Writer(
       generalPool_{pool_->addLeafChild(".general")},
       exportPool_{pool_->addLeafChild(".exportArrow")},
       arrowPool_(arrowPool),
+      metrics_(std::make_shared<WriterMetricsCollector>()),
       stream_(std::make_shared<ArrowDataBufferSink>(
           std::move(sink),
           *generalPool_,
           options.bufferFlushThresholdBytes,
-          options.bufferGrowRatio)),
+          options.bufferGrowRatio,
+          metrics_)),
       arrowContext_(std::make_shared<ArrowContext>()),
       schema_(std::move(schema)),
       arrowSchemaFromHive_(std::move(arrowSchema)),
@@ -475,6 +477,7 @@ Writer::Writer(
       options.parquetWriteTimestampTimeZone.value_or("UTC");
   arrowContext_->properties =
       getArrowParquetWriterOptionsBuilder(options, flushPolicy_, arrowPool_)
+          ->writer_metrics(metrics_)
           ->build();
   arrowContext_->arrowWriterProperties =
       options.getArrowWriterPropertiesBuilder()->build();
@@ -592,6 +595,7 @@ void Writer::createFileWriterIfNotExist() {
 void Writer::initializeArrowSchema(const VectorPtr& data) {
   BOLT_CHECK_NULL(arrowContext_->schema);
 
+  WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
   ArrowSchema schema;
   exportToArrow(data, schema, options_, {}, exportPool_.get());
   auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
@@ -636,16 +640,20 @@ void Writer::splitWriteRecordBatch(const VectorPtr& data) {
   while (offset < dataSize) {
     auto size = std::min<vector_size_t>(dataSize - offset, rowNumPerBatch);
 
-    ArrowArray array;
-    exportToArrow(
-        offset == 0 && size == dataSize ? data : data->slice(offset, size),
-        array,
-        exportPool_.get(),
-        options_);
+    std::shared_ptr<::arrow::RecordBatch> recordBatch;
+    {
+      WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
+      ArrowArray array;
+      exportToArrow(
+          offset == 0 && size == dataSize ? data : data->slice(offset, size),
+          array,
+          exportPool_.get(),
+          options_);
 
-    PARQUET_ASSIGN_OR_THROW(
-        auto recordBatch,
-        ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
+      PARQUET_ASSIGN_OR_THROW(
+          recordBatch,
+          ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
+    }
     writeRecordBatch(recordBatch);
     offset += size;
   }
@@ -678,11 +686,14 @@ void Writer::write(const VectorPtr& data) {
     return;
   }
 
-  ArrowArray array;
-  exportToArrow(data, array, exportPool_.get(), options_);
-  PARQUET_ASSIGN_OR_THROW(
-      auto recordBatch,
-      ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
+  std::shared_ptr<::arrow::RecordBatch> recordBatch;
+  {
+    WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
+    ArrowArray array;
+    exportToArrow(data, array, exportPool_.get(), options_);
+    PARQUET_ASSIGN_OR_THROW(
+        recordBatch, ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
+  }
 
   auto bytes = data->estimateFlatSize();
   auto numRows = data->size();
@@ -727,6 +738,7 @@ void Writer::close() {
     return;
   }
 
+  WriterMetricTimer timer(&metrics_->writeFinalizeWallNanos);
   flush();
   if (!arrowContext_->writer) {
     createEmptyFile();
@@ -737,6 +749,10 @@ void Writer::close() {
   PARQUET_THROW_NOT_OK(stream_->Close());
   arrowContext_->stagingChunks.clear();
   closed_ = true;
+}
+
+dwio::common::WriterMetrics Writer::metrics() const {
+  return metrics_->snapshot();
 }
 
 void Writer::createEmptyFile() {

--- a/bolt/dwio/parquet/writer/Writer.h
+++ b/bolt/dwio/parquet/writer/Writer.h
@@ -42,6 +42,7 @@
 #include "bolt/dwio/parquet/arrow/Properties.h"
 #include "bolt/dwio/parquet/arrow/Types.h"
 #include "bolt/dwio/parquet/arrow/util/Compression.h"
+#include "bolt/dwio/parquet/writer/WriterMetrics.h"
 #include "bolt/vector/ComplexVector.h"
 #include "bolt/vector/arrow/Bridge.h"
 namespace bytedance::bolt::parquet {
@@ -258,6 +259,8 @@ class Writer : public dwio::common::Writer {
 
   void abort() override;
 
+  dwio::common::WriterMetrics metrics() const override;
+
   // Used in data retention scenario. Write parquet with specific row numbers in
   // each row group.
   void rowGroupAlignedFlush(
@@ -288,6 +291,8 @@ class Writer : public dwio::common::Writer {
   std::shared_ptr<memory::MemoryPool> generalPool_;
   std::shared_ptr<memory::MemoryPool> exportPool_;
   arrow::MemoryPool* arrowPool_{nullptr};
+
+  const std::shared_ptr<WriterMetricsCollector> metrics_;
 
   // Temporary Arrow stream for capturing the output.
   std::shared_ptr<ArrowDataBufferSink> stream_;

--- a/bolt/dwio/parquet/writer/WriterMetrics.h
+++ b/bolt/dwio/parquet/writer/WriterMetrics.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+
+#include "bolt/dwio/common/WriterMetrics.h"
+
+namespace bytedance::bolt::parquet {
+
+struct WriterMetricsCollector {
+  std::atomic<uint64_t> writeRecodeWallNanos{0};
+  std::atomic<uint64_t> writeEncodeWallNanos{0};
+  std::atomic<uint64_t> writeCompressionWallNanos{0};
+  std::atomic<uint64_t> writeIOWallNanos{0};
+  std::atomic<uint64_t> writeFinalizeWallNanos{0};
+
+  dwio::common::WriterMetrics snapshot() const {
+    return {
+        .writeRecodeWallNanos =
+            writeRecodeWallNanos.load(std::memory_order_relaxed),
+        .writeEncodeWallNanos =
+            writeEncodeWallNanos.load(std::memory_order_relaxed),
+        .writeCompressionWallNanos =
+            writeCompressionWallNanos.load(std::memory_order_relaxed),
+        .writeIOWallNanos = writeIOWallNanos.load(std::memory_order_relaxed),
+        .writeFinalizeWallNanos =
+            writeFinalizeWallNanos.load(std::memory_order_relaxed)};
+  }
+};
+
+class WriterEncodeMetricTimer {
+ public:
+  explicit WriterEncodeMetricTimer(std::atomic<uint64_t>* metric)
+      : metric_(metric), ownsScope_(metric_ != nullptr && active_ == nullptr) {
+    if (ownsScope_) {
+      active_ = this;
+      start_ = std::chrono::steady_clock::now();
+    }
+  }
+
+  ~WriterEncodeMetricTimer() {
+    if (!ownsScope_) {
+      return;
+    }
+    const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                             std::chrono::steady_clock::now() - start_)
+                             .count();
+    metric_->fetch_add(
+        elapsed > excludedNanos_ ? elapsed - excludedNanos_ : 0,
+        std::memory_order_relaxed);
+    active_ = nullptr;
+  }
+
+  static void exclude(uint64_t nanos) {
+    if (active_ != nullptr) {
+      active_->excludedNanos_ += nanos;
+    }
+  }
+
+ private:
+  inline static thread_local WriterEncodeMetricTimer* active_{nullptr};
+
+  std::atomic<uint64_t>* const metric_;
+  const bool ownsScope_;
+  std::chrono::steady_clock::time_point start_;
+  uint64_t excludedNanos_{0};
+};
+
+class WriterMetricTimer {
+ public:
+  explicit WriterMetricTimer(
+      std::atomic<uint64_t>* metric,
+      bool excludeFromEncode = false)
+      : metric_(metric),
+        excludeFromEncode_(excludeFromEncode),
+        start_(std::chrono::steady_clock::now()) {}
+
+  ~WriterMetricTimer() {
+    if (metric_ != nullptr) {
+      const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                               std::chrono::steady_clock::now() - start_)
+                               .count();
+      metric_->fetch_add(elapsed, std::memory_order_relaxed);
+      if (excludeFromEncode_) {
+        WriterEncodeMetricTimer::exclude(elapsed);
+      }
+    }
+  }
+
+ private:
+  std::atomic<uint64_t>* const metric_;
+  const bool excludeFromEncode_;
+  const std::chrono::steady_clock::time_point start_;
+};
+
+} // namespace bytedance::bolt::parquet

--- a/bolt/exec/TableWriter.cpp
+++ b/bolt/exec/TableWriter.cpp
@@ -267,6 +267,25 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
     }
     lockedStats->addRuntimeStat(
         "numWrittenFiles", RuntimeCounter(stats.numWrittenFiles));
+    lockedStats->addRuntimeStat(
+        "writeRecodeWallNanos",
+        RuntimeCounter(
+            stats.writeRecodeWallNanos, RuntimeCounter::Unit::kNanos));
+    lockedStats->addRuntimeStat(
+        "writeEncodeWallNanos",
+        RuntimeCounter(
+            stats.writeEncodeWallNanos, RuntimeCounter::Unit::kNanos));
+    lockedStats->addRuntimeStat(
+        "writeCompressionWallNanos",
+        RuntimeCounter(
+            stats.writeCompressionWallNanos, RuntimeCounter::Unit::kNanos));
+    lockedStats->addRuntimeStat(
+        "writeIOWallNanos",
+        RuntimeCounter(stats.writeIOWallNanos, RuntimeCounter::Unit::kNanos));
+    lockedStats->addRuntimeStat(
+        "writeFinalizeWallNanos",
+        RuntimeCounter(
+            stats.writeFinalizeWallNanos, RuntimeCounter::Unit::kNanos));
   }
   if (!stats.spillStats.empty()) {
     recordSpillStats(stats.spillStats);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->

Spark only reports the overall Bolt writer duration, which cannot distinguish recoding, encoding, compression, storage IO, and finalization bottlenecks.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

This PR adds five phase metrics to the Bolt Parquet writer:

- `writeRecodeWallNanos`: Bolt vector to Arrow conversion time;
- `writeEncodeWallNanos`: Parquet encoding time, excluding measured compression and sink IO;
- `writeCompressionWallNanos`: Parquet compression time;
- `writeIOWallNanos`: file-sink write and close time;
- `writeFinalizeWallNanos`: Parquet writer finalization time.

The metrics are exposed through `HiveDataSink` runtime statistics and the legacy native writer JNI path. A companion Gluten change displays them on `Execute InsertIntoHiveTable`.

Finalization includes writer flush and close, so encoding, compression, and IO performed during finalization may overlap with `writeFinalizeWallNanos`. The five metrics are not directly additive.

Encoding and compression use relaxed atomic accumulation because column work can run on multiple threads. Unit tests verify that all five metrics are populated.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [x] **Negative Impact**: Explained below (e.g., trade-off for correctness).

The write path adds scoped monotonic-clock reads and relaxed atomic counter updates. It adds no data copies or per-value processing, but no controlled before/after benchmark has been run.

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Add Bolt Parquet writer phase metrics for recoding, encoding, compression, IO, and finalization.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
