### PR TITLE
fix: support unsigned integer vectors in hive hash

### DIFF
--- a/bolt/functions/sparksql/Hash.cpp
+++ b/bolt/functions/sparksql/Hash.cpp
@@ -34,6 +34,7 @@
 #include <type/HugeInt.h>
 #include <type/Type.h>
 #include <vector/ComplexVector.h>
+#include <bit>
 #include <cstdint>
 
 #include "bolt/common/base/BitUtil.h"
@@ -230,6 +231,11 @@ template <TypeKind kind>
 constexpr bool isIntegerType = (kind == TypeKind::BOOLEAN) ||
     (kind == TypeKind::TINYINT) || (kind == TypeKind::SMALLINT) ||
     (kind == TypeKind::INTEGER);
+
+template <TypeKind kind>
+constexpr bool supportsUnsignedIntegerVector = (kind == TypeKind::TINYINT) ||
+    (kind == TypeKind::SMALLINT) || (kind == TypeKind::INTEGER) ||
+    (kind == TypeKind::BIGINT);
 
 template <TypeKind kind>
 constexpr bool isStringType = (kind == TypeKind::VARCHAR) ||
@@ -631,6 +637,23 @@ class HiveHashBase {
 };
 
 template <TypeKind kind>
+class HiveHash;
+
+template <TypeKind kind>
+HiveHashBase::ResultType hashDecodedValue(
+    const DecodedVector& decoded,
+    vector_size_t index,
+    const HiveHash<kind>& hasher,
+    HiveHashBase::SeedType seed);
+
+template <TypeKind kind>
+HiveHashBase::ResultType hashVectorValue(
+    const VectorPtr& vector,
+    vector_size_t index,
+    const HiveHash<kind>& hasher,
+    HiveHashBase::SeedType seed);
+
+template <TypeKind kind>
 class HiveHash : public HiveHashBase {
  public:
   using NativeType = typename VectorValueType<kind>::type;
@@ -821,6 +844,20 @@ class HiveHash : public HiveHashBase {
     }
   }
 
+  template <typename T>
+  requires(
+      supportsUnsignedIntegerVector<kind>&& std::is_unsigned_v<T> &&
+      sizeof(T) == sizeof(NativeType)) inline ResultType
+      hash(T input, SeedType seed) const {
+    if constexpr (sizeof(T) < sizeof(int32_t)) {
+      return HiveHashBase::hashInt32(static_cast<int32_t>(input), seed);
+    } else {
+      // Spark reads UINT32 as LongType. hashLong() returns the low 32 bits for
+      // values that fit in uint32_t.
+      return HiveHashBase::hashInt32(std::bit_cast<int32_t>(input), seed);
+    }
+  }
+
  private:
   template <TypeKind elementKind>
   static ResultType
@@ -836,8 +873,8 @@ class HiveHash : public HiveHashBase {
       if (array->elements()->isNullAt(idx)) {
         result = HiveHashBase::hashNull(result);
       } else {
-        result = hasher.hash(
-            getValueFromVector<elementKind>(array->elements(), idx), result);
+        result = hashVectorValue<elementKind>(
+            array->elements(), idx, hasher, result);
       }
     }
     return result;
@@ -850,8 +887,7 @@ class HiveHash : public HiveHashBase {
     if (baseVector->isNullAt(index)) {
       return HiveHashBase::hashNull(seed);
     } else {
-      return hasher.hash(
-          getValueFromVector<elementKind>(baseVector, index), seed);
+      return hashVectorValue<elementKind>(baseVector, index, hasher, seed);
     }
   }
 };
@@ -876,6 +912,11 @@ class HiveHash<TypeKind::BIGINT> : HiveHashBase {
     } else {
       return HiveHashBase::hashInt64((uint64_t)input, seed);
     }
+  }
+
+  ResultType hash(uint64_t input, SeedType seed) const {
+    BOLT_DCHECK(!isDecimal_);
+    return HiveHashBase::hashInt64(std::bit_cast<int64_t>(input), seed);
   }
 
  private:
@@ -903,6 +944,38 @@ class HiveHash<TypeKind::HUGEINT> : HiveHashBase {
   int8_t scale_;
 };
 
+template <TypeKind kind>
+HiveHashBase::ResultType hashDecodedValue(
+    const DecodedVector& decoded,
+    vector_size_t index,
+    const HiveHash<kind>& hasher,
+    HiveHashBase::SeedType seed) {
+  if constexpr (supportsUnsignedIntegerVector<kind>) {
+    using SignedType = typename TypeTraits<kind>::NativeType;
+    using UnsignedType = std::make_unsigned_t<SignedType>;
+    if (decoded.base()->as<SimpleVector<UnsignedType>>()) {
+      return hasher.hash(decoded.valueAt<UnsignedType>(index), seed);
+    }
+  }
+  return hasher.hash(getValueFromVector<kind>(decoded, index), seed);
+}
+
+template <TypeKind kind>
+HiveHashBase::ResultType hashVectorValue(
+    const VectorPtr& vector,
+    vector_size_t index,
+    const HiveHash<kind>& hasher,
+    HiveHashBase::SeedType seed) {
+  if constexpr (supportsUnsignedIntegerVector<kind>) {
+    using SignedType = typename TypeTraits<kind>::NativeType;
+    using UnsignedType = std::make_unsigned_t<SignedType>;
+    if (auto unsignedVector = vector->as<SimpleVector<UnsignedType>>()) {
+      return hasher.hash(unsignedVector->valueAt(index), seed);
+    }
+  }
+  return hasher.hash(getValueFromVector<kind>(vector, index), seed);
+}
+
 // hash multiple values from input into result with seed, if seed is nullptr,
 // use default seed 0. this function is optimized for no null vector, so that
 // compiler can generate SIMD instructions. we also optimized for complex type
@@ -917,33 +990,44 @@ __attribute__((noinline)) bool hiveHashMultiple(
     HiveHash<typeKind> hasher(input->type());
     if constexpr (typeKind != TypeKind::BOOLEAN) {
       if (input->isFlatEncoding()) {
-        auto flatVector =
-            input->asFlatVector<typename TypeTraits<typeKind>::NativeType>();
-        bool hasNoNull = flatVector->rawNulls()
-            ? bits::isAllSet(
-                  flatVector->rawNulls(), 0, inputSize, bits::kNotNull)
-            : true;
-        if (hasNoNull) {
-          auto rawInput = flatVector->rawValues();
-          for (size_t row = 0; row < inputSize; row++) {
-            result[row] =
-                hasher.hash(rawInput[row], useDefaultSeed ? 0 : result[row]);
-          }
-        } else {
-          for (size_t row = 0; row < inputSize; row++) {
-            HiveHashBase::ResultType hashValue;
-            if (flatVector->isNullAt(row)) {
-              hashValue =
-                  HiveHashBase::hashNull(useDefaultSeed ? 0 : result[row]);
-            } else {
-              hashValue = hasher.hash(
-                  flatVector->valueAtFast(row),
-                  useDefaultSeed ? 0 : result[row]);
+        const auto hashFlatVector = [&](const auto* flatVector) {
+          BOLT_CHECK_NOT_NULL(flatVector);
+          bool hasNoNull = flatVector->rawNulls()
+              ? bits::isAllSet(
+                    flatVector->rawNulls(), 0, inputSize, bits::kNotNull)
+              : true;
+          if (hasNoNull) {
+            auto rawInput = flatVector->rawValues();
+            for (size_t row = 0; row < inputSize; row++) {
+              result[row] =
+                  hasher.hash(rawInput[row], useDefaultSeed ? 0 : result[row]);
             }
-            result[row] = hashValue;
+          } else {
+            for (size_t row = 0; row < inputSize; row++) {
+              HiveHashBase::ResultType hashValue;
+              if (flatVector->isNullAt(row)) {
+                hashValue =
+                    HiveHashBase::hashNull(useDefaultSeed ? 0 : result[row]);
+              } else {
+                hashValue = hasher.hash(
+                    flatVector->valueAtFast(row),
+                    useDefaultSeed ? 0 : result[row]);
+              }
+              result[row] = hashValue;
+            }
           }
+          return true;
+        };
+        if constexpr (supportsUnsignedIntegerVector<typeKind>) {
+          using SignedType = typename TypeTraits<typeKind>::NativeType;
+          if (auto flatVector = input->asFlatVector<SignedType>()) {
+            return hashFlatVector(flatVector);
+          }
+          using UnsignedType = std::make_unsigned_t<SignedType>;
+          return hashFlatVector(input->asFlatVector<UnsignedType>());
         }
-        return true;
+        return hashFlatVector(
+            input->asFlatVector<typename TypeTraits<typeKind>::NativeType>());
       }
     }
     DecodedVector decoded(*input);
@@ -953,9 +1037,7 @@ __attribute__((noinline)) bool hiveHashMultiple(
       if (decoded.isNullAt(i)) {
         hashValue = HiveHashBase::hashNull(seed);
       } else {
-        hashValue = hasher.hash(
-            decoded.valueAt<typename TypeTraits<typeKind>::NativeType>(i),
-            seed);
+        hashValue = hashDecodedValue<typeKind>(decoded, i, hasher, seed);
       }
       result[i] = hashValue;
     }
@@ -1098,8 +1180,13 @@ struct HashFunctionEvaluator {
       if (decoded.isNullAt(row)) {
         hashValue = HashClassBase::hashNull(rawValues[row]);
       } else {
-        hashValue =
-            hasher.hash(getValueFromVector<kind>(decoded, row), rawValues[row]);
+        if constexpr (std::is_same_v<HashClassBase, HiveHashBase>) {
+          hashValue =
+              hashDecodedValue<kind>(decoded, row, hasher, rawValues[row]);
+        } else {
+          hashValue = hasher.hash(
+              getValueFromVector<kind>(decoded, row), rawValues[row]);
+        }
       }
       rawValues[row] = hashValue;
     });

--- a/bolt/functions/sparksql/tests/HiveHashTest.cpp
+++ b/bolt/functions/sparksql/tests/HiveHashTest.cpp
@@ -114,6 +114,85 @@ TEST_F(HiveHashTest, Int64) {
   EXPECT_EQ(HiveHash<int64_t>(std::nullopt), 0);
 }
 
+TEST_F(HiveHashTest, unsignedIntegralVectors) {
+  const auto testFlat = [&](const VectorPtr& input,
+                            const std::vector<int32_t>& expected) {
+    auto result = evaluate<SimpleVector<int32_t>>(
+        "hive_hash(c0)", makeRowVector({input}));
+    assertEqualVectors(makeFlatVector<int32_t>(expected), result);
+  };
+
+  testFlat(
+      makeNullableFlatVector<uint8_t>(
+          {11, std::nullopt, 128, std::numeric_limits<uint8_t>::max()},
+          TINYINT()),
+      {11, 0, 128, 255});
+  testFlat(
+      makeNullableFlatVector<uint16_t>(
+          {11, std::nullopt, 32768, std::numeric_limits<uint16_t>::max()},
+          SMALLINT()),
+      {11, 0, 32768, 65535});
+  testFlat(
+      makeNullableFlatVector<uint32_t>(
+          {11,
+           std::nullopt,
+           uint32_t{1} << 31,
+           std::numeric_limits<uint32_t>::max()},
+          INTEGER()),
+      {11, 0, 0, std::numeric_limits<int32_t>::max()});
+  testFlat(
+      makeNullableFlatVector<uint64_t>(
+          {11,
+           std::nullopt,
+           std::numeric_limits<uint64_t>::max(),
+           std::numeric_limits<uint64_t>::max() - 2022},
+          BIGINT()),
+      {11, 0, 0, 2022});
+
+  const auto testDictionary = [&](const VectorPtr& values,
+                                  const std::vector<int32_t>& expected) {
+    auto input = wrapInDictionary(makeIndices({1, 0}), values);
+    auto result = evaluate<SimpleVector<int32_t>>(
+        "hive_hash(c0)", makeRowVector({input}));
+    assertEqualVectors(makeFlatVector<int32_t>(expected), result);
+  };
+
+  testDictionary(makeFlatVector<uint8_t>({11, 255}, TINYINT()), {255, 11});
+  testDictionary(
+      makeFlatVector<uint16_t>({11, 65535}, SMALLINT()), {65535, 11});
+  testDictionary(
+      makeFlatVector<uint32_t>(
+          {11, std::numeric_limits<uint32_t>::max()}, INTEGER()),
+      {std::numeric_limits<int32_t>::max(), 11});
+  testDictionary(
+      makeFlatVector<uint64_t>(
+          {11, std::numeric_limits<uint64_t>::max()}, BIGINT()),
+      {0, 11});
+
+  auto input = makeFlatVector<uint16_t>({11, 65535}, SMALLINT());
+  SelectivityVector rows(input->size());
+  rows.setValid(0, false);
+  rows.updateBounds();
+  auto result = evaluate<SimpleVector<int32_t>>(
+      "hive_hash(c0)", makeRowVector({input}), rows);
+  assertEqualVectors(makeFlatVector<int32_t>({0, 65535}), result, rows);
+
+  auto array =
+      makeArrayVector({0}, makeFlatVector<uint16_t>({11, 65535}, SMALLINT()));
+  result =
+      evaluate<SimpleVector<int32_t>>("hive_hash(c0)", makeRowVector({array}));
+  assertEqualVectors(makeFlatVector<int32_t>({65876}), result);
+}
+
+TEST_F(HiveHashTest, bigintDictionaryUsesDecodedPath) {
+  auto flat = makeFlatVector<int64_t>({11, 12});
+  auto dictionary = wrapInDictionary(makeIndices({1, 0}), flat);
+  auto result = evaluate<SimpleVector<int32_t>>(
+      "hive_hash(c0)", makeRowVector({dictionary}));
+
+  assertEqualVectors(makeFlatVector<int32_t>({12, 11}), result);
+}
+
 TEST_F(HiveHashTest, Int32) {
   EXPECT_EQ(HiveHash<int32_t>(INT32_MAX), INT32_MAX);
   // INT32_MIN from hive shell


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
`hive_hash` assumes that integer inputs are backed by the signed native vector type for their logical type. Unsigned Parquet reads can instead produce a logical BIGINT backed by `FlatVector<uint64_t>`. The signed flat-vector cast then returns a null pointer, which the fast path dereferences.

The reported crash involves BIGINT, but the same signed-backing assumption is present in the TINYINT, SMALLINT, and INTEGER paths.

Issue Number: close #880

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Support unsigned physical vector representations for `TINYINT`, `SMALLINT`, `INTEGER`, and `BIGINT` in flat and decoded Hive hash paths.
- Use width-appropriate conversions, including bit-preserving conversions for 32-bit and 64-bit values, before applying the existing Hive hash semantics.
- Apply the same type-aware handling to dictionary inputs, selected rows, and nested array values.
- Add regression coverage for all supported unsigned integer widths and the signed BIGINT dictionary path.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: No material performance impact is expected. The existing hash formulas and single-pass processing are unchanged, and the added signed/unsigned vector dispatch does not introduce allocations.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Release Note:

```text
Release Note:
- Fixed a `hive_hash` crash when integer columns are backed by unsigned physical vectors.
```

### Validation

- `HiveHashTest.unsignedIntegralVectors` and `HiveHashTest.bigintDictionaryUsesDecodedPath`: passed.
- Full Release Spark `bolt_functions_spark_test`: 724 tests passed.

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
