### PR TITLE
[Performance] Reuse intermediate column buffers in shuffle read to cut malloc/free churn

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleReader.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.cpp
@@ -436,7 +436,8 @@ BoltColumnarBatchDeserializer::BoltColumnarBatchDeserializer(
     bool isRowFormat,
     AdaptiveParallelZstdCodec* zstdCodec,
     RowBufferPool* rowBufferPool,
-    ShuffleRowToColumnarConverter* row2ColConverter)
+    ShuffleRowToColumnarConverter* row2ColConverter,
+    ColumnBufferPool* columnBufferPool)
     : schema_(schema),
       codec_(codec),
       rowType_(rowType),
@@ -452,7 +453,8 @@ BoltColumnarBatchDeserializer::BoltColumnarBatchDeserializer(
       isRowFormat_(isRowFormat),
       zstdCodec_(zstdCodec),
       rowBufferPool_(rowBufferPool),
-      row2ColConverter_(row2ColConverter) {
+      row2ColConverter_(row2ColConverter),
+      columnBufferPool_(columnBufferPool) {
   auto result = arrow::io::BufferedInputStream::Create(
       shuffleBufferSize, memoryPool, std::move(in));
   BOLT_CHECK(
@@ -512,7 +514,8 @@ RowVectorPtr BoltColumnarBatchDeserializer::next() {
         numRows,
         decompressTime_,
         payloadType_,
-        readAheadBuffer_.size > 0 ? &readAheadBuffer_ : nullptr);
+        readAheadBuffer_.size > 0 ? &readAheadBuffer_ : nullptr,
+        columnBufferPool_);
     BOLT_CHECK(arrowBuffers.ok());
 
     return makeColumnarBatch(
@@ -563,7 +566,8 @@ RowVectorPtr BoltColumnarBatchDeserializer::next() {
         numRows,
         decompressTime_,
         payloadType_,
-        readAheadBuffer_.size > 0 ? &readAheadBuffer_ : nullptr);
+        readAheadBuffer_.size > 0 ? &readAheadBuffer_ : nullptr,
+        columnBufferPool_);
     BOLT_CHECK(
         result.ok(),
         "Failed to deserialize BlockPayload: " + result.status().message());

--- a/bolt/shuffle/sparksql/BoltShuffleReader.h
+++ b/bolt/shuffle/sparksql/BoltShuffleReader.h
@@ -206,7 +206,8 @@ class BoltColumnarBatchDeserializer {
       bool isRowFormat = false,
       AdaptiveParallelZstdCodec* zstdCodec = nullptr,
       RowBufferPool* rowBufferPool = nullptr,
-      ShuffleRowToColumnarConverter* row2ColConverter = nullptr);
+      ShuffleRowToColumnarConverter* row2ColConverter = nullptr,
+      ColumnBufferPool* columnBufferPool = nullptr);
 
   bytedance::bolt::RowVectorPtr next();
 
@@ -253,6 +254,8 @@ class BoltColumnarBatchDeserializer {
   int32_t partialRowSize_{0};
   ShuffleRowToColumnarConverter* row2ColConverter_{nullptr};
   std::unique_ptr<arrow::ResizableBuffer> tailBuffer_{nullptr};
+
+  ColumnBufferPool* columnBufferPool_{nullptr};
 
   // for CompositeRowVector shuffle reader
   RowVectorLayout vectorLayout_{RowVectorLayout::kInvalid};

--- a/bolt/shuffle/sparksql/Options.h
+++ b/bolt/shuffle/sparksql/Options.h
@@ -76,6 +76,8 @@ static constexpr int32_t rowBaseColumnNumThreshold = 5;
 // BufferedInputStream (and deserializer) per stream.
 static constexpr bool kDefaultReuseBufferedInputStream = false;
 
+static constexpr bool kDefaultReuseColumnBuffer = false;
+
 static constexpr int32_t kMaxShuffleWriterBatchBytes =
     200 * 1024 * 1024; // 200MB
 
@@ -123,6 +125,8 @@ struct ShuffleReaderOptions {
   // Reuse a single BufferedInputStream across all reader streams to avoid the
   // overhead of repeatedly creating/destroying one per stream.
   bool reuseBufferedInputStream = kDefaultReuseBufferedInputStream;
+
+  bool reuseColumnBuffer = kDefaultReuseColumnBuffer;
 };
 
 struct PartitionWriterOptions {

--- a/bolt/shuffle/sparksql/Payload.cpp
+++ b/bolt/shuffle/sparksql/Payload.cpp
@@ -205,11 +205,33 @@ arrow::Status compressAndFlush(
   return arrow::Status::OK();
 }
 
+// Allocates a resizable buffer of logical size `size` with `paddedSize` extra
+// SIMD over-read capacity. When `bufferPool` is provided, the buffer is
+// borrowed from the pool (and reused across batches); otherwise it falls back
+// to a fresh arrow::AllocateResizableBuffer, preserving the original behavior.
+arrow::Result<std::shared_ptr<arrow::Buffer>> allocateColumnBuffer(
+    arrow::MemoryPool* pool,
+    ColumnBufferPool* bufferPool,
+    int64_t size,
+    uint32_t paddedSize) {
+  if (bufferPool != nullptr) {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, bufferPool->allocate(size, paddedSize));
+    return buffer;
+  }
+  ARROW_ASSIGN_OR_RAISE(
+      auto buffer, arrow::AllocateResizableBuffer(size + paddedSize, pool));
+  if (paddedSize > 0) {
+    RETURN_NOT_OK(buffer->Resize(size, false));
+  }
+  return buffer;
+}
+
 arrow::Result<std::shared_ptr<arrow::Buffer>> readUncompressedBuffer(
     arrow::io::InputStream* inputStream,
     ByteBuffer** readAheadBuffer,
     arrow::MemoryPool* pool,
-    const uint32_t paddedSize = 0) {
+    const uint32_t paddedSize = 0,
+    ColumnBufferPool* bufferPool = nullptr) {
   int64_t bufferLength;
   if (*readAheadBuffer) {
     RETURN_NOT_OK(internalReadFromCacheOrStream(
@@ -220,30 +242,20 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> readUncompressedBuffer(
   if (bufferLength == kNullBuffer) {
     return nullptr;
   }
+  ARROW_ASSIGN_OR_RAISE(
+      auto buffer,
+      allocateColumnBuffer(pool, bufferPool, bufferLength, paddedSize));
   if (*readAheadBuffer) {
-    ARROW_ASSIGN_OR_RAISE(
-        auto buffer,
-        arrow::AllocateResizableBuffer(bufferLength + paddedSize, pool));
-    if (paddedSize > 0) {
-      RETURN_NOT_OK(buffer->Resize(bufferLength, false));
-    }
     RETURN_NOT_OK(internalReadFromCacheOrStream(
         inputStream,
         readAheadBuffer,
         bufferLength,
         const_cast<uint8_t*>(buffer->data())));
-    return buffer;
   } else {
-    ARROW_ASSIGN_OR_RAISE(
-        auto buffer,
-        arrow::AllocateResizableBuffer(bufferLength + paddedSize, pool));
-    if (paddedSize > 0) {
-      RETURN_NOT_OK(buffer->Resize(bufferLength, false));
-    }
     RETURN_NOT_OK(
         inputStream->Read(bufferLength, const_cast<uint8_t*>(buffer->data())));
-    return buffer;
   }
+  return buffer;
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> readCompressedBuffer(
@@ -252,7 +264,8 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> readCompressedBuffer(
     arrow::MemoryPool* pool,
     uint64_t& decompressTime,
     ByteBuffer** readAheadBuffer,
-    const uint32_t paddedSize = 0) { // align to bytedance::bolt::simd::kPadding
+    const uint32_t paddedSize = 0, // align to bytedance::bolt::simd::kPadding
+    ColumnBufferPool* bufferPool = nullptr) {
   int64_t compressedLength;
   if (*readAheadBuffer) {
     RETURN_NOT_OK(internalReadFromCacheOrStream(
@@ -277,10 +290,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> readCompressedBuffer(
   if (compressedLength == kUncompressedBuffer) {
     ARROW_ASSIGN_OR_RAISE(
         auto uncompressed,
-        arrow::AllocateResizableBuffer(uncompressedLength + paddedSize, pool));
-    if (paddedSize > 0) {
-      RETURN_NOT_OK(uncompressed->Resize(uncompressedLength, false));
-    }
+        allocateColumnBuffer(pool, bufferPool, uncompressedLength, paddedSize));
     if (*readAheadBuffer) {
       RETURN_NOT_OK(internalReadFromCacheOrStream(
           inputStream,
@@ -294,7 +304,8 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> readCompressedBuffer(
     return uncompressed;
   }
   ARROW_ASSIGN_OR_RAISE(
-      auto compressed, arrow::AllocateBuffer(compressedLength, pool));
+      auto compressed,
+      allocateColumnBuffer(pool, bufferPool, compressedLength, paddedSize));
   if (*readAheadBuffer) {
     RETURN_NOT_OK(internalReadFromCacheOrStream(
         inputStream,
@@ -309,10 +320,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> readCompressedBuffer(
   bytedance::bolt::NanosecondTimer timer(&decompressTime);
   ARROW_ASSIGN_OR_RAISE(
       auto output,
-      arrow::AllocateResizableBuffer(uncompressedLength + paddedSize, pool));
-  if (paddedSize > 0) {
-    RETURN_NOT_OK(output->Resize(uncompressedLength, false));
-  }
+      allocateColumnBuffer(pool, bufferPool, uncompressedLength, paddedSize));
   codec->decompress(
       compressed->data(),
       compressedLength,
@@ -560,7 +568,8 @@ BlockPayload::deserialize(
     uint32_t& numRows,
     uint64_t& decompressTime,
     std::optional<uint8_t>& payloadType,
-    ByteBuffer* readAheadBuffer) {
+    ByteBuffer* readAheadBuffer,
+    ColumnBufferPool* bufferPool) {
   static const std::vector<std::shared_ptr<arrow::Buffer>> kEmptyBuffers{};
   std::tuple<uint32_t, uint8_t> rowsAndMode;
   uint8_t type = payloadType.value();
@@ -578,7 +587,13 @@ BlockPayload::deserialize(
         type != Type::kCompressed,
         arrow::Status::Invalid("RowVector mode payload must be compressed"));
     return deserializeRowVectorModeBuffers(
-        inputStream, codec, pool, numRows, decompressTime, &readAheadBuffer);
+        inputStream,
+        codec,
+        pool,
+        numRows,
+        decompressTime,
+        &readAheadBuffer,
+        bufferPool);
   }
 
   auto fields = schema->fields();
@@ -592,10 +607,15 @@ BlockPayload::deserialize(
           pool,
           decompressTime,
           &readAheadBuffer,
-          bytedance::bolt::simd::kPadding);
+          bytedance::bolt::simd::kPadding,
+          bufferPool);
     } else {
       return readUncompressedBuffer(
-          inputStream, &readAheadBuffer, pool, bytedance::bolt::simd::kPadding);
+          inputStream,
+          &readAheadBuffer,
+          pool,
+          bytedance::bolt::simd::kPadding,
+          bufferPool);
     }
   };
 
@@ -647,7 +667,8 @@ BlockPayload::deserializeRowVectorModeBuffers(
     arrow::MemoryPool* pool,
     uint32_t& numRows,
     uint64_t& decompressTime,
-    ByteBuffer** readAheadBuffer) {
+    ByteBuffer** readAheadBuffer,
+    ColumnBufferPool* bufferPool) {
   // lengthBuffer
   std::shared_ptr<arrow::Buffer> lengthBuffer, valueBuffer;
   ARROW_ASSIGN_OR_RAISE(
@@ -667,7 +688,8 @@ BlockPayload::deserializeRowVectorModeBuffers(
           pool,
           decompressTime,
           readAheadBuffer,
-          bytedance::bolt::simd::kPadding));
+          bytedance::bolt::simd::kPadding,
+          bufferPool));
   ARROW_RETURN_IF(
       valueBuffer == nullptr,
       arrow::Status::Invalid(

--- a/bolt/shuffle/sparksql/Payload.h
+++ b/bolt/shuffle/sparksql/Payload.h
@@ -95,7 +95,9 @@ class ColumnBufferPool final {
         return status;
       }
     }
-    buffers_.push_back(buffer);
+    if (buffers_.size() < kMaxPooledBuffers) {
+      buffers_.push_back(buffer);
+    }
     return buffer;
   }
 
@@ -127,6 +129,7 @@ class ColumnBufferPool final {
   }
 
   std::vector<std::shared_ptr<arrow::ResizableBuffer>> buffers_;
+  static constexpr size_t kMaxPooledBuffers = 5000;
   // Indices into buffers_ that are known to be solely owned by the pool and
   // thus reusable. Refilled lazily by refillFreeList() when exhausted.
   std::vector<size_t> freeList_;

--- a/bolt/shuffle/sparksql/Payload.h
+++ b/bolt/shuffle/sparksql/Payload.h
@@ -43,6 +43,96 @@
 namespace bytedance::bolt::shuffle::sparksql {
 class ByteBuffer;
 
+class ColumnBufferPool final {
+ public:
+  explicit ColumnBufferPool(arrow::MemoryPool* pool) : pool_(pool) {}
+
+  // Returns a resizable buffer whose logical size is `size` and whose capacity
+  // is at least `size + padding` (padding reserves SIMD over-read space,
+  // mirroring the non-pooled arrow::AllocateResizableBuffer path). Reuses a
+  // free buffer with sufficient capacity when available, otherwise allocates a
+  // new one and tracks it for future reuse.
+  arrow::Result<std::shared_ptr<arrow::ResizableBuffer>> allocate(
+      int64_t size,
+      int64_t padding) {
+    const int64_t capacity = size + padding;
+    if (freeList_.empty()) {
+      // Rebuild the set of solely-owned buffers. This is the only O(M) step and
+      // is amortized across a whole batch's worth of allocate() calls.
+      refillFreeList();
+    }
+    while (!freeList_.empty()) {
+      const size_t idx = freeList_.back();
+      auto& buffer = buffers_[idx];
+      // refillFreeList() only records buffers with use_count() == 1, and the
+      // pool is single-threaded, so a buffer stays solely-owned until we hand
+      // it out here.
+      if (buffer->capacity() >= capacity) {
+        // Fits within existing capacity: just adjust the logical size. Passing
+        // shrink_to_fit=false guarantees no reallocation happens here, and the
+        // [size, capacity) tail keeps at least `padding` bytes for SIMD.
+        auto status = buffer->Resize(size, /*shrink_to_fit=*/false);
+        if (!status.ok()) {
+          return status;
+        }
+        freeList_.pop_back();
+        return buffer;
+      }
+      // Capacity too small for this request; drop it from the free list for the
+      // current batch rather than reallocating, preserving the original
+      // no-realloc-on-reuse behavior.
+      freeList_.pop_back();
+    }
+    auto result = arrow::AllocateResizableBuffer(capacity, pool_);
+    if (!result.ok()) {
+      return result.status();
+    }
+    std::shared_ptr<arrow::ResizableBuffer> buffer =
+        std::move(result).ValueUnsafe();
+    if (padding > 0) {
+      auto status = buffer->Resize(size, /*shrink_to_fit=*/false);
+      if (!status.ok()) {
+        return status;
+      }
+    }
+    buffers_.push_back(buffer);
+    return buffer;
+  }
+
+  // Number of buffers currently tracked by the pool. Exposed for tests/metrics.
+  size_t numBuffers() const {
+    return buffers_.size();
+  }
+
+  // Drops all cached buffers and frees their memory back to `pool_`. Buffers
+  // that still escaped into a live payload or RowVector (use_count() > 1) stay
+  // alive until their last owner releases them. Call at close() to return
+  // memory eagerly instead of waiting for the pool's own destruction.
+  void release() {
+    buffers_.clear();
+    freeList_.clear();
+  }
+
+ private:
+  // Recomputes freeList_ as the indices of buffers currently owned only by the
+  // pool (use_count() == 1). Buffers still referenced elsewhere are skipped.
+  void refillFreeList() {
+    freeList_.clear();
+    freeList_.reserve(buffers_.size());
+    for (size_t i = 0; i < buffers_.size(); ++i) {
+      if (buffers_[i].use_count() == 1) {
+        freeList_.push_back(i);
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<arrow::ResizableBuffer>> buffers_;
+  // Indices into buffers_ that are known to be solely owned by the pool and
+  // thus reusable. Refilled lazily by refillFreeList() when exhausted.
+  std::vector<size_t> freeList_;
+  arrow::MemoryPool* pool_;
+};
+
 class Payload {
  public:
   enum Type : uint8_t {
@@ -128,7 +218,8 @@ class BlockPayload : public Payload {
       uint32_t& numRows,
       uint64_t& decompressTime,
       std::optional<uint8_t>& payloadType,
-      ByteBuffer* readAheadBuffer);
+      ByteBuffer* readAheadBuffer,
+      ColumnBufferPool* bufferPool = nullptr);
 
   static arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>>
   deserializeRowVectorModeBuffers(
@@ -137,7 +228,8 @@ class BlockPayload : public Payload {
       arrow::MemoryPool* pool,
       uint32_t& numRows,
       uint64_t& decompressTime,
-      ByteBuffer** readAheadBuffer);
+      ByteBuffer** readAheadBuffer,
+      ColumnBufferPool* bufferPool = nullptr);
 
   arrow::Status serialize(arrow::io::OutputStream* outputStream) override;
 

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
@@ -87,8 +87,7 @@ SparkShuffleReader::SparkShuffleReader(
              shuffleReaderOptions_.rowBasedShuffleThreshold)) ||
        (shuffleWriterType_ == ShuffleWriterType::RowBased));
   reuseBufferedInputStream_ = shuffleReaderOptions_.reuseBufferedInputStream;
-  reuseColumnBuffer_ = shuffleReaderOptions_.reuseColumnBuffer;
-  if (reuseColumnBuffer_) {
+  if (shuffleReaderOptions_.reuseColumnBuffer) {
     columnBufferPool_ = std::make_shared<ColumnBufferPool>(arrowPool_.get());
   }
 }

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
@@ -87,6 +87,10 @@ SparkShuffleReader::SparkShuffleReader(
              shuffleReaderOptions_.rowBasedShuffleThreshold)) ||
        (shuffleWriterType_ == ShuffleWriterType::RowBased));
   reuseBufferedInputStream_ = shuffleReaderOptions_.reuseBufferedInputStream;
+  reuseColumnBuffer_ = shuffleReaderOptions_.reuseColumnBuffer;
+  if (reuseColumnBuffer_) {
+    columnBufferPool_ = std::make_shared<ColumnBufferPool>(arrowPool_.get());
+  }
 }
 
 void SparkShuffleReader::init() {
@@ -130,7 +134,8 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
               isRowBased_,
               zstdCodec_.get(),
               rowBufferPool_.get(),
-              row2ColConverter_.get());
+              row2ColConverter_.get(),
+              columnBufferPool_.get());
     }
 
     auto output = columnarBatchDeserializer_->next();
@@ -166,7 +171,8 @@ bytedance::bolt::RowVectorPtr SparkShuffleReader::getOutput() {
                 isRowBased_,
                 zstdCodec_.get(),
                 rowBufferPool_.get(),
-                row2ColConverter_.get());
+                row2ColConverter_.get(),
+                columnBufferPool_.get());
       } else {
         finished_ = true;
         return nullptr;
@@ -189,6 +195,10 @@ void SparkShuffleReader::close() {
   if (columnarBatchDeserializer_) {
     NanosecondTimer timer(&deserializerDestroyTime_);
     columnarBatchDeserializer_ = nullptr;
+  }
+
+  if (columnBufferPool_) {
+    columnBufferPool_->release();
   }
 
   {

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.h
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.h
@@ -143,11 +143,15 @@ class SparkShuffleReader : public bytedance::bolt::exec::SourceOperator {
   std::shared_ptr<RowBufferPool> rowBufferPool_{nullptr};
   std::shared_ptr<ShuffleRowToColumnarConverter> row2ColConverter_{nullptr};
 
+  std::shared_ptr<ColumnBufferPool> columnBufferPool_{nullptr};
+
   std::unique_ptr<BoltColumnarBatchDeserializer> columnarBatchDeserializer_;
 
   bool isRowBased_ = false;
 
   bool reuseBufferedInputStream_ = false;
+
+  bool reuseColumnBuffer_ = false;
 
   bool finished_ = false;
 };

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.h
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.h
@@ -151,8 +151,6 @@ class SparkShuffleReader : public bytedance::bolt::exec::SourceOperator {
 
   bool reuseBufferedInputStream_ = false;
 
-  bool reuseColumnBuffer_ = false;
-
   bool finished_ = false;
 };
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #903 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

introduce a ColumnBufferPool, that recycles the intermediate per-block column buffers across batches instead of returning them to the allocator on every batch.

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
