### PR TITLE
fix: align year formatting for large years with Spark

### DIFF
--- a/bolt/functions/lib/DateTimeFormatter.cpp
+++ b/bolt/functions/lib/DateTimeFormatter.cpp
@@ -1151,8 +1151,9 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
         size += 2;
         break;
       case DateTimeFormatSpecifier::YEAR_OF_ERA:
-        // Timestamp is in [-32767-01-01, 32767-12-31] range.
-        size += std::max((int)token.pattern.minRepresentDigits, 6);
+        // Timestamp covers years up to +/-292278994 (9 digits), plus one
+        // char for a leading sign.
+        size += std::max((int)token.pattern.minRepresentDigits, 9) + 1;
         break;
       case DateTimeFormatSpecifier::DAY_OF_WEEK_0_BASED:
       case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED:
@@ -1166,12 +1167,16 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
       case DateTimeFormatSpecifier::WEEK_YEAR:
         [[fallthrough]];
       case DateTimeFormatSpecifier::YEAR:
-        // Timestamp is in [-32767-01-01, 32767-12-31] range.
+        // Timestamp covers years up to +/-292278994 (9 digits), plus one
+        // char for a leading sign.
         size += token.pattern.minRepresentDigits == 2
             ? 2
-            : std::max((int)token.pattern.minRepresentDigits, 6);
+            : std::max((int)token.pattern.minRepresentDigits, 9) + 1;
         break;
       case DateTimeFormatSpecifier::CENTURY_OF_ERA:
+        // Century of +/-292278994 has up to 7 digits.
+        size += std::max((int)token.pattern.minRepresentDigits, 7);
+        break;
       case DateTimeFormatSpecifier::DAY_OF_YEAR:
         size += std::max((int)token.pattern.minRepresentDigits, 3);
         break;
@@ -1293,13 +1298,18 @@ int32_t DateTimeFormatter::format(
                 padContent(std::abs(year) % 100, '0', 2, maxResultEnd, result);
           } else {
             year = year <= 0 ? std::abs(year - 1) : year;
-            // spark compatibility: year should contain sign if > 9999.
+            // spark compatibility: Java DateTimeFormatter uses
+            // SignStyle.EXCEEDS_PAD for 4+ pattern letters, printing '+'
+            // when the year has more digits than the pattern width; legacy
+            // SimpleDateFormat never prints '+'.
             // However, if a timezone is applied and the same instant in UTC
             // has year-of-era <= 9999 (e.g., Asia/Shanghai at
             // 10000-01-01 07:59:59 equals 9999-12-31 23:59:59 UTC), suppress
             // the leading '+'.
-            bool addPlus = ::bytedance::bolt::kSparkCompatible && year > 9999 &&
-                token.pattern.minRepresentDigits >= 4;
+            bool addPlus = ::bytedance::bolt::kSparkCompatible &&
+                timePolicy != TimePolicy::LEGACY &&
+                token.pattern.minRepresentDigits >= 4 && year > 0 &&
+                countDigits(year) > token.pattern.minRepresentDigits;
             if (addPlus && timezone != nullptr) {
               const auto civilDateTimeUtc =
                   util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
@@ -1367,10 +1377,11 @@ int32_t DateTimeFormatter::format(
             }
             year = weekYear;
           }
-          if (::bytedance::bolt::kSparkCompatible && year < 0 &&
+          if (::bytedance::bolt::kSparkCompatible && year <= 0 &&
               (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
-            // for spark compatibility, year should be positive for LEGACY
-            // policy or has Era
+            // for spark compatibility, year should be the positive
+            // year-of-era for LEGACY policy or when the pattern has an Era:
+            // proleptic year 0 is 1 BC, -1 is 2 BC, etc.
             year = abs(year) + 1;
           }
           if (token.pattern.minRepresentDigits == 2) {
@@ -1383,16 +1394,21 @@ int32_t DateTimeFormatter::format(
                 maxResultEnd,
                 result);
           } else {
-            // spark compatibility: year should contain sign if > 9999.
+            // spark compatibility: Java DateTimeFormatter uses
+            // SignStyle.EXCEEDS_PAD for 4+ pattern letters, printing '+'
+            // when the year has more digits than the pattern width; legacy
+            // SimpleDateFormat never prints '+'.
             // If a timezone is applied and the same instant in UTC has
             // (adjusted) year <= 9999, suppress the leading '+'.
-            bool addPlus = ::bytedance::bolt::kSparkCompatible && year > 9999 &&
-                token.pattern.minRepresentDigits >= 4;
+            bool addPlus = ::bytedance::bolt::kSparkCompatible &&
+                timePolicy != TimePolicy::LEGACY &&
+                token.pattern.minRepresentDigits >= 4 && year > 0 &&
+                countDigits(year) > token.pattern.minRepresentDigits;
             if (addPlus && timezone != nullptr) {
               const auto civilDateTimeUtc =
                   util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
               auto utcYear = civilDateTimeUtc.date.year;
-              if (utcYear < 0 &&
+              if (utcYear <= 0 &&
                   (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
                 utcYear = std::abs(utcYear) + 1;
               }

--- a/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/bolt/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1492,21 +1492,21 @@ TEST_F(JodaDateTimeFormatterTest, parseConsecutiveSpecifiers) {
 TEST_F(JodaDateTimeFormatterTest, formatResultSize) {
   auto* timezone = tz::locateZone("GMT");
 
+  // Year can have up to 9 digits (+/-292278994) plus a leading sign.
   EXPECT_EQ(
-      buildJodaDateTimeFormatter("yyyy-MM-dd")->maxResultSize(timezone), 12);
-  EXPECT_EQ(buildJodaDateTimeFormatter("yyyy-MM")->maxResultSize(timezone), 9);
-  EXPECT_EQ(buildJodaDateTimeFormatter("y")->maxResultSize(timezone), 6);
+      buildJodaDateTimeFormatter("yyyy-MM-dd")->maxResultSize(timezone), 16);
+  EXPECT_EQ(buildJodaDateTimeFormatter("yyyy-MM")->maxResultSize(timezone), 13);
+  EXPECT_EQ(buildJodaDateTimeFormatter("y")->maxResultSize(timezone), 10);
   EXPECT_EQ(
       buildJodaDateTimeFormatter("yyyy////MM////dd")->maxResultSize(timezone),
-      18);
+      22);
   EXPECT_EQ(
       buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS")
           ->maxResultSize(timezone),
-      31);
-  // No padding. CENTURY_OF_ERA can be at most 3 digits.
-  EXPECT_EQ(buildJodaDateTimeFormatter("C")->maxResultSize(timezone), 3);
-  // Needs to pad to make result contain 4 digits.
-  EXPECT_EQ(buildJodaDateTimeFormatter("CCCC")->maxResultSize(timezone), 4);
+      35);
+  // No padding. CENTURY_OF_ERA can be at most 7 digits.
+  EXPECT_EQ(buildJodaDateTimeFormatter("C")->maxResultSize(timezone), 7);
+  EXPECT_EQ(buildJodaDateTimeFormatter("CCCC")->maxResultSize(timezone), 7);
 }
 
 class MysqlDateTimeTest : public DateTimeFormatterTest {};

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -2202,7 +2202,8 @@ TEST_F(SparkSqlDateTimeFunctionsTest, CastStringToLargeTimestamp) {
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkParity) {
-  const std::string prefix = ::bytedance::bolt::kSparkCompatible ? "+" : "";
+  const std::string correctedPrefix =
+      ::bytedance::bolt::kSparkCompatible ? "+" : "";
   auto fromUnixTime = [&](int64_t unixTime) {
     return evaluateOnce<std::string>(
                "from_unixtime(c0, 'yyyy-MM-dd HH:mm:ss')",
@@ -2211,34 +2212,88 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkParity) {
   };
 
   std::vector<std::pair<int64_t, std::string>> cases = {
-      {1764593923251, prefix + "57887-10-03 18:40:51"},
-      {1764592804143, prefix + "57887-09-20 19:49:03"},
-      {1764593758503, prefix + "57887-10-01 20:55:03"},
-      {1764590772393, prefix + "57887-08-28 07:26:33"},
-      {1764593528791, prefix + "57887-09-29 05:06:31"},
-      {1764593955077, prefix + "57887-10-04 03:31:17"},
-      {1764593666320, prefix + "57887-09-30 19:18:40"},
-      {1764593144444, prefix + "57887-09-24 18:20:44"},
-      {1764594190546, prefix + "57887-10-06 20:55:46"},
-      {1764593098611, prefix + "57887-09-24 05:36:51"},
-      {1764592074551, prefix + "57887-09-12 09:09:11"},
-      {1764590721621, prefix + "57887-08-27 17:20:21"},
-      {1764590914524, prefix + "57887-08-29 22:55:24"},
-      {1764592158681, prefix + "57887-09-13 08:31:21"},
-      {1764590816700, prefix + "57887-08-28 19:45:00"},
-      {1764591795161, prefix + "57887-09-09 03:32:41"},
-      {1764594152392, prefix + "57887-10-06 10:19:52"},
-      {1764593373289, prefix + "57887-09-27 09:54:49"},
-      {1764591622807, prefix + "57887-09-07 03:40:07"},
-      {1764592069089, prefix + "57887-09-12 07:38:09"},
+      {1764593923251, "57887-10-03 18:40:51"},
+      {1764592804143, "57887-09-20 19:49:03"},
+      {1764593758503, "57887-10-01 20:55:03"},
+      {1764590772393, "57887-08-28 07:26:33"},
+      {1764593528791, "57887-09-29 05:06:31"},
+      {1764593955077, "57887-10-04 03:31:17"},
+      {1764593666320, "57887-09-30 19:18:40"},
+      {1764593144444, "57887-09-24 18:20:44"},
+      {1764594190546, "57887-10-06 20:55:46"},
+      {1764593098611, "57887-09-24 05:36:51"},
+      {1764592074551, "57887-09-12 09:09:11"},
+      {1764590721621, "57887-08-27 17:20:21"},
+      {1764590914524, "57887-08-29 22:55:24"},
+      {1764592158681, "57887-09-13 08:31:21"},
+      {1764590816700, "57887-08-28 19:45:00"},
+      {1764591795161, "57887-09-09 03:32:41"},
+      {1764594152392, "57887-10-06 10:19:52"},
+      {1764593373289, "57887-09-27 09:54:49"},
+      {1764591622807, "57887-09-07 03:40:07"},
+      {1764592069089, "57887-09-12 07:38:09"},
   };
 
+  // Corrected policy is Spark's default formatting path (java.time), which
+  // prints a leading '+' for years beyond the pattern width. Bolt's default
+  // policy is legacy, so set it explicitly.
+  setTimeParserPolicy("corrected");
+  for (const auto& [input, expected] : cases) {
+    EXPECT_EQ(fromUnixTime(input), correctedPrefix + expected) << input;
+  }
+
+  // Legacy policy uses SimpleDateFormat, which never prints a leading '+'
+  // for years beyond 9999.
+  setTimeParserPolicy("legacy");
   for (const auto& [input, expected] : cases) {
     EXPECT_EQ(fromUnixTime(input), expected) << input;
   }
+  resetQueryConfig();
+}
+
+// Expected values below were produced by the Java classes Spark formats
+// with: java.time.format.DateTimeFormatter (corrected policy, with Spark's
+// y->u pattern rewrite) and java.text.SimpleDateFormat (legacy policy).
+TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeYearSignEdgeCases) {
+  if (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
+  auto fromUnixTime = [&](int64_t unixTime, const std::string& format) {
+    return evaluateOnce<std::string>(
+               fmt::format("from_unixtime(c0, '{}')", format),
+               std::optional<int64_t>{unixTime})
+        .value();
+  };
+
+  setTimeParserPolicy("corrected");
+  // Six-digit year: sign plus all digits. Used to be truncated because
+  // maxResultSize still assumed the pre-CivilDateTime +/-32767 year range.
+  EXPECT_EQ(
+      fromUnixTime(3093527980800, "yyyy-MM-dd HH:mm:ss"),
+      "+100000-01-01 00:00:00");
+  // Java SignStyle.EXCEEDS_PAD prints '+' only when the year has more
+  // digits than the pattern width, not for any year > 9999.
+  EXPECT_EQ(fromUnixTime(1764570096000, "yyyyy"), "57887");
+  // Negative year keeps its sign in addition to zero padding.
+  EXPECT_EQ(fromUnixTime(-62198784344, "yyyyyy"), "-000002");
+  // Proleptic year 0 is year-of-era 1 BC.
+  EXPECT_EQ(fromUnixTime(-62167219200, "yyyy G"), "0001 BC");
+  // Large BC year-of-era also gets the EXCEEDS_PAD sign; used to throw
+  // because the '+' overflowed the undersized result buffer.
+  EXPECT_EQ(fromUnixTime(-3217862448344, "yyyy G"), "+100002 BC");
+
+  setTimeParserPolicy("legacy");
+  // SimpleDateFormat never prints a leading '+'.
+  EXPECT_EQ(
+      fromUnixTime(3093527980800, "yyyy-MM-dd HH:mm:ss"),
+      "100000-01-01 00:00:00");
+  resetQueryConfig();
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkTimezone) {
+  // Expected values follow Spark's default (corrected) formatting; Bolt's
+  // default policy is legacy, which never prints a leading '+'.
+  setTimeParserPolicy("corrected");
   auto fromUnixTime = [&](int64_t unixTime, std::string timeZone) {
     return evaluateOnce<std::string>(
                fmt::format(


### PR DESCRIPTION
### What problem does this PR solve?

Year formatting in `DateTimeFormatter::format` (the `from_unixtime` / `date_format` path) diverges from Spark for years beyond 9999, in four ways uncovered by a 325,730-case differential test against Java ground truth (`java.time.DateTimeFormatter` with Spark's `y`→`u` rewrite for the corrected policy, `java.text.SimpleDateFormat` for legacy). See the linked issue for full details.

Issue Number: close #947

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Four fixes in `DateTimeFormatter.cpp`:

1. **Gate the leading `+` on non-LEGACY policies.** Spark's legacy path (`SimpleDateFormat`) never prints `+` for years beyond 9999; only the corrected path (java.time `SignStyle.EXCEEDS_PAD`) does. The sign was previously printed unconditionally.
2. **Match `SignStyle.EXCEEDS_PAD` exactly.** Java prints the sign only when the year has more digits than the pattern width, not for any year > 9999. Replaced the hardcoded `year > 9999` with `countDigits(year) > minRepresentDigits` — e.g. `yyyyy` on year 57887 (5 digits = width 5) must print `57887`, not `+57887`.
3. **Fix `maxResultSize()` for the extended year range.** It still sized YEAR / YEAR_OF_ERA fields for the pre-CivilDateTime ±32767 range (6 chars). Since the range extension to ±292278994, years with 6+ digits were silently truncated into corrupt output, and `yyyy G` with large BC years threw `BoltRuntimeError` (the `+` overflowed the buffer). Now sized for 9 digits plus a sign; CENTURY_OF_ERA for 7 digits.
4. **Year-0 era off-by-one.** Proleptic year 0 is 1 BC: the era adjustment used `year < 0` and formatted year 0 as `0000 BC` instead of `0001 BC` (Java/Spark behavior). Changed to `year <= 0` (and the same for the UTC-year computation in the `+`-suppression check).

Test changes:

- `FromUnixtimeLargeValuesSparkParity` / `FromUnixtimeLargeValuesSparkTimezone` recorded Spark's **default**-policy output (corrected formatting, with `+`) but ran under Bolt's `QueryConfig` default `timeParserPolicy = "legacy"` — they only passed because bug 1 masked the policy mismatch. The full case table now runs under both policies: `corrected` expecting the `+` prefix and `legacy` expecting none. (Production via Gluten is unaffected: the native side defaults to `corrected` when the session conf is not set.)
- New `FromUnixtimeYearSignEdgeCases` pins Java-derived expectations for: a 6-digit year with sign (previously truncated), the EXCEEDS_PAD width rule, negative-year zero padding, year 0 as `0001 BC`, a large BC era year (previously threw), and legacy without `+`.
- `JodaDateTimeFormatterTest.formatResultSize` updated to the new (correct) size bounds.

**Verification:** after the fix the differential suite matches Java on all ~150k legacy cases and all corrected cases except two known pre-existing classes unrelated to year formatting (post-2037 DST extrapolation and pre-1883 LMT timezone rules, plus the deliberate UTC-year `+`-suppression from 9f5eefa54) — overall diffs dropped from 110,223 to 6,782, none of them year-digit related.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

`maxResultSize()` now reserves a few more bytes per year field for string results; the formatting hot loop is unchanged apart from a `countDigits` call on the already-computed year.

### Release Note

```text
Release Note:
- Fixed year formatting for years beyond 9999 to match Spark: no leading '+' under legacy time parser policy, '+' only when the year exceeds the pattern width (Java SignStyle.EXCEEDS_PAD), no truncated/corrupt output or errors for years with 6+ digits, and proleptic year 0 now formats as era year 0001 BC.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
