### PR TITLE
feat: implement Spark shiftrightunsigned scalar function

### DIFF
--- a/bolt/functions/sparksql/Bitwise.h
+++ b/bolt/functions/sparksql/Bitwise.h
@@ -114,6 +114,32 @@ struct ShiftRightFunction {
 };
 
 template <typename T>
+struct ShiftRightUnsignedFunction {
+  template <typename TInput1, typename TInput2>
+  FOLLY_ALWAYS_INLINE void call(TInput1& result, TInput1 a, TInput2 b) {
+    if constexpr (std::is_same_v<TInput1, int32_t>) {
+      if (b < 0) {
+        b = b % 32 + 32;
+      }
+      if (b >= 32) {
+        b = b % 32;
+      }
+    }
+    if constexpr (std::is_same_v<TInput1, int64_t>) {
+      if (b < 0) {
+        b = b % 64 + 64;
+      }
+      if (b >= 64) {
+        b = b % 64;
+      }
+    }
+    // Java's >>> : shift the bit pattern, not the signed value.
+    using TUnsigned = std::make_unsigned_t<TInput1>;
+    result = static_cast<TInput1>(static_cast<TUnsigned>(a) >> b);
+  }
+};
+
+template <typename T>
 struct BitCountFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(int32_t& result, TInput num) {

--- a/bolt/functions/sparksql/registration/RegisterBitwise.cpp
+++ b/bolt/functions/sparksql/registration/RegisterBitwise.cpp
@@ -68,6 +68,11 @@ void registerBitwiseFunctions(const std::string& prefix) {
       {prefix + "shiftright"});
   registerFunction<ShiftRightFunction, int64_t, int64_t, int32_t>(
       {prefix + "shiftright"});
+
+  registerFunction<ShiftRightUnsignedFunction, int32_t, int32_t, int32_t>(
+      {prefix + "shiftrightunsigned"});
+  registerFunction<ShiftRightUnsignedFunction, int64_t, int64_t, int32_t>(
+      {prefix + "shiftrightunsigned"});
 }
 
 } // namespace bytedance::bolt::functions::sparksql

--- a/bolt/functions/sparksql/tests/BitwiseTest.cpp
+++ b/bolt/functions/sparksql/tests/BitwiseTest.cpp
@@ -109,6 +109,18 @@ class BitwiseTest : public SparkFunctionBaseTest {
       std::optional<T2> b) {
     return evaluateOnce<T1>("shiftright(c0, c1)", a, b);
   }
+
+  template <typename T>
+  std::optional<T> shiftRightUnsigned(std::optional<T> a, std::optional<T> b) {
+    return evaluateOnce<T>("shiftrightunsigned(c0, c1)", a, b);
+  }
+
+  template <typename T1, typename T2>
+  std::optional<T1> shiftRightUnsigned_twoTypes(
+      std::optional<T1> a,
+      std::optional<T2> b) {
+    return evaluateOnce<T1>("shiftrightunsigned(c0, c1)", a, b);
+  }
 };
 
 TEST_F(BitwiseTest, bitwiseAnd) {
@@ -298,6 +310,37 @@ TEST_F(BitwiseTest, shiftRight) {
   EXPECT_EQ((shiftRight_twoTypes<int64_t, int32_t>(kMax64, 1)), kMax64 >> 1);
   EXPECT_EQ(
       (shiftRight_twoTypes<int64_t, int32_t>(kMin64, 1)), -4611686018427387904);
+}
+
+TEST_F(BitwiseTest, shiftRightUnsigned) {
+  // Logical shift: vacated high bits are zero-filled, as with Java's >>>.
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(-1, 1), kMax32);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(-3, 1), 2147483646);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(kMin32, 1), 1073741824);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(kMin32, 31), 1);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(kMax32, 1), kMax32 >> 1);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(kMax32, kMax32), 0);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(0, 5), 0);
+
+  // Shift count is reduced modulo the type width, as in Java.
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(-1, 32), -1);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(-1, 33), kMax32);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(-1, -1), 1);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(-1, kMin32), -1);
+
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(std::nullopt, 1), std::nullopt);
+  EXPECT_EQ(shiftRightUnsigned<int32_t>(1, std::nullopt), std::nullopt);
+
+  EXPECT_EQ((shiftRightUnsigned_twoTypes<int64_t, int32_t>(-1, 1)), kMax64);
+  EXPECT_EQ(
+      (shiftRightUnsigned_twoTypes<int64_t, int32_t>(kMin64, 1)),
+      4611686018427387904);
+  EXPECT_EQ((shiftRightUnsigned_twoTypes<int64_t, int32_t>(kMin64, 63)), 1);
+  EXPECT_EQ(
+      (shiftRightUnsigned_twoTypes<int64_t, int32_t>(kMax64, 1)), kMax64 >> 1);
+  EXPECT_EQ((shiftRightUnsigned_twoTypes<int64_t, int32_t>(-1, 64)), -1);
+  EXPECT_EQ((shiftRightUnsigned_twoTypes<int64_t, int32_t>(-1, 65)), kMax64);
+  EXPECT_EQ((shiftRightUnsigned_twoTypes<int64_t, int32_t>(-1, -1)), 1);
 }
 
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #927

Bolt registers Spark's `shiftleft` and `shiftright` but not `shiftrightunsigned`
(Java's `>>>`), so a query using it cannot be offloaded and falls back.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Adds `shiftrightunsigned` for `(int, int) -> int` and `(bigint, int) -> bigint`,
matching Java's `>>>` as used by Spark's `ShiftRightUnsigned`
(`sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala`):
a logical shift of the bit pattern with the shift count reduced modulo the type
width.

**How.** `ShiftRightUnsignedFunction` is added next to `ShiftRightFunction` in
`bolt/functions/sparksql/Bitwise.h`. The shift-count normalization is copied
verbatim from `ShiftRightFunction` — the repo keeps `ShiftLeftFunction` and
`ShiftRightFunction` as separate, duplicated structs, and this follows that
shape rather than refactoring the three into one. The only difference is the
shift itself, which operates on `std::make_unsigned_t<TInput1>` and casts back,
so vacated high bits are zero-filled instead of sign-filled.

**Why the two-step count normalization is load-bearing.** For negative `b`, C++
`%` truncates toward zero, so `b % W` is in `(-W, 0]` and `b % W + W` is in
`(0, W]`. The value `W` is reachable when `b % W == 0` — e.g. `INT32_MIN`, which
is divisible by both 32 and 64 — and the second `if (b >= W)` folds that to 0.
Both branches together leave the count in `[0, W)` for every `int32` input, so
the shift is always defined. `shiftrightunsigned(-1, -2147483648)` returning
`-1` covers this case in the tests.

**Why the cast back is well defined.** The build is C++23
(`CMakeLists.txt:531`), where converting an out-of-range unsigned value to a
signed type is defined as the congruent value modulo 2^N, i.e. the two's
complement bit pattern. `TUnsigned` is `uint32_t`/`uint64_t`, both of rank at
least `int`, so no integer promotion to a signed type happens before the shift.

**Why only two signatures.** Spark's `ShiftRightUnsigned.inputTypes` is
`(IntegralType, IntegerType)`, and the analyzer promotes `tinyint`/`smallint`
operands to `int` (`shiftrightunsigned(cast(1 as tinyint), 1)` has result type
`int`) and casts a `bigint` shift count down to `int`. These two registrations
are therefore the complete surface, and they match what `shiftright` registers.

Upstream Velox does not implement this function — it appears only in Velox's
coverage data and `coverage.rst` — so there is no upstream implementation to
port from.

**No new files and no CMake changes.** Nothing else needs updating:
`coverage/data/all_scalar_functions.txt` is the full `SHOW FUNCTIONS` list and
already contains the name, and the Spark expression fuzzer enumerates the whole
registry via `getFunctionSignatures()` with an opt-out skip list, so the new
function is fuzzed automatically without an entry.

#### Validation

Run and passing: `pre-commit run --files` over the three touched files —
"Format C++ files" (clang-format 14.0.6) passed. clang-tidy was skipped because
there is no local `compile_commands.json`; CI's `pre-commit-checks.yml` skips
that hook in the same way (`SKIP: clang-tidy`), and the dedicated clang-tidy job
in `build-test.yml` covers it against a configured build.

Expected values: the constants in `BitwiseTest.shiftRightUnsigned` were derived
from Java `>>>` semantics — a logical shift with the count reduced modulo the
type width — and then cross-checked row by row against Apache Spark 4.2.0
(pyspark 4.2.0 on Temurin JDK 21.0.12), covering all 18 int and bigint cases
including the modulo-width and negative-count rows. All 18 agree with the C++
expectations; no expected value needed changing.

Remaining validation gap: the C++ has not been compiled or executed. Opening as
a draft until this passes:

```
make debug
_build/debug/bolt/functions/sparksql/tests/bolt_functions_spark_test \
  --gtest_filter='BitwiseTest.*'
```

### Performance Impact

- [x] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] Positive Impact: I have run benchmarks.
- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

Purely additive: one new struct in a header and two new registrations. No
existing function, signature, or code path is modified, so no existing query
plan changes shape.

### Release Note

```
Release Note:
- Added the Spark `shiftrightunsigned` scalar function for int and bigint inputs.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest). `BitwiseTest.shiftRightUnsigned` — added, not yet executed; see Validation.
- [ ] I have verified the code with local build (Release/Debug). Not yet — see Validation.
- [x] I have run clang-format / linters. `pre-commit run --files` on the three touched files: "Format C++ files" passed; clang-tidy skipped for lack of a local `compile_commands.json`, as CI's `pre-commit-checks.yml` also does.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
