### PR TITLE
feat: support Spark octet_length

### DIFF
--- a/bolt/functions/sparksql/String.h
+++ b/bolt/functions/sparksql/String.h
@@ -120,6 +120,17 @@ struct BitLengthFunction {
   }
 };
 
+/// Returns the number of bytes in a string or binary value.
+template <typename T>
+struct OctetLengthFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const TInput& input) {
+    result = input.size();
+  }
+};
+
 /// chr function
 /// chr(n) -> string
 /// Returns the Unicode code point ``n`` as a single character string.

--- a/bolt/functions/sparksql/registration/RegisterString.cpp
+++ b/bolt/functions/sparksql/registration/RegisterString.cpp
@@ -186,6 +186,10 @@ void registerStringFunctions(const std::string& prefix) {
       {prefix + "bit_length"});
   registerFunction<sparksql::BitLengthFunction, int32_t, Varbinary>(
       {prefix + "bit_length"});
+  registerFunction<sparksql::OctetLengthFunction, int32_t, Varchar>(
+      {prefix + "octet_length"});
+  registerFunction<sparksql::OctetLengthFunction, int32_t, Varbinary>(
+      {prefix + "octet_length"});
   registerFunction<Empty2NullFunction, Varchar, Varchar>(
       {prefix + "empty2null"});
 

--- a/bolt/functions/sparksql/tests/StringTest.cpp
+++ b/bolt/functions/sparksql/tests/StringTest.cpp
@@ -353,6 +353,35 @@ TEST_F(StringTest, bitLengthVarbinary) {
   EXPECT_EQ(bitLength("\U0001F408"), 32);
 }
 
+TEST_F(StringTest, octetLength) {
+  const auto octetLength = [&](const std::optional<std::string>& arg) {
+    return evaluateOnce<int32_t>("octet_length(c0)", arg);
+  };
+
+  EXPECT_EQ(octetLength(std::nullopt), std::nullopt);
+  EXPECT_EQ(octetLength(""), 0);
+  EXPECT_EQ(octetLength(std::string("\0", 1)), 1);
+  EXPECT_EQ(octetLength("123"), 3);
+  EXPECT_EQ(octetLength("😋"), 4);
+  EXPECT_EQ(octetLength(kWomanFacepalmingLightSkinTone), 17);
+
+  const std::string largeInput(1'048'576, 'a');
+  EXPECT_EQ(octetLength(largeInput), 1'048'576);
+}
+
+TEST_F(StringTest, octetLengthVarbinary) {
+  const auto octetLength = [&](const std::optional<std::string>& arg) {
+    return evaluateOnce<int32_t, std::string>(
+        "octet_length(c0)", {arg}, {VARBINARY()});
+  };
+
+  EXPECT_EQ(octetLength(std::nullopt), std::nullopt);
+  EXPECT_EQ(octetLength(""), 0);
+  EXPECT_EQ(octetLength("123"), 3);
+  EXPECT_EQ(octetLength(std::string("\0\xff", 2)), 2);
+  EXPECT_EQ(octetLength("😋"), 4);
+}
+
 TEST_F(StringTest, chr) {
   EXPECT_EQ(chr(-16), "");
   EXPECT_EQ(chr(0), std::string("\0", 1));


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Bolt does not support Spark's `octet_length` function for string and binary inputs. As a result, projections that use it fall back to a non-native execution path.

Issue Number: close #922

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Implement and register `octet_length` for VARCHAR and VARBINARY inputs using byte-length semantics. Add coverage for null propagation, multibyte UTF-8, binary data, and non-inline strings.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: The implementation reads the existing input byte size and writes the result without introducing additional allocations.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Release Note:

```text
Release Note:
- Added Spark `octet_length` support for string and binary inputs.
```

### Validation

- `StringTest.octetLength` and `StringTest.octetLengthVarbinary`: passed in Release and Debug.
- Full Release `bolt_functions_spark_test`: 724 tests passed.
- Representative Spark STRING and BINARY queries executed through Gluten + Bolt matched vanilla Spark. The target projections used `ProjectExecTransformer` instead of the fallback described in #922.

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
