### PR TITLE
fix(build): guard glog with_unwind for non-Linux platforms

### DIFF
--- a/bolt/functions/prestosql/ArithmeticImpl.h
+++ b/bolt/functions/prestosql/ArithmeticImpl.h
@@ -42,7 +42,11 @@ namespace bytedance::bolt::functions {
 /// Round function
 /// when AlwaysRoundNegDec is false, presto semantics is followed which does not
 /// round negative decimals for integrals and round it otherwise
-template <typename TNum, typename TDecimals, bool alwaysRoundNegDec = false>
+template <
+    typename TNum,
+    typename TDecimals,
+    bool alwaysRoundNegDec = false,
+    BigDecimal::RoundingMode mode = BigDecimal::RoundingMode::kHalfUp>
 FOLLY_ALWAYS_INLINE TNum
 round(const TNum& number, const TDecimals& decimals = 0) {
   static_assert(!std::is_same_v<TNum, bool> && "round not supported for bool");
@@ -68,10 +72,21 @@ round(const TNum& number, const TDecimals& decimals = 0) {
       int128_t value = static_cast<int128_t>(number);
       int128_t quotient = value / scalingFactor;
       int128_t remainder = value % scalingFactor;
-      if (value >= 0 && remainder >= scalingFactor / 2) {
-        ++quotient;
-      } else if (remainder <= -scalingFactor / 2) {
-        --quotient;
+      if constexpr (mode == BigDecimal::RoundingMode::kHalfEven) {
+        // Compare |remainder| so the rule is symmetric for negative values;
+        // a tie moves the quotient away from zero only when it is odd.
+        const int128_t half = scalingFactor / 2;
+        const int128_t absRemainder = remainder < 0 ? -remainder : remainder;
+        if (absRemainder > half ||
+            (absRemainder == half && quotient % 2 != 0)) {
+          quotient += value >= 0 ? 1 : -1;
+        }
+      } else {
+        if (value >= 0 && remainder >= scalingFactor / 2) {
+          ++quotient;
+        } else if (remainder <= -scalingFactor / 2) {
+          --quotient;
+        }
       }
       int128_t rounded = quotient * scalingFactor;
       return static_cast<TNum>(rounded);
@@ -85,7 +100,7 @@ round(const TNum& number, const TDecimals& decimals = 0) {
 
   double dNumber = static_cast<double>(number);
   BigDecimal decimal(dNumber);
-  decimal.setScale(decimals);
+  decimal.setScale(decimals, mode);
   if constexpr (std::is_same_v<TNum, double>) {
     auto res = decimal.doubleValue();
     return res;

--- a/bolt/functions/sparksql/Arithmetic.h
+++ b/bolt/functions/sparksql/Arithmetic.h
@@ -215,6 +215,16 @@ struct RoundFunction {
 };
 
 template <typename T>
+struct BRoundFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  call(TInput& result, const TInput& a, const int32_t b = 0) {
+    result = bytedance::bolt::functions::
+        round<TInput, int32_t, true, BigDecimal::RoundingMode::kHalfEven>(a, b);
+  }
+};
+
+template <typename T>
 struct AcoshFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {

--- a/bolt/functions/sparksql/registration/RegisterMathMisc.cpp
+++ b/bolt/functions/sparksql/registration/RegisterMathMisc.cpp
@@ -41,6 +41,19 @@ void registerMathMiscFunctions(const std::string& prefix) {
       {prefix + "round"});
   registerFunction<RoundFunction, double, double, int32_t>({prefix + "round"});
   registerFunction<RoundFunction, float, float, int32_t>({prefix + "round"});
+
+  registerUnaryNumeric<BRoundFunction>({prefix + "bround"});
+  registerFunction<BRoundFunction, int8_t, int8_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, int16_t, int16_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, int32_t, int32_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, int64_t, int64_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, double, double, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, float, float, int32_t>({prefix + "bround"});
   registerFunction<RIntFunction, double, double>({prefix + "rint"});
 
   // Ceil and Floor functions

--- a/bolt/functions/sparksql/tests/SparkRoundTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkRoundTest.cpp
@@ -16,6 +16,8 @@
 
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
+#include <cmath>
+#include <limits>
 #include <type_traits>
 
 namespace bytedance::bolt::functions::sparksql::test {
@@ -24,9 +26,11 @@ namespace {
 class SparkRoundTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
-  void runRoundTest(const std::vector<std::tuple<T, T>>& data) {
+  void runRoundTest(
+      const std::vector<std::tuple<T, T>>& data,
+      const std::string& func = "round") {
     auto result = evaluate<SimpleVector<T>>(
-        "round(c0)", makeRowVector({makeFlatVector<T, 0>(data)}));
+        func + "(c0)", makeRowVector({makeFlatVector<T, 0>(data)}));
     for (int32_t i = 0; i < data.size(); ++i) {
       ASSERT_EQ(result->valueAt(i), std::get<1>(data[i]));
     }
@@ -34,9 +38,10 @@ class SparkRoundTest : public SparkFunctionBaseTest {
 
   template <typename T>
   void runRoundWithDecimalTest(
-      const std::vector<std::tuple<T, int32_t, T>>& data) {
+      const std::vector<std::tuple<T, int32_t, T>>& data,
+      const std::string& func = "round") {
     auto result = evaluate<SimpleVector<T>>(
-        "round(c0, c1)",
+        func + "(c0, c1)",
         makeRowVector(
             {makeFlatVector<T, 0>(data), makeFlatVector<int32_t, 1>(data)}));
     for (int32_t i = 0; i < data.size(); ++i) {
@@ -126,6 +131,81 @@ class SparkRoundTest : public SparkFunctionBaseTest {
         {123, -2, 100},
         {123, -3, 0}};
   }
+
+  // HALF_EVEN only differs from HALF_UP on exact ties, so most rows are ties;
+  // a few non-ties confirm the shared path is unchanged.
+  template <typename T>
+  std::vector<std::tuple<T, T>> testBRoundFloatData() {
+    return {
+        {0.5, 0.0},
+        {1.5, 2.0},
+        {2.5, 2.0},
+        {3.5, 4.0},
+        {-0.5, 0.0},
+        {-1.5, -2.0},
+        {-2.5, -2.0},
+        {-3.5, -4.0},
+        {1.9, 2.0},
+        {1.3, 1.0},
+        {0.0, 0.0}};
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testBRoundWithDecFloatData() {
+    std::vector<std::tuple<T, int32_t, T>> data = {
+        {2.5, 0, 2.0},
+        {-2.5, 0, -2.0},
+        {0.125, 2, 0.12},
+        {-0.125, 2, -0.12},
+        {0.135, 2, 0.14},
+        {0.585, 2, 0.58},
+        {1.615, 2, 1.62},
+        {1.129, 2, 1.13},
+        {-1.129, 1, -1.1},
+        {1.0 / 3, 2, 0.33},
+        {1250.0, -2, 1200.0},
+        {1350.0, -2, 1400.0},
+        {-1250.0, -2, -1200.0},
+        {11111.0, -1, 11110.0},
+        {5.0, -1, 0.0},
+        {15.0, -1, 20.0},
+        {25.0, -1, 20.0},
+        {1.0, -1, 0.0},
+        {0.0, -2, 0.0}};
+
+    // Spark widens float to double before taking the decimal string, so
+    // 0.575f is 0.574999988079071 and 2.675f is 2.6749999523162842: below
+    // the tie, rounded down under either mode. As doubles the strings are
+    // exact ties on an odd digit and round up.
+    if constexpr (std::is_same_v<T, float>) {
+      data.insert(
+          data.end(), {{0.575, 2, 0.57}, {-0.575, 2, -0.57}, {2.675, 2, 2.67}});
+    } else {
+      data.insert(
+          data.end(), {{0.575, 2, 0.58}, {-0.575, 2, -0.58}, {2.675, 2, 2.68}});
+    }
+    return data;
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testBRoundWithDecIntegralData() {
+    return {
+        {1, 0, 1},
+        {-1, 0, -1},
+        {1, 10, 1},
+        {5, -1, 0},
+        {15, -1, 20},
+        {25, -1, 20},
+        {35, -1, 40},
+        {-25, -1, -20},
+        {-35, -1, -40},
+        {24, -1, 20},
+        {26, -1, 30},
+        {125, -1, 120},
+        {123, -2, 100},
+        {123, -3, 0},
+        {12, -2, 0}};
+  }
 };
 
 TEST_F(SparkRoundTest, round) {
@@ -146,6 +226,44 @@ TEST_F(SparkRoundTest, roundWithDecimal) {
   runRoundWithDecimalTest<int32_t>(testRoundWithDecIntegralData<int32_t>());
   runRoundWithDecimalTest<int16_t>(testRoundWithDecIntegralData<int16_t>());
   runRoundWithDecimalTest<int8_t>(testRoundWithDecIntegralData<int8_t>());
+}
+
+TEST_F(SparkRoundTest, bround) {
+  runRoundTest<float>(testBRoundFloatData<float>(), "bround");
+  runRoundTest<double>(testBRoundFloatData<double>(), "bround");
+
+  runRoundTest<int64_t>(testRoundIntegralData<int64_t>(), "bround");
+  runRoundTest<int32_t>(testRoundIntegralData<int32_t>(), "bround");
+  runRoundTest<int16_t>(testRoundIntegralData<int16_t>(), "bround");
+  runRoundTest<int8_t>(testRoundIntegralData<int8_t>(), "bround");
+}
+
+TEST_F(SparkRoundTest, broundWithDecimal) {
+  runRoundWithDecimalTest<float>(testBRoundWithDecFloatData<float>(), "bround");
+  runRoundWithDecimalTest<double>(
+      testBRoundWithDecFloatData<double>(), "bround");
+
+  runRoundWithDecimalTest<int64_t>(
+      testBRoundWithDecIntegralData<int64_t>(), "bround");
+  runRoundWithDecimalTest<int32_t>(
+      testBRoundWithDecIntegralData<int32_t>(), "bround");
+  runRoundWithDecimalTest<int16_t>(
+      testBRoundWithDecIntegralData<int16_t>(), "bround");
+  runRoundWithDecimalTest<int8_t>(
+      testBRoundWithDecIntegralData<int8_t>(), "bround");
+}
+
+TEST_F(SparkRoundTest, broundNonFiniteAndNull) {
+  const auto bround = [&](std::optional<double> a, std::optional<int32_t> b) {
+    return evaluateOnce<double>("bround(c0, c1)", a, b);
+  };
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(std::isnan(bround(kNaN, 2).value()));
+  EXPECT_EQ(bround(kInf, 2), kInf);
+  EXPECT_EQ(bround(-kInf, 2), -kInf);
+  EXPECT_EQ(bround(std::nullopt, 2), std::nullopt);
+  EXPECT_EQ(bround(1.5, std::nullopt), std::nullopt);
 }
 
 } // namespace

--- a/bolt/type/BigDecimal.cpp
+++ b/bolt/type/BigDecimal.cpp
@@ -31,7 +31,7 @@ void BigDecimal::compactVal() {
   }
 }
 
-void BigDecimal::setScale(int newScale) {
+void BigDecimal::setScale(int newScale, RoundingMode mode) {
   if (scale == newScale || isZero) {
     return;
   }
@@ -40,9 +40,17 @@ void BigDecimal::setScale(int newScale) {
     int changeScale = scale - newScale;
     boost::multiprecision::cpp_int scaleVal = boost::multiprecision::pow(
         boost::multiprecision::cpp_int(10), changeScale);
-    boost::multiprecision::cpp_int quotient = intVal % scaleVal;
+    boost::multiprecision::cpp_int remainder = intVal % scaleVal;
     intVal /= scaleVal;
-    bool increment = quotient >= scaleVal / 2;
+    // intVal is the magnitude and sign is tracked separately, so incrementing
+    // rounds away from zero, matching java.math.RoundingMode semantics.
+    const boost::multiprecision::cpp_int half = scaleVal / 2;
+    bool increment;
+    if (mode == RoundingMode::kHalfEven) {
+      increment = remainder > half || (remainder == half && intVal % 2 != 0);
+    } else {
+      increment = remainder >= half;
+    }
     if (increment) {
       intVal++;
     }

--- a/bolt/type/BigDecimal.h
+++ b/bolt/type/BigDecimal.h
@@ -89,7 +89,13 @@ class BigDecimal {
     compactVal();
   }
 
-  void setScale(int newScale);
+  // Mirrors java.math.RoundingMode for the two modes Spark's round/bround use.
+  enum class RoundingMode {
+    kHalfUp, // ties away from zero
+    kHalfEven, // ties to the even neighbor
+  };
+
+  void setScale(int newScale, RoundingMode mode = RoundingMode::kHalfUp);
 
   int getScale() {
     return scale;

--- a/bolt/type/tests/BigDecimalTest.cpp
+++ b/bolt/type/tests/BigDecimalTest.cpp
@@ -98,6 +98,33 @@ TEST(BigDecimalTest, setScale) {
   }
 }
 
+TEST(BigDecimalTest, setScaleHalfEven) {
+  // (input, newScale, expected). All ties except the last two.
+  std::vector<std::tuple<double, int, double>> testData = {
+      {2.5, 0, 2.0},
+      {3.5, 0, 4.0},
+      {-2.5, 0, -2.0},
+      {-3.5, 0, -4.0},
+      {0.125, 2, 0.12},
+      {0.135, 2, 0.14},
+      {2.675, 2, 2.68},
+      {1250.0, -2, 1200.0},
+      {1350.0, -2, 1400.0},
+      {2.674, 2, 2.67},
+      {2.676, 2, 2.68}};
+  for (const auto& data : testData) {
+    BigDecimal decimal(std::get<0>(data));
+    decimal.setScale(std::get<1>(data), BigDecimal::RoundingMode::kHalfEven);
+    EXPECT_EQ(decimal.getScale(), std::get<1>(data));
+    EXPECT_EQ(decimal.doubleValue(), std::get<2>(data));
+  }
+
+  // The default mode is still HALF_UP.
+  BigDecimal decimal(2.5);
+  decimal.setScale(0);
+  EXPECT_EQ(decimal.doubleValue(), 3.0);
+}
+
 } // namespace
 
 } // namespace bytedance::bolt

--- a/conanfile.py
+++ b/conanfile.py
@@ -329,6 +329,9 @@ class BoltConan(ConanFile):
                 run=True,
                 options={"shared": test_runtime_shared},
             )
+            glog_options = {"shared": test_runtime_shared}
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                glog_options["with_unwind"] = False
             self.requires(
                 "glog/0.7.1",
                 build=True,
@@ -336,7 +339,7 @@ class BoltConan(ConanFile):
                 headers=True,
                 libs=True,
                 run=True,
-                options={"shared": test_runtime_shared, "with_unwind": False},
+                options=glog_options,
             )
         if not self.conf.get("tools.build:skip_test", default=True):
             self.test_requires("jemalloc/5.3.0")
@@ -349,7 +352,8 @@ class BoltConan(ConanFile):
 
     # Set default options of third parties here
     def configure(self):
-        self.options[glog].with_unwind = False
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.options[glog].with_unwind = False
         if self.options.shared:
             self.options[gflags].shared = True
             self.options[glog].shared = True


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #951

On macOS, `make debug` fails during dependency resolution, before any
compilation starts:

```
ERROR: option 'with_unwind' doesn't exist
Possible options are ['shared', 'fPIC', 'with_gflags', 'with_threads']
```

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

glog's recipe deletes `with_unwind` in `config_options` on any platform that
is not Linux or FreeBSD, because libunwind is Linux-only. That is why the
error lists only four remaining options. `conanfile.py` sets the option
unconditionally at two sites:

- `build_requirements()`, in the `options` dict passed to the `glog/0.7.1`
  requirement
- `configure()`, as `self.options[glog].with_unwind = False`

Both are now guarded with `self.settings.os in ["Linux", "FreeBSD"]` — the
same predicate the file already uses a few lines above to gate the
`libunwind/1.8.3` requirement itself, so the two stay consistent by
construction.

At the `build_requirements()` site the option dict is built up before the
`self.requires(...)` call rather than inlined, so the key is simply absent on
platforms where glog does not define it.

The value being set was `False`, and glog on macOS behaves as unwind-off
regardless, so omitting the option is semantically identical. Linux and
FreeBSD resolve exactly as before.

#### Validation

Environment: macOS arm64 (Apple Silicon), apple-clang 17, conan 2.22.2,
Python 3.13.

Before this change, `conan graph info` aborts with the error above after
resolving the full recipe graph, so no package is ever built.

After this change, on the same machine:

- dependency graph resolution completes
- `glog/0.7.1` builds successfully in both contexts — package IDs
  `c72e7d7d15fae91c9d53aef22941bd644fd0115a` and
  `fa80f5faed83431df58a4407c7136882f6585b32`
- the dependency build continues past glog through the rest of the graph
  (arrow, boost, duckdb, icu, protobuf and the remainder)

No Linux behaviour is exercised by this change; the guarded branch is the
one that already runs there today.

### Performance Impact

- [x] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] Positive Impact: I have run benchmarks.
- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

Build configuration only. No runtime code is touched.

### Release Note

```
Release Note:
- Fixed macOS builds failing during Conan dependency resolution because the glog `with_unwind` option was set on platforms where glog does not define it.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest). Not applicable — build configuration change.
- [x] I have verified the code with local build (Release/Debug). Debug build on macOS arm64; glog builds and the dependency build proceeds.
- [ ] I have run clang-format / linters. Not applicable — Python, no C++ touched.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
