### PR TITLE
fix(build): guard glog with_unwind for non-Linux platforms

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -329,6 +329,9 @@ class BoltConan(ConanFile):
                 run=True,
                 options={"shared": test_runtime_shared},
             )
+            glog_options = {"shared": test_runtime_shared}
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                glog_options["with_unwind"] = False
             self.requires(
                 "glog/0.7.1",
                 build=True,
@@ -336,7 +339,7 @@ class BoltConan(ConanFile):
                 headers=True,
                 libs=True,
                 run=True,
-                options={"shared": test_runtime_shared, "with_unwind": False},
+                options=glog_options,
             )
         if not self.conf.get("tools.build:skip_test", default=True):
             self.test_requires("jemalloc/5.3.0")
@@ -349,7 +352,8 @@ class BoltConan(ConanFile):
 
     # Set default options of third parties here
     def configure(self):
-        self.options[glog].with_unwind = False
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.options[glog].with_unwind = False
         if self.options.shared:
             self.options[gflags].shared = True
             self.options[glog].shared = True


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #951

On macOS, `make debug` fails during dependency resolution, before any
compilation starts:

```
ERROR: option 'with_unwind' doesn't exist
Possible options are ['shared', 'fPIC', 'with_gflags', 'with_threads']
```

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

glog's recipe deletes `with_unwind` in `config_options` on any platform that
is not Linux or FreeBSD, because libunwind is Linux-only. That is why the
error lists only four remaining options. `conanfile.py` sets the option
unconditionally at two sites:

- `build_requirements()`, in the `options` dict passed to the `glog/0.7.1`
  requirement
- `configure()`, as `self.options[glog].with_unwind = False`

Both are now guarded with `self.settings.os in ["Linux", "FreeBSD"]` — the
same predicate the file already uses a few lines above to gate the
`libunwind/1.8.3` requirement itself, so the two stay consistent by
construction.

At the `build_requirements()` site the option dict is built up before the
`self.requires(...)` call rather than inlined, so the key is simply absent on
platforms where glog does not define it.

The value being set was `False`, and glog on macOS behaves as unwind-off
regardless, so omitting the option is semantically identical. Linux and
FreeBSD resolve exactly as before.

#### Validation

Environment: macOS arm64 (Apple Silicon), apple-clang 17, conan 2.22.2,
Python 3.13.

Before this change, `conan graph info` aborts with the error above after
resolving the full recipe graph, so no package is ever built.

After this change, on the same machine:

- dependency graph resolution completes
- `glog/0.7.1` builds successfully in both contexts — package IDs
  `c72e7d7d15fae91c9d53aef22941bd644fd0115a` and
  `fa80f5faed83431df58a4407c7136882f6585b32`
- the dependency build continues past glog through the rest of the graph
  (arrow, boost, duckdb, icu, protobuf and the remainder)

No Linux behaviour is exercised by this change; the guarded branch is the
one that already runs there today.

### Performance Impact

- [x] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] Positive Impact: I have run benchmarks.
- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

Build configuration only. No runtime code is touched.

### Release Note

```
Release Note:
- Fixed macOS builds failing during Conan dependency resolution because the glog `with_unwind` option was set on platforms where glog does not define it.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest). Not applicable — build configuration change.
- [x] I have verified the code with local build (Release/Debug). Debug build on macOS arm64; glog builds and the dependency build proceeds.
- [ ] I have run clang-format / linters. Not applicable — Python, no C++ touched.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
