### PR TITLE
feat: implement Spark bround scalar function with HALF_EVEN rounding

### DIFF
--- a/bolt/functions/prestosql/ArithmeticImpl.h
+++ b/bolt/functions/prestosql/ArithmeticImpl.h
@@ -42,7 +42,11 @@ namespace bytedance::bolt::functions {
 /// Round function
 /// when AlwaysRoundNegDec is false, presto semantics is followed which does not
 /// round negative decimals for integrals and round it otherwise
-template <typename TNum, typename TDecimals, bool alwaysRoundNegDec = false>
+template <
+    typename TNum,
+    typename TDecimals,
+    bool alwaysRoundNegDec = false,
+    BigDecimal::RoundingMode mode = BigDecimal::RoundingMode::kHalfUp>
 FOLLY_ALWAYS_INLINE TNum
 round(const TNum& number, const TDecimals& decimals = 0) {
   static_assert(!std::is_same_v<TNum, bool> && "round not supported for bool");
@@ -68,10 +72,21 @@ round(const TNum& number, const TDecimals& decimals = 0) {
       int128_t value = static_cast<int128_t>(number);
       int128_t quotient = value / scalingFactor;
       int128_t remainder = value % scalingFactor;
-      if (value >= 0 && remainder >= scalingFactor / 2) {
-        ++quotient;
-      } else if (remainder <= -scalingFactor / 2) {
-        --quotient;
+      if constexpr (mode == BigDecimal::RoundingMode::kHalfEven) {
+        // Compare |remainder| so the rule is symmetric for negative values;
+        // a tie moves the quotient away from zero only when it is odd.
+        const int128_t half = scalingFactor / 2;
+        const int128_t absRemainder = remainder < 0 ? -remainder : remainder;
+        if (absRemainder > half ||
+            (absRemainder == half && quotient % 2 != 0)) {
+          quotient += value >= 0 ? 1 : -1;
+        }
+      } else {
+        if (value >= 0 && remainder >= scalingFactor / 2) {
+          ++quotient;
+        } else if (remainder <= -scalingFactor / 2) {
+          --quotient;
+        }
       }
       int128_t rounded = quotient * scalingFactor;
       return static_cast<TNum>(rounded);
@@ -85,7 +100,7 @@ round(const TNum& number, const TDecimals& decimals = 0) {
 
   double dNumber = static_cast<double>(number);
   BigDecimal decimal(dNumber);
-  decimal.setScale(decimals);
+  decimal.setScale(decimals, mode);
   if constexpr (std::is_same_v<TNum, double>) {
     auto res = decimal.doubleValue();
     return res;

--- a/bolt/functions/sparksql/Arithmetic.h
+++ b/bolt/functions/sparksql/Arithmetic.h
@@ -215,6 +215,16 @@ struct RoundFunction {
 };
 
 template <typename T>
+struct BRoundFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  call(TInput& result, const TInput& a, const int32_t b = 0) {
+    result = bytedance::bolt::functions::
+        round<TInput, int32_t, true, BigDecimal::RoundingMode::kHalfEven>(a, b);
+  }
+};
+
+template <typename T>
 struct AcoshFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {

--- a/bolt/functions/sparksql/registration/RegisterMathMisc.cpp
+++ b/bolt/functions/sparksql/registration/RegisterMathMisc.cpp
@@ -41,6 +41,19 @@ void registerMathMiscFunctions(const std::string& prefix) {
       {prefix + "round"});
   registerFunction<RoundFunction, double, double, int32_t>({prefix + "round"});
   registerFunction<RoundFunction, float, float, int32_t>({prefix + "round"});
+
+  registerUnaryNumeric<BRoundFunction>({prefix + "bround"});
+  registerFunction<BRoundFunction, int8_t, int8_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, int16_t, int16_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, int32_t, int32_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, int64_t, int64_t, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, double, double, int32_t>(
+      {prefix + "bround"});
+  registerFunction<BRoundFunction, float, float, int32_t>({prefix + "bround"});
   registerFunction<RIntFunction, double, double>({prefix + "rint"});
 
   // Ceil and Floor functions

--- a/bolt/functions/sparksql/tests/SparkRoundTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkRoundTest.cpp
@@ -16,6 +16,8 @@
 
 #include "bolt/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
+#include <cmath>
+#include <limits>
 #include <type_traits>
 
 namespace bytedance::bolt::functions::sparksql::test {
@@ -24,9 +26,11 @@ namespace {
 class SparkRoundTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
-  void runRoundTest(const std::vector<std::tuple<T, T>>& data) {
+  void runRoundTest(
+      const std::vector<std::tuple<T, T>>& data,
+      const std::string& func = "round") {
     auto result = evaluate<SimpleVector<T>>(
-        "round(c0)", makeRowVector({makeFlatVector<T, 0>(data)}));
+        func + "(c0)", makeRowVector({makeFlatVector<T, 0>(data)}));
     for (int32_t i = 0; i < data.size(); ++i) {
       ASSERT_EQ(result->valueAt(i), std::get<1>(data[i]));
     }
@@ -34,9 +38,10 @@ class SparkRoundTest : public SparkFunctionBaseTest {
 
   template <typename T>
   void runRoundWithDecimalTest(
-      const std::vector<std::tuple<T, int32_t, T>>& data) {
+      const std::vector<std::tuple<T, int32_t, T>>& data,
+      const std::string& func = "round") {
     auto result = evaluate<SimpleVector<T>>(
-        "round(c0, c1)",
+        func + "(c0, c1)",
         makeRowVector(
             {makeFlatVector<T, 0>(data), makeFlatVector<int32_t, 1>(data)}));
     for (int32_t i = 0; i < data.size(); ++i) {
@@ -126,6 +131,81 @@ class SparkRoundTest : public SparkFunctionBaseTest {
         {123, -2, 100},
         {123, -3, 0}};
   }
+
+  // HALF_EVEN only differs from HALF_UP on exact ties, so most rows are ties;
+  // a few non-ties confirm the shared path is unchanged.
+  template <typename T>
+  std::vector<std::tuple<T, T>> testBRoundFloatData() {
+    return {
+        {0.5, 0.0},
+        {1.5, 2.0},
+        {2.5, 2.0},
+        {3.5, 4.0},
+        {-0.5, 0.0},
+        {-1.5, -2.0},
+        {-2.5, -2.0},
+        {-3.5, -4.0},
+        {1.9, 2.0},
+        {1.3, 1.0},
+        {0.0, 0.0}};
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testBRoundWithDecFloatData() {
+    std::vector<std::tuple<T, int32_t, T>> data = {
+        {2.5, 0, 2.0},
+        {-2.5, 0, -2.0},
+        {0.125, 2, 0.12},
+        {-0.125, 2, -0.12},
+        {0.135, 2, 0.14},
+        {0.585, 2, 0.58},
+        {1.615, 2, 1.62},
+        {1.129, 2, 1.13},
+        {-1.129, 1, -1.1},
+        {1.0 / 3, 2, 0.33},
+        {1250.0, -2, 1200.0},
+        {1350.0, -2, 1400.0},
+        {-1250.0, -2, -1200.0},
+        {11111.0, -1, 11110.0},
+        {5.0, -1, 0.0},
+        {15.0, -1, 20.0},
+        {25.0, -1, 20.0},
+        {1.0, -1, 0.0},
+        {0.0, -2, 0.0}};
+
+    // Spark widens float to double before taking the decimal string, so
+    // 0.575f is 0.574999988079071 and 2.675f is 2.6749999523162842: below
+    // the tie, rounded down under either mode. As doubles the strings are
+    // exact ties on an odd digit and round up.
+    if constexpr (std::is_same_v<T, float>) {
+      data.insert(
+          data.end(), {{0.575, 2, 0.57}, {-0.575, 2, -0.57}, {2.675, 2, 2.67}});
+    } else {
+      data.insert(
+          data.end(), {{0.575, 2, 0.58}, {-0.575, 2, -0.58}, {2.675, 2, 2.68}});
+    }
+    return data;
+  }
+
+  template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testBRoundWithDecIntegralData() {
+    return {
+        {1, 0, 1},
+        {-1, 0, -1},
+        {1, 10, 1},
+        {5, -1, 0},
+        {15, -1, 20},
+        {25, -1, 20},
+        {35, -1, 40},
+        {-25, -1, -20},
+        {-35, -1, -40},
+        {24, -1, 20},
+        {26, -1, 30},
+        {125, -1, 120},
+        {123, -2, 100},
+        {123, -3, 0},
+        {12, -2, 0}};
+  }
 };
 
 TEST_F(SparkRoundTest, round) {
@@ -146,6 +226,44 @@ TEST_F(SparkRoundTest, roundWithDecimal) {
   runRoundWithDecimalTest<int32_t>(testRoundWithDecIntegralData<int32_t>());
   runRoundWithDecimalTest<int16_t>(testRoundWithDecIntegralData<int16_t>());
   runRoundWithDecimalTest<int8_t>(testRoundWithDecIntegralData<int8_t>());
+}
+
+TEST_F(SparkRoundTest, bround) {
+  runRoundTest<float>(testBRoundFloatData<float>(), "bround");
+  runRoundTest<double>(testBRoundFloatData<double>(), "bround");
+
+  runRoundTest<int64_t>(testRoundIntegralData<int64_t>(), "bround");
+  runRoundTest<int32_t>(testRoundIntegralData<int32_t>(), "bround");
+  runRoundTest<int16_t>(testRoundIntegralData<int16_t>(), "bround");
+  runRoundTest<int8_t>(testRoundIntegralData<int8_t>(), "bround");
+}
+
+TEST_F(SparkRoundTest, broundWithDecimal) {
+  runRoundWithDecimalTest<float>(testBRoundWithDecFloatData<float>(), "bround");
+  runRoundWithDecimalTest<double>(
+      testBRoundWithDecFloatData<double>(), "bround");
+
+  runRoundWithDecimalTest<int64_t>(
+      testBRoundWithDecIntegralData<int64_t>(), "bround");
+  runRoundWithDecimalTest<int32_t>(
+      testBRoundWithDecIntegralData<int32_t>(), "bround");
+  runRoundWithDecimalTest<int16_t>(
+      testBRoundWithDecIntegralData<int16_t>(), "bround");
+  runRoundWithDecimalTest<int8_t>(
+      testBRoundWithDecIntegralData<int8_t>(), "bround");
+}
+
+TEST_F(SparkRoundTest, broundNonFiniteAndNull) {
+  const auto bround = [&](std::optional<double> a, std::optional<int32_t> b) {
+    return evaluateOnce<double>("bround(c0, c1)", a, b);
+  };
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(std::isnan(bround(kNaN, 2).value()));
+  EXPECT_EQ(bround(kInf, 2), kInf);
+  EXPECT_EQ(bround(-kInf, 2), -kInf);
+  EXPECT_EQ(bround(std::nullopt, 2), std::nullopt);
+  EXPECT_EQ(bround(1.5, std::nullopt), std::nullopt);
 }
 
 } // namespace

--- a/bolt/type/BigDecimal.cpp
+++ b/bolt/type/BigDecimal.cpp
@@ -31,7 +31,7 @@ void BigDecimal::compactVal() {
   }
 }
 
-void BigDecimal::setScale(int newScale) {
+void BigDecimal::setScale(int newScale, RoundingMode mode) {
   if (scale == newScale || isZero) {
     return;
   }
@@ -40,9 +40,17 @@ void BigDecimal::setScale(int newScale) {
     int changeScale = scale - newScale;
     boost::multiprecision::cpp_int scaleVal = boost::multiprecision::pow(
         boost::multiprecision::cpp_int(10), changeScale);
-    boost::multiprecision::cpp_int quotient = intVal % scaleVal;
+    boost::multiprecision::cpp_int remainder = intVal % scaleVal;
     intVal /= scaleVal;
-    bool increment = quotient >= scaleVal / 2;
+    // intVal is the magnitude and sign is tracked separately, so incrementing
+    // rounds away from zero, matching java.math.RoundingMode semantics.
+    const boost::multiprecision::cpp_int half = scaleVal / 2;
+    bool increment;
+    if (mode == RoundingMode::kHalfEven) {
+      increment = remainder > half || (remainder == half && intVal % 2 != 0);
+    } else {
+      increment = remainder >= half;
+    }
     if (increment) {
       intVal++;
     }

--- a/bolt/type/BigDecimal.h
+++ b/bolt/type/BigDecimal.h
@@ -89,7 +89,13 @@ class BigDecimal {
     compactVal();
   }
 
-  void setScale(int newScale);
+  // Mirrors java.math.RoundingMode for the two modes Spark's round/bround use.
+  enum class RoundingMode {
+    kHalfUp, // ties away from zero
+    kHalfEven, // ties to the even neighbor
+  };
+
+  void setScale(int newScale, RoundingMode mode = RoundingMode::kHalfUp);
 
   int getScale() {
     return scale;

--- a/bolt/type/tests/BigDecimalTest.cpp
+++ b/bolt/type/tests/BigDecimalTest.cpp
@@ -98,6 +98,33 @@ TEST(BigDecimalTest, setScale) {
   }
 }
 
+TEST(BigDecimalTest, setScaleHalfEven) {
+  // (input, newScale, expected). All ties except the last two.
+  std::vector<std::tuple<double, int, double>> testData = {
+      {2.5, 0, 2.0},
+      {3.5, 0, 4.0},
+      {-2.5, 0, -2.0},
+      {-3.5, 0, -4.0},
+      {0.125, 2, 0.12},
+      {0.135, 2, 0.14},
+      {2.675, 2, 2.68},
+      {1250.0, -2, 1200.0},
+      {1350.0, -2, 1400.0},
+      {2.674, 2, 2.67},
+      {2.676, 2, 2.68}};
+  for (const auto& data : testData) {
+    BigDecimal decimal(std::get<0>(data));
+    decimal.setScale(std::get<1>(data), BigDecimal::RoundingMode::kHalfEven);
+    EXPECT_EQ(decimal.getScale(), std::get<1>(data));
+    EXPECT_EQ(decimal.doubleValue(), std::get<2>(data));
+  }
+
+  // The default mode is still HALF_UP.
+  BigDecimal decimal(2.5);
+  decimal.setScale(0);
+  EXPECT_EQ(decimal.doubleValue(), 3.0);
+}
+
 } // namespace
 
 } // namespace bytedance::bolt


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #926

Bolt registers Spark's `round` but not `bround`. Spark's `BRound` differs only
in rounding mode — `HALF_EVEN` rather than `HALF_UP` — so a query using
`bround` cannot be offloaded and falls back.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Adds `bround` for the same six signatures `round` registers: unary numeric plus
`(int8|int16|int32|int64|double|float, int32) -> same`, matching Spark's
`BRound` (`sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala`),
which is `Round` with `HALF_EVEN`.

**Why `round` is unaffected.** This is the main thing to check when reviewing,
since the change touches shared code. `BigDecimal::setScale` gains a
`RoundingMode` parameter defaulted to `kHalfUp`, and the free `round<>` template
in `ArithmeticImpl.h` gains a `mode` template parameter defaulted to
`kHalfUp`. Every existing call site is unchanged and resolves to the default, so
the `HALF_UP` path is byte-for-byte the behaviour it had before. The new
`kHalfEven` branches are only reachable through `BRoundFunction`.

**Two rounding paths, both handled.** Floating point goes through `BigDecimal`,
where a tie increments only when the truncated magnitude is odd. Integrals with
negative decimals never reach `BigDecimal` — they take the `alwaysRoundNegDec`
branch in `ArithmeticImpl.h`, which needed its own `HALF_EVEN` handling. That
branch compares `|remainder|` rather than the signed remainder so the tie rule
stays symmetric across zero, and moves the quotient away from zero only when it
is odd. Without this, `bround(-25, -1)` and `bround(25, -1)` would disagree.

**Ties are decided on the decimal string, not the binary value.** `BigDecimal`
constructs from the shortest round-trip decimal representation, which is why
`bround(1.615D, 2)` is `1.62` even though the stored double is slightly below
1.615. This also produces a genuine float/double divergence: Spark widens float
to double before taking that string, so `0.575f` becomes `0.574999988079071` and
falls below the tie, while `0.575D` is an exact tie on an odd digit and rounds
up. The float and double expectations in the test data differ accordingly, with
a comment explaining why.

#### Validation

Expected values were taken from Apache Spark 3.5.5 (pyspark 3.5.5 on OpenJDK 17,
`spark.sql.ansi.enabled=false`), the version `scripts/launch-spark.sh` targets.
Every tie case in the test data was confirmed against it, including the ones
that distinguish `HALF_EVEN` from `HALF_UP`: `bround(0.5, 0) = 0`,
`bround(2.5, 0) = 2`, `bround(3.5, 0) = 4`, `bround(1250.0, -2) = 1200`,
`bround(1350.0, -2) = 1400`, `bround(15, -1) = 20`, `bround(25, -1) = 20`,
`bround(35, -1) = 40`, `bround(-25, -1) = -20`. Each of these returns a
different value under `HALF_UP`, so the test set fails if the mode is not
threaded through correctly.

Test coverage added:

- `SparkRoundTest.bround` and `SparkRoundTest.broundWithDecimal` — the unary and
  two-argument forms across float, double, and all four integral widths
- `SparkRoundTest.broundNonFiniteAndNull` — NaN, infinities, and null inputs
- `BigDecimalTest` — `setScale` with `kHalfEven` directly, so the type-level
  behaviour is covered independently of the SQL function

`pre-commit run --files` passes over the touched files ("Format C++ files",
clang-format 14.0.6). clang-tidy is skipped locally for lack of a
`compile_commands.json`, as `pre-commit-checks.yml` also does.

Remaining validation gap: the C++ has not been compiled or executed locally — a
full dependency build is still in progress. Opening as a draft until
`SparkRoundTest.*` and `BigDecimalTest.*` pass.

### Performance Impact

- [x] No Impact: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] Positive Impact: I have run benchmarks.
- [ ] Negative Impact: Explained below (e.g., trade-off for correctness).

The rounding mode is a template parameter and a compile-time `if constexpr`, so
the existing `round` path compiles to the same code it did before. No existing
function, signature, or query plan changes shape.

### Release Note

```
Release Note:
- Added the Spark `bround` scalar function (HALF_EVEN rounding) for float, double, and integral inputs.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest). Added, not yet executed; see Validation.
- [ ] I have verified the code with local build (Release/Debug). Not yet — see Validation.
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
