### PR TITLE
feat: implement Spark octet_length scalar function

### DIFF
--- a/bolt/functions/sparksql/String.h
+++ b/bolt/functions/sparksql/String.h
@@ -120,6 +120,16 @@ struct BitLengthFunction {
   }
 };
 
+template <typename T>
+struct OctetLengthFunction {
+  BOLT_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, TInput& input) {
+    result = input.size();
+  }
+};
+
 /// chr function
 /// chr(n) -> string
 /// Returns the Unicode code point ``n`` as a single character string.

--- a/bolt/functions/sparksql/registration/RegisterString.cpp
+++ b/bolt/functions/sparksql/registration/RegisterString.cpp
@@ -186,6 +186,10 @@ void registerStringFunctions(const std::string& prefix) {
       {prefix + "bit_length"});
   registerFunction<sparksql::BitLengthFunction, int32_t, Varbinary>(
       {prefix + "bit_length"});
+  registerFunction<sparksql::OctetLengthFunction, int32_t, Varchar>(
+      {prefix + "octet_length"});
+  registerFunction<sparksql::OctetLengthFunction, int32_t, Varbinary>(
+      {prefix + "octet_length"});
   registerFunction<Empty2NullFunction, Varchar, Varchar>(
       {prefix + "empty2null"});
 

--- a/bolt/functions/sparksql/tests/StringTest.cpp
+++ b/bolt/functions/sparksql/tests/StringTest.cpp
@@ -353,6 +353,45 @@ TEST_F(StringTest, bitLengthVarbinary) {
   EXPECT_EQ(bitLength("\U0001F408"), 32);
 }
 
+TEST_F(StringTest, octetLength) {
+  auto octetLength = [&](std::optional<std::string> arg) {
+    return evaluateOnce<int32_t>("octet_length(c0)", arg);
+  };
+
+  EXPECT_EQ(octetLength(""), 0);
+  EXPECT_EQ(octetLength(std::string("\0", 1)), 1);
+  EXPECT_EQ(octetLength("1"), 1);
+  EXPECT_EQ(octetLength("123"), 3);
+  // Consists of four codepoints.
+  EXPECT_EQ(octetLength("café"), 5);
+  EXPECT_EQ(octetLength("日本"), 6);
+  EXPECT_EQ(octetLength("😋"), 4);
+  // Consists of five codepoints.
+  EXPECT_EQ(octetLength(kWomanFacepalmingLightSkinTone), 17);
+  EXPECT_EQ(octetLength("\U0001F408"), 4);
+  EXPECT_EQ(octetLength(std::nullopt), std::nullopt);
+}
+
+TEST_F(StringTest, octetLengthVarbinary) {
+  auto octetLength = [&](std::optional<std::string> arg) {
+    return evaluateOnce<int32_t, std::string>(
+        "octet_length(c0)", {arg}, {VARBINARY()});
+  };
+
+  EXPECT_EQ(octetLength(""), 0);
+  EXPECT_EQ(octetLength(std::string("\0", 1)), 1);
+  EXPECT_EQ(octetLength("1"), 1);
+  EXPECT_EQ(octetLength("123"), 3);
+  // Consists of four codepoints.
+  EXPECT_EQ(octetLength("café"), 5);
+  EXPECT_EQ(octetLength("日本"), 6);
+  EXPECT_EQ(octetLength("😋"), 4);
+  // Consists of five codepoints.
+  EXPECT_EQ(octetLength(kWomanFacepalmingLightSkinTone), 17);
+  EXPECT_EQ(octetLength("\U0001F408"), 4);
+  EXPECT_EQ(octetLength(std::nullopt), std::nullopt);
+}
+
 TEST_F(StringTest, chr) {
   EXPECT_EQ(chr(-16), "");
   EXPECT_EQ(chr(0), std::string("\0", 1));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #922

Bolt registers Spark's `bit_length` and `length` but not `octet_length`, so a query using it cannot be offloaded and falls back.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Description

Adds `octet_length` for `Varchar -> int` and `Varbinary -> int`, matching Spark's `OctetLength` (`sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala`), which returns the byte length of the input.

**Mirrors `bit_length`.** `OctetLengthFunction` is added directly after `BitLengthFunction` in `bolt/functions/sparksql/String.h` and is identical apart from dropping the bits-per-byte multiply: `result = input.size()` rather than `result = input.size() * 8`. `StringView::size()` is already the byte count, so UTF-8 falls out without any encoding-aware work. The two registrations sit next to the `bit_length` pair in `RegisterString.cpp` and cover the same two input types.

**Bytes, not characters.** This is the distinction the tests are built around. Spark's `length` on a string counts code points while `octet_length` counts bytes, so they diverge on non-ASCII input: `length('cafe')` with an accented e is 4 while `octet_length` is 5, and for a two-character CJK string `length` is 2 while `octet_length` is 6. On `Varbinary` the two agree, since there is no character interpretation to make.

Note that `length` is registered through `lengthSignatures()`/`makeLength` as a vector function, while `bit_length` uses the simple-function path. `octet_length` follows `bit_length`, which is the right shape for a fixed one-argument signature.

#### Validation

Expected values were taken from Apache Spark 3.5.5 (pyspark 3.5.5 on OpenJDK 17), the version `scripts/launch-spark.sh` targets. Empty string is 0, `abc` is 3, a four-codepoint accented string is 5 bytes, a two-character CJK string is 6 bytes, null propagates, and `cast('abc' as binary)` is 3.

Two of the constants are also corroborated by existing assertions in the same file, independently of Spark: `bitLength(kWomanFacepalmingLightSkinTone)` is 136, and 136 / 8 = 17, which matches `lengthVarbinary(kWomanFacepalmingLightSkinTone)` at 17.

Test coverage added: `StringTest.octetLength` covers the empty string, an embedded NUL byte, ASCII, the multi-byte cases above, a five-codepoint emoji sequence, and null input. `StringTest.octetLengthVarbinary` covers the `Varbinary` overload, mirroring `bitLengthVarbinary`.

`pre-commit run --files` passes over the three touched files (Format C++ files, clang-format 14.0.6). clang-tidy is skipped locally for lack of a `compile_commands.json`, as `pre-commit-checks.yml` also does.

Remaining validation gap: the C++ has not been compiled or executed locally, since a full dependency build is still in progress. Opening as a draft until `StringTest.octetLength*` passes.

### Performance Impact

- [x] No Impact: This change does not affect the critical path.

Purely additive: one new struct in a header and two new registrations. No existing function, signature, or code path is modified, so no existing query plan changes shape. No new files and no CMake changes.

### Release Note

Added the Spark `octet_length` scalar function for string and binary inputs.

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest). Added, not yet executed; see Validation.
- [ ] I have verified the code with local build (Release/Debug). Not yet — see Validation.
- [x] I have run clang-format / linters.

### Breaking Changes

- [x] No
