### PR TITLE
fix(flinksql): align lpad and rpad null semantics

### DIFF
--- a/bolt/functions/flinksql/String.h
+++ b/bolt/functions/flinksql/String.h
@@ -19,7 +19,21 @@
 #include "bolt/functions/Macros.h"
 #include "bolt/functions/lib/string/StringCore.h"
 #include "bolt/functions/lib/string/StringImpl.h"
+#include "bolt/functions/sparksql/String.h"
 namespace bytedance::bolt::functions::flinksql {
+
+template <typename T>
+struct FlinkLPadFunction : public sparksql::PadFunctionBase<
+                               T,
+                               true,
+                               sparksql::PadInvalidInputPolicy::kReturnNull> {};
+
+template <typename T>
+struct FlinkRPadFunction : public sparksql::PadFunctionBase<
+                               T,
+                               false,
+                               sparksql::PadInvalidInputPolicy::kReturnNull> {};
+
 /// isDigit function
 /// isDigit(str) -> boolean
 /// returns true if the given string is a digit, false otherwise

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -43,6 +43,10 @@ static void registerPrestoMathFunctionAliases(const std::string& prefix) {
 namespace flinksql {
 
 static void registerStringFunctions(const std::string& prefix) {
+  registerFunction<FlinkLPadFunction, Varchar, Varchar, int32_t, Varchar>(
+      {prefix + "lpad"});
+  registerFunction<FlinkRPadFunction, Varchar, Varchar, int32_t, Varchar>(
+      {prefix + "rpad"});
   registerFunction<IsAlphaFunction, bool, Varchar>({prefix + "is_alpha"});
   registerFunction<IsDecimalFunction, bool, Varchar>({prefix + "is_decimal"});
   registerFunction<IsDigitFunction, bool, Varchar>({prefix + "is_digit"});

--- a/bolt/functions/flinksql/tests/StringFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/StringFunctionsTest.cpp
@@ -21,6 +21,22 @@ namespace bytedance::bolt::functions::flinksql::test {
 namespace {
 class StringFunctionsTest : public FlinkFunctionBaseTest {
  public:
+  std::optional<std::string> lpad(
+      std::optional<std::string> string,
+      std::optional<int32_t> size,
+      std::optional<std::string> padString) {
+    return evaluateOnce<std::string>(
+        "lpad(c0, c1, c2)", string, size, padString);
+  }
+
+  std::optional<std::string> rpad(
+      std::optional<std::string> string,
+      std::optional<int32_t> size,
+      std::optional<std::string> padString) {
+    return evaluateOnce<std::string>(
+        "rpad(c0, c1, c2)", string, size, padString);
+  }
+
   std::optional<bool> isDigit(std::optional<std::string> str) {
     return evaluateOnce<bool>("is_digit(c0)", str);
   }
@@ -31,6 +47,36 @@ class StringFunctionsTest : public FlinkFunctionBaseTest {
     return evaluateOnce<bool>("is_decimal(c0)", str);
   }
 };
+
+TEST_F(StringFunctionsTest, lpad) {
+  EXPECT_EQ("h", lpad("hi", 1, "??"));
+  EXPECT_EQ("???hi", lpad("hi", 5, "??"));
+  EXPECT_EQ("?", lpad("", 1, "??"));
+  EXPECT_EQ("", lpad("hi", 0, "??"));
+  EXPECT_EQ("ää", lpad("äääääääää", 2, "?"));
+  EXPECT_EQ("?äääääääää", lpad("äääääääää", 10, "?"));
+
+  EXPECT_EQ(std::nullopt, lpad("hi", -1, "??"));
+  EXPECT_EQ(std::nullopt, lpad("hi", 5, ""));
+  EXPECT_EQ(std::nullopt, lpad(std::nullopt, 5, "??"));
+  EXPECT_EQ(std::nullopt, lpad("hi", std::nullopt, "??"));
+  EXPECT_EQ(std::nullopt, lpad("hi", 5, std::nullopt));
+}
+
+TEST_F(StringFunctionsTest, rpad) {
+  EXPECT_EQ("h", rpad("hi", 1, "??"));
+  EXPECT_EQ("hi???", rpad("hi", 5, "??"));
+  EXPECT_EQ("?", rpad("", 1, "??"));
+  EXPECT_EQ("", rpad("hi", 0, "??"));
+  EXPECT_EQ("ää", rpad("äääääääää", 2, "?"));
+  EXPECT_EQ("äääääääää?", rpad("äääääääää", 10, "?"));
+
+  EXPECT_EQ(std::nullopt, rpad("hi", -1, "??"));
+  EXPECT_EQ(std::nullopt, rpad("hi", 5, ""));
+  EXPECT_EQ(std::nullopt, rpad(std::nullopt, 5, "??"));
+  EXPECT_EQ(std::nullopt, rpad("hi", std::nullopt, "??"));
+  EXPECT_EQ(std::nullopt, rpad("hi", 5, std::nullopt));
+}
 
 TEST_F(StringFunctionsTest, splitIndex) {
   auto splitIndex = [&](std::optional<std::string> input,

--- a/bolt/functions/sparksql/String.h
+++ b/bolt/functions/sparksql/String.h
@@ -45,41 +45,67 @@
 #include "bolt/functions/lib/string/StringImpl.h"
 namespace bytedance::bolt::functions::sparksql {
 
-template <typename T, bool lpad>
+// Controls the dialect-specific behavior for negative sizes and empty pads.
+enum class PadInvalidInputPolicy {
+  kThrow,
+  kReturnNull,
+};
+
+template <
+    typename T,
+    bool lpad,
+    PadInvalidInputPolicy invalidInputPolicy = PadInvalidInputPolicy::kThrow>
 struct PadFunctionBase {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
 
-  FOLLY_ALWAYS_INLINE void call(
+  FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size,
       const arg_type<Varchar>& padString) {
-    stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, padString);
+    return applyPad<false /*isAscii*/>(result, string, size, padString);
   }
 
-  FOLLY_ALWAYS_INLINE void call(
+  FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size) {
-    stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, {" "});
+    return applyPad<false /*isAscii*/>(result, string, size, {" "});
   }
 
-  FOLLY_ALWAYS_INLINE void callAscii(
+  FOLLY_ALWAYS_INLINE bool callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size,
       const arg_type<Varchar>& padString) {
-    stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, padString);
+    return applyPad<true /*isAscii*/>(result, string, size, padString);
   }
 
-  FOLLY_ALWAYS_INLINE void callAscii(
+  FOLLY_ALWAYS_INLINE bool callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size) {
-    stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, {" "});
+    return applyPad<true /*isAscii*/>(result, string, size, {" "});
+  }
+
+ private:
+  template <bool isAscii>
+  FOLLY_ALWAYS_INLINE bool applyPad(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& string,
+      const arg_type<int64_t>& size,
+      const arg_type<Varchar>& padString) {
+    if constexpr (invalidInputPolicy == PadInvalidInputPolicy::kReturnNull) {
+      if (size < 0 || padString.empty()) {
+        return false;
+      }
+    }
+
+    stringImpl::pad<lpad, isAscii>(result, string, size, padString);
+    return true;
   }
 };
 

--- a/bolt/functions/sparksql/tests/StringTest.cpp
+++ b/bolt/functions/sparksql/tests/StringTest.cpp
@@ -1139,6 +1139,9 @@ TEST_F(StringTest, rpad) {
   // Invalid UTF-8 chars
   EXPECT_EQ(invalidString + "x", rpad(invalidString, 8, "x"));
   EXPECT_EQ("abc" + invalidPadString, rpad("abc", 6, invalidPadString));
+
+  BOLT_ASSERT_THROW(rpad("abc", -1, "x"), "pad size must be in the range");
+  BOLT_ASSERT_THROW(rpad("abc", 5, ""), "padString must not be empty");
 }
 
 TEST_F(StringTest, lpad) {
@@ -1172,6 +1175,9 @@ TEST_F(StringTest, lpad) {
   // Invalid UTF-8 chars
   EXPECT_EQ("x" + invalidString, lpad(invalidString, 8, "x"));
   EXPECT_EQ(invalidPadString + "abc", lpad("abc", 6, invalidPadString));
+
+  BOLT_ASSERT_THROW(lpad("abc", -1, "x"), "pad size must be in the range");
+  BOLT_ASSERT_THROW(lpad("abc", 5, ""), "padString must not be empty");
 }
 
 TEST_F(StringTest, left) {


### PR DESCRIPTION
### What problem does this PR solve?

Flink `LPAD` and `RPAD` return null when the requested length is negative or
the padding string is empty. Bolt's existing Spark implementations reject both
inputs with a user error, so the Flink planner cannot map these functions to
Bolt without changing query behavior.

Issue Number: N/A

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add a compile-time invalid-input policy to the shared padding implementation.
Spark keeps the existing exception behavior by default. Flink registers its own
`lpad` and `rpad` specializations, which return null for negative lengths and
empty padding strings while continuing to use the same padding algorithm.

The tests cover padding, truncation, UTF-8 input, null propagation, negative
lengths, and empty padding strings. Spark tests also verify that its existing
exceptions remain unchanged.

### Performance Impact

- [x] **No Impact**: The policy is selected at compile time. The Flink path only
  adds the argument checks required by its SQL semantics, and the Spark path
  retains its existing checks.
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
- Added Flink-compatible null semantics for LPAD and RPAD.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    N/A
    ```
    </details>
