### PR TITLE
fix: read UTF8 byte arrays as binary in Spark

### DIFF
--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1194,10 +1194,20 @@ TypePtr ReaderBase::convertType(
         switch (schemaElement.type) {
           case thrift::Type::BYTE_ARRAY:
           case thrift::Type::FIXED_LEN_BYTE_ARRAY:
-            checkRequested([](const TypePtr& t) {
+            checkRequested([&](const TypePtr& t) {
+              if (::bytedance::bolt::kSparkCompatible &&
+                  schemaElement.type == thrift::Type::BYTE_ARRAY &&
+                  t->kind() == TypeKind::VARBINARY) {
+                return true;
+              }
               return t->kind() == TypeKind::VARCHAR ||
                   acceptsVarcharFileForReaderCast(t);
             });
+            if (::bytedance::bolt::kSparkCompatible &&
+                schemaElement.type == thrift::Type::BYTE_ARRAY &&
+                requestedType && requestedType->isVarbinary()) {
+              return VARBINARY();
+            }
             return VARCHAR();
           default:
             BOLT_FAIL(

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -2237,6 +2237,39 @@ TEST_F(ParquetTableScanTest, convertTypePolicyValueChecks) {
   }
 }
 
+TEST_F(ParquetTableScanTest, readUtf8AnnotatedByteArrayAsVarbinary) {
+  if (!::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
+
+  const std::vector<std::string> expectedValues = {
+      "127.0.0.1", "2001:db8::1", "spark-compatible"};
+  auto data = makeRowVector(
+      {"c0"}, {makeFlatVector<StringView>(expectedValues.size(), [&](auto row) {
+        return StringView(expectedValues[row]);
+      })});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {data}, WriterOptions{});
+
+  // VARCHAR is written as Parquet BYTE_ARRAY with UTF8/string annotation.
+  // Spark's Parquet reader accepts these bytes when the requested Spark type
+  // is BinaryType, so the Spark-compatible Bolt reader must do the same.
+  auto declared = ROW({"c0"}, {VARBINARY()});
+  auto plan =
+      PlanBuilder(pool()).tableScan(declared, {}, "", declared).planNode();
+  auto result = AssertQueryBuilder(plan)
+                    .split(makeSplit(file->getPath()))
+                    .copyResults(pool());
+
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->size(), expectedValues.size());
+  ASSERT_TRUE(result->type()->equivalent(*declared));
+  auto actualValues = result->childAt(0)->asFlatVector<StringView>();
+  for (auto row = 0; row < result->size(); ++row) {
+    EXPECT_EQ(actualValues->valueAt(row), StringView(expectedValues[row]));
+  }
+}
+
 TEST_F(ParquetTableScanTest, floatingPointToVarcharValueFilters) {
   // Floating point -> VARCHAR follows Spark's vectorized Parquet reader
   // conversion. Value filters cannot run against the physical floating-point


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #957

Spark-compatible Parquet reads fail during schema conversion when a regular `BYTE_ARRAY` has a UTF8 or JSON annotation but Spark requests the column as `BinaryType` (`VARBINARY` in Bolt). The annotated branch only accepts and returns `VARCHAR`, producing a `BYTE_ARRAY(UTF8) -> VARBINARY` schema mismatch.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

When `kSparkCompatible` is enabled, allow a UTF8/JSON-annotated regular Parquet `BYTE_ARRAY` to satisfy a requested `VARBINARY` type and return `VARBINARY` from schema conversion. This follows Spark's requested schema while preserving the bytes as-is.

The compatibility rule deliberately requires all three conditions:

- Spark-compatible mode is enabled;
- the physical Parquet type is regular `BYTE_ARRAY`;
- the requested Bolt type is `VARBINARY`.

This preserves existing non-Spark behavior and does not broaden `FIXED_LEN_BYTE_ARRAY`. A regression test writes an annotated byte-array column and verifies that reading it through a declared `VARBINARY` schema preserves both the result type and bytes.

Validation:

- Before the implementation change, `ParquetTableScanTest.readUtf8AnnotatedByteArrayAsVarbinary` failed with `From Kind: BYTE_ARRAY(UTF8), To Kind: VARBINARY`.
- After the change, the same targeted test passes.
- `ParquetTableScanTest.convertTypePolicyValueChecks` and the new test pass together (2/2).
- The target was built with `cmake --build --preset conan-debug --target bolt_dwio_parquet_table_scan_test -j 10`.
- `pre-commit run clang-format` passes for both modified files.

### Performance Impact

- [x] **No Impact**: The change only adds schema checks during reader setup and does not affect the data decoding loop.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Allow Spark-compatible Parquet reads to interpret UTF8/JSON-annotated regular `BYTE_ARRAY` columns as binary when the requested type is `VARBINARY`.

Release Note:

```text
Release Note:
- Allow Spark to read UTF8/JSON-annotated Parquet BYTE_ARRAY columns as BinaryType.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
