### PR TITLE
test: add local TPC-DS benchmark

### DIFF
--- a/bolt/benchmarks/CMakeLists.txt
+++ b/bolt/benchmarks/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(bolt_benchmark_builder ${BOLT_BENCHMARK_DEPS})
 
 if(${BOLT_BUILD_BENCHMARKS})
   add_subdirectory(tpch)
+  add_subdirectory(tpcds)
   add_subdirectory(paimon)
 endif()
 

--- a/bolt/benchmarks/tpcds/CMakeLists.txt
+++ b/bolt/benchmarks/tpcds/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# --------------------------------------------------------------------------
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file has been modified by ByteDance Ltd. and/or its affiliates on
+# 2026-08-28.
+#
+# Original file was released under the Apache License 2.0,
+# with the full license text available at:
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This modified file is released under the same license.
+# --------------------------------------------------------------------------
+
+add_executable(
+  bolt_tpcds_benchmark
+  TpcdsBenchmark.cpp
+  TpcdsBenchmarkMain.cpp
+)
+
+target_link_libraries(
+  bolt_tpcds_benchmark
+  PRIVATE
+    bolt_query_benchmark
+    bolt_testutils
+    bolt_window
+    ${FOLLY_BENCHMARK}
+)

--- a/bolt/benchmarks/tpcds/TpcdsBenchmark.cpp
+++ b/bolt/benchmarks/tpcds/TpcdsBenchmark.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/benchmarks/tpcds/TpcdsBenchmark.h"
+
+#include <folly/Benchmark.h>
+
+#include "bolt/benchmarks/QueryBenchmarkBase.h"
+#include "bolt/connectors/hive/HiveConnector.h"
+#include "bolt/connectors/hive/HiveConnectorSplit.h"
+#include "bolt/exec/PartitionFunction.h"
+#include "bolt/exec/tests/utils/TpcdsQueryBuilder.h"
+#include "bolt/functions/prestosql/window/WindowFunctionsRegistration.h"
+
+using namespace bytedance::bolt;
+using namespace bytedance::bolt::exec;
+using namespace bytedance::bolt::exec::test;
+
+DEFINE_string(
+    bolt_benchmark_tpcds_data_path,
+    "",
+    "Root of the TPC-DS Parquet data. Each table must have its own "
+    "subdirectory.");
+DEFINE_string(
+    bolt_benchmark_tpcds_plan_path,
+    "",
+    "Directory containing serialized Bolt plans named after SQL files, for "
+    "example q1.json and q14a.json. Uppercase Q1.json is also accepted.");
+DEFINE_string(
+    bolt_benchmark_tpcds_query_path,
+    "",
+    "Directory containing the 103 TPC-DS SQL files. If set, the query "
+    "manifest is validated before execution.");
+DEFINE_string(
+    bolt_benchmark_tpcds_query,
+    "q1",
+    "Query name to run in verbose mode, including a/b suffixes.");
+DEFINE_bool(
+    bolt_benchmark_tpcds_run_query,
+    true,
+    "Run --bolt_benchmark_tpcds_query once and print execution statistics.");
+
+namespace {
+
+class TpcdsBenchmark : public QueryBenchmarkBase {
+ public:
+  void initialize() override {
+    QueryBenchmarkBase::initialize();
+
+    constexpr std::string_view kPrestoPrefix = "presto.default.";
+    functions::prestosql::registerAllScalarFunctions(
+        std::string{kPrestoPrefix});
+    aggregate::prestosql::registerAllAggregateFunctions(
+        std::string{kPrestoPrefix});
+    window::prestosql::registerAllWindowFunctions(std::string{kPrestoPrefix});
+
+    Type::registerSerDe();
+    common::Filter::registerSerDe();
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+    exec::registerPartitionFunctionSerDe();
+
+    BOLT_USER_CHECK(
+        !FLAGS_bolt_benchmark_tpcds_data_path.empty(),
+        "--bolt_benchmark_tpcds_data_path is required");
+    BOLT_USER_CHECK(
+        !FLAGS_bolt_benchmark_tpcds_plan_path.empty(),
+        "--bolt_benchmark_tpcds_plan_path is required");
+    if (!FLAGS_bolt_benchmark_tpcds_query_path.empty()) {
+      TpcdsPlanLoader::validateQueryDirectory(
+          FLAGS_bolt_benchmark_tpcds_query_path);
+    }
+
+    queryBuilder_ = std::make_unique<TpcdsQueryBuilder>(
+        dwio::common::toFileFormat(FLAGS_bolt_benchmark_data_format),
+        ioExecutor_.get());
+    queryBuilder_->initialize(FLAGS_bolt_benchmark_tpcds_data_path);
+    pool_ = memory::memoryManager()->addLeafPool("TpcdsBenchmark");
+  }
+
+  void shutdown() {
+    if (queryBuilder_ != nullptr) {
+      queryBuilder_->shutdown();
+      queryBuilder_.reset();
+    }
+    pool_.reset();
+    QueryBenchmarkBase::shutdown();
+  }
+
+  void runMain(std::ostream& out, RunStats& runStats) override {
+    if (!FLAGS_bolt_benchmark_tpcds_run_query) {
+      folly::runBenchmarks();
+      return;
+    }
+
+    auto plan = getPlan(FLAGS_bolt_benchmark_tpcds_query);
+    auto [cursor, results] = run(plan);
+    BOLT_USER_CHECK_NOT_NULL(cursor, "TPC-DS query failed");
+    auto task = cursor->task();
+    ensureTaskCompletion(task.get());
+    if (FLAGS_bolt_benchmark_include_results) {
+      printResults(results, out);
+    }
+
+    const auto stats = task->taskStats();
+    for (const auto& pipeline : stats.pipelineStats) {
+      for (const auto& op : pipeline.operatorStats) {
+        if (op.operatorType == "TableScan") {
+          runStats.rawInputBytes += op.rawInputBytes;
+        }
+      }
+    }
+    out << fmt::format(
+               "Execution time: {}\n"
+               "Splits total: {}, finished: {}\n"
+               "Memory pool peak bytes: {}\n",
+               succinctMillis(
+                   stats.executionEndTimeMs - stats.executionStartTimeMs),
+               stats.numTotalSplits,
+               stats.numFinishedSplits,
+               task->pool()->peakBytes())
+        << printPlanWithStats(
+               *plan.plan,
+               stats,
+               FLAGS_bolt_benchmark_include_custom_stats,
+               true)
+        << std::endl;
+  }
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> listSplits(
+      const std::string& path,
+      int32_t numSplitsPerFile,
+      const TpchPlan& plan) override {
+    auto splits = QueryBenchmarkBase::listSplits(path, numSplitsPerFile, plan);
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> result;
+    result.reserve(splits.size());
+    for (const auto& split : splits) {
+      auto hiveSplit =
+          std::dynamic_pointer_cast<connector::hive::HiveConnectorSplit>(split);
+      BOLT_CHECK_NOT_NULL(hiveSplit);
+      result.push_back(
+          connector::hive::HiveConnectorSplitBuilder(hiveSplit->filePath)
+              .connectorId(queryBuilder_->connectorId())
+              .fileFormat(hiveSplit->fileFormat)
+              .start(hiveSplit->start)
+              .length(hiveSplit->length)
+              .build());
+    }
+    return result;
+  }
+
+  void registerBenchmarks() {
+    for (const auto& queryName : TpcdsPlanLoader::queryNames()) {
+      folly::addBenchmark(__FILE__, queryName, [this, queryName]() {
+        run(getPlan(queryName));
+        return 1;
+      });
+    }
+  }
+
+ private:
+  TpchPlan getPlan(const std::string& queryName) {
+    return queryBuilder_->getQueryPlan(
+        queryName, FLAGS_bolt_benchmark_tpcds_plan_path, pool_.get());
+  }
+
+  std::unique_ptr<TpcdsQueryBuilder> queryBuilder_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+} // namespace
+
+int tpcdsBenchmarkMain() {
+  TpcdsBenchmark benchmark;
+  benchmark.initialize();
+  benchmark.registerBenchmarks();
+  if (FLAGS_bolt_benchmark_test_flags_file.empty()) {
+    RunStats ignored;
+    benchmark.runMain(std::cout, ignored);
+  } else {
+    benchmark.runAllCombinations();
+  }
+  benchmark.shutdown();
+  return 0;
+}

--- a/bolt/benchmarks/tpcds/TpcdsBenchmark.h
+++ b/bolt/benchmarks/tpcds/TpcdsBenchmark.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+int tpcdsBenchmarkMain();

--- a/bolt/benchmarks/tpcds/TpcdsBenchmarkMain.cpp
+++ b/bolt/benchmarks/tpcds/TpcdsBenchmarkMain.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "bolt/benchmarks/tpcds/TpcdsBenchmark.h"
+
+int main(int argc, char** argv) {
+  gflags::SetUsageMessage(
+      "Run serialized TPC-DS plans against local Hive-style data.");
+  folly::Init init{&argc, &argv, false};
+  return tpcdsBenchmarkMain();
+}

--- a/bolt/core/Expressions.cpp
+++ b/bolt/core/Expressions.cpp
@@ -227,7 +227,9 @@ TypedExprPtr CastTypedExpr::create(const folly::dynamic& obj, void* context) {
   auto inputs = deserializeInputs(obj, context);
 
   return std::make_shared<CastTypedExpr>(
-      std::move(type), std::move(inputs), obj["nullOnFailure"].asBool());
+      std::move(type),
+      std::move(inputs),
+      obj.count("nullOnFailure") && obj["nullOnFailure"].asBool());
 }
 
 } // namespace bytedance::bolt::core

--- a/bolt/core/PlanNode.cpp
+++ b/bolt/core/PlanNode.cpp
@@ -437,12 +437,13 @@ folly::dynamic AggregationNode::Aggregate::serialize() const {
 AggregationNode::Aggregate AggregationNode::Aggregate::deserialize(
     const folly::dynamic& obj,
     void* context) {
-  auto call = ISerializable::deserialize<CallTypedExpr>(obj["call"]);
+  auto call = ISerializable::deserialize<CallTypedExpr>(obj["call"], context);
   auto rawInputTypes =
       ISerializable::deserialize<std::vector<Type>>(obj["rawInputTypes"]);
   FieldAccessTypedExprPtr mask;
   if (obj.count("mask")) {
-    mask = ISerializable::deserialize<FieldAccessTypedExpr>(obj["mask"]);
+    mask =
+        ISerializable::deserialize<FieldAccessTypedExpr>(obj["mask"], context);
   }
   auto sortingKeys = deserializeFields(obj["sortingKeys"], context);
   auto sortingOrders = deserializeSortingOrders(obj["sortingOrders"]);
@@ -693,7 +694,8 @@ PlanNodePtr GroupIdNode::create(const folly::dynamic& obj, void* context) {
   for (const auto& info : obj["groupingKeyInfos"]) {
     groupingKeyInfos.push_back(
         {info["output"].asString(),
-         ISerializable::deserialize<FieldAccessTypedExpr>(info["input"])});
+         ISerializable::deserialize<FieldAccessTypedExpr>(
+             info["input"], context)});
   }
 
   auto groupingSets =
@@ -1133,7 +1135,7 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
 
   TypedExprPtr filter;
   if (obj.count("filter")) {
-    filter = ISerializable::deserialize<ITypedExpr>(obj["filter"]);
+    filter = ISerializable::deserialize<ITypedExpr>(obj["filter"], context);
   }
 
   auto outputType = deserializeRowType(obj["outputType"]);
@@ -1205,7 +1207,7 @@ PlanNodePtr MergeJoinNode::create(const folly::dynamic& obj, void* context) {
 
   TypedExprPtr filter;
   if (obj.count("filter")) {
-    filter = ISerializable::deserialize<ITypedExpr>(obj["filter"]);
+    filter = ISerializable::deserialize<ITypedExpr>(obj["filter"], context);
   }
 
   auto outputType = deserializeRowType(obj["outputType"]);
@@ -2607,7 +2609,7 @@ folly::dynamic FilterNode::serialize() const {
 PlanNodePtr FilterNode::create(const folly::dynamic& obj, void* context) {
   auto source = deserializeSingleSource(obj, context);
 
-  auto filter = ISerializable::deserialize<ITypedExpr>(obj["filter"]);
+  auto filter = ISerializable::deserialize<ITypedExpr>(obj["filter"], context);
   return std::make_shared<FilterNode>(
       deserializePlanNodeId(obj), filter, std::move(source));
 }

--- a/bolt/exec/tests/CMakeLists.txt
+++ b/bolt/exec/tests/CMakeLists.txt
@@ -43,6 +43,15 @@ add_test(
 
 target_link_libraries(aggregate_companion_functions_test PRIVATE bolt_gtest_main)
 
+add_executable(tpcds_plan_loader_test TpcdsPlanLoaderTest.cpp)
+add_test(
+  NAME tpcds_plan_loader_test
+  COMMAND
+    tpcds_plan_loader_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(tpcds_plan_loader_test PRIVATE bolt_gtest_main)
+
 add_executable(
   bolt_exec_test
   AddressableNonNullValueListTest.cpp

--- a/bolt/exec/tests/TpcdsPlanLoaderTest.cpp
+++ b/bolt/exec/tests/TpcdsPlanLoaderTest.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "bolt/connectors/hive/TableHandle.h"
+#include "bolt/exec/PartitionFunction.h"
+#include "bolt/exec/tests/utils/PlanBuilder.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/exec/tests/utils/TpcdsPlanLoader.h"
+
+namespace bytedance::bolt::exec::test {
+namespace {
+
+class TpcdsPlanLoaderTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    Type::registerSerDe();
+    common::Filter::registerSerDe();
+    connector::hive::HiveTableHandle::registerSerDe();
+    connector::hive::HiveColumnHandle::registerSerDe();
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+    registerPartitionFunctionSerDe();
+  }
+
+  void writePlan(const std::string& name, const core::PlanNodePtr& plan) {
+    std::ofstream output(std::filesystem::path(directory_->path) / name);
+    output << folly::toJson(plan->serialize());
+  }
+
+  std::shared_ptr<TempDirectoryPath> directory_ = TempDirectoryPath::create();
+};
+
+TEST_F(TpcdsPlanLoaderTest, queryManifest) {
+  EXPECT_EQ(TpcdsPlanLoader::queryNames().size(), 103);
+  EXPECT_NE(
+      std::find(
+          TpcdsPlanLoader::queryNames().begin(),
+          TpcdsPlanLoader::queryNames().end(),
+          "q14a"),
+      TpcdsPlanLoader::queryNames().end());
+  EXPECT_NE(
+      std::find(
+          TpcdsPlanLoader::queryNames().begin(),
+          TpcdsPlanLoader::queryNames().end(),
+          "q14b"),
+      TpcdsPlanLoader::queryNames().end());
+}
+
+TEST_F(TpcdsPlanLoaderTest, loadsVariantAndStripsPartitionedOutput) {
+  auto serializedPlan =
+      PlanBuilder()
+          .tableScan("store_sales", ROW({"ss_item_sk"}, {INTEGER()}))
+          .partitionedOutput({}, 1)
+          .planNode();
+  writePlan("q14a.json", serializedPlan);
+
+  TpcdsPlanLoader loader(directory_->path);
+  auto plan = loader.loadPlan("Q14A");
+  EXPECT_EQ(plan.planName, "Q14A");
+  EXPECT_EQ(plan.plan->name(), "TableScan");
+  const auto scans = TpcdsPlanLoader::collectTableScanNodes(plan.plan);
+  ASSERT_EQ(scans.size(), 1);
+  EXPECT_EQ(scans.front()->tableHandle()->name(), "store_sales");
+}
+
+TEST_F(TpcdsPlanLoaderTest, acceptsPrestoUppercaseFileName) {
+  auto serializedPlan =
+      PlanBuilder().values({}).partitionedOutput({}, 1).planNode();
+  writePlan("Q1.json", serializedPlan);
+
+  TpcdsPlanLoader loader(directory_->path);
+  EXPECT_EQ(loader.loadPlan("q1").plan->name(), "Values");
+}
+
+TEST_F(TpcdsPlanLoaderTest, rejectsUnknownOrMissingQuery) {
+  TpcdsPlanLoader loader(directory_->path);
+  EXPECT_THROW(loader.loadPlan("q100"), BoltUserError);
+  EXPECT_THROW(loader.loadPlan("q2"), BoltUserError);
+}
+
+} // namespace
+} // namespace bytedance::bolt::exec::test

--- a/bolt/exec/tests/utils/CMakeLists.txt
+++ b/bolt/exec/tests/utils/CMakeLists.txt
@@ -43,6 +43,8 @@ bolt_add_library(
   QueryAssertions.cpp
   RowBasedSerde.cpp
   SumNonPODAggregate.cpp
+  TpcdsPlanLoader.cpp
+  TpcdsQueryBuilder.cpp
   TpchQueryBuilder.cpp
   VectorTestUtil.cpp
 )

--- a/bolt/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/bolt/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -143,12 +143,14 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
         infoColumns) {
   auto file =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
-  const int64_t fileSize = file->size();
+  BOLT_CHECK_GT(splitCount, 0);
+  const uint64_t fileSize = file->size();
   // Take the upper bound.
-  const int splitSize = std::ceil((fileSize) / splitCount);
+  const uint64_t splitSize =
+      fileSize / splitCount + (fileSize % splitCount != 0);
   std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> splits;
   // Add all the splits.
-  for (int i = 0; i < splitCount; i++) {
+  for (uint32_t i = 0; i < splitCount; i++) {
     auto splitBuilder = HiveConnectorSplitBuilder(filePath)
                             .connectorId(kHiveConnectorId)
                             .fileFormat(format)

--- a/bolt/exec/tests/utils/TpcdsPlanLoader.cpp
+++ b/bolt/exec/tests/utils/TpcdsPlanLoader.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/exec/tests/utils/TpcdsPlanLoader.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+
+#include <fmt/format.h>
+#include <folly/json.h>
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/common/serialization/Serializable.h"
+
+namespace bytedance::bolt::exec::test {
+namespace {
+
+void collectTableScanNodesRecursive(
+    const core::PlanNodePtr& node,
+    std::vector<core::TableScanNodePtr>& scans) {
+  if (auto scan = std::dynamic_pointer_cast<const core::TableScanNode>(node)) {
+    scans.push_back(std::move(scan));
+  }
+  for (const auto& source : node->sources()) {
+    collectTableScanNodesRecursive(source, scans);
+  }
+}
+
+std::string readFile(const std::string& path) {
+  std::ifstream input(path);
+  BOLT_USER_CHECK(input, "Failed to open TPC-DS plan file: {}", path);
+
+  std::stringstream contents;
+  contents << input.rdbuf();
+  return contents.str();
+}
+
+std::string lowercase(std::string value) {
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return std::tolower(c);
+      });
+  return value;
+}
+
+} // namespace
+
+TpcdsPlanLoader::TpcdsPlanLoader(
+    std::string planDirectory,
+    memory::MemoryPool* pool,
+    bool stripPartitionedOutput)
+    : planDirectory_(std::move(planDirectory)),
+      pool_(pool),
+      stripPartitionedOutput_(stripPartitionedOutput) {
+  if (pool_ == nullptr) {
+    ownedPool_ = memory::memoryManager()->addLeafPool("TpcdsPlanLoader");
+    pool_ = ownedPool_.get();
+  }
+}
+
+TpchPlan TpcdsPlanLoader::loadPlan(const std::string& queryName) const {
+  const auto path = pathForQuery(queryName);
+  folly::dynamic serializedPlan;
+  try {
+    serializedPlan = folly::parseJson(readFile(path));
+  } catch (const std::exception& error) {
+    BOLT_USER_FAIL(
+        "Failed to parse TPC-DS plan JSON from {}: {}", path, error.what());
+  }
+
+  core::PlanNodePtr plan;
+  try {
+    plan = ISerializable::deserialize<core::PlanNode>(serializedPlan, pool_);
+  } catch (const std::exception& error) {
+    BOLT_USER_FAIL(
+        "Failed to deserialize TPC-DS plan from {}: {}", path, error.what());
+  }
+
+  maybeStripPartitionedOutput(plan);
+  return {
+      .plan = std::move(plan),
+      .dataFiles = {},
+      .dataFileFormat = dwio::common::FileFormat::PARQUET,
+      .planName = queryName};
+}
+
+const std::vector<std::string>& TpcdsPlanLoader::queryNames() {
+  static const std::vector<std::string> kQueryNames = {
+      "q1",  "q2",  "q3",  "q4",  "q5",   "q6",   "q7",   "q8",   "q9",
+      "q10", "q11", "q12", "q13", "q14a", "q14b", "q15",  "q16",  "q17",
+      "q18", "q19", "q20", "q21", "q22",  "q23a", "q23b", "q24a", "q24b",
+      "q25", "q26", "q27", "q28", "q29",  "q30",  "q31",  "q32",  "q33",
+      "q34", "q35", "q36", "q37", "q38",  "q39a", "q39b", "q40",  "q41",
+      "q42", "q43", "q44", "q45", "q46",  "q47",  "q48",  "q49",  "q50",
+      "q51", "q52", "q53", "q54", "q55",  "q56",  "q57",  "q58",  "q59",
+      "q60", "q61", "q62", "q63", "q64",  "q65",  "q66",  "q67",  "q68",
+      "q69", "q70", "q71", "q72", "q73",  "q74",  "q75",  "q76",  "q77",
+      "q78", "q79", "q80", "q81", "q82",  "q83",  "q84",  "q85",  "q86",
+      "q87", "q88", "q89", "q90", "q91",  "q92",  "q93",  "q94",  "q95",
+      "q96", "q97", "q98", "q99"};
+  return kQueryNames;
+}
+
+void TpcdsPlanLoader::validateQueryDirectory(const std::string& sqlDirectory) {
+  std::set<std::string> actualQueryNames;
+  std::error_code error;
+  for (const auto& entry : std::filesystem::directory_iterator(
+           sqlDirectory,
+           std::filesystem::directory_options::skip_permission_denied,
+           error)) {
+    if (entry.is_regular_file() &&
+        lowercase(entry.path().extension().string()) == ".sql") {
+      actualQueryNames.insert(lowercase(entry.path().stem().string()));
+    }
+  }
+  BOLT_USER_CHECK(
+      !error,
+      "Failed to scan TPC-DS SQL directory {}: {}",
+      sqlDirectory,
+      error.message());
+
+  const std::set<std::string> expectedQueryNames(
+      queryNames().begin(), queryNames().end());
+  BOLT_USER_CHECK(
+      actualQueryNames == expectedQueryNames,
+      "TPC-DS SQL directory must contain the 103 standard query files "
+      "q1.sql through q99.sql, including the a/b variants; found {} files",
+      actualQueryNames.size());
+}
+
+std::vector<core::TableScanNodePtr> TpcdsPlanLoader::collectTableScanNodes(
+    const core::PlanNodePtr& plan) {
+  std::vector<core::TableScanNodePtr> scans;
+  if (plan != nullptr) {
+    collectTableScanNodesRecursive(plan, scans);
+  }
+  return scans;
+}
+
+std::string TpcdsPlanLoader::pathForQuery(const std::string& queryName) const {
+  const auto normalizedQueryName = lowercase(queryName);
+  BOLT_USER_CHECK(
+      std::find(
+          queryNames().begin(), queryNames().end(), normalizedQueryName) !=
+          queryNames().end(),
+      "Unknown TPC-DS query: {}",
+      queryName);
+
+  const auto planDirectory = std::filesystem::path(planDirectory_);
+  const std::array candidates = {
+      planDirectory / fmt::format("{}.json", normalizedQueryName),
+      planDirectory / fmt::format("Q{}.json", normalizedQueryName.substr(1)),
+  };
+  for (const auto& candidate : candidates) {
+    if (std::filesystem::is_regular_file(candidate)) {
+      return candidate.string();
+    }
+  }
+  BOLT_USER_FAIL(
+      "TPC-DS plan file does not exist for {} in {} (tried {} and {})",
+      normalizedQueryName,
+      planDirectory_,
+      candidates[0].filename().string(),
+      candidates[1].filename().string());
+}
+
+void TpcdsPlanLoader::maybeStripPartitionedOutput(
+    core::PlanNodePtr& plan) const {
+  if (!stripPartitionedOutput_ || plan == nullptr) {
+    return;
+  }
+  if (auto output =
+          std::dynamic_pointer_cast<const core::PartitionedOutputNode>(plan)) {
+    BOLT_CHECK_EQ(
+        output->sources().size(),
+        1,
+        "PartitionedOutput must have exactly one source");
+    plan = output->sources().front();
+  }
+}
+
+} // namespace bytedance::bolt::exec::test

--- a/bolt/exec/tests/utils/TpcdsPlanLoader.h
+++ b/bolt/exec/tests/utils/TpcdsPlanLoader.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "bolt/exec/tests/utils/TpchQueryBuilder.h"
+
+namespace bytedance::bolt::exec::test {
+
+/// Loads serialized Bolt plans for the TPC-DS queries. Plan file names match
+/// the SQL file stems, for example q1.json, q14a.json and q14b.json.
+class TpcdsPlanLoader {
+ public:
+  TpcdsPlanLoader(
+      std::string planDirectory,
+      memory::MemoryPool* pool = nullptr,
+      bool stripPartitionedOutput = true);
+
+  /// Loads and deserializes the plan for 'queryName'.
+  TpchPlan loadPlan(const std::string& queryName) const;
+
+  /// Returns all query names represented by the TPC-DS SQL files.
+  static const std::vector<std::string>& queryNames();
+
+  /// Verifies that sqlDirectory contains exactly the supported .sql files.
+  static void validateQueryDirectory(const std::string& sqlDirectory);
+
+  /// Returns all table scans in depth-first plan order.
+  static std::vector<core::TableScanNodePtr> collectTableScanNodes(
+      const core::PlanNodePtr& plan);
+
+ private:
+  std::string pathForQuery(const std::string& queryName) const;
+  void maybeStripPartitionedOutput(core::PlanNodePtr& plan) const;
+
+  const std::string planDirectory_;
+  memory::MemoryPool* pool_;
+  std::shared_ptr<memory::MemoryPool> ownedPool_;
+  const bool stripPartitionedOutput_;
+};
+
+} // namespace bytedance::bolt::exec::test

--- a/bolt/exec/tests/utils/TpcdsQueryBuilder.cpp
+++ b/bolt/exec/tests/utils/TpcdsQueryBuilder.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#include "bolt/exec/tests/utils/TpcdsQueryBuilder.h"
+
+#include <algorithm>
+#include <filesystem>
+
+#include "bolt/common/base/Exceptions.h"
+#include "bolt/connectors/Connector.h"
+#include "bolt/connectors/hive/HiveConnector.h"
+#include "bolt/exec/tests/utils/HiveConnectorTestBase.h"
+
+namespace bytedance::bolt::exec::test {
+
+TpcdsQueryBuilder::TpcdsQueryBuilder(
+    dwio::common::FileFormat format,
+    folly::Executor* ioExecutor,
+    std::shared_ptr<const config::ConfigBase> connectorConfig)
+    : format_(format),
+      ioExecutor_(ioExecutor),
+      connectorConfig_(
+          connectorConfig != nullptr
+              ? std::move(connectorConfig)
+              : std::make_shared<const config::ConfigBase>(
+                    std::unordered_map<std::string, std::string>{})) {}
+
+void TpcdsQueryBuilder::initialize(const std::string& dataPath) {
+  tableDataFiles_.clear();
+
+  std::error_code error;
+  for (const auto& tableEntry : std::filesystem::directory_iterator(
+           dataPath,
+           std::filesystem::directory_options::skip_permission_denied,
+           error)) {
+    if (!tableEntry.is_directory()) {
+      continue;
+    }
+
+    const auto tableName = tableEntry.path().filename().string();
+    if (tableName.empty() || tableName.front() == '.') {
+      continue;
+    }
+
+    auto& files = tableDataFiles_[tableName];
+    std::error_code fileError;
+    for (const auto& fileEntry : std::filesystem::directory_iterator(
+             tableEntry.path(),
+             std::filesystem::directory_options::skip_permission_denied,
+             fileError)) {
+      const auto filename = fileEntry.path().filename().string();
+      if (fileEntry.is_regular_file() && !filename.empty() &&
+          filename.front() != '.') {
+        files.push_back(fileEntry.path().string());
+      }
+    }
+    BOLT_USER_CHECK(
+        !fileError,
+        "Failed to scan TPC-DS table directory {}: {}",
+        tableEntry.path().string(),
+        fileError.message());
+    std::sort(files.begin(), files.end());
+  }
+
+  BOLT_USER_CHECK(
+      !error,
+      "Failed to scan TPC-DS data path {}: {}",
+      dataPath,
+      error.message());
+  BOLT_USER_CHECK(
+      !tableDataFiles_.empty(),
+      "No table subdirectories found in TPC-DS data path: {}",
+      dataPath);
+}
+
+TpchPlan TpcdsQueryBuilder::getQueryPlan(
+    const std::string& queryName,
+    const std::string& planDirectory,
+    memory::MemoryPool* pool) {
+  auto plan = TpcdsPlanLoader(planDirectory, pool).loadPlan(queryName);
+  const auto scans = TpcdsPlanLoader::collectTableScanNodes(plan.plan);
+
+  if (!scans.empty() && connectorId_.empty()) {
+    connectorId_ = scans.front()->tableHandle()->connectorId();
+    if (!connector::isConnectorRegistered(connectorId_)) {
+      if (!connector::hasConnectorFactory(connector::kHiveConnectorName)) {
+        connector::registerConnectorFactory(
+            std::make_shared<connector::hive::HiveConnectorFactory>());
+      }
+      auto connectorInstance =
+          connector::getConnectorFactory(connector::kHiveConnectorName)
+              ->newConnector(connectorId_, connectorConfig_, ioExecutor_);
+      connector::registerConnector(std::move(connectorInstance));
+      ownedConnector_ = true;
+    }
+  }
+
+  for (const auto& scan : scans) {
+    const auto& tableName = scan->tableHandle()->name();
+    const auto* files = findDataFiles(tableName);
+    BOLT_USER_CHECK(
+        files != nullptr,
+        "No data files found for TPC-DS table '{}' used by {}",
+        tableName,
+        queryName);
+    plan.dataFiles[scan->id()] = *files;
+  }
+
+  plan.dataFileFormat = format_;
+  return plan;
+}
+
+std::shared_ptr<connector::ConnectorSplit> TpcdsQueryBuilder::makeSplit(
+    const std::string& filePath) const {
+  return connector::hive::HiveConnectorSplitBuilder(filePath)
+      .connectorId(connectorId_.empty() ? kHiveConnectorId : connectorId_)
+      .fileFormat(format_)
+      .build();
+}
+
+void TpcdsQueryBuilder::shutdown() {
+  if (ownedConnector_ && !connectorId_.empty()) {
+    connector::unregisterConnector(connectorId_);
+  }
+  ownedConnector_ = false;
+  connectorId_.clear();
+}
+
+const std::vector<std::string>* TpcdsQueryBuilder::findDataFiles(
+    const std::string& tableName) const {
+  auto it = tableDataFiles_.find(tableName);
+  if (it != tableDataFiles_.end() && !it->second.empty()) {
+    return &it->second;
+  }
+
+  const auto dot = tableName.rfind('.');
+  if (dot != std::string::npos) {
+    it = tableDataFiles_.find(tableName.substr(dot + 1));
+    if (it != tableDataFiles_.end() && !it->second.empty()) {
+      return &it->second;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace bytedance::bolt::exec::test

--- a/bolt/exec/tests/utils/TpcdsQueryBuilder.h
+++ b/bolt/exec/tests/utils/TpcdsQueryBuilder.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file has been modified by ByteDance Ltd. and/or its affiliates on
+ * 2026-08-28.
+ *
+ * Original file was released under the Apache License 2.0,
+ * with the full license text available at:
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This modified file is released under the same license.
+ * --------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+
+#include "bolt/connectors/hive/HiveConnectorSplit.h"
+#include "bolt/exec/tests/utils/TpcdsPlanLoader.h"
+
+namespace bytedance::bolt::exec::test {
+
+/// Loads TPC-DS plans and binds their table scans to a Hive-style data tree.
+class TpcdsQueryBuilder {
+ public:
+  explicit TpcdsQueryBuilder(
+      dwio::common::FileFormat format = dwio::common::FileFormat::PARQUET,
+      folly::Executor* ioExecutor = nullptr,
+      std::shared_ptr<const config::ConfigBase> connectorConfig = nullptr);
+
+  /// Discovers data files below dataPath/<table-name>/.
+  void initialize(const std::string& dataPath);
+
+  TpchPlan getQueryPlan(
+      const std::string& queryName,
+      const std::string& planDirectory,
+      memory::MemoryPool* pool);
+
+  std::shared_ptr<connector::ConnectorSplit> makeSplit(
+      const std::string& filePath) const;
+
+  void shutdown();
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+ private:
+  const std::vector<std::string>* findDataFiles(
+      const std::string& tableName) const;
+
+  const dwio::common::FileFormat format_;
+  folly::Executor* const ioExecutor_;
+  const std::shared_ptr<const config::ConfigBase> connectorConfig_;
+  std::string connectorId_;
+  bool ownedConnector_{false};
+  std::unordered_map<std::string, std::vector<std::string>> tableDataFiles_;
+};
+
+} // namespace bytedance::bolt::exec::test

--- a/scripts/tpcds/generate_plans.py
+++ b/scripts/tpcds/generate_plans.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+# Copyright (c) ByteDance Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate benchmark-ready Bolt TPC-DS plans through a Presto native worker.
+
+The native worker must be configured to dump each received single-node bolt
+plan as a JSON file. This tool submits the SQL files one at a time, detects the
+new dump, validates its shape, writes it under the SQL stem, and cancels the
+query as soon as the plan has been captured.
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+VARIANT_QUERY_NUMBERS = {14, 23, 24, 39}
+QUERY_NAMES = tuple(
+    query_name
+    for query_number in range(1, 100)
+    for query_name in (
+        (f"q{query_number}a", f"q{query_number}b")
+        if query_number in VARIANT_QUERY_NUMBERS
+        else (f"q{query_number}",)
+    )
+)
+
+FileState = Tuple[int, int]
+Snapshot = Dict[Path, FileState]
+
+
+class PlanGenerationError(RuntimeError):
+    """Reports a query submission or plan dump failure."""
+
+
+def normalize_sql(sql: str) -> str:
+    """Removes the statement terminator rejected by the HTTP query API."""
+    sql = sql.strip()
+    if sql.endswith(";"):
+        sql = sql[:-1].rstrip()
+    if not sql:
+        raise PlanGenerationError("SQL file is empty")
+    return sql
+
+
+def find_query_files(
+    query_directory: Path, selected_queries: Sequence[str]
+) -> List[Tuple[str, Path]]:
+    """Finds and validates the requested TPC-DS SQL files."""
+    if not query_directory.is_dir():
+        raise PlanGenerationError(
+            f"TPC-DS query directory does not exist: {query_directory}"
+        )
+
+    files: Dict[str, Path] = {}
+    for path in query_directory.iterdir():
+        if not path.is_file() or path.suffix.lower() != ".sql":
+            continue
+        query_name = path.stem.lower()
+        if query_name in files:
+            raise PlanGenerationError(
+                f"Duplicate TPC-DS query name {query_name}: "
+                f"{files[query_name]} and {path}"
+            )
+        files[query_name] = path
+
+    if selected_queries:
+        names = []
+        for query_name in selected_queries:
+            query_name = query_name.lower()
+            if query_name not in QUERY_NAMES:
+                raise PlanGenerationError(f"Unknown TPC-DS query: {query_name}")
+            if query_name not in files:
+                raise PlanGenerationError(
+                    f"TPC-DS SQL file is missing for {query_name} in {query_directory}"
+                )
+            if query_name not in names:
+                names.append(query_name)
+    else:
+        expected = set(QUERY_NAMES)
+        actual = set(files)
+        if actual != expected:
+            missing = ", ".join(sorted(expected - actual)) or "none"
+            extra = ", ".join(sorted(actual - expected)) or "none"
+            raise PlanGenerationError(
+                "TPC-DS query directory must contain the 103 SQL files; "
+                f"missing: {missing}; extra: {extra}"
+            )
+        names = list(QUERY_NAMES)
+
+    return [(name, files[name]) for name in names]
+
+
+def snapshot_json_files(directory: Path) -> Snapshot:
+    """Records JSON files so a subsequent native-worker dump can be found."""
+    result = {}
+    for path in directory.rglob("*.json"):
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            continue
+        if path.is_file():
+            result[path.resolve()] = (stat.st_mtime_ns, stat.st_size)
+    return result
+
+
+def node_names(plan: Mapping[str, object]) -> Iterable[str]:
+    """Yields plan node names by following source edges."""
+    name = plan.get("name")
+    if isinstance(name, str):
+        yield name
+    sources = plan.get("sources", [])
+    if isinstance(sources, list):
+        for source in sources:
+            if isinstance(source, dict):
+                yield from node_names(source)
+
+
+def validate_plan(plan: object, source: Path) -> Mapping[str, object]:
+    """Checks that a dump is a complete local Bolt PlanNode tree."""
+    if not isinstance(plan, dict):
+        raise PlanGenerationError(f"Plan dump is not a JSON object: {source}")
+    if not isinstance(plan.get("id"), str):
+        raise PlanGenerationError(f"Plan dump has no string node id: {source}")
+    if not isinstance(plan.get("name"), str) or not str(plan["name"]).endswith("Node"):
+        raise PlanGenerationError(f"Plan dump has no PlanNode name: {source}")
+    if not isinstance(plan.get("sources"), list):
+        raise PlanGenerationError(f"Plan dump has no source list: {source}")
+
+    names = set(node_names(plan))
+    if "TableScanNode" not in names:
+        raise PlanGenerationError(
+            f"Plan dump contains no TableScanNode and is not a TPC-DS plan: {source}"
+        )
+    unsupported = names.intersection({"ExchangeNode", "RemoteSourceNode"})
+    if unsupported:
+        raise PlanGenerationError(
+            "Plan dump is distributed rather than single-node; found "
+            f"{', '.join(sorted(unsupported))} in {source}"
+        )
+    return plan
+
+
+def changed_plans(
+    dump_directory: Path, before: Snapshot
+) -> List[Tuple[Path, Mapping[str, object]]]:
+    """Returns complete PlanNode dumps created or changed after a snapshot."""
+    plans = []
+    for path, state in snapshot_json_files(dump_directory).items():
+        if before.get(path) == state:
+            continue
+        try:
+            with path.open(encoding="utf-8") as source:
+                value = json.load(source)
+            plan = validate_plan(value, path)
+        except (OSError, json.JSONDecodeError, PlanGenerationError):
+            continue
+        plans.append((path, plan))
+    return plans
+
+
+def choose_plan(
+    candidates: Sequence[Tuple[Path, Mapping[str, object]]], query_name: str
+) -> Optional[Tuple[Path, Mapping[str, object]]]:
+    """Selects one plan, allowing duplicate worker dumps of the same tree."""
+    if not candidates:
+        return None
+
+    by_contents: Dict[str, List[Path]] = {}
+    plans_by_contents: Dict[str, Mapping[str, object]] = {}
+    for path, plan in candidates:
+        contents = json.dumps(plan, sort_keys=True, separators=(",", ":"))
+        by_contents.setdefault(contents, []).append(path)
+        plans_by_contents[contents] = plan
+    if len(by_contents) != 1:
+        paths = ", ".join(str(path) for path, _ in candidates)
+        raise PlanGenerationError(
+            f"Multiple different plan dumps appeared while generating {query_name}: "
+            f"{paths}. Use a dump directory dedicated to this generator."
+        )
+
+    contents, paths = next(iter(by_contents.items()))
+    return paths[0], plans_by_contents[contents]
+
+
+def write_plan(path: Path, plan: Mapping[str, object]) -> None:
+    """Atomically writes a normalized PlanNode JSON file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(plan, output, indent=2)
+            output.write("\n")
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def parse_headers(values: Sequence[str]) -> Dict[str, str]:
+    """Parses repeatable NAME=VALUE HTTP header options."""
+    headers = {}
+    for value in values:
+        name, separator, header_value = value.partition("=")
+        if not separator or not name.strip():
+            raise PlanGenerationError(
+                f"Invalid HTTP header {value!r}; expected NAME=VALUE"
+            )
+        headers[name.strip()] = header_value
+    return headers
+
+
+class PrestoClient:
+    """Minimal client for the documented Presto statement HTTP protocol."""
+
+    def __init__(
+        self,
+        server: str,
+        user: str,
+        catalog: str,
+        schema: str,
+        session_properties: Sequence[str],
+        extra_headers: Mapping[str, str],
+        timeout: float,
+    ) -> None:
+        self.statement_url = f"{server.rstrip('/')}/v1/statement"
+        self.timeout = timeout
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Presto-User": user,
+            "X-Presto-Source": "bolt-tpcds-plan-generator",
+            "X-Presto-Catalog": catalog,
+            "X-Presto-Schema": schema,
+            "X-Presto-Session": ",".join(session_properties),
+            **extra_headers,
+        }
+
+    def _json_request(
+        self,
+        method: str,
+        url: str,
+        body: Optional[bytes] = None,
+        trace_token: Optional[str] = None,
+    ) -> Mapping[str, object]:
+        headers = dict(self.headers)
+        if trace_token:
+            headers["X-Presto-Trace-Token"] = trace_token
+        request = urllib.request.Request(url, data=body, headers=headers, method=method)
+        deadline = time.monotonic() + self.timeout
+        while True:
+            try:
+                with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                    return json.load(response)
+            except urllib.error.HTTPError as error:
+                if error.code == 503 and time.monotonic() < deadline:
+                    time.sleep(0.1)
+                    continue
+                detail = error.read().decode("utf-8", errors="replace")
+                raise PlanGenerationError(
+                    f"Presto returned HTTP {error.code} for {method} {url}: {detail}"
+                ) from error
+            except (OSError, json.JSONDecodeError) as error:
+                raise PlanGenerationError(
+                    f"Presto request failed for {method} {url}: {error}"
+                ) from error
+
+    def submit(self, sql: str, trace_token: str) -> Mapping[str, object]:
+        """Submits one SQL statement."""
+        return self._json_request(
+            "POST", self.statement_url, sql.encode("utf-8"), trace_token
+        )
+
+    def advance(self, next_uri: str) -> Mapping[str, object]:
+        """Advances a query until the worker receives its plan."""
+        return self._json_request("GET", next_uri)
+
+    def cancel(self, next_uri: str) -> None:
+        """Cancels a query after its plan has been dumped."""
+        request = urllib.request.Request(
+            next_uri, headers=self.headers, method="DELETE"
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout):
+                return
+        except urllib.error.HTTPError as error:
+            if error.code not in (404, 410):
+                detail = error.read().decode("utf-8", errors="replace")
+                raise PlanGenerationError(
+                    f"Failed to cancel Presto query: HTTP {error.code}: {detail}"
+                ) from error
+        except OSError as error:
+            raise PlanGenerationError(
+                f"Failed to cancel Presto query through {next_uri}: {error}"
+            ) from error
+
+
+def query_error(response: Mapping[str, object]) -> Optional[str]:
+    """Extracts a readable error from a Presto QueryResults document."""
+    error = response.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message", "unknown Presto error")
+    failure = error.get("failureInfo")
+    if isinstance(failure, dict) and failure.get("message") != message:
+        return f"{message}: {failure.get('message')}"
+    return str(message)
+
+
+def generate_one_plan(
+    query_name: str,
+    sql: str,
+    output_path: Path,
+    dump_directory: Path,
+    client: PrestoClient,
+    dump_timeout: float,
+    poll_interval: float,
+) -> Path:
+    """Submits one query and saves the native worker's dumped PlanNode."""
+    before = snapshot_json_files(dump_directory)
+    response = client.submit(sql, query_name)
+    next_uri = response.get("nextUri")
+    deadline = time.monotonic() + dump_timeout
+
+    try:
+        while True:
+            selected = choose_plan(changed_plans(dump_directory, before), query_name)
+            if selected is not None:
+                _, plan = selected
+                write_plan(output_path, plan)
+                return output_path
+
+            error = query_error(response)
+            if error:
+                raise PlanGenerationError(
+                    f"Presto failed while generating {query_name}: {error}"
+                )
+            if time.monotonic() >= deadline:
+                query_id = response.get("id", "unknown")
+                raise PlanGenerationError(
+                    f"Timed out waiting for the native worker to dump {query_name} "
+                    f"(Presto query {query_id}). Verify the worker plan-dump-dir "
+                    f"points to {dump_directory}."
+                )
+
+            if isinstance(next_uri, str):
+                response = client.advance(next_uri)
+                next_uri = response.get("nextUri")
+            else:
+                time.sleep(poll_interval)
+    finally:
+        if isinstance(next_uri, str):
+            client.cancel(next_uri)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query-dir",
+        required=True,
+        type=Path,
+        help="Directory containing q1.sql through q99.sql and a/b variants",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory in which q1.json through q99.json are written",
+    )
+    parser.add_argument(
+        "--dump-dir",
+        required=True,
+        type=Path,
+        help="Directory configured as plan-dump-dir on the native worker",
+    )
+    parser.add_argument(
+        "--server",
+        default="http://127.0.0.1:8080",
+        help="Presto coordinator URL (default: %(default)s)",
+    )
+    parser.add_argument("--user", default="bolt", help="Presto user")
+    parser.add_argument("--catalog", default="hive", help="Presto catalog")
+    parser.add_argument("--schema", default="tpcds", help="Presto schema")
+    parser.add_argument(
+        "--query",
+        action="append",
+        default=[],
+        help="Generate only this query; may be repeated (default: all 103)",
+    )
+    parser.add_argument(
+        "--session",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Additional Presto session property; may be repeated",
+    )
+    parser.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Additional HTTP header; may be repeated",
+    )
+    parser.add_argument(
+        "--dump-timeout",
+        type=float,
+        default=60.0,
+        help="Seconds to wait for each worker plan dump (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--http-timeout",
+        type=float,
+        default=10.0,
+        help="Seconds allowed for each HTTP request (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=0.1,
+        help="Seconds between dump checks after a query ends (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace existing output plan files",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.dump_timeout <= 0 or args.http_timeout <= 0:
+            raise PlanGenerationError("Timeout values must be positive")
+        if args.poll_interval <= 0:
+            raise PlanGenerationError("--poll-interval must be positive")
+
+        query_files = find_query_files(args.query_dir, args.query)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        args.dump_dir.mkdir(parents=True, exist_ok=True)
+
+        output_paths = {
+            name: args.output_dir / f"{name}.json" for name, _ in query_files
+        }
+        existing = [path for path in output_paths.values() if path.exists()]
+        if existing and not args.overwrite:
+            raise PlanGenerationError(
+                "Output plans already exist; pass --overwrite to replace them: "
+                + ", ".join(str(path) for path in existing)
+            )
+
+        session_properties = ["single_node_execution_enabled=true"]
+        session_properties.extend(args.session)
+        client = PrestoClient(
+            args.server,
+            args.user,
+            args.catalog,
+            args.schema,
+            session_properties,
+            parse_headers(args.header),
+            args.http_timeout,
+        )
+
+        for index, (query_name, query_path) in enumerate(query_files, start=1):
+            print(f"[{index}/{len(query_files)}] Generating {query_name}", flush=True)
+            sql = normalize_sql(query_path.read_text(encoding="utf-8"))
+            path = generate_one_plan(
+                query_name,
+                sql,
+                output_paths[query_name],
+                args.dump_dir,
+                client,
+                args.dump_timeout,
+                args.poll_interval,
+            )
+            print(f"[{index}/{len(query_files)}] Wrote {path}", flush=True)
+        return 0
+    except (OSError, PlanGenerationError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add a local Parquet-backed TPC-DS benchmark with support for all 103 query names and serialized Presto plans. Report task memory-pool peak bytes for each verbose query execution.

Add plan loading tests, expression deserialization compatibility, and a reproducible generator for the Q14, Q23, Q24, and Q39 a/b variants.

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #959

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [x] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

The workflow has three inputs:

  1. Local Parquet data
  2. Serialized single-node Bolt plans
  3. The bolt_tpcds_benchmark executable

How to run tpcds benchmark:
  _build/Release/bolt/benchmarks/tpcds/bolt_tpcds_benchmark \
    --bolt_benchmark_tpcds_data_path=/data/tpcds100  \
    --bolt_benchmark_tpcds_plan_path=/tmp/BoltPlans/presto/tpcds/sf100/plans \
    --bolt_benchmark_tpcds_run_query=true \
    --bm_regex='q(1|2|14a)$'

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- add TPCDS benchmark tool
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)

