### PR TITLE
fix: decide year plus sign by local year only, matching Spark

### DIFF
--- a/bolt/functions/lib/DateTimeFormatter.cpp
+++ b/bolt/functions/lib/DateTimeFormatter.cpp
@@ -1301,23 +1301,12 @@ int32_t DateTimeFormatter::format(
             // spark compatibility: Java DateTimeFormatter uses
             // SignStyle.EXCEEDS_PAD for 4+ pattern letters, printing '+'
             // when the year has more digits than the pattern width; legacy
-            // SimpleDateFormat never prints '+'.
-            // However, if a timezone is applied and the same instant in UTC
-            // has year-of-era <= 9999 (e.g., Asia/Shanghai at
-            // 10000-01-01 07:59:59 equals 9999-12-31 23:59:59 UTC), suppress
-            // the leading '+'.
+            // SimpleDateFormat never prints '+'. Like Java, the decision is
+            // based on the local (timezone-adjusted) year only.
             bool addPlus = ::bytedance::bolt::kSparkCompatible &&
                 timePolicy != TimePolicy::LEGACY &&
                 token.pattern.minRepresentDigits >= 4 && year > 0 &&
                 countDigits(year) > token.pattern.minRepresentDigits;
-            if (addPlus && timezone != nullptr) {
-              const auto civilDateTimeUtc =
-                  util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
-              const auto utcYearEra = civilDateTimeUtc.date.year <= 0
-                  ? std::abs(civilDateTimeUtc.date.year - 1)
-                  : civilDateTimeUtc.date.year;
-              addPlus = utcYearEra > 9999;
-            }
             if (addPlus) {
               *result++ = '+';
             }
@@ -1397,23 +1386,12 @@ int32_t DateTimeFormatter::format(
             // spark compatibility: Java DateTimeFormatter uses
             // SignStyle.EXCEEDS_PAD for 4+ pattern letters, printing '+'
             // when the year has more digits than the pattern width; legacy
-            // SimpleDateFormat never prints '+'.
-            // If a timezone is applied and the same instant in UTC has
-            // (adjusted) year <= 9999, suppress the leading '+'.
+            // SimpleDateFormat never prints '+'. Like Java, the decision is
+            // based on the local (timezone-adjusted) year only.
             bool addPlus = ::bytedance::bolt::kSparkCompatible &&
                 timePolicy != TimePolicy::LEGACY &&
                 token.pattern.minRepresentDigits >= 4 && year > 0 &&
                 countDigits(year) > token.pattern.minRepresentDigits;
-            if (addPlus && timezone != nullptr) {
-              const auto civilDateTimeUtc =
-                  util::toCivilDateTime(timestamp, allowOverflow, isPrecision);
-              auto utcYear = civilDateTimeUtc.date.year;
-              if (utcYear <= 0 &&
-                  (hasEra_ || timePolicy == TimePolicy::LEGACY)) {
-                utcYear = std::abs(utcYear) + 1;
-              }
-              addPlus = utcYear > 9999;
-            }
             if (addPlus) {
               *result++ = '+';
             }

--- a/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkSqlDateTimeFunctionsTest.cpp
@@ -2282,19 +2282,33 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeYearSignEdgeCases) {
   // because the '+' overflowed the undersized result buffer.
   EXPECT_EQ(fromUnixTime(-3217862448344, "yyyy G"), "+100002 BC");
 
+  // With a timezone, the sign still follows the local year only (Java
+  // semantics): UTC 99999-12-31 16:00:00 is Shanghai 100000-01-01
+  // 00:00:00, whose 6 digits exceed both widths below.
+  auto fromUnixTimeTz = [&](int64_t unixTime, const std::string& format) {
+    return evaluateOnce<std::string>(
+               fmt::format("from_unixtime(c0, '{}', 'Asia/Shanghai')", format),
+               std::optional<int64_t>{unixTime})
+        .value();
+  };
+  EXPECT_EQ(fromUnixTimeTz(3093527952000, "yyyyy"), "+100000");
+  EXPECT_EQ(fromUnixTimeTz(3093527952000, "yyyy"), "+100000");
+
+  // Legacy policy (SimpleDateFormat) never prints a leading '+', for both
+  // the same instants and the same widths as above.
   setTimeParserPolicy("legacy");
-  // SimpleDateFormat never prints a leading '+'.
   EXPECT_EQ(
       fromUnixTime(3093527980800, "yyyy-MM-dd HH:mm:ss"),
       "100000-01-01 00:00:00");
+  // Width equal to the digit count still has no sign, matching corrected.
+  EXPECT_EQ(fromUnixTime(1764570096000, "yyyyy"), "57887");
+  EXPECT_EQ(fromUnixTimeTz(3093527952000, "yyyyy"), "100000");
+  EXPECT_EQ(fromUnixTimeTz(3093527952000, "yyyy"), "100000");
   resetQueryConfig();
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkTimezone) {
-  // Expected values follow Spark's default (corrected) formatting; Bolt's
-  // default policy is legacy, which never prints a leading '+'.
-  setTimeParserPolicy("corrected");
-  auto fromUnixTime = [&](int64_t unixTime, std::string timeZone) {
+  auto fromUnixTime = [&](int64_t unixTime, const std::string& timeZone) {
     return evaluateOnce<std::string>(
                fmt::format(
                    "from_unixtime(c0, 'yyyy-MM-dd HH:mm:ss', '{}')", timeZone),
@@ -2302,14 +2316,47 @@ TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeLargeValuesSparkTimezone) {
         .value();
   };
 
-  EXPECT_EQ(
-      fromUnixTime(253402300799, "Asia/Shanghai"), "10000-01-01 07:59:59");
-  EXPECT_EQ(
-      fromUnixTime(253402300801, "Asia/Shanghai"),
-      ::bytedance::bolt::kSparkCompatible ? "+10000-01-01 08:00:01"
-                                          : "10000-01-01 08:00:01");
-  EXPECT_EQ(
-      fromUnixTime(253402300801, "America/Los_Angeles"), "9999-12-31 16:00:01");
+  // Expected values verified against Spark 3.2.4/3.5.9. The '+' is decided by
+  // the local (timezone-adjusted) year only, never by UTC: UTC
+  // 9999-12-31 23:59:59 is Shanghai 10000-01-01 07:59:59, which prints '+'
+  // under corrected but not under legacy (SimpleDateFormat).
+  struct Case {
+    int64_t unixTime;
+    const char* timeZone;
+    const char* corrected;
+    const char* legacy;
+  };
+  const std::vector<Case> cases = {
+      {253402300799,
+       "Asia/Shanghai",
+       "+10000-01-01 07:59:59",
+       "10000-01-01 07:59:59"},
+      {253402300801,
+       "Asia/Shanghai",
+       "+10000-01-01 08:00:01",
+       "10000-01-01 08:00:01"},
+      // Local year in Los Angeles is 9999, so no sign under either policy.
+      {253402300801,
+       "America/Los_Angeles",
+       "9999-12-31 16:00:01",
+       "9999-12-31 16:00:01"},
+  };
+
+  setTimeParserPolicy("corrected");
+  for (const auto& c : cases) {
+    // Non-SPARK_COMPATIBLE builds never print '+', matching the legacy text.
+    EXPECT_EQ(
+        fromUnixTime(c.unixTime, c.timeZone),
+        ::bytedance::bolt::kSparkCompatible ? c.corrected : c.legacy)
+        << c.unixTime << " @ " << c.timeZone;
+  }
+
+  setTimeParserPolicy("legacy");
+  for (const auto& c : cases) {
+    EXPECT_EQ(fromUnixTime(c.unixTime, c.timeZone), c.legacy)
+        << c.unixTime << " @ " << c.timeZone;
+  }
+  resetQueryConfig();
 }
 
 TEST_F(SparkSqlDateTimeFunctionsTest, FromUnixtimeYYYYThrowError) {


### PR DESCRIPTION
### What problem does this PR solve?

With a timezone applied, `date_format` / `from_unixtime` decided the year's leading `+` from the **UTC** year against a fixed `9999` threshold, instead of from the local (timezone-adjusted) year. Spark decides the sign from the local year only (Java `SignStyle.EXCEEDS_PAD`), so Bolt dropped the `+` where Spark keeps it (e.g. `Asia/Shanghai` local year 10000, UTC year 9999).

Issue Number: close #962

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

`9f5eefa54` (PR #427) added a UTC-based suppression: when a timezone is set, the `+` for years beyond 9999 was suppressed if the same instant's **UTC** year did not exceed 9999. It was introduced to fix #426, where `from_unixtime(253402300799, ...)` at `Asia/Shanghai` printed a `+` that Spark did not — but that observation was **legacy**-policy behavior (SimpleDateFormat never prints `+`), misattributed to a UTC rule. Under corrected policy Spark actually **does** print `+10000-...` there.

This PR removes the UTC suppression in both the `YEAR_OF_ERA` and `YEAR` branches. The `+` now follows the local year alone, exactly like Java's `SignStyle.EXCEEDS_PAD` (`countDigits(localYear) > patternWidth`), which is what Spark's `Iso8601TimestampFormatter` does — `formatter.withZone(zoneId).format(instant)` uses the zone only to project the instant into local time, then formats the local year. The legacy gate (no `+` under legacy policy), merged in #948, remains and is the correct fix for #426.

**Source evidence** — Apache Spark tag `v3.2.4`, pinned to commit [`0ae10ac1`](https://github.com/apache/spark/tree/0ae10ac18298d1792828f1d59b652ef17462d76e) (a lightweight tag pointing straight at this commit), so the permalinks below are stable:

1. corrected — zone is used once, only to project the instant into local time ([`TimestampFormatter.scala#L129-L139`](https://github.com/apache/spark/blob/0ae10ac18298d1792828f1d59b652ef17462d76e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala#L129-L139)):

```scala
override def format(instant: Instant): String = {
  try {
    formatter.withZone(zoneId).format(instant)   // zoneId used once, for local projection
  } catch checkFormattedDiff(toJavaTimestamp(instantToMicros(instant)),
    (t: Timestamp) => format(t))
}

override def format(us: Long): String = {
  val instant = DateTimeUtils.microsToInstant(us)   // absolute instant, no zone
  format(instant)
}
```

2. pattern — `y`→`u` when no era, so 4+ letters map to `SignStyle.EXCEEDS_PAD` on the local year ([`DateTimeFormatterHelper.scala#L334-L339`](https://github.com/apache/spark/blob/0ae10ac18298d1792828f1d59b652ef17462d76e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala#L334-L339)):

```scala
// In DateTimeFormatter, 'u' supports negative years. We substitute 'y' to 'u'
// here ... We only do this substitution when there is no era designator found.
if (!eraDesignatorContained) {
  patternPart.replace("y", "u")
} else {
  patternPart
}
```

3. legacy — `FastDateFormat` (SimpleDateFormat semantics), never prints `+` ([`TimestampFormatter.scala#L250-L277`](https://github.com/apache/spark/blob/0ae10ac18298d1792828f1d59b652ef17462d76e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala#L250-L277)):

```scala
class LegacyFastTimestampFormatter(pattern: String, zoneId: ZoneId, locale: Locale)
    extends TimestampFormatter {
  @transient private lazy val fastDateFormat =
    FastDateFormat.getInstance(pattern, TimeZone.getTimeZone(zoneId), locale)
  // ...
  override def format(timestamp: Long): String = {
    val julianMicros = rebaseGregorianToJulianMicros(timestamp)
    cal.setTimeInMillis(...)
    fastDateFormat.format(cal)
  }
```

Behavior changes (all verified against Spark 3.2.4/3.5.9):
- `Asia/Shanghai`, corrected: `from_unixtime(253402300799, 'yyyy-MM-dd HH:mm:ss')` → `+10000-01-01 07:59:59` (was `10000-...`).
- Wider patterns at their own boundary: `yyyyy` prints `+` only when the year exceeds 5 digits — a fixed 9999 threshold was also wrong here.

Tests now exercise **both** corrected and legacy policies:
- `FromUnixtimeLargeValuesSparkParity` already ran the full case table under both policies.
- `FromUnixtimeLargeValuesSparkTimezone` is reworked to run every timezone case under both policies (corrected with `+`, legacy without), with expectations taken from real Spark.
- `FromUnixtimeYearSignEdgeCases` adds legacy assertions mirroring its corrected sign/width cases, plus the `yyyyy`/`yyyy` timezone-boundary cases.

**Verification:** after removing the suppression, the 325,730-case differential against the Spark-verified Java ground truth has zero sign-related diffs; the only remaining diffs are unrelated timezone-rule issues (pre-1883 LMT, post-2037 DST extrapolation).

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

Removes a `toCivilDateTime` call from the timezone formatting path (the suppression no longer recomputes the UTC civil date).

### Release Note

```text
Release Note:
- Fixed date_format/from_unixtime to decide the year's leading '+' from the local (timezone-adjusted) year, matching Spark, instead of the UTC year. With a session timezone, years beyond the pattern width now print '+' consistently (e.g. Asia/Shanghai '+10000-01-01 07:59:59' under corrected policy).
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
