### PR TITLE
fix: handle floating-point cast boundaries safely

### DIFF
--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -48,8 +48,8 @@ constexpr auto kDecimalStringFormat = kIsInSpark
     ? DecimalUtil::DecimalStringFormat::kSpark
     : DecimalUtil::DecimalStringFormat::kPlain;
 
-// convert status to indicate whether conversion behaviors.
-// Note: for INTEGER_OVERFLOW, the output value should save a wrapped value.
+// Conversion status used by the cast policy to decide whether to keep the
+// produced value, throw, or return null.
 enum class ConvertStatus : int8_t {
   SUCCESS,
   INTEGER_OVERFLOW,
@@ -197,6 +197,22 @@ tryIntegerToInteger(const From& from, To& to) {
     // save wrapped value and return overflow status, will handle it in caller
     // function
     to = static_cast<To>(from);
+    return ConvertStatus::INTEGER_OVERFLOW;
+  }
+  to = static_cast<To>(from);
+  return ConvertStatus::SUCCESS;
+}
+
+template <typename From, typename To>
+FOLLY_ALWAYS_INLINE ConvertStatus
+tryFloatingPointToInteger(const From& from, To& to) {
+  using Limits = util::FloatingPointToIntegralLimits<To>;
+  if (FOLLY_UNLIKELY(Limits::isPositiveOverflow(from))) {
+    to = std::numeric_limits<To>::max();
+    return ConvertStatus::INTEGER_OVERFLOW;
+  }
+  if (FOLLY_UNLIKELY(Limits::isNegativeOverflow(from))) {
+    to = std::numeric_limits<To>::min();
     return ConvertStatus::INTEGER_OVERFLOW;
   }
   to = static_cast<To>(from);
@@ -368,58 +384,44 @@ class Converter {
         using LimitType = typename util::
             Converter<originKind, void, util::TruncateCastPolicy>::LimitType;
 
-        if constexpr (kIsInSpark) {
-          if (std::isnan(from)) {
-            to = 0;
-            return ConvertStatus::INTEGER_OVERFLOW;
-          }
-          if (LimitType::isPositiveOverflow(from)) {
-            to = LimitType::max();
-            return ConvertStatus::INTEGER_OVERFLOW;
-          }
-          if (LimitType::isNegativeOverflow(from)) {
-            to = LimitType::min();
-            return ConvertStatus::INTEGER_OVERFLOW;
-          }
-
-          using FirstStageType = typename LimitType::FirstStageType;
-          const auto integral = static_cast<FirstStageType>(from);
-          to = static_cast<ToType>(integral);
-          if constexpr (LimitType::kByteOrSmallInt) {
-            if (FOLLY_UNLIKELY(
-                    integral > std::numeric_limits<ToType>::max() ||
-                    integral < std::numeric_limits<ToType>::min())) {
-              return ConvertStatus::INTEGER_OVERFLOW;
+        if (std::isnan(from)) {
+          to = 0;
+          return kIsInSpark ? ConvertStatus::INTEGER_OVERFLOW
+                            : ConvertStatus::SUCCESS;
+        }
+        if (LimitType::isPositiveOverflow(from)) {
+          to = LimitType::max();
+          if constexpr (kIsInSpark && std::is_same_v<ToType, int64_t>) {
+            // Spark accepts the double-rounded Long.MaxValue boundary and
+            // saturates it using JVM floating point conversion semantics.
+            if (from == LimitType::template firstPositiveOverflow<FromType>()) {
+              return ConvertStatus::SUCCESS;
             }
           }
-          return ConvertStatus::SUCCESS;
-        } else {
-          if (std::isnan(from)) {
-            to = 0;
-            return ConvertStatus::SUCCESS;
-          }
-          if (from > LimitType::maxLimit()) {
-            to = LimitType::max();
-            return ConvertStatus::INTEGER_OVERFLOW;
-          }
-          if (from < LimitType::minLimit()) {
-            to = LimitType::min();
-            return ConvertStatus::INTEGER_OVERFLOW;
-          }
-          if (FOLLY_UNLIKELY(
-                  (from > std::numeric_limits<ToType>::max()) ||
-                  (from < std::numeric_limits<ToType>::min()))) {
-            to = LimitType::cast(from);
-            return ConvertStatus::INTEGER_OVERFLOW;
-          }
-          to = LimitType::cast(from);
-          return ConvertStatus::SUCCESS;
+          return ConvertStatus::INTEGER_OVERFLOW;
         }
+        if (LimitType::isNegativeOverflow(from)) {
+          to = LimitType::min();
+          return ConvertStatus::INTEGER_OVERFLOW;
+        }
+
+        using FirstStageType = typename LimitType::FirstStageType;
+        const auto integral = static_cast<FirstStageType>(from);
+        to = static_cast<ToType>(integral);
+        if constexpr (LimitType::kByteOrSmallInt) {
+          if (FOLLY_UNLIKELY(
+                  integral > std::numeric_limits<ToType>::max() ||
+                  integral < std::numeric_limits<ToType>::min())) {
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
+        }
+        return ConvertStatus::SUCCESS;
       } else {
         if (std::isnan(from)) {
           return ConvertStatus::OTHER_FAILURE;
         }
-        return tryIntegerToInteger<FromType, ToType>(std::round(from), to);
+        return tryFloatingPointToInteger<FromType, ToType>(
+            std::round(from), to);
       }
     } else if constexpr (fromDecimal) {
       const auto scaleFactor = DecimalUtil::getPowersOfTen(fromScale_);

--- a/bolt/expression/CastExpr-tpl.cpp
+++ b/bolt/expression/CastExpr-tpl.cpp
@@ -364,29 +364,57 @@ class Converter {
       }
     } else if constexpr (fromFloat) {
       if constexpr (truncate) {
-        if (std::isnan(from)) {
-          to = 0;
-          return ConvertStatus::SUCCESS;
-        }
         constexpr TypeKind originKind = ToKind::storage;
         using LimitType = typename util::
             Converter<originKind, void, util::TruncateCastPolicy>::LimitType;
-        if (from > LimitType::maxLimit()) {
-          to = LimitType::max();
-          return ConvertStatus::INTEGER_OVERFLOW;
-        }
-        if (from < LimitType::minLimit()) {
-          to = LimitType::min();
-          return ConvertStatus::INTEGER_OVERFLOW;
-        }
-        if (FOLLY_UNLIKELY(
-                (from > std::numeric_limits<ToType>::max()) ||
-                (from < std::numeric_limits<ToType>::min()))) {
+
+        if constexpr (kIsInSpark) {
+          if (std::isnan(from)) {
+            to = 0;
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
+          if (LimitType::isPositiveOverflow(from)) {
+            to = LimitType::max();
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
+          if (LimitType::isNegativeOverflow(from)) {
+            to = LimitType::min();
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
+
+          using FirstStageType = typename LimitType::FirstStageType;
+          const auto integral = static_cast<FirstStageType>(from);
+          to = static_cast<ToType>(integral);
+          if constexpr (LimitType::kByteOrSmallInt) {
+            if (FOLLY_UNLIKELY(
+                    integral > std::numeric_limits<ToType>::max() ||
+                    integral < std::numeric_limits<ToType>::min())) {
+              return ConvertStatus::INTEGER_OVERFLOW;
+            }
+          }
+          return ConvertStatus::SUCCESS;
+        } else {
+          if (std::isnan(from)) {
+            to = 0;
+            return ConvertStatus::SUCCESS;
+          }
+          if (from > LimitType::maxLimit()) {
+            to = LimitType::max();
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
+          if (from < LimitType::minLimit()) {
+            to = LimitType::min();
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
+          if (FOLLY_UNLIKELY(
+                  (from > std::numeric_limits<ToType>::max()) ||
+                  (from < std::numeric_limits<ToType>::min()))) {
+            to = LimitType::cast(from);
+            return ConvertStatus::INTEGER_OVERFLOW;
+          }
           to = LimitType::cast(from);
-          return ConvertStatus::INTEGER_OVERFLOW;
+          return ConvertStatus::SUCCESS;
         }
-        to = LimitType::cast(from);
-        return ConvertStatus::SUCCESS;
       } else {
         if (std::isnan(from)) {
           return ConvertStatus::OTHER_FAILURE;

--- a/bolt/expression/tests/CastExprTest.cpp
+++ b/bolt/expression/tests/CastExprTest.cpp
@@ -1280,6 +1280,55 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
   }
 }
 
+TEST_F(CastExprTest, floatingPointToIntegralBoundaries) {
+  if (::bytedance::bolt::kSparkCompatible) {
+    GTEST_SKIP();
+  }
+
+  const auto testBoundaries = [&]() {
+    testCast<float, int32_t>(
+        "integer",
+        {0x1.fffffep30f, -0x1p31f},
+        {2'147'483'520, std::numeric_limits<int32_t>::min()});
+    testTryCast<float, int32_t>(
+        "integer",
+        {0x1.fffffep30f, 0x1p31f, -0x1p31f, -0x1.000002p31f},
+        {2'147'483'520,
+         std::nullopt,
+         std::numeric_limits<int32_t>::min(),
+         std::nullopt});
+    testInvalidCast<float>("integer", {0x1p31f}, "Cannot cast");
+
+    testCast<double, int64_t>(
+        "bigint",
+        {0x1.fffffffffffffp62, -0x1p63},
+        {9'223'372'036'854'774'784LL, std::numeric_limits<int64_t>::min()});
+    testTryCast<double, int64_t>(
+        "bigint",
+        {0x1.fffffffffffffp62, 0x1p63, -0x1p63, -0x1.0000000000001p63},
+        {9'223'372'036'854'774'784LL,
+         std::nullopt,
+         std::numeric_limits<int64_t>::min(),
+         std::nullopt});
+    testInvalidCast<double>("bigint", {0x1p63}, "Cannot cast");
+
+    testTryCast<float, int64_t>(
+        "bigint",
+        {0x1.fffffep62f, 0x1p63f, -0x1p63f, -0x1.000002p63f},
+        {9'223'371'487'098'961'920LL,
+         std::nullopt,
+         std::numeric_limits<int64_t>::min(),
+         std::nullopt});
+    testInvalidCast<float>("bigint", {0x1p63f}, "Cannot cast");
+  };
+
+  setCastIntByTruncate(false);
+  testBoundaries();
+
+  setCastIntByTruncate(true);
+  testBoundaries();
+}
+
 TEST_F(CastExprTest, primitiveValidCornerCases) {
   // To integer.
   {

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -704,6 +704,70 @@ TEST_F(SparkCastExprTest, overflow) {
       false);
 }
 
+TEST_F(SparkCastExprTest, floatingPointToIntegralBoundaries) {
+  testCast<float, int32_t>(
+      "integer",
+      {0x1.fffffep30f, 0x1p31f, -0x1p31f},
+      {2'147'483'520,
+       std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min()});
+  testCast<double, int64_t>(
+      "bigint",
+      {0x1.fffffffffffffp62, 0x1p63, -0x1p63},
+      {9'223'372'036'854'774'784LL,
+       std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min()});
+
+  testTryCast<double, int32_t>(
+      "integer",
+      {2'147'483'647.0,
+       0x1.fffffffffffffp30,
+       0x1p31,
+       -0x1p31,
+       -2'147'483'648.5,
+       -2'147'483'649.0,
+       std::numeric_limits<double>::quiet_NaN(),
+       std::numeric_limits<double>::infinity(),
+       -std::numeric_limits<double>::infinity()},
+      {std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::max(),
+       std::nullopt,
+       std::numeric_limits<int32_t>::min(),
+       std::numeric_limits<int32_t>::min(),
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt});
+  testTryCast<double, int64_t>(
+      "bigint",
+      {0x1.fffffffffffffp62, 0x1p63, -0x1p63, -0x1.0000000000001p63},
+      {9'223'372'036'854'774'784LL,
+       std::nullopt,
+       std::numeric_limits<int64_t>::min(),
+       std::nullopt});
+  testTryCast<float, int32_t>(
+      "integer",
+      {0x1.fffffep30f, 0x1p31f, -0x1p31f, -0x1.000002p31f},
+      {2'147'483'520,
+       std::nullopt,
+       std::numeric_limits<int32_t>::min(),
+       std::nullopt});
+  testTryCast<double, int16_t>(
+      "smallint",
+      {32'767.75, 32'768.0, -32'768.75, -32'769.0},
+      {std::numeric_limits<int16_t>::max(),
+       std::nullopt,
+       std::numeric_limits<int16_t>::min(),
+       std::nullopt});
+  testTryCast<double, int8_t>(
+      "tinyint",
+      {127.75, 128.0, -128.75, -129.0},
+      {std::numeric_limits<int8_t>::max(),
+       std::nullopt,
+       std::numeric_limits<int8_t>::min(),
+       std::nullopt});
+}
+
 TEST_F(SparkCastExprTest, timestampToString) {
   testCast<Timestamp, std::string>(
       "string",

--- a/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/bolt/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -740,8 +740,21 @@ TEST_F(SparkCastExprTest, floatingPointToIntegralBoundaries) {
        std::nullopt});
   testTryCast<double, int64_t>(
       "bigint",
-      {0x1.fffffffffffffp62, 0x1p63, -0x1p63, -0x1.0000000000001p63},
+      {0x1.fffffffffffffp62,
+       0x1p63,
+       0x1.0000000000001p63,
+       -0x1p63,
+       -0x1.0000000000001p63},
       {9'223'372'036'854'774'784LL,
+       std::numeric_limits<int64_t>::max(),
+       std::nullopt,
+       std::numeric_limits<int64_t>::min(),
+       std::nullopt});
+  testTryCast<float, int64_t>(
+      "bigint",
+      {0x1.fffffep62f, 0x1p63f, 0x1.000002p63f, -0x1p63f, -0x1.000002p63f},
+      {9'223'371'487'098'961'920LL,
+       std::numeric_limits<int64_t>::max(),
        std::nullopt,
        std::numeric_limits<int64_t>::min(),
        std::nullopt});

--- a/bolt/type/Conversions.h
+++ b/bolt/type/Conversions.h
@@ -64,6 +64,32 @@ struct TruncateLegacyCastPolicy {
   static constexpr bool legacyCast = true;
 };
 
+// Floating point to signed integer conversion is defined only when the
+// truncated value is representable. These limits identify the first values
+// outside that range without converting the floating point input first.
+template <typename T>
+struct FloatingPointToIntegralLimits {
+  template <typename FP>
+  static constexpr FP firstPositiveOverflow() {
+    return -static_cast<FP>(std::numeric_limits<T>::min());
+  }
+
+  template <typename FP>
+  static constexpr bool isPositiveOverflow(const FP& value) {
+    return value >= firstPositiveOverflow<FP>();
+  }
+
+  template <typename FP>
+  static constexpr bool isNegativeOverflow(const FP& value) {
+    constexpr FP kMin = static_cast<FP>(std::numeric_limits<T>::min());
+    constexpr FP kFirstNegativeOverflow = kMin - FP{1};
+    if constexpr (kFirstNegativeOverflow == kMin) {
+      return value < kMin;
+    }
+    return value <= kFirstNegativeOverflow;
+  }
+};
+
 template <TypeKind KIND, typename = void, typename TPolicy = DefaultCastPolicy>
 struct Converter {
   template <typename T>
@@ -324,26 +350,21 @@ struct Converter<
     static constexpr bool kByteOrSmallInt =
         std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t>;
     using FirstStageType = std::conditional_t<kByteOrSmallInt, int32_t, T>;
+    using FirstStageLimits = FloatingPointToIntegralLimits<FirstStageType>;
 
-    // Floating point to signed integer conversion is defined only when the
-    // truncated value is representable. Use the exclusive limits of that
-    // range so the conversion itself never relies on undefined behavior.
+    template <typename FP>
+    static constexpr FP firstPositiveOverflow() {
+      return FirstStageLimits::template firstPositiveOverflow<FP>();
+    }
+
     template <typename FP>
     static constexpr bool isPositiveOverflow(const FP& value) {
-      constexpr FP kFirstPositiveOverflow =
-          -static_cast<FP>(std::numeric_limits<FirstStageType>::min());
-      return value >= kFirstPositiveOverflow;
+      return FirstStageLimits::template isPositiveOverflow<FP>(value);
     }
 
     template <typename FP>
     static constexpr bool isNegativeOverflow(const FP& value) {
-      constexpr FP kMin =
-          static_cast<FP>(std::numeric_limits<FirstStageType>::min());
-      constexpr FP kFirstNegativeOverflow = kMin - FP{1};
-      if constexpr (kFirstNegativeOverflow == kMin) {
-        return value < kMin;
-      }
-      return value <= kFirstNegativeOverflow;
+      return FirstStageLimits::template isNegativeOverflow<FP>(value);
     }
 
     static int64_t minLimit() {

--- a/bolt/type/Conversions.h
+++ b/bolt/type/Conversions.h
@@ -323,6 +323,29 @@ struct Converter<
   struct LimitType {
     static constexpr bool kByteOrSmallInt =
         std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t>;
+    using FirstStageType = std::conditional_t<kByteOrSmallInt, int32_t, T>;
+
+    // Floating point to signed integer conversion is defined only when the
+    // truncated value is representable. Use the exclusive limits of that
+    // range so the conversion itself never relies on undefined behavior.
+    template <typename FP>
+    static constexpr bool isPositiveOverflow(const FP& value) {
+      constexpr FP kFirstPositiveOverflow =
+          -static_cast<FP>(std::numeric_limits<FirstStageType>::min());
+      return value >= kFirstPositiveOverflow;
+    }
+
+    template <typename FP>
+    static constexpr bool isNegativeOverflow(const FP& value) {
+      constexpr FP kMin =
+          static_cast<FP>(std::numeric_limits<FirstStageType>::min());
+      constexpr FP kFirstNegativeOverflow = kMin - FP{1};
+      if constexpr (kFirstNegativeOverflow == kMin) {
+        return value < kMin;
+      }
+      return value <= kFirstNegativeOverflow;
+    }
+
     static int64_t minLimit() {
       if (kByteOrSmallInt) {
         return std::numeric_limits<int32_t>::min();
@@ -349,10 +372,7 @@ struct Converter<
     }
     template <typename FP>
     static T cast(const FP& v) {
-      if (kByteOrSmallInt) {
-        return T(int32_t(v));
-      }
-      return T(v);
+      return static_cast<T>(static_cast<FirstStageType>(v));
     }
   };
 
@@ -363,12 +383,12 @@ struct Converter<
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::max();
-      } else if (v > LimitType::maxLimit()) {
+      } else if (LimitType::isPositiveOverflow(v)) {
         return LimitType::max();
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::min();
-      } else if (v < LimitType::minLimit()) {
+      } else if (LimitType::isNegativeOverflow(v)) {
         return LimitType::min();
       }
       return LimitType::cast(v);
@@ -392,12 +412,12 @@ struct Converter<
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::max();
-      } else if (v > LimitType::maxLimit()) {
+      } else if (LimitType::isPositiveOverflow(v)) {
         return LimitType::max();
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::min();
-      } else if (v < LimitType::minLimit()) {
+      } else if (LimitType::isNegativeOverflow(v)) {
         return LimitType::min();
       }
       return LimitType::cast(v);

--- a/bolt/type/tests/ConversionsTest.cpp
+++ b/bolt/type/tests/ConversionsTest.cpp
@@ -601,6 +601,50 @@ TEST_F(ConversionsTest, toIntegeralTypes) {
   }
 }
 
+TEST_F(ConversionsTest, truncateFloatingPointToIntegralBoundaries) {
+  testConversion<double, int64_t>(
+      {0x1.fffffffffffffp62, 0x1p63, -0x1p63},
+      {9'223'372'036'854'774'784LL,
+       std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min()},
+      /*truncate*/ true);
+  testConversion<double, int32_t>(
+      {0x1.fffffffffffffp30, 0x1p31, -0x1p31},
+      {std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min()},
+      /*truncate*/ true);
+  testConversion<double, int16_t>(
+      {0x1.fffffffffffffp30, 0x1p31, -0x1p31},
+      {-1, -1, 0},
+      /*truncate*/ true);
+  testConversion<double, int8_t>(
+      {0x1.fffffffffffffp30, 0x1p31, -0x1p31},
+      {-1, -1, 0},
+      /*truncate*/ true);
+
+  testConversion<float, int64_t>(
+      {0x1.fffffep62f, 0x1p63f, -0x1p63f},
+      {9'223'371'487'098'961'920LL,
+       std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min()},
+      /*truncate*/ true);
+  testConversion<float, int32_t>(
+      {0x1.fffffep30f, 0x1p31f, -0x1p31f},
+      {2'147'483'520,
+       std::numeric_limits<int32_t>::max(),
+       std::numeric_limits<int32_t>::min()},
+      /*truncate*/ true);
+  testConversion<float, int16_t>(
+      {0x1.fffffep30f, 0x1p31f, -0x1p31f},
+      {-128, -1, 0},
+      /*truncate*/ true);
+  testConversion<float, int8_t>(
+      {0x1.fffffep30f, 0x1p31f, -0x1p31f},
+      {-128, -1, 0},
+      /*truncate*/ true);
+}
+
 TEST_F(ConversionsTest, toString) {
   // From integral types.
   {


### PR DESCRIPTION
### What problem does this PR solve?

Signed integer maxima are not always exactly representable by the source floating-point type. For example, converting `INT_MAX` to `float` produces `2^31`, and converting `BIGINT_MAX` to `double` produces `2^63`. A range check against the rounded maximum can therefore accept the first overflowing value and pass it to a C++ floating-point-to-integer conversion, whose behavior is undefined outside the destination range.

This affected both compatibility modes:

- Presto CAST could return a wrapped minimum instead of raising an error, and TRY_CAST could return that value instead of null.
- Spark CAST/TRY_CAST needed separate handling for JVM saturation, BYTE/SHORT's intermediate INT conversion, NaN, fractional boundary values, and Spark's BIGINT upper-bound rule.

Issue Number: close #809

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Introduce a shared floating-point-to-integral boundary helper based on the first positive overflow value (`-min`) and the exact negative boundary representable by the source type.
- Check those boundaries before every floating-point-to-integer `static_cast`, removing undefined conversions without using exceptions or an `Expected` object on the row path.
- Preserve Presto semantics in both conversion modes: HALF_UP rounding by default, optional truncation, CAST errors on overflow, and TRY_CAST nulls.
- Preserve Spark legacy CAST semantics: JVM-style saturation for INT/BIGINT, NaN-to-zero, and FP-to-BYTE/SHORT conversion through INT before narrowing.
- Preserve Spark TRY_CAST's exact boundary behavior, including accepting the double-rounded `2^63` BIGINT boundary as `BIGINT_MAX` while rejecting the next representable value.
- Add focused CAST and TRY_CAST regression coverage for REAL/DOUBLE to BIGINT, INTEGER, SMALLINT, and TINYINT at both sides of each boundary.

The dialect-specific behavior is selected with compile-time branches in the implementation. The shared public helper only describes safe representable ranges and does not depend on the configured SQL dialect.

Relevant upstream behavior:

- [Presto DOUBLE cast tests](https://github.com/prestodb/presto/blob/45e5851b633ad5e4c46d87bcdd62acc3f822d95b/presto-main-base/src/test/java/com/facebook/presto/type/TestDoubleOperators.java#L202-L256)
- [Presto REAL cast tests](https://github.com/prestodb/presto/blob/45e5851b633ad5e4c46d87bcdd62acc3f822d95b/presto-main-base/src/test/java/com/facebook/presto/type/TestRealOperators.java#L192-L225)
- [Spark numeric conversion rules](https://github.com/apache/spark/blob/383c6f8f4f30171b174e00c4da3b2c308766e8a4/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala#L121-L176)
- [Velox boundary fix used for cross-checking](https://github.com/facebookincubator/velox/commit/375eeccf8a79ff43701d07c930adaac9f673de80)

### Performance Impact

- [x] **No expected regression**: The in-range hot path retains the same comparison and conversion shape.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

No performance regression is expected. For ordinary in-range values, the conversion still consists of two floating-point comparisons followed by one hardware conversion. Presto truncation removes duplicated range checks. Spark's additional BIGINT equality check is reached only from the positive-overflow branch, and all dialect/target-type choices are `if constexpr` branches with no runtime mode dispatch. No dedicated benchmark was run for this revision.

### Release Note

Release Note:

```text
Release Note:
- Fixed unsafe floating-point-to-integral boundary handling in Presto and Spark CAST/TRY_CAST.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation performed:

- Presto Release: `bolt_expression_test` passed 1,250 tests with 4 skipped; `bolt_type_test` passed 215 tests.
- Spark Release: `bolt_expression_test` passed 1,138 tests with 116 skipped; `bolt_type_test` passed 214 tests with 1 skipped.
- Spark Release functions: the complete run passed 727 tests and failed only the two `JsonFunctionSonicOnDemandPerfTest.slowParseLargeJson*` cases because `data/large_slow_parse.json` is absent from this checkout. Re-running with those two missing-data cases excluded passed all 727 runnable tests.
- Debug/Release and Presto/Spark target builds completed successfully. The new dialect-specific boundary tests and `ConversionsTest.truncateFloatingPointToIntegralBoundaries` passed in all affected configurations.
- After merging the latest `upstream/main`, Debug/Presto and Release/Spark were rebuilt, and all four focused boundary regressions passed again.
- Repository pre-commit hooks and `git diff --check` passed for the change.
- ASAN/TSAN were not run.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
