### PR TITLE
docs: add issue-filing guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,24 @@ the skipped check has been validated separately.
 - Do not add AI attribution, generated-by text, or an agent as a co-author.
 - Review the staged diff and run the relevant hooks and tests before committing.
 
+## Issues
+
+- Pick the matching form under
+  [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) (bug report, build issue,
+  compatibility report, documentation issue, feature request, performance
+  issue, chore) and mirror its fields as the issue body headings. Fill every
+  required field; a compatibility report needs a minimal self-contained
+  reproduction plus an explicit expected-vs-actual comparison.
+- Keep the template's title prefix (e.g. `[Compatibility] `) and make the rest
+  a short one-line summary, not a full sentence describing the whole finding.
+- Apply the labels the template declares; skip any label that does not exist in
+  the repository instead of failing or inventing new ones.
+- Sanitize issue content before posting: no internal application IDs, cluster
+  or dashboard URLs, table or column names, business keys, or internal build
+  numbers. Reproduce with self-contained literals instead.
+- Do not create, edit, or close issues unless the user authorizes that
+  external action.
+
 ## Pull Requests
 
 - Push topic branches to the contributor fork and open PRs against the intended


### PR DESCRIPTION
### What problem does this PR solve?

`AGENTS.md` documents commit and PR conventions for coding agents, but says nothing about how to file issues. In practice an agent recently created an issue with a free-form body instead of the issue-template structure, an overlong title, and a label that does not exist in the repository, and internal data sanitization was only handled because the user asked for it explicitly.

Issue Number: N/A

### Type of Change

- [x] 📝 Documentation only

### Description

Add an `## Issues` section to `AGENTS.md` (between Commit Messages and Pull Requests) that requires agents to:

- pick the matching form under `.github/ISSUE_TEMPLATE/` and mirror its fields as the issue body headings, filling every required field (with a minimal self-contained reproduction and expected-vs-actual comparison for compatibility reports);
- keep the template's title prefix (e.g. `[Compatibility] `) followed by a short one-line summary;
- apply the labels the template declares, skipping any label that does not exist in the repository;
- sanitize issue content before posting (no internal application IDs, cluster/dashboard URLs, table or column names, business keys, or internal build numbers);
- not create, edit, or close issues without explicit user authorization.

### Performance Impact

- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).

### Release Note

Release Note:

```text
Release Note:
- None (agent documentation only).
```

### Checklist (For Author)

- [x] No need to test or manual test.

`pre-commit run --files AGENTS.md` passes (whitespace, EOF, license header, and spell checks).

### Breaking Changes

- [x] No
