### PR TITLE
feat(arrow): export constant arrays as dictionaries

### DIFF
--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -60,6 +60,58 @@ static constexpr size_t kMaxReusableScratchBufferBytes{32UL << 10};
 constexpr const char kArrowExtensionNameKey[] = "ARROW:extension:name";
 constexpr const char kSparkVariantExtensionName[] = "spark.variant";
 
+bool isSupportedArrayConstantElementType(const Type& type) {
+  if (type.isDate() || type.isDecimal()) {
+    return false;
+  }
+
+  switch (type.kind()) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      return true;
+    default:
+      return false;
+  }
+}
+} // namespace
+
+bool shouldExportArrayConstantAsDictionary(
+    const BaseVector& vector,
+    const ArrowOptions& options) {
+  if (vector.encoding() != VectorEncoding::Simple::CONSTANT ||
+      options.flattenConstant || !options.arrayConstantAsDictionary ||
+      vector.typeKind() != TypeKind::ARRAY || vector.size() == 0 ||
+      (vector.mayHaveNulls() && vector.isNullAt(0))) {
+    return false;
+  }
+  return isSupportedArrayConstantElementType(*vector.type()->childAt(0));
+}
+
+namespace {
+
+void normalizeArrayConstantForDictionaryExport(
+    const VectorPtr& vector,
+    const ArrowOptions& options) {
+  if (!shouldExportArrayConstantAsDictionary(*vector, options)) {
+    return;
+  }
+
+  // Preserve the outer Constant<Array<T>>, but flatten encoded elements such
+  // as those produced by ARRAY_DISTINCT. Consumers of this path support only
+  // a top-level Dictionary<List<T>>, not Dictionary<List<Dictionary<T>>>.
+  auto* array = vector->valueVector()->as<ArrayVector>();
+  BOLT_CHECK_NOT_NULL(
+      array, "Expected Constant<Array> backing vector to be ArrayVector");
+  BaseVector::flattenVector(array->elements());
+}
+
 void clearNullableFlag(int64_t& flags) {
   flags = flags & (~ARROW_FLAG_NULLABLE);
 }
@@ -2149,6 +2201,37 @@ void exportConstant(
   runEnds->release = releaseArrowArray;
 }
 
+void exportArrayConstantAsDictionary(
+    const BaseVector& vector,
+    const Selection& rows,
+    const ArrowOptions& options,
+    ArrowArray& out,
+    memory::MemoryPool* pool,
+    BoltToArrowBridgeHolder& holder) {
+  const auto numRows = rows.count();
+  auto& values = *vector.valueVector();
+  auto* constant = vector.as<ConstantVector<ComplexType>>();
+
+  out.n_buffers = 2;
+  out.n_children = 0;
+  out.length = numRows;
+
+  auto* dictionary = holder.allocateDictionary();
+  std::memset(dictionary, 0, sizeof(ArrowArray));
+
+  Selection selectedValue(values.size());
+  selectedValue.clearAll();
+  selectedValue.addRange(constant->index(), 1);
+  exportToArrowImpl(values, selectedValue, options, *dictionary, pool);
+  out.dictionary = dictionary;
+
+  auto indices = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  std::memset(indices->asMutable<void>(), 0, numRows * sizeof(vector_size_t));
+  holder.setBuffer(1, indices);
+  out.buffers[0] = nullptr;
+  out.buffers[1] = indices->as<void>();
+}
+
 void exportToArrowImpl(
     const BaseVector& vec,
     const Selection& rows,
@@ -2199,9 +2282,13 @@ void exportToArrowImpl(
           : exportDictionary(vec, rows, options, out, pool, *holder);
       break;
     case VectorEncoding::Simple::CONSTANT:
-      options.flattenConstant
-          ? exportFlattenedVector(vec, rows, options, out, pool, *holder)
-          : exportConstant(vec, rows, options, out, pool, *holder);
+      if (options.flattenConstant) {
+        exportFlattenedVector(vec, rows, options, out, pool, *holder);
+      } else if (shouldExportArrayConstantAsDictionary(vec, options)) {
+        exportArrayConstantAsDictionary(vec, rows, options, out, pool, *holder);
+      } else {
+        exportConstant(vec, rows, options, out, pool, *holder);
+      }
       break;
     default:
       BOLT_NYI("{} cannot be exported to Arrow yet.", vec.encoding());
@@ -2572,6 +2659,7 @@ void exportToArrow(
         BaseVector::loadedVectorShared(vector), arrowArray, pool, options);
     return;
   }
+  normalizeArrayConstantForDictionaryExport(vector, options);
   if (vector->encoding() == VectorEncoding::Simple::CONSTANT &&
       options.flattenConstant && vector->valueVector() != nullptr &&
       !vector->wrappedVector()->isFlatEncoding()) {
@@ -2672,6 +2760,8 @@ void exportToArrow(
     return;
   }
 
+  normalizeArrayConstantForDictionaryExport(vec, options);
+
   auto& type = vec->type();
 
   arrowSchema.name = nullptr;
@@ -2762,6 +2852,18 @@ void exportToArrow(
       exportToArrow(
           vec->valueVector(), *arrowSchema.dictionary, options, {}, pool);
     }
+  } else if (shouldExportArrayConstantAsDictionary(*vec, options)) {
+    arrowSchema.n_children = 0;
+    arrowSchema.children = nullptr;
+    arrowSchema.format = "i";
+    bridgeHolder->dictionary = std::make_unique<ArrowSchema>();
+    arrowSchema.dictionary = bridgeHolder->dictionary.get();
+    exportToArrow(
+        vec->valueVector(), *arrowSchema.dictionary, options, {}, pool);
+
+    arrowSchema.release = releaseArrowSchema;
+    arrowSchema.private_data = bridgeHolder.release();
+    return;
   } else if (
       vec->encoding() == VectorEncoding::Simple::CONSTANT &&
       !options.flattenConstant) {

--- a/bolt/vector/arrow/Bridge.cpp
+++ b/bolt/vector/arrow/Bridge.cpp
@@ -3746,6 +3746,7 @@ SchemaSignature makeSchemaSignature(
   mixSignature(signature, options.useLargeString ? 1 : 0);
   mixSignature(signature, options.stringViewCopyValues ? 1 : 0);
   mixSignature(signature, options.exportToArrowIPC ? 1 : 0);
+  mixSignature(signature, options.arrayConstantAsDictionary ? 1 : 0);
   for (const auto& fieldName : fieldNames) {
     ++signature.fields;
     mixStringView(signature, fieldName);
@@ -3941,6 +3942,10 @@ class ReusableArrowBatchPool::Impl {
     auto loadedVector = vector->encoding() == VectorEncoding::Simple::LAZY
         ? BaseVector::loadedVectorShared(vector)
         : vector;
+    // Normalize before both ArrowArray export and schema cache lookup so they
+    // observe the same vector encoding. This is a no-op unless the opt-in
+    // constant-array Dictionary export applies.
+    normalizeArrayConstantForDictionaryExport(loadedVector, options);
     auto holder = std::make_unique<ExportHolder>();
     for (auto& slot : slots_) {
       if (slot->tryExport(loadedVector, pool, options)) {

--- a/bolt/vector/arrow/Bridge.h
+++ b/bolt/vector/arrow/Bridge.h
@@ -60,8 +60,21 @@ struct ArrowOptions {
   // be modified.
   bool stringViewCopyValues{false};
   bool exportToArrowIPC{false};
+  // When true, export ARRAY-type CONSTANT vectors as Arrow Dictionary
+  // (1 value + N zero indices) instead of Run-End Encoded. Needed for
+  // consumers that don't support REE (e.g. Arrow Java < 19). Other types
+  // (scalar, map, struct) are unaffected and use REE.
+  bool arrayConstantAsDictionary{false};
 };
 namespace bytedance::bolt {
+/// Returns true when the vector will use the experimental
+/// Dictionary<List<T>> export path for ARRAY constants. Callers that prepare
+/// or size an export must use this predicate to stay aligned with the actual
+/// ArrowSchema and ArrowArray exporters.
+bool shouldExportArrayConstantAsDictionary(
+    const BaseVector& vector,
+    const ArrowOptions& options);
+
 /// Export a generic Bolt Vector to an ArrowArray, as defined by Arrow's C data
 /// interface:
 ///

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -31,6 +31,7 @@
 #include <arrow/api.h>
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
+#include <arrow/type_traits.h>
 #include <gtest/gtest.h>
 
 #include "bolt/common/base/Nulls.h"
@@ -57,10 +58,89 @@ struct BoltToArrowType<Timestamp> {
   using type = int64_t;
 };
 
+std::shared_ptr<arrow::Array> toArrow(
+    const VectorPtr& vec,
+    const ArrowOptions& options,
+    memory::MemoryPool* pool);
+
 class ArrowBridgeArrayExportTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  template <typename T>
+  void testConstantPrimitiveArrayAsDictionary(const std::vector<T>& expected) {
+    auto arrays = vectorMaker_.arrayVector<T>({expected});
+    auto constant = BaseVector::wrapInConstant(32, 0, arrays);
+
+    ArrowOptions options;
+    options.arrayConstantAsDictionary = true;
+    auto exported = toArrow(constant, options, pool_.get());
+
+    ASSERT_OK(exported->ValidateFull());
+    ASSERT_EQ(exported->type_id(), arrow::Type::DICTIONARY);
+    const auto& dictionary =
+        static_cast<const arrow::DictionaryArray&>(*exported);
+    ASSERT_EQ(dictionary.length(), 32);
+    ASSERT_EQ(dictionary.null_count(), 0);
+
+    const auto& indices =
+        static_cast<const arrow::Int32Array&>(*dictionary.indices());
+    for (int64_t row = 0; row < indices.length(); ++row) {
+      ASSERT_FALSE(indices.IsNull(row));
+      EXPECT_EQ(indices.Value(row), 0);
+    }
+
+    const auto& list =
+        static_cast<const arrow::ListArray&>(*dictionary.dictionary());
+    ASSERT_EQ(list.length(), 1);
+    ASSERT_EQ(list.value_offset(0), 0);
+    ASSERT_EQ(list.value_length(0), expected.size());
+
+    using ArrowType = typename arrow::CTypeTraits<T>::ArrowType;
+    using ArrowArray = typename arrow::TypeTraits<ArrowType>::ArrayType;
+    const auto& values = static_cast<const ArrowArray&>(*list.values());
+    ASSERT_EQ(values.length(), expected.size());
+    for (int64_t i = 0; i < values.length(); ++i) {
+      EXPECT_EQ(values.Value(i), expected[i]);
+    }
+  }
+
+  void testConstantStringLikeArrayAsDictionary(
+      const std::vector<StringView>& expected,
+      const TypePtr& elementType,
+      arrow::Type::type expectedArrowType) {
+    auto arrays = vectorMaker_.arrayVector<StringView>({expected}, elementType);
+    auto constant = BaseVector::wrapInConstant(32, 0, arrays);
+
+    ArrowOptions options;
+    options.arrayConstantAsDictionary = true;
+    auto exported = toArrow(constant, options, pool_.get());
+
+    ASSERT_OK(exported->ValidateFull());
+    ASSERT_EQ(exported->type_id(), arrow::Type::DICTIONARY);
+    const auto& dictionary =
+        static_cast<const arrow::DictionaryArray&>(*exported);
+    const auto& list =
+        static_cast<const arrow::ListArray&>(*dictionary.dictionary());
+    ASSERT_EQ(list.length(), 1);
+    ASSERT_EQ(list.value_length(0), expected.size());
+    ASSERT_EQ(list.values()->type_id(), expectedArrowType);
+    if (expectedArrowType == arrow::Type::BINARY) {
+      const auto& values =
+          static_cast<const arrow::BinaryArray&>(*list.values());
+      ASSERT_EQ(values.length(), expected.size());
+      for (int64_t i = 0; i < values.length(); ++i) {
+        EXPECT_EQ(values.GetString(i), expected[i].str());
+      }
+      return;
+    }
+    const auto& values = static_cast<const arrow::StringArray&>(*list.values());
+    ASSERT_EQ(values.length(), expected.size());
+    for (int64_t i = 0; i < values.length(); ++i) {
+      EXPECT_EQ(values.GetString(i), expected[i].str());
+    }
   }
 
   template <typename T>
@@ -1648,7 +1728,9 @@ TEST_F(ArrowBridgeArrayExportTest, constantArrayRowNestedVector) {
       std::dynamic_pointer_cast<ConstantVector<ComplexType>>(
           BaseVector::wrapInConstant(size, 22, constBaseVector));
 
-  auto array = toArrow(constArrayVector, {}, pool_.get());
+  ArrowOptions options;
+  options.arrayConstantAsDictionary = true;
+  auto array = toArrow(constArrayVector, options, pool_.get());
 
   ASSERT_OK(array->ValidateFull());
   EXPECT_EQ(array->null_count(), 0);
@@ -2860,5 +2942,228 @@ TEST_F(ArrowBridgeArrayExportTest, complexTimestampTest) {
 //     BOLT_CHECK_EQ(timestamp.getNanos(), expectedRes[i].getNanos());
 //   }
 // }
+
+TEST_F(ArrowBridgeArrayExportTest, constantArrayAsDictionary) {
+  // Build an ARRAY constant: all rows reference the same list.
+  auto elements = vectorMaker_.flatVector<int64_t>({10, 20, 30, 40});
+  auto offsets = AlignedBuffer::allocate<vector_size_t>(2, pool_.get());
+  auto* rawOffsets = offsets->asMutable<vector_size_t>();
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 4;
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(1, pool_.get());
+  sizes->asMutable<vector_size_t>()[0] = 4;
+  auto innerArray = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(BIGINT()),
+      BufferPtr(nullptr),
+      1,
+      offsets,
+      sizes,
+      elements,
+      0);
+
+  const vector_size_t numRows = 100;
+  VectorPtr constant = BaseVector::wrapInConstant(numRows, 0, innerArray);
+
+  ArrowOptions opts;
+  opts.arrayConstantAsDictionary = true;
+  auto array = toArrow(constant, opts, pool_.get());
+
+  // Must validate as a dictionary-encoded array.
+  ASSERT_OK(array->ValidateFull());
+  ASSERT_EQ(array->type_id(), arrow::Type::DICTIONARY);
+
+  auto dictArray = static_cast<const arrow::DictionaryArray*>(array.get());
+  ASSERT_EQ(dictArray->length(), numRows);
+  ASSERT_EQ(dictArray->null_count(), 0);
+
+  // All indices must be 0.
+  auto typedIndices =
+      static_cast<const arrow::Int32Array*>(dictArray->indices().get());
+  for (int64_t i = 0; i < numRows; ++i) {
+    EXPECT_FALSE(typedIndices->IsNull(i));
+    EXPECT_EQ(typedIndices->Value(i), 0);
+  }
+
+  // Dictionary must be a ListArray with exactly 1 entry containing
+  // [10, 20, 30, 40].
+  auto dict = dictArray->dictionary();
+  ASSERT_EQ(dict->type_id(), arrow::Type::LIST);
+  auto dictList = static_cast<const arrow::ListArray*>(dict.get());
+  ASSERT_EQ(dictList->length(), 1);
+  EXPECT_EQ(dictList->value_offset(0), 0);
+  EXPECT_EQ(dictList->value_length(0), 4);
+  auto dictValues =
+      static_cast<const arrow::Int64Array*>(dictList->values().get());
+  EXPECT_EQ(dictValues->Value(0), 10);
+  EXPECT_EQ(dictValues->Value(1), 20);
+  EXPECT_EQ(dictValues->Value(2), 30);
+  EXPECT_EQ(dictValues->Value(3), 40);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, constantPrimitiveArraysAsDictionary) {
+  testConstantPrimitiveArrayAsDictionary<bool>({true, false, true});
+  testConstantPrimitiveArrayAsDictionary<int8_t>({-7, 0, 12});
+  testConstantPrimitiveArrayAsDictionary<int16_t>({-1024, 0, 2048});
+  testConstantPrimitiveArrayAsDictionary<int32_t>({-100000, 0, 200000});
+  testConstantPrimitiveArrayAsDictionary<int64_t>(
+      {-10000000000LL, 0, 20000000000LL});
+  testConstantPrimitiveArrayAsDictionary<float>({-1.5F, 0.0F, 2.25F});
+  testConstantPrimitiveArrayAsDictionary<double>({-1.5, 0.0, 2.25});
+}
+
+TEST_F(ArrowBridgeArrayExportTest, constantStringArrayAsDictionary) {
+  testConstantStringLikeArrayAsDictionary(
+      {StringView(""), StringView("alpha"), StringView("longer string value")},
+      VARCHAR(),
+      arrow::Type::STRING);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, constantVarbinaryArrayAsDictionary) {
+  const std::string binaryWithZero{"A\0B", 3};
+  testConstantStringLikeArrayAsDictionary(
+      {StringView(""),
+       StringView("binary"),
+       StringView(binaryWithZero.data(), binaryWithZero.size())},
+      VARBINARY(),
+      arrow::Type::BINARY);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, constantArrayAsDictionaryWithIndex) {
+  // Constant wraps index=1 of a 3-element inner array.
+  auto elements = vectorMaker_.flatVector<int64_t>({1, 2, 3, 4, 5, 6});
+  auto offsets = AlignedBuffer::allocate<vector_size_t>(4, pool_.get());
+  auto* rawOffsets = offsets->asMutable<vector_size_t>();
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 2;
+  rawOffsets[2] = 4;
+  rawOffsets[3] = 6;
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(3, pool_.get());
+  auto* rawSizes = sizes->asMutable<vector_size_t>();
+  rawSizes[0] = 2;
+  rawSizes[1] = 2;
+  rawSizes[2] = 2;
+  auto innerArray = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(BIGINT()),
+      BufferPtr(nullptr),
+      3,
+      offsets,
+      sizes,
+      elements,
+      0);
+
+  const vector_size_t numRows = 50;
+  // Wrap the second element ([3, 4]).
+  VectorPtr constant = BaseVector::wrapInConstant(numRows, 1, innerArray);
+
+  ArrowOptions opts;
+  opts.arrayConstantAsDictionary = true;
+  auto array = toArrow(constant, opts, pool_.get());
+  ASSERT_OK(array->ValidateFull());
+
+  auto dictArray = static_cast<const arrow::DictionaryArray*>(array.get());
+  auto dictList =
+      static_cast<const arrow::ListArray*>(dictArray->dictionary().get());
+  ASSERT_EQ(dictList->length(), 1);
+  EXPECT_EQ(dictList->value_length(0), 2);
+  auto dictValues =
+      static_cast<const arrow::Int64Array*>(dictList->values().get());
+  EXPECT_EQ(dictValues->Value(0), 3);
+  EXPECT_EQ(dictValues->Value(1), 4);
+}
+
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    constantArrayDictionaryFlattensDictionaryElements) {
+  // ARRAY_DISTINCT produces an ArrayVector whose elements are Dictionary
+  // encoded. When a CROSS JOIN wraps this array in a ConstantVector, the
+  // Dictionary export must retain only the outer Constant<Array> encoding.
+  auto indices = makeBuffer<vector_size_t>({2, 1, 0});
+  auto encodedElements = BaseVector::wrapInDictionary(
+      nullptr,
+      indices,
+      3,
+      vectorMaker_.flatVector<StringView>({"alpha", "beta", "gamma"}));
+  auto innerArray = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(VARCHAR()),
+      nullptr,
+      1,
+      makeBuffer<vector_size_t>({0}),
+      makeBuffer<vector_size_t>({3}),
+      encodedElements);
+  auto constant = BaseVector::wrapInConstant(100, 0, innerArray);
+
+  ArrowOptions opts;
+  opts.arrayConstantAsDictionary = true;
+  ArrowSchema schema;
+  ::bytedance::bolt::exportToArrow(constant, schema, opts);
+  ASSERT_NE(schema.dictionary, nullptr);
+  EXPECT_STREQ(schema.format, "i");
+  EXPECT_STREQ(schema.dictionary->format, "+l");
+  ASSERT_EQ(schema.dictionary->n_children, 1);
+  EXPECT_STREQ(schema.dictionary->children[0]->format, "u");
+  EXPECT_EQ(schema.dictionary->children[0]->dictionary, nullptr);
+
+  auto array = toArrow(constant, opts, pool_.get());
+  ASSERT_OK(array->ValidateFull());
+  auto dictArray = static_cast<const arrow::DictionaryArray*>(array.get());
+  auto dictList =
+      static_cast<const arrow::ListArray*>(dictArray->dictionary().get());
+  ASSERT_EQ(dictList->values()->type_id(), arrow::Type::STRING);
+  auto values =
+      static_cast<const arrow::StringArray*>(dictList->values().get());
+  EXPECT_EQ(values->GetString(0), "gamma");
+  EXPECT_EQ(values->GetString(1), "beta");
+  EXPECT_EQ(values->GetString(2), "alpha");
+
+  schema.release(&schema);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, constantArrayDictionaryFlagOffUsesRee) {
+  // When flag is off (default), ARRAY constant should use REE (+r).
+  auto elements = vectorMaker_.flatVector<int64_t>({1, 2});
+  auto offsets = AlignedBuffer::allocate<vector_size_t>(2, pool_.get());
+  offsets->asMutable<vector_size_t>()[0] = 0;
+  offsets->asMutable<vector_size_t>()[1] = 2;
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(1, pool_.get());
+  sizes->asMutable<vector_size_t>()[0] = 2;
+  auto innerArray = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(BIGINT()),
+      BufferPtr(nullptr),
+      1,
+      offsets,
+      sizes,
+      elements,
+      0);
+  VectorPtr constant = BaseVector::wrapInConstant(10, 0, innerArray);
+
+  ArrowSchema schema;
+  ::bytedance::bolt::exportToArrow(constant, schema, ArrowOptions{});
+  std::string format(schema.format);
+  EXPECT_EQ(format, "+r");
+  schema.release(&schema);
+}
+
+TEST_F(ArrowBridgeArrayExportTest, unsupportedLogicalTypeArrayConstantsUseRee) {
+  ArrowOptions options;
+  options.arrayConstantAsDictionary = true;
+
+  auto dateArray = vectorMaker_.arrayVector<int32_t>({{0, 1}}, DATE());
+  auto dateConstant = BaseVector::wrapInConstant(10, 0, dateArray);
+  auto exportedDate = toArrow(dateConstant, options, pool_.get());
+  ASSERT_OK(exportedDate->ValidateFull());
+  EXPECT_EQ(exportedDate->type_id(), arrow::Type::RUN_END_ENCODED);
+
+  auto timestampArray = vectorMaker_.arrayVector<Timestamp>(
+      {{Timestamp(1, 100), Timestamp(2, 200)}}, TIMESTAMP());
+  auto timestampConstant = BaseVector::wrapInConstant(10, 0, timestampArray);
+  auto exportedTimestamp = toArrow(timestampConstant, options, pool_.get());
+  ASSERT_OK(exportedTimestamp->ValidateFull());
+  EXPECT_EQ(exportedTimestamp->type_id(), arrow::Type::RUN_END_ENCODED);
+}
+
 } // namespace
 } // namespace bytedance::bolt::test

--- a/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/bolt/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1120,6 +1120,76 @@ TEST_F(
       std::make_pair(true, false), exportAndRelease(flatVector, options_));
 }
 
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    reusableArrowBatchPoolInvalidatesSchemaForArrayConstantDictionaryOption) {
+  auto arrays = vectorMaker_.arrayVector<int64_t>({{10, 20, 30}});
+  auto constant = BaseVector::wrapInConstant(16, 0, arrays);
+  ReusableArrowBatchPool batchPool(1);
+
+  auto exportAndValidate = [&](const ArrowOptions& options,
+                               bool expectedSchemaRebuilt,
+                               arrow::Type::type expectedType) {
+    ArrowSchema schema{};
+    ArrowArray array{};
+    EXPECT_EQ(
+        expectedSchemaRebuilt,
+        batchPool.exportToArrow(
+            constant, pool_.get(), options, &schema, &array));
+    EXPECT_OK_AND_ASSIGN(auto type, arrow::ImportType(&schema));
+    EXPECT_OK_AND_ASSIGN(auto imported, arrow::ImportArray(&array, type));
+    ASSERT_OK(imported->ValidateFull());
+    EXPECT_EQ(expectedType, imported->type_id());
+  };
+
+  exportAndValidate(options_, true, arrow::Type::RUN_END_ENCODED);
+
+  auto dictionaryOptions = options_;
+  dictionaryOptions.arrayConstantAsDictionary = true;
+  exportAndValidate(dictionaryOptions, true, arrow::Type::DICTIONARY);
+  exportAndValidate(dictionaryOptions, false, arrow::Type::DICTIONARY);
+  exportAndValidate(options_, true, arrow::Type::RUN_END_ENCODED);
+}
+
+TEST_F(
+    ArrowBridgeArrayExportTest,
+    reusableArrowBatchPoolNormalizesArrayConstantDictionaryElements) {
+  auto indices = makeBuffer<vector_size_t>({2, 1, 0});
+  auto encodedElements = BaseVector::wrapInDictionary(
+      nullptr, indices, 3, vectorMaker_.flatVector<int64_t>({10, 20, 30}));
+  auto arrays = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(BIGINT()),
+      nullptr,
+      1,
+      makeBuffer<vector_size_t>({0}),
+      makeBuffer<vector_size_t>({3}),
+      encodedElements);
+  auto constant = BaseVector::wrapInConstant(16, 0, arrays);
+
+  ArrowOptions options;
+  options.arrayConstantAsDictionary = true;
+  ReusableArrowBatchPool batchPool(1);
+  ArrowSchema schema{};
+  ArrowArray array{};
+  EXPECT_TRUE(
+      batchPool.exportToArrow(constant, pool_.get(), options, &schema, &array));
+
+  EXPECT_OK_AND_ASSIGN(auto type, arrow::ImportType(&schema));
+  EXPECT_OK_AND_ASSIGN(auto imported, arrow::ImportArray(&array, type));
+  ASSERT_OK(imported->ValidateFull());
+  ASSERT_EQ(arrow::Type::DICTIONARY, imported->type_id());
+  const auto& dictionary =
+      static_cast<const arrow::DictionaryArray&>(*imported);
+  const auto& list =
+      static_cast<const arrow::ListArray&>(*dictionary.dictionary());
+  ASSERT_EQ(arrow::Type::INT64, list.values()->type_id());
+  const auto& values = static_cast<const arrow::Int64Array&>(*list.values());
+  EXPECT_EQ(30, values.Value(0));
+  EXPECT_EQ(20, values.Value(1));
+  EXPECT_EQ(10, values.Value(2));
+}
+
 TEST_F(ArrowBridgeArrayExportTest, reusableArrowBatchPoolZeroSlots) {
   ReusableArrowBatchPool batchPool(0);
   EXPECT_EQ(0, batchPool.size());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #968

Bolt exports `ConstantVector<Array<T>>` as run-end encoded Arrow data when
constant flattening is disabled. Some Arrow consumers support Dictionary arrays
but not run-end encoded arrays. Their current fallback is to flatten the
constant, which duplicates the same list and its elements for every row.

This PR adds a compact, opt-in Dictionary representation for that compatibility
case while preserving all existing defaults.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- add `ArrowOptions::arrayConstantAsDictionary`, disabled by default
- export eligible non-null `ConstantVector<Array<T>>` values as
  `Dictionary<int32, List<T>>`, with one dictionary value and all-zero indices
- use one eligibility predicate for ArrowSchema and ArrowArray export
- export only the referenced backing value, including constants with a non-zero
  backing index
- normalize dictionary-encoded array elements while preserving the outer
  constant encoding, avoiding nested `Dictionary<List<Dictionary<T>>>` output
- initially allow Boolean, signed integers, Float, Double, VARCHAR, and VARBINARY
- retain the existing REE behavior for unsupported types, null constants, empty
  vectors, and when the new option is disabled
- keep `flattenConstant=true` as the highest-precedence request
- include `arrayConstantAsDictionary` in the reusable Arrow schema cache key
- normalize array elements before both reusable ArrowArray export and schema
  cache lookup, keeping cached schemas and reusable arrays structurally aligned

### Performance Impact

- [x] **No Impact**: The new option is disabled by default, so existing callers
  retain the current export path.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

When enabled for a constant array, the exported representation changes from
`N` copies of the list payload to `N` int32 indices plus one list value. This
removes payload duplication from the Arrow boundary.

### Release Note

```text
Release Note:
- Add an opt-in Arrow Dictionary representation for supported constant arrays.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with a local Release build.
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation:

```text
cmake --build _build/Release --target bolt_arrow_bridge_test -j 8
./_build/Release/bolt/vector/arrow/tests/bolt_arrow_bridge_test \
  --gtest_filter='ArrowBridgeArrayExportTest.*'

60 tests passed.
The 10 focused constant-array Dictionary and fallback tests also passed.
Two reusable-pool regression tests cover option toggling and a first batch with
dictionary-encoded array elements.
clang-format 14.0.6 and git diff --check passed.
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)