### PR TITLE
fix(type): fix decimal cast error formatting

### DIFF
--- a/bolt/type/DecimalUtil.h
+++ b/bolt/type/DecimalUtil.h
@@ -869,7 +869,7 @@ class DecimalUtil {
     if (auto status =
             parseDecimalComponents(s.data(), s.size(), decimalComponents);
         !status.ok()) {
-      return Status::UserError("Value is not a number. " + status.message());
+      return Status::UserError("Value is not a number. {}", status.message());
     }
 
     // Count number of significant digits (without leading zeros).

--- a/bolt/type/tests/DecimalTest.cpp
+++ b/bolt/type/tests/DecimalTest.cpp
@@ -151,6 +151,24 @@ TEST(DecimalTest, decimalToString) {
   ASSERT_EQ(maxLongDecimal.length(), 38);
 }
 
+TEST(DecimalTest, toDecimalValueErrorMessage) {
+  const std::vector<std::pair<std::string, std::string>> testCases = {
+      {"1{", "Value is not a number. Chars '{' are invalid."},
+      {"1{}", "Value is not a number. Chars '{}' are invalid."},
+      {"1{0x}", "Value is not a number. Chars '{0x}' are invalid."},
+      {"1{{", "Value is not a number. Chars '{{' are invalid."},
+  };
+
+  for (const auto& [input, expectedMessage] : testCases) {
+    SCOPED_TRACE(input);
+    int64_t decimalValue{0};
+    const auto status = DecimalUtil::toDecimalValue<int64_t>(
+        StringView(input), 18, 2, decimalValue);
+    EXPECT_EQ(status.code(), StatusCode::kUserError);
+    EXPECT_EQ(status.message(), expectedMessage);
+  }
+}
+
 TEST(DecimalTest, unsignedDecimalToString) {
   std::string result(32, '\0');
   const auto size =


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Invalid decimal text containing braces could make error construction throw `fmt::format_error` instead of returning a decimal conversion error.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Pass the decimal parser message as a format argument so braces are treated as data. Add direct regression coverage for brace-containing parser errors.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fix decimal conversion errors for invalid text containing braces.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
