### PR TITLE
perf(parquet): pass through eligible string dictionaries

### DIFF
--- a/bolt/dwio/parquet/arrow/Encoding.cpp
+++ b/bolt/dwio/parquet/arrow/Encoding.cpp
@@ -796,16 +796,23 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
   template <typename ArrayType>
   void PutBinaryDictionaryArray(const ArrayType& array) {
     DCHECK_EQ(array.null_count(), 0);
+    auto on_found = [](int32_t memo_index) {};
     for (int64_t i = 0; i < array.length(); i++) {
       auto v = array.GetView(i);
       if (ARROW_PREDICT_FALSE(v.size() > kMaxByteArraySize)) {
         throw ParquetException(
             "Parquet cannot store strings with size 2GB or more");
       }
-      dict_encoded_size_ += static_cast<int64_t>(v.size()) + sizeof(uint32_t);
+      auto on_not_found = [this, &v](int32_t memo_index) {
+        dict_encoded_size_ += static_cast<int64_t>(v.size()) + sizeof(uint32_t);
+      };
       int32_t unused_memo_index;
       PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
-          v.data(), static_cast<int32_t>(v.size()), &unused_memo_index));
+          v.data(),
+          static_cast<int32_t>(v.size()),
+          on_found,
+          on_not_found,
+          &unused_memo_index));
     }
   }
 

--- a/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
+++ b/bolt/dwio/parquet/arrow/tests/ColumnWriterTest.cpp
@@ -597,6 +597,25 @@ TYPED_TEST(TestPrimitiveWriter, RequiredDictionary) {
   this->TestRequiredWithEncoding(Encoding::PLAIN_DICTIONARY);
 }
 
+TEST_F(TestByteArrayValuesWriter, DictionaryArraySizeCountsDistinctValues) {
+  ::arrow::StringBuilder builder;
+  ASSERT_OK(builder.Append("a"));
+  ASSERT_OK(builder.Append("a"));
+  ASSERT_OK(builder.Append("bb"));
+  ASSERT_OK_AND_ASSIGN(auto dictionary, builder.Finish());
+
+  auto encoder = MakeTypedEncoder<ByteArrayType>(
+      Encoding::PLAIN, /*use_dictionary=*/true, this->descr_);
+  auto* dictionaryEncoder =
+      dynamic_cast<DictEncoder<ByteArrayType>*>(encoder.get());
+  ASSERT_NE(nullptr, dictionaryEncoder);
+
+  dictionaryEncoder->PutDictionary(*dictionary);
+
+  EXPECT_EQ(2, dictionaryEncoder->num_entries());
+  EXPECT_EQ(2 * sizeof(uint32_t) + 3, dictionaryEncoder->dict_encoded_size());
+}
+
 /*
 TYPED_TEST(TestPrimitiveWriter, RequiredRLE) {
   this->TestRequiredWithEncoding(Encoding::RLE);

--- a/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/bolt/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -130,6 +130,21 @@ class ParquetWriterTest : public ParquetTestBase {
         readerOptions);
   }
 
+  bool hasPageEncoding(
+      const std::string& parquetPath,
+      int32_t column,
+      thrift::PageType::type pageType,
+      thrift::Encoding::type encoding) {
+    const auto stats = createLocalParquetReader(parquetPath)
+                           ->fileMetaData()
+                           .rowGroup(0)
+                           .columnChunk(column)
+                           .pageEncodingStats();
+    return std::find_if(stats.begin(), stats.end(), [&](const auto& stat) {
+             return stat.page_type == pageType && stat.encoding == encoding;
+           }) != stats.end();
+  }
+
   template <typename Callback>
   int64_t forEachDataPage(
       const std::string& parquetPath,
@@ -185,6 +200,17 @@ class ParquetWriterTest : public ParquetTestBase {
     writer->write(data);
     writer->close();
     assertRead(parquetPath, rows, schema, data);
+  }
+
+  VectorPtr repeatDictionary(
+      VectorPtr values,
+      vector_size_t size,
+      BufferPtr nulls = nullptr) {
+    BOLT_CHECK_GT(values->size(), 0);
+    auto indices = makeIndices(
+        size, [&](vector_size_t row) { return row % values->size(); });
+    return BaseVector::wrapInDictionary(
+        std::move(nulls), std::move(indices), size, std::move(values));
   }
 
   std::shared_ptr<const Type> getType() {
@@ -407,6 +433,469 @@ TEST_F(ParquetWriterTest, dictToArrow) {
   std::string parquetPath = tempPath_->path + "/dictToArrow.parquet";
   assertWrite(parquetPath, kRows, schema, data);
 };
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughDuplicateValues) {
+  const vector_size_t kRows = 10'000;
+  auto dictionary = makeFlatVector<std::string>(
+      64, [](auto /*row*/) { return std::string(256, 'a'); });
+  auto data = makeRowVector({repeatDictionary(dictionary, kRows)});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughDuplicateValues.parquet";
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.dictionaryPageSizeLimit = 64 * 1024;
+  writerOptions.dataPageSize = 1024;
+  writerOptions.compression = CompressionKind_NONE;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, kRows, schema, data);
+  const auto stats = createLocalParquetReader(parquetPath)
+                         ->fileMetaData()
+                         .rowGroup(0)
+                         .columnChunk(0)
+                         .pageEncodingStats();
+  const auto hasPage = [&](thrift::PageType::type pageType,
+                           thrift::Encoding::type encoding) {
+    return std::find_if(stats.begin(), stats.end(), [&](const auto& stat) {
+             return stat.page_type == pageType && stat.encoding == encoding;
+           }) != stats.end();
+  };
+  EXPECT_TRUE(
+      hasPage(thrift::PageType::DICTIONARY_PAGE, thrift::Encoding::PLAIN));
+  EXPECT_TRUE(hasPage(thrift::PageType::DATA_PAGE, thrift::Encoding::PLAIN));
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughAfterEmptyBatch) {
+  const vector_size_t kRows = 10'000;
+  auto data = makeRowVector({repeatDictionary(
+      makeFlatVector<std::string>(
+          16, [](auto /*row*/) { return std::string("value"); }),
+      kRows)});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughAfterEmptyBatch.parquet";
+
+  vp::WriterOptions writerOptions{};
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(BaseVector::create(schema, 0, leafPool_.get()));
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, kRows, schema, data);
+  const auto stats = createLocalParquetReader(parquetPath)
+                         ->fileMetaData()
+                         .rowGroup(0)
+                         .columnChunk(0)
+                         .pageEncodingStats();
+  EXPECT_NE(
+      std::find_if(
+          stats.begin(),
+          stats.end(),
+          [](const auto& stat) {
+            return stat.page_type == thrift::PageType::DATA_PAGE &&
+                stat.encoding == thrift::Encoding::PLAIN;
+          }),
+      stats.end());
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughStringTypesAndMetrics) {
+  const vector_size_t kRows = 4 * 1024;
+  auto varchar = repeatDictionary(
+      makeFlatVector<std::string>(
+          16, [](auto row) { return fmt::format("varchar_{:02}", row); }),
+      kRows,
+      makeNulls(kRows, [](auto row) { return row % 17 == 0; }));
+  auto varbinary = repeatDictionary(
+      makeFlatVector<std::string>(
+          32,
+          [](auto row) { return fmt::format("binary_{:02}", row); },
+          nullptr,
+          VARBINARY()),
+      kRows,
+      makeNulls(kRows, [](auto row) { return row % 23 == 0; }));
+  auto allNull = repeatDictionary(
+      makeFlatVector<std::string>({"unused_0", "unused_1"}),
+      kRows,
+      makeNulls(kRows, [](auto /*row*/) { return true; }));
+  auto data = makeRowVector({varchar, varbinary, allNull});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughStringTypes.parquet";
+
+  ArrowSchema cArrowSchema;
+  exportToArrow(
+      BaseVector::create(schema, 0, leafPool_.get()),
+      cArrowSchema,
+      ArrowOptions{
+          .flattenDictionary = true,
+          .flattenConstant = true,
+          .useLargeString = true});
+  auto flatArrowSchema = ::arrow::ImportSchema(&cArrowSchema).ValueOrDie();
+  std::vector<std::shared_ptr<::arrow::Field>> nullableFields;
+  nullableFields.reserve(flatArrowSchema->num_fields());
+  for (const auto& field : flatArrowSchema->fields()) {
+    nullableFields.push_back(field->WithNullable(true));
+  }
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.writeBatchBytes = 1024;
+  writerOptions.minBatchSize = 128;
+  writerOptions.compression = CompressionKind_SNAPPY;
+  writerOptions.dataPageVersion = vp::arrow::ParquetDataPageVersion::V2;
+  auto writer = createLocalWriter(
+      parquetPath,
+      schema,
+      writerOptions,
+      ::arrow::schema(std::move(nullableFields)),
+      nullptr);
+  writer->write(data);
+  const auto firstWriteMetrics = writer->metrics();
+  EXPECT_GT(firstWriteMetrics.writeRecodeWallNanos, 0);
+  EXPECT_GT(firstWriteMetrics.writeEncodeWallNanos, 0);
+  EXPECT_GT(firstWriteMetrics.writeIOWallNanos, 0);
+  EXPECT_EQ(firstWriteMetrics.writeFinalizeWallNanos, 0);
+
+  writer->write(data);
+  const auto secondWriteMetrics = writer->metrics();
+  EXPECT_GT(
+      secondWriteMetrics.writeRecodeWallNanos,
+      firstWriteMetrics.writeRecodeWallNanos);
+  EXPECT_GT(
+      secondWriteMetrics.writeEncodeWallNanos,
+      firstWriteMetrics.writeEncodeWallNanos);
+  writer->close();
+  const auto closedMetrics = writer->metrics();
+  EXPECT_GT(closedMetrics.writeCompressionWallNanos, 0);
+  EXPECT_GT(closedMetrics.writeFinalizeWallNanos, 0);
+
+  auto expected = BaseVector::create(schema, 2 * kRows, pool_.get());
+  expected->copy(data.get(), 0, 0, kRows);
+  expected->copy(data.get(), kRows, 0, kRows);
+  assertRead(parquetPath, 2 * kRows, schema, expected);
+
+  auto reader = createLocalParquetReader(parquetPath);
+  for (int32_t column = 0; column < 2; ++column) {
+    const auto stats = reader->fileMetaData()
+                           .rowGroup(0)
+                           .columnChunk(column)
+                           .pageEncodingStats();
+    EXPECT_NE(
+        std::find_if(
+            stats.begin(),
+            stats.end(),
+            [](const auto& stat) {
+              return stat.page_type == thrift::PageType::DICTIONARY_PAGE;
+            }),
+        stats.end());
+  }
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughSelectiveFlatten) {
+  const vector_size_t kRows = 1024;
+  auto integer = repeatDictionary(
+      makeFlatVector<int32_t>(8, [](auto row) { return row * 7; }), kRows);
+  auto innerDictionary = repeatDictionary(
+      makeFlatVector<std::string>(
+          16, [](auto row) { return fmt::format("nested_{:02}", row); }),
+      kRows);
+  auto nestedDictionary = repeatDictionary(innerDictionary, kRows);
+  auto nullableDictionary = repeatDictionary(
+      makeFlatVector<std::string>(
+          8,
+          [](auto row) { return fmt::format("nullable_{:02}", row); },
+          [](auto row) { return row == 3; }),
+      kRows);
+
+  auto array = makeArrayVector<std::string>(
+      kRows,
+      [](auto /*row*/) { return 2; },
+      [](auto index) { return fmt::format("element_{:02}", index % 11); });
+  auto* arrayVector = array->asUnchecked<ArrayVector>();
+  arrayVector->elements() = repeatDictionary(
+      arrayVector->elements(), arrayVector->elements()->size());
+
+  auto passthrough = repeatDictionary(
+      makeFlatVector<std::string>(
+          8, [](auto /*row*/) { return std::string("passthrough"); }),
+      kRows);
+  auto data = makeRowVector(
+      {integer, nestedDictionary, nullableDictionary, array, passthrough});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughSelectiveFlatten.parquet";
+
+  vp::WriterOptions writerOptions{};
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  EXPECT_EQ(VectorEncoding::Simple::DICTIONARY, integer->encoding());
+  EXPECT_EQ(VectorEncoding::Simple::DICTIONARY, nestedDictionary->encoding());
+  EXPECT_EQ(VectorEncoding::Simple::DICTIONARY, nullableDictionary->encoding());
+  EXPECT_EQ(
+      VectorEncoding::Simple::DICTIONARY, arrayVector->elements()->encoding());
+  EXPECT_EQ(VectorEncoding::Simple::DICTIONARY, passthrough->encoding());
+  assertRead(parquetPath, kRows, schema, data);
+
+  const auto stats = createLocalParquetReader(parquetPath)
+                         ->fileMetaData()
+                         .rowGroup(0)
+                         .columnChunk(4)
+                         .pageEncodingStats();
+  EXPECT_NE(
+      std::find_if(
+          stats.begin(),
+          stats.end(),
+          [](const auto& stat) {
+            return stat.page_type == thrift::PageType::DATA_PAGE &&
+                stat.encoding == thrift::Encoding::PLAIN;
+          }),
+      stats.end());
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughSchemaTransitions) {
+  const vector_size_t kRows = 2048;
+  auto firstDictionary = repeatDictionary(
+      makeFlatVector<std::string>(
+          16, [](auto row) { return fmt::format("first_{:02}", row); }),
+      kRows);
+  auto secondDictionary = repeatDictionary(
+      makeFlatVector<std::string>(
+          8, [](auto row) { return fmt::format("second_{:02}", row); }),
+      kRows);
+  auto nestedDictionary = repeatDictionary(firstDictionary, kRows);
+  auto nullableDictionary = repeatDictionary(
+      makeFlatVector<std::string>(
+          8,
+          [](auto row) { return fmt::format("nullable_{:02}", row); },
+          [](auto row) { return row == 3; }),
+      kRows);
+  auto flat = makeFlatVector<std::string>(
+      kRows,
+      [](auto row) { return fmt::format("flat_{:04}", row); },
+      [](auto row) { return row % 29 == 0; });
+  std::vector<RowVectorPtr> batches = {
+      makeRowVector({firstDictionary}),
+      makeRowVector({secondDictionary}),
+      makeRowVector({nestedDictionary}),
+      makeRowVector({nullableDictionary}),
+      makeRowVector({flat}),
+      makeRowVector({firstDictionary})};
+  auto schema = std::static_pointer_cast<const RowType>(batches[0]->type());
+  auto expected = BaseVector::create(
+      schema, batches.size() * static_cast<size_t>(kRows), pool_.get());
+  for (size_t i = 0; i < batches.size(); ++i) {
+    expected->copy(batches[i].get(), i * kRows, 0, kRows);
+  }
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughSchemaTransitions.parquet";
+
+  ArrowSchema cArrowSchema;
+  exportToArrow(
+      BaseVector::create(schema, 0, leafPool_.get()),
+      cArrowSchema,
+      ArrowOptions{
+          .flattenDictionary = true,
+          .flattenConstant = true,
+          .useLargeString = true});
+  auto nullableSchema = ::arrow::ImportSchema(&cArrowSchema).ValueOrDie();
+
+  vp::WriterOptions writerOptions{};
+  auto writer =
+      createLocalWriter(parquetPath, schema, writerOptions, nullableSchema);
+  for (size_t i = 0; i < batches.size(); ++i) {
+    writer->write(batches[i]);
+    if (i == 1) {
+      writer->flush();
+    }
+  }
+  writer->close();
+
+  assertRead(parquetPath, batches.size() * kRows, schema, expected);
+  const auto metadata =
+      vp::arrow::ParquetFileReader::OpenFile(parquetPath)->metadata();
+  EXPECT_TRUE(metadata->schema()->group_node()->field(0)->is_optional());
+}
+
+TEST_F(ParquetWriterTest, dictionaryInputRespectsOutputDictionaryOptions) {
+  const vector_size_t kRows = 1024;
+  const auto makeColumn = [&]() {
+    return repeatDictionary(
+        makeFlatVector<std::string>(
+            8, [](auto row) { return fmt::format("value_{:02}", row); }),
+        kRows);
+  };
+  auto data =
+      makeRowVector({"enabled", "disabled"}, {makeColumn(), makeColumn()});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+
+  const auto writeAndCheck = [&](const std::string& name,
+                                 vp::WriterOptions writerOptions,
+                                 const std::vector<bool>& expectedPages) {
+    const auto parquetPath = tempPath_->path + "/" + name + ".parquet";
+    auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+    writer->write(data);
+    writer->close();
+    assertRead(parquetPath, kRows, schema, data);
+
+    auto reader = createLocalParquetReader(parquetPath);
+    for (int32_t column = 0; column < expectedPages.size(); ++column) {
+      const auto stats = reader->fileMetaData()
+                             .rowGroup(0)
+                             .columnChunk(column)
+                             .pageEncodingStats();
+      const bool hasDictionaryPage =
+          std::find_if(stats.begin(), stats.end(), [](const auto& stat) {
+            return stat.page_type == thrift::PageType::DICTIONARY_PAGE;
+          }) != stats.end();
+      EXPECT_EQ(expectedPages[column], hasDictionaryPage);
+    }
+  };
+
+  vp::WriterOptions globallyDisabled{};
+  globallyDisabled.enableDictionary = false;
+  writeAndCheck(
+      "inputDictionaryGloballyDisabled", globallyDisabled, {false, false});
+
+  vp::WriterOptions columnDisabled{};
+  columnDisabled.columnEnableDictionaryMap["disabled"] = false;
+  writeAndCheck("inputDictionaryColumnDisabled", columnDisabled, {true, false});
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughUsesWholeInputForReuse) {
+  constexpr vector_size_t kRows = 16 * 100;
+  const auto makeColumn = [&](vector_size_t dictionarySize) {
+    return repeatDictionary(
+        makeFlatVector<std::string>(
+            dictionarySize, [](auto /*row*/) { return std::string(64, 'a'); }),
+        kRows);
+  };
+  auto data = makeRowVector(
+      {"at_threshold", "over_threshold"}, {makeColumn(16), makeColumn(17)});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughReuseThreshold.parquet";
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.writeBatchBytes = 1;
+  writerOptions.minBatchSize = 128;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, kRows, schema, data);
+  EXPECT_TRUE(hasPageEncoding(
+      parquetPath, 0, thrift::PageType::DATA_PAGE, thrift::Encoding::PLAIN));
+  EXPECT_FALSE(hasPageEncoding(
+      parquetPath, 1, thrift::PageType::DATA_PAGE, thrift::Encoding::PLAIN));
+  EXPECT_TRUE(hasPageEncoding(
+      parquetPath,
+      1,
+      thrift::PageType::DATA_PAGE,
+      thrift::Encoding::RLE_DICTIONARY));
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughHonorsColumnOptions) {
+  constexpr vector_size_t kRows = 16 * 100;
+  const auto makeColumn = [&]() {
+    return repeatDictionary(
+        makeFlatVector<std::string>(
+            16, [](auto /*row*/) { return std::string(64, 'a'); }),
+        kRows);
+  };
+  auto globalLimit = makeColumn();
+  const auto dictionaryBytes = globalLimit->valueVector()->estimateFlatSize();
+  auto data = makeRowVector(
+      {"global_limit", "column_limit", "disabled"},
+      {globalLimit, makeColumn(), makeColumn()});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto parquetPath =
+      tempPath_->path + "/dictionaryPassthroughColumnOptions.parquet";
+
+  vp::WriterOptions writerOptions{};
+  writerOptions.dictionaryPageSizeLimit = dictionaryBytes - 1;
+  writerOptions.columnDictionaryPageSizeLimitMap["column_limit"] =
+      dictionaryBytes;
+  writerOptions.columnEnableDictionaryMap["disabled"] = false;
+  auto writer = createLocalWriter(parquetPath, schema, writerOptions);
+  writer->write(data);
+  writer->close();
+
+  assertRead(parquetPath, kRows, schema, data);
+  EXPECT_FALSE(hasPageEncoding(
+      parquetPath, 0, thrift::PageType::DATA_PAGE, thrift::Encoding::PLAIN));
+  EXPECT_TRUE(hasPageEncoding(
+      parquetPath,
+      0,
+      thrift::PageType::DATA_PAGE,
+      thrift::Encoding::RLE_DICTIONARY));
+  EXPECT_TRUE(hasPageEncoding(
+      parquetPath, 1, thrift::PageType::DATA_PAGE, thrift::Encoding::PLAIN));
+  EXPECT_FALSE(hasPageEncoding(
+      parquetPath,
+      2,
+      thrift::PageType::DICTIONARY_PAGE,
+      thrift::Encoding::PLAIN));
+  EXPECT_TRUE(hasPageEncoding(
+      parquetPath, 2, thrift::PageType::DATA_PAGE, thrift::Encoding::PLAIN));
+}
+
+TEST_F(ParquetWriterTest, dictionaryPassthroughOnlyUsesDirectWritePath) {
+  constexpr vector_size_t kRows = 16 * 100;
+  auto data = makeRowVector({repeatDictionary(
+      makeFlatVector<std::string>(
+          16, [](auto /*row*/) { return std::string(64, 'a'); }),
+      kRows)});
+  auto schema = std::static_pointer_cast<const RowType>(data->type());
+  const auto writeAndCheck = [&](const std::string& name,
+                                 std::unique_ptr<vp::Writer> writer,
+                                 bool expectPlainDataPage) {
+    const auto parquetPath = tempPath_->path + "/" + name + ".parquet";
+    writer->write(data);
+    writer->close();
+    assertRead(parquetPath, kRows, schema, data);
+    EXPECT_EQ(
+        expectPlainDataPage,
+        hasPageEncoding(
+            parquetPath,
+            0,
+            thrift::PageType::DATA_PAGE,
+            thrift::Encoding::PLAIN));
+  };
+
+  vp::WriterOptions directOptions{};
+  const auto directPath =
+      tempPath_->path + "/dictionaryPassthroughDirect.parquet";
+  writeAndCheck(
+      "dictionaryPassthroughDirect",
+      createLocalWriter(directPath, schema, directOptions),
+      true);
+
+  const auto stagingPath =
+      tempPath_->path + "/dictionaryPassthroughStaging.parquet";
+  auto stagingWriter = createWriter(
+      createSink(stagingPath),
+      [&]() {
+        return std::make_unique<LambdaFlushPolicy>(
+            kRowsInRowGroup, kBytesInRowGroup, []() { return false; });
+      },
+      schema);
+  writeAndCheck(
+      "dictionaryPassthroughStaging", std::move(stagingWriter), false);
+
+  vp::WriterOptions alignedOptions{};
+  alignedOptions.enableRowGroupAlignedWrite = true;
+  alignedOptions.expectedRowsInEachBlock = {kRows + 1};
+  const auto alignedPath =
+      tempPath_->path + "/dictionaryPassthroughAligned.parquet";
+  writeAndCheck(
+      "dictionaryPassthroughAligned",
+      createLocalWriter(alignedPath, schema, alignedOptions),
+      false);
+}
 
 TEST_F(ParquetWriterTest, reuseArrowSchemaAcrossEncodings) {
   const vector_size_t kRows = 64;

--- a/bolt/dwio/parquet/writer/Writer.cpp
+++ b/bolt/dwio/parquet/writer/Writer.cpp
@@ -67,6 +67,8 @@ struct ArrowContext {
   int64_t stagingBytes = 0;
   // columns, Arrays
   std::vector<std::vector<std::shared_ptr<::arrow::Array>>> stagingChunks;
+  std::vector<bool> dictionaryPassthroughColumns;
+  std::vector<int64_t> dictionaryPassthroughByteLimits;
 };
 
 Compression::type getArrowParquetCompression(
@@ -143,6 +145,7 @@ std::shared_ptr<FileEncryptionProperties> getEncryptionProperties(
 namespace {
 
 constexpr int64_t DEFAULT_PARQUET_BLOCK_SIZE = 128 * 1024 * 1024; // 128M
+constexpr int64_t kMinRowsPerDictionaryValue = 100;
 
 std::shared_ptr<WriterProperties::Builder> getArrowParquetWriterOptionsBuilder(
     const parquet::WriterOptions& options,
@@ -319,8 +322,19 @@ std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
     const Type& type,
     const std::shared_ptr<::arrow::Field>& fieldNullable,
     const std::string& name = "") {
+  auto fieldType = field->type();
+  if (fieldType->id() == ::arrow::Type::DICTIONARY) {
+    fieldType = std::static_pointer_cast<::arrow::DictionaryType>(fieldType)
+                    ->value_type();
+  }
+  auto nullableType = fieldNullable->type();
+  if (nullableType->id() == ::arrow::Type::DICTIONARY) {
+    nullableType =
+        std::static_pointer_cast<::arrow::DictionaryType>(nullableType)
+            ->value_type();
+  }
   BOLT_DCHECK(
-      field->type()->Equals(fieldNullable->type()),
+      fieldType->Equals(nullableType),
       "field name: {}, type: {}; fieldNullable name: {}, type: {}.",
       name,
       field->type()->ToString(),
@@ -379,6 +393,78 @@ std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
   } else {
     return field->WithNullable(fieldNullable->nullable());
   }
+}
+
+bool hasDictionaryDescendant(const VectorPtr& vector) {
+  if (!vector) {
+    return false;
+  }
+
+  auto loaded = BaseVector::loadedVectorShared(vector);
+  switch (loaded->encoding()) {
+    case VectorEncoding::Simple::DICTIONARY:
+      return true;
+    case VectorEncoding::Simple::ROW:
+      for (const auto& child : loaded->asUnchecked<RowVector>()->children()) {
+        if (hasDictionaryDescendant(child)) {
+          return true;
+        }
+      }
+      return false;
+    case VectorEncoding::Simple::ARRAY:
+      return hasDictionaryDescendant(
+          loaded->asUnchecked<ArrayVector>()->elements());
+    case VectorEncoding::Simple::MAP: {
+      const auto* map = loaded->asUnchecked<MapVector>();
+      return hasDictionaryDescendant(map->mapKeys()) ||
+          hasDictionaryDescendant(map->mapValues());
+    }
+    default:
+      return false;
+  }
+}
+
+bool needsFlatten(
+    const VectorPtr& vector,
+    vector_size_t dictionaryDecisionRows,
+    int64_t dictionaryByteLimit) {
+  auto loaded = BaseVector::loadedVectorShared(vector);
+  if (loaded->encoding() == VectorEncoding::Simple::DICTIONARY) {
+    auto values = BaseVector::loadedVectorShared(loaded->valueVector());
+    if (!values->type()->isPrimitiveType() || !values->isFlatEncoding()) {
+      return true;
+    }
+    const auto kind = values->typeKind();
+    if ((kind != TypeKind::VARCHAR && kind != TypeKind::VARBINARY) ||
+        values->mayHaveNulls()) {
+      return true;
+    }
+    if (dictionaryByteLimit <= 0 ||
+        values->estimateFlatSize() >
+            static_cast<uint64_t>(dictionaryByteLimit)) {
+      return true;
+    }
+    return static_cast<int64_t>(values->size()) * kMinRowsPerDictionaryValue >
+        dictionaryDecisionRows;
+  }
+
+  if (loaded->encoding() == VectorEncoding::Simple::CONSTANT) {
+    return loaded->valueVector() && !loaded->wrappedVector()->isFlatEncoding();
+  }
+
+  return !loaded->type()->isPrimitiveType() && hasDictionaryDescendant(loaded);
+}
+
+bool hasVariantType(const TypePtr& type) {
+  if (type->isVariant()) {
+    return true;
+  }
+  for (uint32_t i = 0; i < type->size(); ++i) {
+    if (hasVariantType(type->childAt(i))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 } // namespace
@@ -446,7 +532,7 @@ Writer::Writer(
     : pool_(std::move(pool)),
       generalPool_{pool_->addLeafChild(".general")},
       exportPool_{pool_->addLeafChild(".exportArrow")},
-      arrowPool_(arrowPool),
+      arrowPool_(arrowPool ? arrowPool : ::arrow::default_memory_pool()),
       metrics_(std::make_shared<WriterMetricsCollector>()),
       stream_(std::make_shared<ArrowDataBufferSink>(
           std::move(sink),
@@ -475,6 +561,31 @@ Writer::Writer(
       options.parquetWriteTimestampUnit.value_or(TimestampUnit::kNano);
   options_.timestampTimeZone =
       options.parquetWriteTimestampTimeZone.value_or("UTC");
+  options_.flattenDictionary = !options.enableDictionary ||
+      enableRowGroupAlignedWrite_ || !enableFlushBasedOnBlockSize_ ||
+      hasVariantType(schema_);
+  arrowContext_->dictionaryPassthroughColumns.resize(schema_->size(), true);
+  arrowContext_->dictionaryPassthroughByteLimits.resize(
+      schema_->size(), options.dictionaryPageSizeLimit);
+  bool hasPassthroughColumn = false;
+  for (size_t i = 0; i < schema_->size(); ++i) {
+    const auto enableIt =
+        options.columnEnableDictionaryMap.find(schema_->nameOf(i));
+    if (enableIt != options.columnEnableDictionaryMap.end() &&
+        !enableIt->second) {
+      arrowContext_->dictionaryPassthroughColumns[i] = false;
+    }
+    const auto limitIt =
+        options.columnDictionaryPageSizeLimitMap.find(schema_->nameOf(i));
+    if (limitIt != options.columnDictionaryPageSizeLimitMap.end()) {
+      arrowContext_->dictionaryPassthroughByteLimits[i] = limitIt->second;
+    }
+    const auto kind = schema_->childAt(i)->kind();
+    hasPassthroughColumn |= arrowContext_->dictionaryPassthroughColumns[i] &&
+        arrowContext_->dictionaryPassthroughByteLimits[i] > 0 &&
+        (kind == TypeKind::VARCHAR || kind == TypeKind::VARBINARY);
+  }
+  options_.flattenDictionary |= !hasPassthroughColumn;
   arrowContext_->properties =
       getArrowParquetWriterOptionsBuilder(options, flushPolicy_, arrowPool_)
           ->writer_metrics(metrics_)
@@ -485,6 +596,100 @@ Writer::Writer(
 
   VLOG(1) << "WriteOption values of ParquetWriter: "
           << WriterOptionsToString(options);
+}
+
+VectorPtr Writer::flattenIfNeeded(
+    const VectorPtr& data,
+    ArrowOptions& exportOptions,
+    vector_size_t dictionaryDecisionRows) {
+  if (options_.flattenDictionary) {
+    return data;
+  }
+
+  auto loadedData = BaseVector::loadedVectorShared(data);
+  auto rowVector = std::dynamic_pointer_cast<RowVector>(loadedData);
+  BOLT_CHECK_NOT_NULL(rowVector, "Arrow export expects a RowVector.");
+
+  const auto& children = rowVector->children();
+  std::vector<VectorPtr> loadedChildren(children.size());
+  std::vector<bool> flatten(children.size(), false);
+  bool anyFlatten = false;
+  bool anyPassthrough = false;
+  for (size_t i = 0; i < children.size(); ++i) {
+    loadedChildren[i] = BaseVector::loadedVectorShared(children[i]);
+    if (loadedChildren[i]->encoding() != VectorEncoding::Simple::DICTIONARY) {
+      continue;
+    }
+    flatten[i] = !arrowContext_->dictionaryPassthroughColumns[i] ||
+        needsFlatten(
+            loadedChildren[i],
+            dictionaryDecisionRows,
+            arrowContext_->dictionaryPassthroughByteLimits[i]);
+    if (!flatten[i] && arrowContext_->schema &&
+        arrowContext_->schema->field(i)->type()->id() !=
+            ::arrow::Type::DICTIONARY) {
+      flatten[i] = true;
+    }
+    anyFlatten |= flatten[i];
+    anyPassthrough |= !flatten[i];
+  }
+
+  if (arrowContext_->schema) {
+    for (size_t i = 0; i < children.size(); ++i) {
+      const bool exportsDictionary =
+          loadedChildren[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+          !flatten[i];
+      const auto& field = arrowContext_->schema->field(i);
+      if (!exportsDictionary &&
+          field->type()->id() == ::arrow::Type::DICTIONARY) {
+        const auto dictionaryType =
+            std::static_pointer_cast<::arrow::DictionaryType>(field->type());
+        arrowContext_->schema =
+            arrowContext_->schema
+                ->SetField(i, field->WithType(dictionaryType->value_type()))
+                .ValueOrDie();
+      }
+    }
+  }
+
+  if (!anyPassthrough) {
+    exportOptions.flattenDictionary = true;
+    return data;
+  }
+
+  for (size_t i = 0; i < children.size(); ++i) {
+    if (loadedChildren[i]->encoding() != VectorEncoding::Simple::DICTIONARY) {
+      flatten[i] = needsFlatten(
+          loadedChildren[i],
+          dictionaryDecisionRows,
+          arrowContext_->dictionaryPassthroughByteLimits[i]);
+      anyFlatten |= flatten[i];
+    }
+  }
+
+  if (!anyFlatten) {
+    return data;
+  }
+
+  std::vector<VectorPtr> newChildren(children);
+  for (size_t i = 0; i < children.size(); ++i) {
+    if (flatten[i]) {
+      newChildren[i] = BaseVector::create(
+          loadedChildren[i]->type(),
+          loadedChildren[i]->size(),
+          exportPool_.get());
+      newChildren[i]->copy(
+          loadedChildren[i].get(), 0, 0, loadedChildren[i]->size());
+    }
+  }
+
+  return std::make_shared<RowVector>(
+      rowVector->pool(),
+      rowVector->type(),
+      rowVector->nulls(),
+      rowVector->size(),
+      std::move(newChildren),
+      rowVector->getNullCount());
 }
 
 Writer::Writer(
@@ -592,12 +797,13 @@ void Writer::createFileWriterIfNotExist() {
   }
 }
 
-void Writer::initializeArrowSchema(const VectorPtr& data) {
+void Writer::initializeArrowSchema(
+    const VectorPtr& data,
+    const ArrowOptions& exportOptions) {
   BOLT_CHECK_NULL(arrowContext_->schema);
 
-  WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
   ArrowSchema schema;
-  exportToArrow(data, schema, options_, {}, exportPool_.get());
+  exportToArrow(data, schema, exportOptions, {}, exportPool_.get());
   auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
 
   std::vector<std::shared_ptr<::arrow::Field>> fields;
@@ -637,18 +843,30 @@ void Writer::splitWriteRecordBatch(const VectorPtr& data) {
 
   vector_size_t offset = 0;
   auto dataSize = data->size();
+  if (dataSize == 0) {
+    if (options_.flattenDictionary && !arrowContext_->schema) {
+      WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
+      initializeArrowSchema(data, options_);
+    }
+    return;
+  }
+
   while (offset < dataSize) {
     auto size = std::min<vector_size_t>(dataSize - offset, rowNumPerBatch);
 
     std::shared_ptr<::arrow::RecordBatch> recordBatch;
     {
       WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
+      const auto batch =
+          offset == 0 && size == dataSize ? data : data->slice(offset, size);
+      auto exportOptions = options_;
+      auto exportData = flattenIfNeeded(batch, exportOptions, dataSize);
+      if (!arrowContext_->schema) {
+        initializeArrowSchema(exportData, exportOptions);
+      }
+
       ArrowArray array;
-      exportToArrow(
-          offset == 0 && size == dataSize ? data : data->slice(offset, size),
-          array,
-          exportPool_.get(),
-          options_);
+      exportToArrow(exportData, array, exportPool_.get(), exportOptions);
 
       PARQUET_ASSIGN_OR_THROW(
           recordBatch,
@@ -674,16 +892,19 @@ void Writer::write(const VectorPtr& data) {
       data->type()->equivalent(*schema_),
       "The file schema type should be equal with the input rowvector type.");
 
-  if (!arrowContext_->schema) {
-    initializeArrowSchema(data);
-    if (enableRowGroupAlignedWrite_ || !enableFlushBasedOnBlockSize_) {
-      arrowContext_->stagingChunks.resize(arrowContext_->schema->num_fields());
-    }
-  }
-
   if (!enableRowGroupAlignedWrite_ && enableFlushBasedOnBlockSize_) {
     splitWriteRecordBatch(data);
     return;
+  }
+
+  if (!arrowContext_->schema) {
+    {
+      WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
+      initializeArrowSchema(data, options_);
+    }
+    if (enableRowGroupAlignedWrite_ || !enableFlushBasedOnBlockSize_) {
+      arrowContext_->stagingChunks.resize(arrowContext_->schema->num_fields());
+    }
   }
 
   std::shared_ptr<::arrow::RecordBatch> recordBatch;
@@ -758,8 +979,13 @@ dwio::common::WriterMetrics Writer::metrics() const {
 void Writer::createEmptyFile() {
   BOLT_CHECK_NULL(arrowContext_->writer);
   if (!arrowContext_->schema) {
-    initializeArrowSchema(BaseVector::create(
-        std::static_pointer_cast<const Type>(schema_), 0, exportPool_.get()));
+    WriterMetricTimer timer(&metrics_->writeRecodeWallNanos);
+    initializeArrowSchema(
+        BaseVector::create(
+            std::static_pointer_cast<const Type>(schema_),
+            0,
+            exportPool_.get()),
+        options_);
   }
   createFileWriterIfNotExist();
 }

--- a/bolt/dwio/parquet/writer/Writer.h
+++ b/bolt/dwio/parquet/writer/Writer.h
@@ -269,7 +269,14 @@ class Writer : public dwio::common::Writer {
       std::shared_ptr<::arrow::RecordBatch>& recordBatch);
 
  private:
-  void initializeArrowSchema(const VectorPtr& data);
+  VectorPtr flattenIfNeeded(
+      const VectorPtr& data,
+      ArrowOptions& exportOptions,
+      vector_size_t dictionaryDecisionRows);
+
+  void initializeArrowSchema(
+      const VectorPtr& data,
+      const ArrowOptions& exportOptions);
 
   void splitWriteRecordBatch(const VectorPtr& data);
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Direct Parquet writes flatten input `DictionaryVector<VARCHAR/VARBINARY>` data before the Parquet writer rebuilds the same dictionary. This adds avoidable decoding, string materialization, and hashing work.

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Pass eligible low-cardinality, top-level VARCHAR/VARBINARY dictionaries directly to Arrow on the Direct write path. Unsupported columns use selective flattening; high-cardinality batches, Staging, row-aligned, and VARIANT writers retain the existing behavior.

The implementation also handles cached-schema transitions, writer dictionary options and page limits, null Arrow pools, distinct-size accounting for duplicate dictionary values, split batches, and preserves writer phase-metric boundaries.

Related community work:
[Velox PR #17986](https://github.com/facebookincubator/velox/pull/17986) and [Velox issue #17988](https://github.com/facebookincubator/velox/issues/17988).

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    Release, CPU-pinned, five paired rounds, Data Page V2, no compression, MemorySink:
    
    | Workload | Before median | After median | Paired median speedup |
    |---|---:|---:|---:|
    | VARCHAR Card10 | 4.913 ms | 1.556 ms | 3.131x |
    | VARCHAR Card100 | 5.096 ms | 1.864 ms | 2.722x |
    | VARCHAR Card1000 | 5.066 ms | 4.368 ms | 1.158x |
    | VARCHAR Card10000 fallback | 5.914 ms | 5.829 ms | 1.015x |
    | 10 dictionary VARCHAR columns | 53.864 ms | 14.303 ms | 3.766x |
    | Direct, 10 columns × 200 batches | 970.419 ms | 339.256 ms | 2.841x |
    
    Staging and MAP controls remain within about ±2%. Output bytes, row counts, row groups, data pages, and dictionary pages match the baseline in all 16 measured cases.
    
    Benchmark target: `bolt_dwio_parquet_writer_benchmark`, run with
    `taskset -c 4`, dictionary/control `--bm_regex` filters,
    `--bm_min_usec=400000`, and `--bm_max_secs=3`.

    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

```text
Release Note:
Optimize direct Parquet writes by passing through eligible string dictionaries.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
