### PR TITLE
fix(shuffle): write buffered data directly to final output on stop

### DIFF
--- a/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.cpp
@@ -212,9 +212,28 @@ arrow::Status BoltRowBasedSortShuffleWriter::reclaimFixedSize(
 
 arrow::Status BoltRowBasedSortShuffleWriter::stop() {
   setSplitState(SplitState::kStop);
-  RETURN_NOT_OK(tryEvict());
   {
-    RETURN_NOT_OK(partitionWriter_->stop(&metrics_));
+    const auto isCompositeVector = vectorLayout_ == RowVectorLayout::kComposite;
+    RETURN_NOT_OK(partitionWriter_->stop(
+        &metrics_,
+        [this, isCompositeVector](uint32_t partitionId) -> arrow::Status {
+          if (partitionId >= sortedRows_.size()) {
+            return arrow::Status::OK();
+          }
+          auto& rows = sortedRows_[partitionId];
+          const auto rawSize = isCompositeVector ? getTotalRowBytes(rows)
+                                                 : partitionBytes_[partitionId];
+          RETURN_NOT_OK(partitionWriter_->writeFinal(
+              partitionId, rows, rawSize, isCompositeVector));
+          partitionBytes_[partitionId] = 0;
+          return arrow::Status::OK();
+        }));
+    if (vectorLayout_ == RowVectorLayout::kColumnar) {
+      rowConverter_->reset();
+    } else if (compositeRowVectorConverter_) {
+      compositeRowVectorConverter_->reset();
+    }
+    boltPool_->release();
     metrics_.useRowBased = 1;
     combinedVectorNumber_ = combineVectorTimes_ > 0
         ? (combinedVectorNumber_ / combineVectorTimes_)

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -736,10 +736,20 @@ arrow::Status BoltShuffleWriter::stop() {
     stat();
   } else {
     setSplitState(SplitState::kStop);
-    RETURN_NOT_OK(tryEvict());
+    partitionWriter_->setRowFormat(true);
     {
       SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingStop]);
-      RETURN_NOT_OK(partitionWriter_->stop(&metrics_));
+      RETURN_NOT_OK(partitionWriter_->stop(
+          &metrics_, [this](uint32_t partitionId) -> arrow::Status {
+            if (partitionId >= sortedRows_.size()) {
+              return arrow::Status::OK();
+            }
+            auto& rows = sortedRows_[partitionId];
+            return partitionWriter_->writeFinal(
+                partitionId, rows, getTotalRowBytes(rows), true);
+          }));
+      compositeRowVectorConverter_->reset();
+      boltPool_->release();
     }
   }
   metrics_.useV2 = 0;

--- a/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriterV2.cpp
@@ -265,12 +265,32 @@ arrow::Status BoltShuffleWriterV2::stop() {
     }
     setSplitState(SplitState::kStop);
     shrinkBufferPoolMemory();
-    ARROW_ASSIGN_OR_RAISE(auto ret, sequentialEvictAllPartitions());
-    (void)ret;
     {
       SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingStop]);
       setSplitState(SplitState::kStop);
-      RETURN_NOT_OK(partitionWriter_->stop(&metrics_));
+      RETURN_NOT_OK(partitionWriter_->stop(
+          &metrics_, [this](uint32_t partitionId) -> arrow::Status {
+            auto numRows = partitionBufferBase_[partitionId];
+            if (numRows == 0) {
+              return arrow::Status::OK();
+            }
+            bool mayUseRowVectorMode = true;
+            ARROW_ASSIGN_OR_RAISE(
+                auto buffers,
+                assembleBuffersGeneral(partitionId, mayUseRowVectorMode));
+            if (buffers.empty()) {
+              return arrow::Status::OK();
+            }
+            auto payload = std::make_unique<InMemoryPayload>(
+                numRows,
+                mayUseRowVectorMode ? &isValidityBufferRowVectorMode_
+                                    : &isValidityBuffer_,
+                std::move(buffers),
+                mayUseRowVectorMode);
+            RETURN_NOT_OK(partitionWriter_->writeFinal(
+                partitionId, std::move(payload), hasComplexType_));
+            return resetValidityBuffer(partitionId);
+          }));
       metrics_.rowVectorModeCompress = rowVectorModeCompress_;
       releaseBufferPoolMemory();
     }
@@ -278,10 +298,19 @@ arrow::Status BoltShuffleWriterV2::stop() {
     stat();
   } else {
     setSplitState(SplitState::kStop);
-    RETURN_NOT_OK(tryEvict());
+    partitionWriter_->setRowFormat(true);
     {
       SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingStop]);
-      RETURN_NOT_OK(partitionWriter_->stop(&metrics_));
+      RETURN_NOT_OK(partitionWriter_->stop(
+          &metrics_, [this](uint32_t partitionId) -> arrow::Status {
+            if (partitionId >= sortedRows_.size()) {
+              return arrow::Status::OK();
+            }
+            auto& rows = sortedRows_[partitionId];
+            return partitionWriter_->writeFinal(
+                partitionId, rows, getTotalRowBytes(rows), true);
+          }));
+      compositeRowVectorConverter_->reset();
     }
   }
   metrics_.useV2 = 1;

--- a/bolt/shuffle/sparksql/Utils.cpp
+++ b/bolt/shuffle/sparksql/Utils.cpp
@@ -308,6 +308,13 @@ int64_t getBufferSize(const std::shared_ptr<arrow::Array>& array) {
   return getBufferSize(array->data()->buffers);
 }
 
+int64_t getTotalRowBytes(const std::vector<uint8_t*>& rows) {
+  return std::accumulate(
+      rows.begin(), rows.end(), int64_t{0}, [](int64_t sum, uint8_t* row) {
+        return sum + *reinterpret_cast<int32_t*>(row) + sizeof(int32_t);
+      });
+}
+
 int64_t getMaxCompressedBufferSize(
     const std::vector<std::shared_ptr<arrow::Buffer>>& buffers,
     Codec* codec) {

--- a/bolt/shuffle/sparksql/Utils.h
+++ b/bolt/shuffle/sparksql/Utils.h
@@ -68,6 +68,8 @@ int64_t getBufferSize(const std::shared_ptr<arrow::Array>& array);
 int64_t getBufferSize(
     const std::vector<std::shared_ptr<arrow::Buffer>>& buffers);
 
+int64_t getTotalRowBytes(const std::vector<uint8_t*>& rows);
+
 int64_t getMaxCompressedBufferSize(
     const std::vector<std::shared_ptr<arrow::Buffer>>& buffers,
     Codec* codec);

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
@@ -660,12 +660,24 @@ arrow::Status LocalPartitionWriter::mergeSpills(uint32_t partitionId) {
 }
 
 arrow::Status LocalPartitionWriter::stop(ShuffleWriterMetrics* metrics) {
+  return stopInternal(metrics, {});
+}
+
+arrow::Status LocalPartitionWriter::stop(
+    ShuffleWriterMetrics* metrics,
+    const StopCallback& callback) {
+  return stopInternal(metrics, callback);
+}
+
+arrow::Status LocalPartitionWriter::stopInternal(
+    ShuffleWriterMetrics* metrics,
+    const StopCallback& callback) {
   if (stopped_) {
     return arrow::Status::OK();
   }
   stopped_ = true;
   if (isRowFormat_) {
-    return stopInRowFormat(metrics);
+    return stopInRowFormat(metrics, callback);
   }
 
   RETURN_NOT_OK(finishSpill());
@@ -686,6 +698,9 @@ arrow::Status LocalPartitionWriter::stop(ShuffleWriterMetrics* metrics) {
     RETURN_NOT_OK(mergeSpills(pid));
     if (payloadCache_ && payloadCache_->hasCachedPayloads(pid)) {
       RETURN_NOT_OK(payloadCache_->write(pid, dataFileOs_.get()));
+    }
+    if (callback) {
+      RETURN_NOT_OK(callback(pid));
     }
     if (merger_) {
       ARROW_ASSIGN_OR_RAISE(auto merged, merger_->finish(pid));
@@ -715,6 +730,23 @@ arrow::Status LocalPartitionWriter::stop(ShuffleWriterMetrics* metrics) {
   // Populate shuffle writer metrics.
   RETURN_NOT_OK(populateMetrics(metrics));
 
+  return arrow::Status::OK();
+}
+
+arrow::Status LocalPartitionWriter::writeFinal(
+    uint32_t partitionId,
+    std::unique_ptr<InMemoryPayload> inMemoryPayload,
+    bool hasComplexType) {
+  rawPartitionLengths_[partitionId] += inMemoryPayload->getBufferSize();
+  auto payloadType =
+      codec_ ? Payload::Type::kCompressed : Payload::Type::kUncompressed;
+  ARROW_ASSIGN_OR_RAISE(
+      auto payload,
+      inMemoryPayload->toBlockPayload(
+          payloadType, payloadPool_.get(), codec_.get(), hasComplexType));
+  RETURN_NOT_OK(payload->serialize(dataFileOs_.get()));
+  compressTime_ += payload->getCompressTime();
+  writeTime_ += payload->getWriteTime();
   return arrow::Status::OK();
 }
 
@@ -958,11 +990,7 @@ arrow::Status LocalPartitionWriter::evict(
   // compress and flush
   for (auto pid = 0; pid < rows.size(); ++pid) {
     if (isCompositeVector) {
-      pBytes = std::accumulate(
-          rows[pid].begin(),
-          rows[pid].end(),
-          0,
-          [](uint64_t sum, uint8_t* row) { return sum + *(int32_t*)row; });
+      pBytes = getTotalRowBytes(rows[pid]);
     } else {
       pBytes = partitionBytes[pid];
       partitionBytes[pid] = 0;
@@ -1003,34 +1031,70 @@ arrow::Status LocalPartitionWriter::stopEvictRowsSequential() {
 }
 
 arrow::Status LocalPartitionWriter::stopInRowFormat(
-    ShuffleWriterMetrics* metrics) {
+    ShuffleWriterMetrics* metrics,
+    const StopCallback& callback) {
   // Open final data file.
   // If options_.bufferedWrite is set, it will acquire 16KB memory that can
   // trigger spill.
   RETURN_NOT_OK(openDataFile());
 
   int64_t endInFinalFile = 0;
+  auto writeTimeBeforeStop = zstdCodec_ ? zstdCodec_->getWriteTime() : 0;
   LOG(INFO) << "LocalPartitionWriter stopped. Total spills: " << spills_.size();
   // Iterator over pid.
-  {
-    bytedance::bolt::NanosecondTimer timer(&writeTime_);
-    for (auto pid = 0; pid < numPartitions_; ++pid) {
-      // Record start offset.
-      auto startInFinalFile = endInFinalFile;
+  for (auto pid = 0; pid < numPartitions_; ++pid) {
+    // Record start offset.
+    auto startInFinalFile = endInFinalFile;
+    {
+      bytedance::bolt::NanosecondTimer timer(&writeTime_);
       RETURN_NOT_OK(mergeRowSpills(pid));
-      ARROW_ASSIGN_OR_RAISE(endInFinalFile, dataFileOs_->Tell());
-      partitionLengths_[pid] = endInFinalFile - startInFinalFile;
     }
+    if (callback) {
+      RETURN_NOT_OK(callback(pid));
+    }
+    ARROW_ASSIGN_OR_RAISE(endInFinalFile, dataFileOs_->Tell());
+    partitionLengths_[pid] = endInFinalFile - startInFinalFile;
   }
 
   ARROW_ASSIGN_OR_RAISE(totalBytesWritten_, dataFileOs_->Tell());
 
   // Close Final file. Clear buffered resources.
   RETURN_NOT_OK(clearResource());
-  compressTime_ += zstdCodec_->getCompressTime();
-  writeTime_ += zstdCodec_->getWriteTime();
+  if (zstdCodec_) {
+    compressTime_ += zstdCodec_->getCompressTime();
+    spillTime_ += writeTimeBeforeStop;
+    writeTime_ += zstdCodec_->getWriteTime() - writeTimeBeforeStop;
+  }
   // Populate shuffle writer metrics.
   RETURN_NOT_OK(populateMetrics(metrics));
+  return arrow::Status::OK();
+}
+
+arrow::Status LocalPartitionWriter::writeFinal(
+    uint32_t partitionId,
+    std::vector<uint8_t*>& rows,
+    int64_t rawSize,
+    bool isCompositeVector) {
+  if (rows.empty()) {
+    return arrow::Status::OK();
+  }
+  if (!zstdCodec_) {
+    zstdCodec_ = std::make_shared<AdaptiveParallelZstdCodec>(
+        options_.compressionLevel,
+        true,
+        payloadPool_.get(),
+        options_.checksumEnabled);
+  }
+  RowBlockPayload payload(
+      folly::Range<uint8_t**>(rows.data(), rows.size()),
+      rawSize,
+      payloadPool_.get(),
+      zstdCodec_.get(),
+      isCompositeVector ? RowVectorLayout::kComposite
+                        : RowVectorLayout::kColumnar);
+  RETURN_NOT_OK(payload.serialize(dataFileOs_.get()));
+  rawPartitionLengths_[partitionId] += rawSize;
+  rows.clear();
   return arrow::Status::OK();
 }
 

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.h
@@ -77,6 +77,15 @@ class LocalPartitionWriter : public PartitionWriter {
   /// more memory.
   arrow::Status stop(ShuffleWriterMetrics* metrics) override;
 
+  arrow::Status stop(
+      ShuffleWriterMetrics* metrics,
+      const StopCallback& callback) override;
+
+  arrow::Status writeFinal(
+      uint32_t partitionId,
+      std::unique_ptr<InMemoryPayload> inMemoryPayload,
+      bool hasComplexType) override;
+
   // Spill source:
   // 1. Other op.
   // 2. PayloadMerger merging payloads or compressing merged payload.
@@ -99,9 +108,16 @@ class LocalPartitionWriter : public PartitionWriter {
       std::vector<std::vector<uint8_t*>>& rows,
       std::vector<int64_t>& partitionBytes,
       const bool isCompositeVector) override;
+  arrow::Status writeFinal(
+      uint32_t partitionId,
+      std::vector<uint8_t*>& rows,
+      int64_t rawSize,
+      bool isCompositeVector) override;
   arrow::Status startEvictRowsSequential();
   arrow::Status stopEvictRowsSequential();
-  arrow::Status stopInRowFormat(ShuffleWriterMetrics* metrics);
+  arrow::Status stopInRowFormat(
+      ShuffleWriterMetrics* metrics,
+      const StopCallback& callback);
   arrow::Status mergeRowSpills(uint32_t partitionId);
 
   bool canSpill() override;
@@ -124,6 +140,10 @@ class LocalPartitionWriter : public PartitionWriter {
   std::string nextSpilledFileDir();
 
   arrow::Status openDataFile();
+
+  arrow::Status stopInternal(
+      ShuffleWriterMetrics* metrics,
+      const StopCallback& callback);
 
   arrow::Status mergeSpills(uint32_t partitionId);
 

--- a/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <functional>
 #include <iostream>
 #include "bolt/shuffle/sparksql/Options.h"
 #include "bolt/shuffle/sparksql/Payload.h"
@@ -45,6 +46,8 @@ struct Evict {
 
 class PartitionWriter {
  public:
+  using StopCallback = std::function<arrow::Status(uint32_t)>;
+
   PartitionWriter(
       uint32_t numPartitions,
       PartitionWriterOptions options,
@@ -70,6 +73,15 @@ class PartitionWriter {
   virtual arrow::Status reclaimFixedSize(int64_t size, int64_t* actual) = 0;
 
   virtual arrow::Status stop(ShuffleWriterMetrics* metrics) = 0;
+
+  virtual arrow::Status stop(
+      ShuffleWriterMetrics* metrics,
+      const StopCallback& callback) {
+    for (auto partitionId = 0; partitionId < numPartitions_; ++partitionId) {
+      RETURN_NOT_OK(callback(partitionId));
+    }
+    return stop(metrics);
+  }
 
   /// Evict buffers for `partitionId` partition.
   virtual arrow::Status evict(
@@ -103,12 +115,36 @@ class PartitionWriter {
     return false;
   }
 
+  virtual arrow::Status writeFinal(
+      uint32_t partitionId,
+      std::unique_ptr<InMemoryPayload> inMemoryPayload,
+      bool hasComplexType) {
+    return evict(
+        partitionId,
+        std::move(inMemoryPayload),
+        Evict::kCacheNoMerge,
+        false,
+        hasComplexType);
+  }
+
   // for BoltRowBasedSortShuffleWriter
   virtual arrow::Status evict(
       std::vector<std::vector<uint8_t*>>& rows,
       std::vector<int64_t>& partitionBytes,
       const bool isCompositeVector) {
     return arrow::Status::OK();
+  }
+
+  virtual arrow::Status writeFinal(
+      uint32_t partitionId,
+      std::vector<uint8_t*>& rows,
+      int64_t rawSize,
+      bool isCompositeVector) {
+    std::vector<std::vector<uint8_t*>> partitionRows(numPartitions_);
+    partitionRows[partitionId].swap(rows);
+    std::vector<int64_t> partitionBytes(numPartitions_, 0);
+    partitionBytes[partitionId] = rawSize;
+    return evict(partitionRows, partitionBytes, isCompositeVector);
   }
   FLATTEN void setRowFormat(bool isRow) {
     isRowFormat_ = isRow;

--- a/bolt/shuffle/sparksql/partition_writer/rss/CelebornPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/rss/CelebornPartitionWriter.cpp
@@ -106,78 +106,72 @@ arrow::Status CelebornPartitionWriter::evict(
     std::vector<std::vector<uint8_t*>>& rows,
     std::vector<int64_t>& partitionBytes,
     const bool isCompositeVector) {
-  // evict rows in all partitions
+  for (auto pid = 0; pid < rows.size(); ++pid) {
+    auto rawSize =
+        isCompositeVector ? getTotalRowBytes(rows[pid]) : partitionBytes[pid];
+    partitionBytes[pid] = 0;
+    RETURN_NOT_OK(writeFinal(pid, rows[pid], rawSize, isCompositeVector));
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornPartitionWriter::writeFinal(
+    uint32_t partitionId,
+    std::vector<uint8_t*>& rows,
+    int64_t rawSize,
+    bool isCompositeVector) {
+  if (rows.empty()) {
+    return arrow::Status::OK();
+  }
+  bytedance::bolt::NanosecondTimer timer(&spillTime_);
   if (!zstdCodec_) {
-    // Disable checksum for Celeborn cause celeborn already has checksum inside
+    // Disable checksum for Celeborn because Celeborn already has its own.
     zstdCodec_ = std::make_shared<AdaptiveParallelZstdCodec>(
         options_.compressionLevel, true, payloadPool_.get(), false);
   }
-  RowVectorLayout layout = isCompositeVector ? RowVectorLayout::kComposite
-                                             : RowVectorLayout::kColumnar;
-  int64_t pBytes = 0;
-  // compress and flush
-  for (auto pid = 0; pid < rows.size(); ++pid) {
-    if (isCompositeVector) {
-      pBytes = std::accumulate(
-          rows[pid].begin(),
-          rows[pid].end(),
-          0,
-          [](uint64_t sum, uint8_t* row) { return sum + *(int32_t*)row; });
-    } else {
-      pBytes = partitionBytes[pid];
-      partitionBytes[pid] = 0;
-    }
-    if (!rows[pid].empty()) {
-      auto totalRowCount = rows[pid].size();
-      size_t slicedAvgNumRows = totalRowCount;
-      int32_t fragCnt = 1;
-      if (pBytes > options_.shuffleBufferSize) {
-        fragCnt = std::round(1.0 * pBytes / options_.shuffleBufferSize);
-        slicedAvgNumRows = (totalRowCount + fragCnt - 1) / fragCnt;
-        VLOG(1) << __FUNCTION__ << ": pBytes " << pBytes
-                << ", options_.shuffleBufferSize " << options_.shuffleBufferSize
-                << ", fragCnt = " << fragCnt
-                << ", slicedAvgNumRows = " << slicedAvgNumRows
-                << ", totalRowCount = " << totalRowCount;
-      }
-      BOLT_DCHECK(
-          pBytes != 0,
-          "rows = " + std::to_string(rows[pid].size()) +
-              ", but bytes = " + std::to_string(pBytes));
-
-      size_t startIndex = 0;
-      do {
-        auto slicedNumRows =
-            std::min(slicedAvgNumRows, totalRowCount - startIndex);
-        auto payload = std::make_unique<RowBlockPayload>(
-            folly::Range<uint8_t**>(
-                rows[pid].data() + startIndex, slicedNumRows),
-            pBytes / fragCnt,
-            payloadPool_.get(),
-            zstdCodec_.get(),
-            layout);
-
-        // Copy payload to arrow buffered os.
-        ARROW_ASSIGN_OR_RAISE(
-            auto celebornBufferOs,
-            arrow::io::BufferOutputStream::Create(
-                options_.pushBufferMaxSize, pool_));
-        RETURN_NOT_OK(payload->serialize(celebornBufferOs.get()));
-        payload = nullptr; // Invalidate payload immediately.
-
-        ARROW_ASSIGN_OR_RAISE(auto buffer, celebornBufferOs->Finish());
-        bytesEvicted_[pid] += celebornClient_->pushPartitionData(
-            pid,
-            reinterpret_cast<char*>(const_cast<uint8_t*>(buffer->data())),
-            buffer->size());
-        startIndex += slicedNumRows;
-      } while (startIndex < totalRowCount);
-      BOLT_CHECK(startIndex == totalRowCount);
-
-      rawPartitionLengths_[pid] += pBytes;
-      rows[pid].clear();
-    }
+  BOLT_DCHECK(
+      rawSize != 0,
+      "rows = " + std::to_string(rows.size()) +
+          ", but bytes = " + std::to_string(rawSize));
+  auto totalRowCount = rows.size();
+  size_t slicedAvgNumRows = totalRowCount;
+  int32_t fragCnt = 1;
+  if (rawSize > options_.shuffleBufferSize) {
+    fragCnt = std::round(1.0 * rawSize / options_.shuffleBufferSize);
+    slicedAvgNumRows = (totalRowCount + fragCnt - 1) / fragCnt;
+    VLOG(1) << __FUNCTION__ << ": rawSize " << rawSize
+            << ", options_.shuffleBufferSize " << options_.shuffleBufferSize
+            << ", fragCnt = " << fragCnt
+            << ", slicedAvgNumRows = " << slicedAvgNumRows
+            << ", totalRowCount = " << totalRowCount;
   }
+
+  size_t startIndex = 0;
+  do {
+    auto slicedNumRows = std::min(slicedAvgNumRows, totalRowCount - startIndex);
+    RowBlockPayload payload(
+        folly::Range<uint8_t**>(rows.data() + startIndex, slicedNumRows),
+        rawSize / fragCnt,
+        payloadPool_.get(),
+        zstdCodec_.get(),
+        isCompositeVector ? RowVectorLayout::kComposite
+                          : RowVectorLayout::kColumnar);
+    ARROW_ASSIGN_OR_RAISE(
+        auto celebornBufferOs,
+        arrow::io::BufferOutputStream::Create(
+            options_.pushBufferMaxSize, pool_));
+    RETURN_NOT_OK(payload.serialize(celebornBufferOs.get()));
+    ARROW_ASSIGN_OR_RAISE(auto buffer, celebornBufferOs->Finish());
+    bytesEvicted_[partitionId] += celebornClient_->pushPartitionData(
+        partitionId,
+        reinterpret_cast<char*>(const_cast<uint8_t*>(buffer->data())),
+        buffer->size());
+    startIndex += slicedNumRows;
+  } while (startIndex < totalRowCount);
+  BOLT_CHECK(startIndex == totalRowCount);
+
+  rawPartitionLengths_[partitionId] += rawSize;
+  rows.clear();
   return arrow::Status::OK();
 }
 

--- a/bolt/shuffle/sparksql/partition_writer/rss/CelebornPartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/rss/CelebornPartitionWriter.h
@@ -66,6 +66,11 @@ class CelebornPartitionWriter final : public RemotePartitionWriter {
       std::vector<std::vector<uint8_t*>>& rows,
       std::vector<int64_t>& partitionBytes,
       const bool isCompositeVector) override;
+  arrow::Status writeFinal(
+      uint32_t partitionId,
+      std::vector<uint8_t*>& rows,
+      int64_t rawSize,
+      bool isCompositeVector) override;
 
  private:
   void init();

--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -15,7 +15,9 @@
  */
 
 #include <vector/ComplexVector.h>
+#include <cstring>
 #include <filesystem>
+#include <limits>
 #include "bolt/common/caching/AsyncDataCache.h"
 #include "bolt/common/memory/sparksql/tests/MemoryTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
@@ -23,6 +25,7 @@
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/exec/tests/utils/MemoryHogOperator.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.h"
 #include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
 #include "bolt/shuffle/sparksql/partitioner/Partitioning.h"
 #include "bolt/shuffle/sparksql/tests/ShuffleTestBase.h"
@@ -51,6 +54,50 @@ class ShuffleMemoryTest : public ShuffleTestBase {
   // makes large splits lets the per-partition repeats deduplicate (small
   // compressed output); one that fragments into tiny splits re-stores them.
   ShuffleWriterMetrics runReclaimableHogScenario(int32_t writerType);
+
+  std::shared_ptr<CompositeRowVector> createCompositeInput(
+      const RowVectorPtr& input,
+      row::RowFormat rowFormat) {
+    ShuffleColumnarToRowConverter converter(
+        std::dynamic_pointer_cast<const RowType>(input->type()),
+        pool(),
+        rowFormat);
+    auto stats =
+        converter.getWithStats(input, std::numeric_limits<int64_t>::max());
+    std::vector<std::vector<uint8_t*>> rows(1);
+    std::vector<uint32_t> partitions(input->size(), 0);
+    std::vector<int64_t> partitionBytes(1, 0);
+    converter.convert(stats, partitions, rows, partitionBytes);
+
+    auto names = input->type()->asRow().names();
+    auto types = input->type()->asRow().children();
+    names.insert(names.begin(), "pid");
+    types.insert(types.begin(), INTEGER());
+    auto rowType = ROW(std::move(names), std::move(types));
+    auto validColumns =
+        std::make_unique<SelectivityVector>(rowType->size(), true);
+    auto children = input->children();
+    children.insert(
+        children.begin(),
+        makeFlatVector<int32_t>(input->size(), [](auto) { return 0; }));
+    auto composite = std::make_shared<CompositeRowVector>(
+        rowType,
+        input->size(),
+        pool(),
+        std::move(validColumns),
+        std::move(children));
+    composite->allocateRows(partitionBytes[0]);
+    RowInfoTracker tracker(composite.get(), 0, input->size());
+    for (auto i = 0; i < input->size(); ++i) {
+      const auto rowSize =
+          *reinterpret_cast<int32_t*>(rows[0][i]) + kSizeOfRowHeader;
+      auto* row = composite->newRow();
+      std::memcpy(row, rows[0][i], rowSize);
+      composite->store(i, row);
+      composite->advance(rowSize);
+    }
+    return composite;
+  }
 
   // Asserts the shuffle output compressed far below the raw size, i.e. the
   // writer made splits large enough for the per-partition repeats to dedup.
@@ -152,6 +199,130 @@ TEST_F(ShuffleMemoryTest, testMinMemLimit) {
   inputData.inputsPerMapper.emplace_back(20, rowVector);
 
   executeTestWithCustomInput(param, inputData);
+}
+
+TEST_F(ShuffleMemoryTest, testV2StopWritesRemainingDataDirectly) {
+  ShuffleTestParam param;
+  param.partitioning = "hash";
+  param.shuffleMode = 2;
+  param.writerType = PartitionWriterType::kLocal;
+  param.dataTypeGroup = DataTypeGroup::kString;
+  param.numPartitions = 4;
+  param.numMappers = 1;
+  param.memoryLimit = 256 * 1024 * 1024;
+
+  auto input = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int32_t>({10, 20, 30, 40, 50, 60, 70, 80}),
+       makeFlatVector<std::string>(
+           {"a", "bb", "ccc", "dddd", "e", "ff", "ggg", "hhhh"})});
+  ShuffleInputData inputData;
+  inputData.inputsPerMapper.push_back({input});
+
+  ShuffleRunResult result;
+  executeTestWithCustomInput(param, inputData, &result);
+  EXPECT_EQ(result.metrics.totalBytesEvicted, 0);
+  EXPECT_GT(result.metrics.totalBytesWritten, 0);
+}
+
+TEST_F(ShuffleMemoryTest, testRowBasedStopWritesRemainingDataDirectly) {
+  ShuffleTestParam param;
+  param.partitioning = "hash";
+  param.shuffleMode = 3;
+  param.writerType = PartitionWriterType::kLocal;
+  param.dataTypeGroup = DataTypeGroup::kString;
+  param.numPartitions = 4;
+  param.numMappers = 1;
+  param.memoryLimit = 256 * 1024 * 1024;
+
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<std::string>(
+          {"row0", "row1", "row2", "row3", "row4", "row5"})});
+  ShuffleInputData inputData;
+  inputData.inputsPerMapper.push_back({input});
+
+  ShuffleRunResult result;
+  executeTestWithCustomInput(param, inputData, &result);
+  EXPECT_EQ(result.metrics.totalBytesEvicted, 0);
+  EXPECT_GT(result.metrics.totalBytesWritten, 0);
+}
+
+TEST_F(ShuffleMemoryTest, testCelebornRowBasedStopReportsEvictTime) {
+  ShuffleTestParam param;
+  param.partitioning = "hash";
+  param.shuffleMode = 3;
+  param.writerType = PartitionWriterType::kCeleborn;
+  param.dataTypeGroup = DataTypeGroup::kString;
+  param.numPartitions = 4;
+  param.numMappers = 1;
+  param.memoryLimit = 256 * 1024 * 1024;
+
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<std::string>(
+          {"row0", "row1", "row2", "row3", "row4", "row5"})});
+  ShuffleInputData inputData;
+  inputData.inputsPerMapper.push_back({input});
+
+  ShuffleRunResult result;
+  executeTestWithCustomInput(param, inputData, &result);
+  EXPECT_GT(result.metrics.totalBytesWritten, 0);
+  EXPECT_GT(result.metrics.totalEvictTime, 0);
+}
+
+TEST_F(ShuffleMemoryTest, testV1CompositeStopWritesRemainingDataDirectly) {
+  ShuffleTestParam param;
+  param.partitioning = "hash";
+  param.shuffleMode = 1;
+  param.writerType = PartitionWriterType::kLocal;
+  param.dataTypeGroup = DataTypeGroup::kString;
+  param.numPartitions = 4;
+  param.numMappers = 1;
+  param.memoryLimit = 256 * 1024 * 1024;
+
+  auto compositeInput = createCompositeInput(
+      makeRowVector(
+          {"c0", "c1"},
+          {makeFlatVector<int32_t>({10, 20, 30, 40, 50, 60, 70, 80}),
+           makeFlatVector<std::string>(
+               {"a", "bb", "ccc", "dddd", "e", "ff", "ggg", "hhhh"})}),
+      param.rowFormat);
+  ShuffleInputData inputData;
+  inputData.inputsPerMapper.push_back({compositeInput});
+
+  ShuffleRunResult result;
+  executeTestWithCustomInput(param, inputData, &result);
+  EXPECT_EQ(result.metrics.totalBytesEvicted, 0);
+  EXPECT_GT(result.metrics.totalBytesWritten, 0);
+  EXPECT_EQ(result.metrics.dataSize, compositeInput->totalRowSize());
+}
+
+TEST_F(ShuffleMemoryTest, testV2CompositeStopWritesRemainingDataDirectly) {
+  ShuffleTestParam param;
+  param.partitioning = "hash";
+  param.shuffleMode = 2;
+  param.writerType = PartitionWriterType::kLocal;
+  param.dataTypeGroup = DataTypeGroup::kString;
+  param.numPartitions = 4;
+  param.numMappers = 1;
+  param.memoryLimit = 256 * 1024 * 1024;
+
+  auto compositeInput = createCompositeInput(
+      makeRowVector(
+          {"c0", "c1"},
+          {makeFlatVector<int32_t>({10, 20, 30, 40, 50, 60, 70, 80}),
+           makeFlatVector<std::string>(
+               {"a", "bb", "ccc", "dddd", "e", "ff", "ggg", "hhhh"})}),
+      param.rowFormat);
+  ShuffleInputData inputData;
+  inputData.inputsPerMapper.push_back({compositeInput});
+
+  ShuffleRunResult result;
+  executeTestWithCustomInput(param, inputData, &result);
+  EXPECT_EQ(result.metrics.totalBytesEvicted, 0);
+  EXPECT_GT(result.metrics.totalBytesWritten, 0);
+  EXPECT_EQ(result.metrics.dataSize, compositeInput->totalRowSize());
 }
 
 TEST_F(ShuffleMemoryTest, testExtrameLargeRowVector) {

--- a/bolt/shuffle/sparksql/tests/ShuffleMiscTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMiscTest.cpp
@@ -21,6 +21,7 @@
 #include "bolt/row/CompactRow.h"
 #include "bolt/row/dense/DenseRow.h"
 #include "bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.h"
+#include "bolt/shuffle/sparksql/Utils.h"
 
 namespace bytedance::bolt::shuffle::sparksql::test {
 
@@ -64,6 +65,15 @@ std::vector<std::string_view> rowBodies(const std::vector<uint8_t*>& rows) {
 }
 
 } // namespace
+
+TEST_F(ShuffleMiscTest, TotalRowBytesIncludesHeadersAndUsesInt64) {
+  int32_t rowSize = std::numeric_limits<int32_t>::max();
+  std::vector<uint8_t*> rows(2, reinterpret_cast<uint8_t*>(&rowSize));
+
+  EXPECT_EQ(
+      getTotalRowBytes(rows),
+      2LL * (std::numeric_limits<int32_t>::max() + kSizeOfRowHeader));
+}
 
 // End-to-end test: RoundRobin with Adaptive mode, >=8000 partitions and >=5
 // columns should use V1 consistently on both writer and reader side.

--- a/bolt/shuffle/sparksql/tests/ShuffleTestBase.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleTestBase.cpp
@@ -30,6 +30,7 @@
 #include "bolt/shuffle/sparksql/CelebornReaderStreamIterator.h"
 #include "bolt/shuffle/sparksql/Options.h"
 #include "bolt/shuffle/sparksql/ShuffleReaderNode.h"
+#include "bolt/shuffle/sparksql/ShuffleRowToColumnarConverter.h"
 #include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
 #include "bolt/shuffle/sparksql/partition_writer/rss/NativeCelebornClient.h"
 #include "bolt/shuffle/sparksql/tests/CelebornTestUtils.h"
@@ -666,6 +667,24 @@ ShuffleRunResult ShuffleTestBase::runShuffle(
       auto curBatch = readerCursor->current();
       // deep copy to avoid hold shuffle reader memory
       if (param.verifyOutput) {
+        if (RowVector::isComposite(curBatch)) {
+          auto composite =
+              std::dynamic_pointer_cast<CompositeRowVector>(curBatch);
+          std::vector<std::string_view> rows;
+          rows.reserve(composite->size());
+          for (auto row = 0; row < composite->size(); ++row) {
+            auto* data = composite->rowAt(row);
+            auto* end = row + 1 < composite->size()
+                ? composite->rowAt(row + 1)
+                : composite->rowAt(0) + composite->totalRowSize();
+            rows.emplace_back(data, end - data);
+          }
+          ShuffleRowToColumnarConverter converter(
+              outputType, pool(), param.rowFormat);
+          result.partitionOutputs[i].push_back(converter.convert(rows));
+          readerCursor->current().reset();
+          continue;
+        }
         VectorPtr copy =
             BaseVector::create(curBatch->type(), curBatch->size(), pool());
         copy->copy(curBatch.get(), 0, 0, curBatch->size());
@@ -719,7 +738,8 @@ ShuffleRunResult ShuffleTestBase::runShuffle(
 
 void ShuffleTestBase::executeTestWithCustomInput(
     const ShuffleTestParam& param,
-    ShuffleInputData& inputData) {
+    ShuffleInputData& inputData,
+    ShuffleRunResult* resultOut) {
   const bool needsPid =
       (param.partitioning == "hash" || param.partitioning == "range");
 
@@ -738,6 +758,13 @@ void ShuffleTestBase::executeTestWithCustomInput(
   BOLT_CHECK(!allBaseBatches.empty(), "Input batches should not be empty");
   auto outputType =
       std::dynamic_pointer_cast<const RowType>(allBaseBatches[0]->type());
+  if (needsPid && RowVector::isComposite(allBaseBatches[0])) {
+    auto names = outputType->names();
+    auto types = outputType->children();
+    names.erase(names.begin());
+    types.erase(types.begin());
+    outputType = ROW(std::move(names), std::move(types));
+  }
 
   auto result = runShuffle(writerInputs, outputType, param);
 
@@ -752,6 +779,9 @@ void ShuffleTestBase::executeTestWithCustomInput(
   }
 
   if (!param.verifyOutput) {
+    if (resultOut != nullptr) {
+      *resultOut = std::move(result);
+    }
     return;
   }
 
@@ -788,6 +818,9 @@ void ShuffleTestBase::executeTestWithCustomInput(
   }
 
   result.partitionOutputs.clear();
+  if (resultOut != nullptr) {
+    *resultOut = std::move(result);
+  }
 }
 
 void ShuffleTestBase::executeTest(const ShuffleTestParam& param) {

--- a/bolt/shuffle/sparksql/tests/ShuffleTestBase.h
+++ b/bolt/shuffle/sparksql/tests/ShuffleTestBase.h
@@ -100,7 +100,8 @@ class ShuffleTestBase : public bytedance::bolt::exec::test::OperatorTestBase {
   // writer with custom input data and then shuffle reader and verify output
   void executeTestWithCustomInput(
       const ShuffleTestParam& param,
-      ShuffleInputData& inputData);
+      ShuffleInputData& inputData,
+      ShuffleRunResult* resultOut = nullptr);
 
   // execute test with param, generating input data internally
   void executeTest(const ShuffleTestParam& param);


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #972 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

  This PR avoids writing the remaining in-memory shuffle data to temporary spill files during stop().

  Previously, the writer flushed the remaining data through the normal eviction path:

  memory -> temporary spill file -> final shuffle file

  The new path writes the remaining partition data directly to the final output:

  memory -> final shuffle file

  Data spilled earlier because of memory pressure continues to use the existing spill and merge path.


### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [x] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
  For data still in memory when stop() is called, this removes:

  - One temporary-file write
  - One temporary-file read
  - One copy into the final shuffle file
  - Temporary-file creation and deletion overhead

    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
