### PR TITLE
fix(parquet): allow schema mismatch for empty files

### DIFF
--- a/bolt/dwio/parquet/reader/ParquetReader.cpp
+++ b/bolt/dwio/parquet/reader/ParquetReader.cpp
@@ -1059,7 +1059,10 @@ TypePtr ReaderBase::convertType(
   // requested type (caller is only inferring the file's declared schema).
   auto checkRequested =
       [&](const std::function<bool(const TypePtr&)>& isCompatibleFunc) {
-        if (requestedType == nullptr) {
+        // An empty file cannot supply a value that violates the requested
+        // schema. Keep deriving its physical schema, but don't reject a
+        // requested type mismatch before the reader can return zero rows.
+        if (requestedType == nullptr || fileMetaData_->num_rows == 0) {
           return;
         }
         const bool strictMatch = isCompatibleFunc(requestedType);

--- a/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1993,6 +1993,30 @@ TEST_F(ParquetTableScanTest, convertTypePolicyMatrix) {
   }
 }
 
+TEST_F(ParquetTableScanTest, allowsStructuralMismatchForEmptyFile) {
+  auto fileType = ROW({"c0"}, {DOUBLE()});
+  auto emptyData = std::make_shared<RowVector>(
+      pool(),
+      fileType,
+      nullptr,
+      0,
+      std::vector<VectorPtr>{BaseVector::create(DOUBLE(), 0, pool())});
+  auto file = exec::test::TempFilePath::create();
+  writeToParquetFile(file->getPath(), {emptyData}, WriterOptions{});
+
+  auto declaredType = ROW({"c0"}, {ARRAY(DOUBLE())});
+  auto plan = PlanBuilder(pool())
+                  .tableScan(declaredType, {}, "", declaredType)
+                  .planNode();
+  auto result = AssertQueryBuilder(plan)
+                    .split(makeSplit(file->getPath()))
+                    .copyResults(pool());
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->size(), 0);
+  EXPECT_TRUE(result->type()->equivalent(*declaredType));
+}
+
 // Targeted value-validation companion for the matrix above. The cases
 // here exercise the data path (not just convertType), so we explicitly
 // check the column-reader-level cast and the integer-widening path


### PR DESCRIPTION
### What problem does this PR solve?

An empty Parquet file can still carry a physical schema that differs from the requested table schema. In a minimal reproduction, the file footer has `num_rows = 0`, while a synthetic column `c0` is physically `DOUBLE` and requested as `ARRAY(DOUBLE)`. The reader rejects this mismatch during schema initialization even though the file cannot supply any values.

Fixes #976

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Skip requested-type compatibility rejection only when the Parquet footer reports exactly zero rows. The reader still derives the physical schema and returns zero rows. Non-empty files retain the existing compatibility checks.

Add a table-scan regression test that writes an empty `DOUBLE` Parquet file, requests `ARRAY(DOUBLE)`, and verifies a successful zero-row result.

### Performance Impact

- [x] **No Impact**: The additional branch only applies during schema initialization for files whose footer reports zero rows.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Validation

- `ParquetTableScanTest.allowsStructuralMismatchForEmptyFile` passed.
- `ParquetTableScanTest.convertTypePolicyMatrix` passed, preserving the non-empty compatibility policy.

### Release Note

```text
Release Note:
- Allow empty Parquet files to return zero rows when their physical schema differs from the requested schema.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the targeted tests with a local build.
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
