### PR TITLE
feat(paimon): add generic Bolt filesystem support

### DIFF
--- a/bolt/common/file/FileSystems.cpp
+++ b/bolt/common/file/FileSystems.cpp
@@ -32,6 +32,7 @@
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <folly/synchronization/CallOnce.h>
+#include <sys/stat.h>
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/common/config/Config.h"
 #include "bolt/common/file/File.h"
@@ -72,6 +73,10 @@ void copyOpenFileOptionsFromConfig(
       options.values[key] = value;
     }
   }
+}
+
+FileInfo FileSystem::fileInfo(std::string_view /* path */) {
+  BOLT_UNSUPPORTED("fileInfo not implemented");
 }
 
 std::map<std::string, std::string> getConfFromString(
@@ -239,7 +244,28 @@ class LocalFileSystem : public FileSystem {
     return std::filesystem::is_directory(file);
   }
 
-  virtual std::vector<std::string> list(std::string_view path) override {
+  FileInfo fileInfo(std::string_view path) override {
+    const std::string localPath{extractPath(path)};
+    struct stat fileStat {};
+    BOLT_CHECK_EQ(
+        ::stat(localPath.c_str(), &fileStat),
+        0,
+        "Cannot stat local path {}: {}",
+        localPath,
+        folly::errnoStr(errno));
+
+    const auto status = std::filesystem::status(localPath);
+    FileInfo info;
+    info.isDirectory = std::filesystem::is_directory(status);
+    info.modificationTimeMs = static_cast<int64_t>(fileStat.st_mtime) * 1000;
+    if (info.isDirectory) {
+      return info;
+    }
+    info.size = std::filesystem::file_size(localPath);
+    return info;
+  }
+
+  std::vector<std::string> list(std::string_view path) override {
     auto directoryPath = extractPath(path);
     const std::filesystem::path folder{directoryPath};
     std::vector<std::string> filePaths;
@@ -250,8 +276,9 @@ class LocalFileSystem : public FileSystem {
   }
 
   void mkdir(std::string_view path) override {
+    const auto localPath = extractPath(path);
     std::error_code ec;
-    std::filesystem::create_directories(path, ec);
+    std::filesystem::create_directories(localPath, ec);
     BOLT_CHECK_EQ(
         0,
         ec.value(),
@@ -263,8 +290,9 @@ class LocalFileSystem : public FileSystem {
   }
 
   void rmdir(std::string_view path) override {
+    const auto localPath = extractPath(path);
     std::error_code ec;
-    std::filesystem::remove_all(path, ec);
+    std::filesystem::remove_all(localPath, ec);
     BOLT_CHECK_EQ(
         0,
         ec.value(),

--- a/bolt/common/file/FileSystems.h
+++ b/bolt/common/file/FileSystems.h
@@ -106,6 +106,13 @@ struct FileSystemOptions {
   bool readAheadEnabled{false};
 };
 
+struct FileInfo {
+  bool isDirectory{false};
+  uint64_t size{0};
+  // Milliseconds since unix epoch.
+  int64_t modificationTimeMs{0};
+};
+
 /// An abstract FileSystem
 class FileSystem {
  public:
@@ -166,6 +173,8 @@ class FileSystem {
   virtual bool isDirectory(std::string_view path) const {
     BOLT_UNSUPPORTED("isDirectory not implemented");
   }
+
+  virtual FileInfo fileInfo(std::string_view path);
 
   /// Returns the list of files or folders in a path. Currently, this method
   /// will be used for testing, but we will need change this to an iterator

--- a/bolt/common/file/tests/FileTest.cpp
+++ b/bolt/common/file/tests/FileTest.cpp
@@ -235,6 +235,26 @@ TEST(LocalFile, viaRegistry) {
   lfs->remove(filename);
 }
 
+TEST(LocalFile, fileInfo) {
+  filesystems::registerLocalFileSystem();
+  auto temp = exec::test::TempDirectoryPath::create();
+  const auto directory = "file:" + temp->getPath() + "/metadata";
+  const auto file = directory + "/metadata.txt";
+  auto fs = filesystems::getFileSystem(file, nullptr);
+  fs->mkdir(directory);
+  auto out = fs->openFileForWrite(file);
+  out->append("bolt");
+  out->close();
+
+  const auto fileMetadata = fs->fileInfo(file);
+  EXPECT_FALSE(fileMetadata.isDirectory);
+  EXPECT_EQ(fileMetadata.size, 4);
+
+  const auto directoryMetadata = fs->fileInfo(directory);
+  EXPECT_TRUE(directoryMetadata.isDirectory);
+  EXPECT_EQ(directoryMetadata.size, 0);
+}
+
 TEST(LocalFile, rename) {
   filesystems::registerLocalFileSystem();
   auto tempFolder = ::exec::test::TempDirectoryPath::create();

--- a/bolt/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
+++ b/bolt/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
@@ -30,9 +30,11 @@
 
 #include "bolt/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h"
 
+#include <azure/storage/files/datalake/datalake_responses.hpp>
 #include <fmt/format.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <glog/logging.h>
+#include <chrono>
 
 #include "bolt/connectors/hive/storage_adapters/abfs/AbfsPath.h"
 #include "bolt/connectors/hive/storage_adapters/abfs/AbfsReadFile.h"
@@ -49,6 +51,30 @@ AbfsFileSystem::AbfsFileSystem(std::shared_ptr<const config::ConfigBase> config)
 
 std::string AbfsFileSystem::name() const {
   return "ABFS";
+}
+
+FileInfo AbfsFileSystem::fileInfo(std::string_view path) {
+  auto abfsPath = std::make_shared<AbfsPath>(path);
+  auto client =
+      AzureClientProviderFactories::getWriteFileClient(abfsPath, *config_);
+  try {
+    const auto properties = client->getProperties();
+    const auto modified = static_cast<std::chrono::system_clock::time_point>(
+        properties.LastModified);
+    return {
+        .isDirectory = properties.IsDirectory,
+        .size = properties.IsDirectory
+            ? 0
+            : static_cast<uint64_t>(properties.FileSize),
+        .modificationTimeMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                modified.time_since_epoch())
+                .count()};
+  } catch (Azure::Storage::StorageException& error) {
+    throwStorageExceptionWithOperationDetails(
+        "GetProperties", std::string(path), error);
+    throw;
+  }
 }
 
 std::unique_ptr<ReadFile> AbfsFileSystem::openFileForRead(

--- a/bolt/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
+++ b/bolt/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
@@ -52,6 +52,8 @@ class AbfsFileSystem : public FileSystem {
 
   std::string name() const override;
 
+  FileInfo fileInfo(std::string_view path) override;
+
   std::unique_ptr<ReadFile> openFileForRead(
       std::string_view path,
       const FileOptions& options = {}) override;

--- a/bolt/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/bolt/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -84,7 +84,67 @@ class TestAzureClientProvider final : public AzureClientProvider {
   std::unique_ptr<AzureClientProvider> delegated_;
 };
 
+class MetadataDataLakeFileClient : public MockDataLakeFileClient {
+ public:
+  explicit MetadataDataLakeFileClient(std::string path)
+      : path_(std::move(path)) {}
+
+  Azure::Storage::Files::DataLake::Models::PathProperties getProperties()
+      override {
+    Azure::Storage::Files::DataLake::Models::PathProperties properties;
+    if (path_ == "missing") {
+      Azure::Storage::StorageException error("Path not found");
+      error.StatusCode = Azure::Core::Http::HttpStatusCode::NotFound;
+      throw error;
+    }
+    properties.IsDirectory = path_ == "directory";
+    properties.FileSize = 4;
+    properties.LastModified = std::chrono::system_clock::time_point{
+        std::chrono::milliseconds{1'234'000}};
+    return properties;
+  }
+
+ private:
+  std::string path_;
+};
+
+class MetadataAzureClientProvider : public AzureClientProvider {
+ public:
+  std::unique_ptr<AzureBlobClient> getReadFileClient(
+      const std::shared_ptr<AbfsPath>&,
+      const config::ConfigBase&) override {
+    BOLT_FAIL("File metadata must use Data Lake path properties");
+  }
+
+  std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
+      const std::shared_ptr<AbfsPath>& path,
+      const config::ConfigBase&) override {
+    return std::make_unique<MetadataDataLakeFileClient>(path->filePath());
+  }
+};
+
 } // namespace
+
+TEST(AbfsFileInfoTest, fileAndDirectoryMetadata) {
+  registerAzureClientProviderFactory("metadata", [](const std::string&) {
+    return std::make_unique<MetadataAzureClientProvider>();
+  });
+  AbfsFileSystem fs(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{}));
+  const auto file =
+      fs.fileInfo("abfs://test@metadata.dfs.core.windows.net/file");
+  EXPECT_FALSE(file.isDirectory);
+  EXPECT_EQ(file.size, 4);
+  EXPECT_EQ(file.modificationTimeMs, 1'234'000);
+  const auto directory =
+      fs.fileInfo("abfs://test@metadata.dfs.core.windows.net/directory");
+  EXPECT_TRUE(directory.isDirectory);
+  EXPECT_EQ(directory.size, 0);
+  EXPECT_EQ(directory.modificationTimeMs, 1'234'000);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo("abfs://test@metadata.dfs.core.windows.net/missing"),
+      error_code::kFileNotFound);
+}
 
 class AbfsFileSystemTest : public testing::Test {
  public:

--- a/bolt/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
+++ b/bolt/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
@@ -38,6 +38,7 @@
 
 #include <fmt/format.h>
 #include <glog/logging.h>
+#include <chrono>
 #include <filesystem>
 #include <memory>
 #include <stdexcept>
@@ -236,6 +237,54 @@ bool GcsFileSystem::exists(std::string_view path) {
       impl_->getClient()->GetBucketMetadata(bucket);
 
   return metadata.ok();
+}
+
+FileInfo GcsFileSystem::fileInfo(std::string_view path) {
+  BOLT_CHECK(isGcsFile(path), kGcsInvalidPath, path);
+  const auto objectPath = gcsPath(path);
+  const auto separator = objectPath.find('/');
+  const std::string bucket = objectPath.substr(0, separator);
+  std::string key =
+      separator == std::string::npos ? "" : objectPath.substr(separator + 1);
+  const auto toMillis = [](auto time) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               time.time_since_epoch())
+        .count();
+  };
+
+  if (key.empty()) {
+    const auto metadata = impl_->getClient()->GetBucketMetadata(bucket);
+    checkGcsStatus(
+        metadata.status(), "Failed to get GCS bucket metadata", bucket, key);
+    return {
+        .isDirectory = true,
+        .size = 0,
+        .modificationTimeMs = toMillis(metadata->updated())};
+  }
+
+  const auto metadata = impl_->getClient()->GetObjectMetadata(bucket, key);
+  if (metadata.ok()) {
+    const bool isDirectory = key.back() == '/';
+    return {
+        .isDirectory = isDirectory,
+        .size = isDirectory ? 0 : metadata->size(),
+        .modificationTimeMs = toMillis(metadata->updated())};
+  }
+  if (metadata.status().code() != gc::StatusCode::kNotFound) {
+    checkGcsStatus(
+        metadata.status(), "Failed to get GCS file metadata", bucket, key);
+  }
+
+  if (key.back() != '/') {
+    key += '/';
+  }
+  for (auto&& entry : impl_->getClient()->ListObjects(
+           bucket, gcs::Prefix(key), gcs::MaxResults(1))) {
+    checkGcsStatus(
+        entry.status(), "Failed to get GCS directory metadata", bucket, key);
+    return {.isDirectory = true};
+  }
+  BOLT_FILE_NOT_FOUND_ERROR("GCS path not found: {}", path);
 }
 
 std::vector<std::string> GcsFileSystem::list(std::string_view path) {

--- a/bolt/connectors/hive/storage_adapters/gcs/GcsFileSystem.h
+++ b/bolt/connectors/hive/storage_adapters/gcs/GcsFileSystem.h
@@ -92,6 +92,9 @@ class GcsFileSystem : public FileSystem {
   /// google::cloud::storage::Client::GetObjectMetadata
   bool exists(std::string_view path) override;
 
+  /// Prefix-only directories have no modification time and report zero.
+  FileInfo fileInfo(std::string_view path) override;
+
   /// List the objects associated to a path using
   /// google::cloud::storage::Client::ListObjects
   std::vector<std::string> list(std::string_view path) override;

--- a/bolt/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
+++ b/bolt/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
@@ -215,6 +215,39 @@ TEST_F(GcsFileSystemTest, missingFile) {
       gcfs.openFileForRead(gcsFile), error_code::kFileNotFound);
 }
 
+TEST_F(GcsFileSystemTest, fileInfo) {
+  const auto bucket = emulator_->preexistingBucketName();
+  GcsFileSystem fs(bucket, emulator_->hiveConfig());
+  fs.initializeClient();
+  auto file = fs.openFileForWrite(gcsURI(bucket, "dir/data"));
+  file->append("bolt");
+  file->close();
+  auto empty = fs.openFileForWrite(gcsURI(bucket, "empty"));
+  empty->close();
+  const auto info = fs.fileInfo(gcsURI(bucket, "dir/data"));
+  EXPECT_FALSE(info.isDirectory);
+  EXPECT_EQ(info.size, 4);
+  EXPECT_GT(info.modificationTimeMs, 0);
+  const auto emptyInfo = fs.fileInfo(gcsURI(bucket, "empty"));
+  EXPECT_FALSE(emptyInfo.isDirectory);
+  EXPECT_EQ(emptyInfo.size, 0);
+  for (const auto* key : {"", "dir", "dir/"}) {
+    const auto directory = fs.fileInfo(gcsURI(bucket, key));
+    EXPECT_TRUE(directory.isDirectory) << key;
+    EXPECT_EQ(directory.size, 0);
+  }
+  EXPECT_TRUE(fs.fileInfo(gcsURI(bucket)).isDirectory);
+  fs.mkdir(gcsURI(bucket, "marker/"));
+  EXPECT_TRUE(fs.fileInfo(gcsURI(bucket, "marker/")).isDirectory);
+  EXPECT_TRUE(fs.fileInfo(gcsURI(bucket, "marker")).isDirectory);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo(gcsURI(bucket, "missing")), error_code::kFileNotFound);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo(gcsURI(bucket, "di")), error_code::kFileNotFound);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo("gs://missing-bucket/"), error_code::kFileNotFound);
+}
+
 TEST_F(GcsFileSystemTest, missingBucket) {
   filesystems::GcsFileSystem gcfs(
       emulator_->preexistingBucketName(), emulator_->hiveConfig());

--- a/bolt/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/bolt/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -323,6 +323,15 @@ void HdfsFileSystem::rmdir(std::string_view path) {
       impl_->hdfsShim()->GetLastExceptionRootCause());
 }
 
+FileInfo HdfsFileSystem::fileInfo(std::string_view path) {
+  const auto hdfsInfo = stat(path);
+  FileInfo info;
+  info.isDirectory = hdfsInfo.isDir;
+  info.size = hdfsInfo.isDir ? 0 : hdfsInfo.size;
+  info.modificationTimeMs = hdfsInfo.modificationTimeMs;
+  return info;
+}
+
 HdfsFileSystem::HdfsFileInfo HdfsFileSystem::stat(std::string_view path) const {
   // Only remove the scheme for hdfs path.
   if (path.find(kScheme) == 0) {

--- a/bolt/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/bolt/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -101,6 +101,8 @@ class HdfsFileSystem : public FileSystem {
 
   void rmdir(std::string_view path) override;
 
+  FileInfo fileInfo(std::string_view path) override;
+
   // Returns metadata for the given HDFS path
   //
   // Throws a bolt exception on error.

--- a/bolt/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/bolt/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -543,6 +543,54 @@ bool S3FileSystem::exists(std::string_view path) {
   return impl_->s3Client()->HeadObject(request).IsSuccess();
 }
 
+FileInfo S3FileSystem::fileInfo(std::string_view path) {
+  const auto objectPath = getPath(path);
+  const auto separator = objectPath.find('/');
+  const std::string bucket(objectPath.substr(0, separator));
+  std::string key = separator == std::string_view::npos
+      ? ""
+      : std::string(objectPath.substr(separator + 1));
+
+  if (!key.empty()) {
+    Aws::S3::Model::HeadObjectRequest request;
+    request.SetBucket(awsString(bucket));
+    request.SetKey(awsString(key));
+    const auto outcome = impl_->s3Client()->HeadObject(request);
+    if (outcome.IsSuccess()) {
+      const auto& metadata = outcome.GetResult();
+      const bool isDirectory = key.back() == '/';
+      return {
+          .isDirectory = isDirectory,
+          .size = isDirectory
+              ? 0
+              : static_cast<uint64_t>(metadata.GetContentLength()),
+          .modificationTimeMs = metadata.GetLastModified().Millis()};
+    }
+    if (outcome.GetError().GetResponseCode() !=
+        Aws::Http::HttpResponseCode::NOT_FOUND) {
+      BOLT_CHECK_AWS_OUTCOME(
+          outcome, "Failed to get S3 file metadata", bucket, key);
+    }
+  }
+
+  // Object stores can represent directories solely by their children's prefix.
+  const bool isBucket = key.empty();
+  if (!isBucket && key.back() != '/') {
+    key += '/';
+  }
+  Aws::S3::Model::ListObjectsRequest request;
+  request.SetBucket(awsString(bucket));
+  request.SetPrefix(awsString(key));
+  request.SetMaxKeys(1);
+  const auto outcome = impl_->s3Client()->ListObjects(request);
+  BOLT_CHECK_AWS_OUTCOME(
+      outcome, "Failed to get S3 directory metadata", bucket, key);
+  if (isBucket || !outcome.GetResult().GetContents().empty()) {
+    return {.isDirectory = true};
+  }
+  BOLT_FILE_NOT_FOUND_ERROR("S3 path not found: {}", path);
+}
+
 void S3FileSystem::mkdir(std::string_view path) {
   std::string bucket;
   std::string key;

--- a/bolt/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/bolt/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -87,6 +87,9 @@ class S3FileSystem : public FileSystem {
   /// Checks that the path exists.
   bool exists(std::string_view path) override;
 
+  /// Prefix-only directories have no modification time and report zero.
+  FileInfo fileInfo(std::string_view path) override;
+
   /// List the objects associated to a path.
   std::vector<std::string> list(std::string_view path) override;
 

--- a/bolt/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/bolt/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -30,6 +30,7 @@
 
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <filesystem>
 
 #include "bolt/common/memory/Memory.h"
 #include "bolt/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
@@ -148,6 +149,40 @@ TEST_F(S3FileSystemTest, missingFile) {
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
   BOLT_ASSERT_RUNTIME_THROW_CODE(
       s3fs.openFileForRead(s3File), error_code::kFileNotFound);
+}
+
+TEST_F(S3FileSystemTest, fileInfo) {
+  const char* bucket = "metadata";
+  addBucket(bucket);
+  std::filesystem::create_directories(localPath(bucket) + "/dir");
+  LocalWriteFile file(localPath(bucket) + "/dir/data");
+  file.append("bolt");
+  file.close();
+  LocalWriteFile empty(localPath(bucket) + "/empty");
+  empty.close();
+  filesystems::S3FileSystem fs(bucket, minioServer_->hiveConfig());
+  const auto info = fs.fileInfo(s3URI(bucket, "dir/data"));
+  EXPECT_FALSE(info.isDirectory);
+  EXPECT_EQ(info.size, 4);
+  EXPECT_GT(info.modificationTimeMs, 0);
+  const auto emptyInfo = fs.fileInfo(s3URI(bucket, "empty"));
+  EXPECT_FALSE(emptyInfo.isDirectory);
+  EXPECT_EQ(emptyInfo.size, 0);
+  for (const auto* key : {"", "dir", "dir/"}) {
+    const auto directory = fs.fileInfo(s3URI(bucket, key));
+    EXPECT_TRUE(directory.isDirectory) << key;
+    EXPECT_EQ(directory.size, 0);
+  }
+  EXPECT_TRUE(fs.fileInfo("s3://metadata").isDirectory);
+  fs.mkdir(s3URI(bucket, "marker/"));
+  EXPECT_TRUE(fs.fileInfo(s3URI(bucket, "marker/")).isDirectory);
+  EXPECT_TRUE(fs.fileInfo(s3URI(bucket, "marker")).isDirectory);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo(s3URI(bucket, "missing")), error_code::kFileNotFound);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo(s3URI(bucket, "di")), error_code::kFileNotFound);
+  BOLT_ASSERT_RUNTIME_THROW_CODE(
+      fs.fileInfo("s3://missing-bucket/"), error_code::kFileNotFound);
 }
 
 TEST_F(S3FileSystemTest, missingBucket) {

--- a/bolt/connectors/paimon/CMakeLists.txt
+++ b/bolt/connectors/paimon/CMakeLists.txt
@@ -15,6 +15,7 @@
 bolt_add_library(
     bolt_connector_paimon
     PaimonConnector.cpp
+    PaimonBoltFileSystem.cpp
     PaimonConfig.cpp
     PaimonDataSource.cpp
     PaimonFilterTranslator.cpp
@@ -22,16 +23,11 @@ bolt_add_library(
     BoltMemoryPool.h
 )
 
-if(${BOLT_ENABLE_HDFS})
-  target_sources(bolt_connector_paimon PRIVATE PaimonBoltHdfsFileSystem.cpp)
-endif()
-
 target_link_libraries(
   bolt_connector_paimon
   PUBLIC
     bolt_common_io
     bolt_connector
-    $<$<BOOL:${BOLT_ENABLE_HDFS}>:bolt_hdfs>
     bolt_dwio_parquet_reader
     bolt_dwio_parquet_writer
     bolt_file
@@ -41,7 +37,6 @@ target_link_libraries(
     arrow::arrow
     Paimon::core
     $<LINK_LIBRARY:WHOLE_ARCHIVE,Paimon::format_avro>
-    $<LINK_LIBRARY:WHOLE_ARCHIVE,Paimon::fs_local>
   PRIVATE
     Paimon::libavrocpp
 )

--- a/bolt/connectors/paimon/PaimonBoltFileSystem.cpp
+++ b/bolt/connectors/paimon/PaimonBoltFileSystem.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "bolt/connectors/paimon/PaimonBoltHdfsFileSystem.h"
+#include "bolt/connectors/paimon/PaimonBoltFileSystem.h"
 
 #include <algorithm>
 #include <atomic>
@@ -28,8 +28,6 @@
 #include "bolt/common/config/Config.h"
 #include "bolt/common/file/File.h"
 #include "bolt/common/file/FileSystems.h"
-#include "bolt/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
-#include "bolt/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
 
 #include "paimon/factories/factory_creator.h"
 #include "paimon/result.h"
@@ -40,7 +38,7 @@ namespace bytedance::bolt::connector::paimon {
 namespace {
 
 constexpr std::string_view kHdfsScheme{"hdfs://"};
-constexpr std::string_view kIdentifier{"bolt_hdfs"};
+constexpr std::string_view kIdentifier{"bolt"};
 
 std::string uriAuthorityPrefix(const std::string& uri) {
   if (uri.rfind(std::string(kHdfsScheme), 0) != 0) {
@@ -68,9 +66,9 @@ std::string joinDirAndBasename(
   return dir + "/" + basename;
 }
 
-class PaimonBoltHdfsInputStream final : public ::paimon::InputStream {
+class PaimonBoltInputStream final : public ::paimon::InputStream {
  public:
-  PaimonBoltHdfsInputStream(
+  PaimonBoltInputStream(
       std::shared_ptr<bytedance::bolt::ReadFile> file,
       std::string uri)
       : file_(std::move(file)), uri_(std::move(uri)) {}
@@ -156,9 +154,9 @@ class PaimonBoltHdfsInputStream final : public ::paimon::InputStream {
   std::atomic<int64_t> pos_{0};
 };
 
-class PaimonBoltHdfsOutputStream final : public ::paimon::OutputStream {
+class PaimonBoltOutputStream final : public ::paimon::OutputStream {
  public:
-  PaimonBoltHdfsOutputStream(
+  PaimonBoltOutputStream(
       std::shared_ptr<bytedance::bolt::WriteFile> file,
       std::string uri)
       : file_(std::move(file)), uri_(std::move(uri)) {}
@@ -211,9 +209,9 @@ class PaimonBoltHdfsOutputStream final : public ::paimon::OutputStream {
   int64_t pos_{0};
 };
 
-class PaimonBoltHdfsBasicFileStatus final : public ::paimon::BasicFileStatus {
+class PaimonBoltBasicFileStatus final : public ::paimon::BasicFileStatus {
  public:
-  PaimonBoltHdfsBasicFileStatus(std::string path, bool isDir)
+  PaimonBoltBasicFileStatus(std::string path, bool isDir)
       : path_(std::move(path)), isDir_(isDir) {}
 
   bool IsDir() const override {
@@ -229,9 +227,9 @@ class PaimonBoltHdfsBasicFileStatus final : public ::paimon::BasicFileStatus {
   bool isDir_{false};
 };
 
-class PaimonBoltHdfsFileStatus final : public ::paimon::FileStatus {
+class PaimonBoltFileStatus final : public ::paimon::FileStatus {
  public:
-  PaimonBoltHdfsFileStatus(
+  PaimonBoltFileStatus(
       std::string path,
       bool isDir,
       uint64_t len,
@@ -277,8 +275,8 @@ std::unordered_map<std::string, std::string> toUnordered(
 void ensurePaimonFactoryRegistered() {
   static std::once_flag flag;
   std::call_once(flag, []() {
-    auto* factory = new bytedance::bolt::connector::paimon::
-        PaimonBoltHdfsFileSystemFactory();
+    auto* factory =
+        new bytedance::bolt::connector::paimon::PaimonBoltFileSystemFactory();
     ::paimon::FactoryCreator::GetInstance()->Register(
         factory->Identifier(), factory);
   });
@@ -286,38 +284,38 @@ void ensurePaimonFactoryRegistered() {
 
 } // namespace
 
-PaimonBoltHdfsFileSystem::PaimonBoltHdfsFileSystem(
+PaimonBoltFileSystem::PaimonBoltFileSystem(
     std::map<std::string, std::string> options)
     : connectorProperties_(
           std::make_shared<bytedance::bolt::config::ConfigBase>(
               toUnordered(options),
               /*_mutable=*/false)) {}
 
-PaimonBoltHdfsFileSystem::~PaimonBoltHdfsFileSystem() = default;
+PaimonBoltFileSystem::~PaimonBoltFileSystem() = default;
 
 ::paimon::Result<std::unique_ptr<::paimon::InputStream>>
-PaimonBoltHdfsFileSystem::Open(const std::string& path) const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
+PaimonBoltFileSystem::Open(const std::string& path) const {
   try {
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
     auto file = fs->openFileForRead(path, {});
     auto shared = std::shared_ptr<bytedance::bolt::ReadFile>(std::move(file));
-    return std::make_unique<PaimonBoltHdfsInputStream>(std::move(shared), path);
+    return std::make_unique<PaimonBoltInputStream>(std::move(shared), path);
   } catch (const std::exception& e) {
-    return ::paimon::Status::IOError(std::string("Open failed: ") + e.what());
+    return ::paimon::Status::IOError(
+        "Open failed for " + path + ": " + e.what());
   }
 }
 
 ::paimon::Result<std::unique_ptr<::paimon::OutputStream>>
-PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
-    const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
+PaimonBoltFileSystem::Create(const std::string& path, bool overwrite) const {
   try {
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
     if (fs->exists(path)) {
       if (!overwrite) {
         return ::paimon::Status::Invalid(
-            "do not allow overwrite, but the file already exists");
+            "Do not allow overwrite, but the file already exists: " + path);
       }
       fs->remove(path);
     }
@@ -327,62 +325,64 @@ PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
     options.shouldThrowOnFileAlreadyExists = false;
     auto file = fs->openFileForWrite(path, options);
     auto shared = std::shared_ptr<bytedance::bolt::WriteFile>(std::move(file));
-    return std::make_unique<PaimonBoltHdfsOutputStream>(
-        std::move(shared), path);
+    return std::make_unique<PaimonBoltOutputStream>(std::move(shared), path);
   } catch (const std::exception& e) {
-    return ::paimon::Status::IOError(std::string("Create failed: ") + e.what());
+    return ::paimon::Status::IOError(
+        "Create failed for " + path + ": " + e.what());
   }
 }
 
-::paimon::Status PaimonBoltHdfsFileSystem::Mkdirs(
-    const std::string& path) const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
+::paimon::Status PaimonBoltFileSystem::Mkdirs(const std::string& path) const {
   try {
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
     fs->mkdir(path);
     return ::paimon::Status::OK();
   } catch (const std::exception& e) {
-    return ::paimon::Status::IOError(std::string("Mkdirs failed: ") + e.what());
+    return ::paimon::Status::IOError(
+        "Mkdirs failed for " + path + ": " + e.what());
   }
 }
 
-::paimon::Status PaimonBoltHdfsFileSystem::Rename(
+::paimon::Status PaimonBoltFileSystem::Rename(
     const std::string& src,
     const std::string& dst) const {
   const auto srcPrefix = uriAuthorityPrefix(src);
   const auto dstPrefix = uriAuthorityPrefix(dst);
   if (!srcPrefix.empty() && !dstPrefix.empty() && srcPrefix != dstPrefix) {
     return ::paimon::Status::Invalid(
-        "Rename across different HDFS authorities is not supported");
+        "Rename across different HDFS authorities is not supported: " + src +
+        " -> " + dst);
   }
 
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(src, connectorProperties_);
   try {
-    fs->rename(src, dst, /*overwrite=*/false);
+    auto sourceFs =
+        bytedance::bolt::filesystems::getFileSystem(src, connectorProperties_);
+    auto destinationFs =
+        bytedance::bolt::filesystems::getFileSystem(dst, connectorProperties_);
+    if (sourceFs->name() != destinationFs->name()) {
+      return ::paimon::Status::Invalid(
+          "Rename across different Bolt filesystems is not supported: " + src +
+          " -> " + dst);
+    }
+    sourceFs->rename(src, dst, /*overwrite=*/false);
     return ::paimon::Status::OK();
   } catch (const std::exception& e) {
-    return ::paimon::Status::IOError(std::string("Rename failed: ") + e.what());
+    return ::paimon::Status::IOError(
+        "Rename failed for " + src + " -> " + dst + ": " + e.what());
   }
 }
 
-::paimon::Status PaimonBoltHdfsFileSystem::Delete(
+::paimon::Status PaimonBoltFileSystem::Delete(
     const std::string& path,
     bool recursive) const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
-    auto* hdfsFs =
-        dynamic_cast<bytedance::bolt::filesystems::HdfsFileSystem*>(fs.get());
-    if (!hdfsFs) {
-      return ::paimon::Status::NotImplemented(
-          "hdfs:// path did not resolve to HdfsFileSystem");
-    }
-
-    if (hdfsFs->stat(path).isDir) {
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
+    if (fs->fileInfo(path).isDirectory) {
       if (!recursive) {
         return ::paimon::Status::Invalid(
-            "non-recursive directory delete is not supported");
+            "Non-recursive directory delete is not supported for " + path);
       }
       fs->rmdir(path);
     } else {
@@ -390,89 +390,69 @@ PaimonBoltHdfsFileSystem::Create(const std::string& path, bool overwrite)
     }
     return ::paimon::Status::OK();
   } catch (const std::exception& e) {
-    return ::paimon::Status::IOError(std::string("Delete failed: ") + e.what());
+    return ::paimon::Status::IOError(
+        "Delete failed for " + path + ": " + e.what());
   }
 }
 
 ::paimon::Result<std::unique_ptr<::paimon::FileStatus>>
-PaimonBoltHdfsFileSystem::GetFileStatus(const std::string& path) const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
+PaimonBoltFileSystem::GetFileStatus(const std::string& path) const {
   try {
-    auto* hdfsFs =
-        dynamic_cast<bytedance::bolt::filesystems::HdfsFileSystem*>(fs.get());
-    if (!hdfsFs) {
-      return ::paimon::Status::NotImplemented(
-          "hdfs:// path did not resolve to HdfsFileSystem");
-    }
-    auto info = hdfsFs->stat(path);
-    return std::make_unique<PaimonBoltHdfsFileStatus>(
-        path, info.isDir, info.size, info.modificationTimeMs);
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
+    const auto info = fs->fileInfo(path);
+    return std::make_unique<PaimonBoltFileStatus>(
+        path, info.isDirectory, info.size, info.modificationTimeMs);
   } catch (const std::exception& e) {
     return ::paimon::Status::IOError(
-        std::string("GetFileStatus failed: ") + e.what());
+        "GetFileStatus failed for " + path + ": " + e.what());
   }
 }
 
-::paimon::Status PaimonBoltHdfsFileSystem::ListDir(
+::paimon::Status PaimonBoltFileSystem::ListDir(
     const std::string& directory,
     std::vector<std::unique_ptr<::paimon::BasicFileStatus>>* file_status_list)
     const {
-  auto fs = bytedance::bolt::filesystems::getFileSystem(
-      directory, connectorProperties_);
   try {
+    auto fs = bytedance::bolt::filesystems::getFileSystem(
+        directory, connectorProperties_);
     if (!fs->exists(directory)) {
       return ::paimon::Status::OK();
     }
-
-    auto* hdfsFs =
-        dynamic_cast<bytedance::bolt::filesystems::HdfsFileSystem*>(fs.get());
-    if (!hdfsFs) {
-      return ::paimon::Status::NotImplemented(
-          "hdfs:// path did not resolve to HdfsFileSystem");
-    }
-    if (!hdfsFs->stat(directory).isDir) {
+    if (!fs->fileInfo(directory).isDirectory) {
       return ::paimon::Status::IOError(
-          "ListDir target exists and is not a directory");
+          "ListDir target is not a directory: " + directory);
     }
 
     auto entries = fs->list(directory);
     file_status_list->reserve(file_status_list->size() + entries.size());
     for (const auto& entry : entries) {
       const std::string full = joinDirAndBasename(directory, entry);
-      const bool isDir = hdfsFs->stat(full).isDir;
+      const bool isDir = fs->fileInfo(full).isDirectory;
       file_status_list->emplace_back(
-          std::make_unique<PaimonBoltHdfsBasicFileStatus>(full, isDir));
+          std::make_unique<PaimonBoltBasicFileStatus>(full, isDir));
     }
     return ::paimon::Status::OK();
   } catch (const std::exception& e) {
     return ::paimon::Status::IOError(
-        std::string("ListDir failed: ") + e.what());
+        "ListDir failed for " + directory + ": " + e.what());
   }
 }
 
-::paimon::Status PaimonBoltHdfsFileSystem::ListFileStatus(
+::paimon::Status PaimonBoltFileSystem::ListFileStatus(
     const std::string& path,
     std::vector<std::unique_ptr<::paimon::FileStatus>>* file_status_list)
     const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
     if (!fs->exists(path)) {
       return ::paimon::Status::OK();
     }
-
-    auto* hdfsFs =
-        dynamic_cast<bytedance::bolt::filesystems::HdfsFileSystem*>(fs.get());
-    if (!hdfsFs) {
-      return ::paimon::Status::NotImplemented(
-          "hdfs:// path did not resolve to HdfsFileSystem");
-    }
-
-    if (!hdfsFs->stat(path).isDir) {
-      auto info = hdfsFs->stat(path);
-      file_status_list->emplace_back(std::make_unique<PaimonBoltHdfsFileStatus>(
-          path, info.isDir, info.size, info.modificationTimeMs));
+    const auto info = fs->fileInfo(path);
+    if (!info.isDirectory) {
+      file_status_list->emplace_back(std::make_unique<PaimonBoltFileStatus>(
+          path, info.isDirectory, info.size, info.modificationTimeMs));
       return ::paimon::Status::OK();
     }
 
@@ -480,43 +460,44 @@ PaimonBoltHdfsFileSystem::GetFileStatus(const std::string& path) const {
     file_status_list->reserve(file_status_list->size() + entries.size());
     for (const auto& entry : entries) {
       const std::string full = joinDirAndBasename(path, entry);
-      auto info = hdfsFs->stat(full);
-      file_status_list->emplace_back(std::make_unique<PaimonBoltHdfsFileStatus>(
-          full, info.isDir, info.size, info.modificationTimeMs));
+      const auto entryInfo = fs->fileInfo(full);
+      file_status_list->emplace_back(std::make_unique<PaimonBoltFileStatus>(
+          full,
+          entryInfo.isDirectory,
+          entryInfo.size,
+          entryInfo.modificationTimeMs));
     }
     return ::paimon::Status::OK();
   } catch (const std::exception& e) {
     return ::paimon::Status::IOError(
-        std::string("ListFileStatus failed: ") + e.what());
+        "ListFileStatus failed for " + path + ": " + e.what());
   }
 }
 
-::paimon::Result<bool> PaimonBoltHdfsFileSystem::Exists(
+::paimon::Result<bool> PaimonBoltFileSystem::Exists(
     const std::string& path) const {
-  auto fs =
-      bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
   try {
+    auto fs =
+        bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
     return fs->exists(path);
   } catch (const std::exception& e) {
-    return ::paimon::Status::IOError(std::string("Exists failed: ") + e.what());
+    return ::paimon::Status::IOError(
+        "Exists failed for " + path + ": " + e.what());
   }
 }
 
-const char* PaimonBoltHdfsFileSystemFactory::Identifier() const {
+const char* PaimonBoltFileSystemFactory::Identifier() const {
   return kIdentifier.data();
 }
 
 ::paimon::Result<std::unique_ptr<::paimon::FileSystem>>
-PaimonBoltHdfsFileSystemFactory::Create(
+PaimonBoltFileSystemFactory::Create(
     const std::string& /*path*/,
     const std::map<std::string, std::string>& options) const {
-  return std::make_unique<PaimonBoltHdfsFileSystem>(options);
+  return std::make_unique<PaimonBoltFileSystem>(options);
 }
 
-void EnsurePaimonBoltHdfsFileSystemRegistered() {
-  static std::once_flag flag;
-  std::call_once(
-      flag, []() { bytedance::bolt::filesystems::registerHdfsFileSystem(); });
+void EnsurePaimonBoltFileSystemRegistered() {
   ensurePaimonFactoryRegistered();
 }
 

--- a/bolt/connectors/paimon/PaimonBoltFileSystem.cpp
+++ b/bolt/connectors/paimon/PaimonBoltFileSystem.cpp
@@ -298,7 +298,10 @@ PaimonBoltFileSystem::Open(const std::string& path) const {
   try {
     auto fs =
         bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
-    auto file = fs->openFileForRead(path, {});
+    bytedance::bolt::filesystems::FileOptions options;
+    bytedance::bolt::filesystems::copyOpenFileOptionsFromConfig(
+        connectorProperties_.get(), options);
+    auto file = fs->openFileForRead(path, options);
     auto shared = std::shared_ptr<bytedance::bolt::ReadFile>(std::move(file));
     return std::make_unique<PaimonBoltInputStream>(std::move(shared), path);
   } catch (const std::exception& e) {
@@ -321,6 +324,8 @@ PaimonBoltFileSystem::Create(const std::string& path, bool overwrite) const {
     }
 
     bytedance::bolt::filesystems::FileOptions options;
+    bytedance::bolt::filesystems::copyOpenFileOptionsFromConfig(
+        connectorProperties_.get(), options);
     options.shouldCreateParentDirectories = true;
     options.shouldThrowOnFileAlreadyExists = false;
     auto file = fs->openFileForWrite(path, options);
@@ -379,13 +384,19 @@ PaimonBoltFileSystem::Create(const std::string& path, bool overwrite) const {
   try {
     auto fs =
         bytedance::bolt::filesystems::getFileSystem(path, connectorProperties_);
-    if (fs->fileInfo(path).isDirectory) {
-      if (!recursive) {
-        return ::paimon::Status::Invalid(
-            "Non-recursive directory delete is not supported for " + path);
-      }
+    const bool isDirectory = fs->fileInfo(path).isDirectory;
+    if (isDirectory && fs->name() == "GCS") {
+      // GCS rmdir currently deletes the whole bucket, and remove only deletes
+      // a marker object without checking for children. Neither is safe here.
+      return ::paimon::Status::NotImplemented(
+          "GCS directory deletion is not supported by the Bolt Paimon filesystem: " +
+          path);
+    }
+    if (isDirectory && recursive) {
       fs->rmdir(path);
     } else {
+      // Let the backend reject non-empty directories without relying on
+      // listing or risking a recursive deletion of newly created children.
       fs->remove(path);
     }
     return ::paimon::Status::OK();

--- a/bolt/connectors/paimon/PaimonBoltFileSystem.h
+++ b/bolt/connectors/paimon/PaimonBoltFileSystem.h
@@ -26,16 +26,11 @@
 
 namespace bytedance::bolt::connector::paimon {
 
-// Paimon filesystem implementation backed by Bolt's registered hdfs://
-// filesystem.
-//
-// This class expects hdfs:// URIs. It resolves the underlying Bolt filesystem
-// via `bytedance::bolt::filesystems::getFileSystem(hdfsUri,
-// connectorProperties)`.
-class PaimonBoltHdfsFileSystem final : public ::paimon::FileSystem {
+// Paimon filesystem implementation backed by Bolt's registered filesystems.
+class PaimonBoltFileSystem final : public ::paimon::FileSystem {
  public:
-  explicit PaimonBoltHdfsFileSystem(std::map<std::string, std::string> options);
-  ~PaimonBoltHdfsFileSystem() override;
+  explicit PaimonBoltFileSystem(std::map<std::string, std::string> options);
+  ~PaimonBoltFileSystem() override;
 
   ::paimon::Result<std::unique_ptr<::paimon::InputStream>> Open(
       const std::string& path) const override;
@@ -70,10 +65,9 @@ class PaimonBoltHdfsFileSystem final : public ::paimon::FileSystem {
       connectorProperties_;
 };
 
-class PaimonBoltHdfsFileSystemFactory final
-    : public ::paimon::FileSystemFactory {
+class PaimonBoltFileSystemFactory final : public ::paimon::FileSystemFactory {
  public:
-  ~PaimonBoltHdfsFileSystemFactory() override = default;
+  ~PaimonBoltFileSystemFactory() override = default;
 
   const char* Identifier() const override;
 
@@ -82,12 +76,8 @@ class PaimonBoltHdfsFileSystemFactory final
       const std::map<std::string, std::string>& options) const override;
 };
 
-// Ensures that:
-// 1) Bolt HDFS filesystem backend is registered (so bolt can resolve hdfs://
-// URIs), and 2) paimon-cpp FileSystemFactory identifier "bolt_hdfs" is
-// registered.
-//
-// Safe to call multiple times.
-void EnsurePaimonBoltHdfsFileSystemRegistered();
+// Registers the paimon-cpp FileSystemFactory identifier "bolt". Safe to call
+// multiple times.
+void EnsurePaimonBoltFileSystemRegistered();
 
 } // namespace bytedance::bolt::connector::paimon

--- a/bolt/connectors/paimon/PaimonConnector.cpp
+++ b/bolt/connectors/paimon/PaimonConnector.cpp
@@ -15,12 +15,14 @@
  */
 
 #include "bolt/connectors/paimon/PaimonConnector.h"
+
+#include <algorithm>
+#include <mutex>
+
 #include <paimon/factories/factory.h>
 #include <paimon/factories/factory_creator.h>
 #include <paimon/format/file_format_factory.h>
-#include <paimon/fs/file_system_factory.h>
-#include <algorithm>
-#include "bolt/connectors/paimon/PaimonBoltHdfsFileSystem.h"
+#include "bolt/connectors/paimon/PaimonBoltFileSystem.h"
 #include "bolt/connectors/paimon/PaimonConfig.h"
 #include "bolt/connectors/paimon/PaimonDataSource.h"
 #include "bolt/connectors/paimon/PaimonParquetReader.h"
@@ -39,20 +41,6 @@ class AvroFileFormatFactory : public ::paimon::FileFormatFactory {
       const std::map<std::string, std::string>& options) const override;
 };
 } // namespace paimon::avro
-
-namespace paimon {
-
-class LocalFileSystemFactory : public ::paimon::FileSystemFactory {
- public:
-  static const char IDENTIFIER[];
-
-  const char* Identifier() const override;
-
-  ::paimon::Result<std::unique_ptr<::paimon::FileSystem>> Create(
-      const std::string& path,
-      const std::map<std::string, std::string>& options) const override;
-};
-} // namespace paimon
 
 namespace bytedance::bolt::connector::paimon {
 
@@ -73,20 +61,6 @@ void ensureAvroFormatFactoryRegistered() {
   });
 }
 
-void ensureLocalFileSystemFactoryRegistered() {
-  static std::once_flag flag;
-  std::call_once(flag, []() {
-    auto* factory = new ::paimon::LocalFileSystemFactory;
-    const auto& items =
-        ::paimon::FactoryCreator::GetInstance()->GetRegisteredType();
-    if (std::find(items.begin(), items.end(), factory->Identifier()) ==
-        items.end()) {
-      ::paimon::FactoryCreator::GetInstance()->Register(
-          factory->Identifier(), factory);
-    }
-  });
-}
-
 } // namespace
 
 std::unique_ptr<DataSource> PaimonConnector::createDataSource(
@@ -96,7 +70,15 @@ std::unique_ptr<DataSource> PaimonConnector::createDataSource(
         columnHandles,
     std::shared_ptr<ConnectorQueryCtx> queryCtx,
     const core::QueryConfig& queryConfig) {
-  auto paimonConfig = std::make_shared<PaimonConfig>(config_);
+  auto configs = config_ == nullptr
+      ? std::unordered_map<std::string, std::string>{}
+      : config_->rawConfigsCopy();
+  for (const auto& [key, value] :
+       queryCtx->sessionProperties()->rawConfigsCopy()) {
+    configs[key] = value;
+  }
+  auto mergedConfig = std::make_shared<config::ConfigBase>(std::move(configs));
+  auto paimonConfig = std::make_shared<PaimonConfig>(mergedConfig);
   return std::make_unique<PaimonDataSource>(
       outputType,
       tableHandle,
@@ -110,17 +92,13 @@ PaimonConnectorFactory::PaimonConnectorFactory()
     : ConnectorFactory(kPaimonConnectorName) {
   LOG(INFO)
       << "[PAIMON] PaimonConnectorFactory constructed, registering factories";
-  // Register paimon factories (parquet format, avro format, local filesystem,
-  // HDFS filesystem) so they are available when paimon-cpp resolves
-  // format identifiers. Using explicit calls rather than relying on
-  // REGISTER_PAIMON_FACTORY's static constructors, which the linker may strip
-  // from paimon's format libraries.
+  // Register paimon factories (parquet format, avro format, Bolt filesystem)
+  // so they are available when paimon-cpp resolves format identifiers. Using
+  // explicit calls avoids linker stripping of REGISTER_PAIMON_FACTORY's static
+  // constructors from paimon's format libraries.
   EnsurePaimonParquetFormatRegistered();
   ensureAvroFormatFactoryRegistered();
-  ensureLocalFileSystemFactoryRegistered();
-#ifdef BOLT_ENABLE_HDFS
-  EnsurePaimonBoltHdfsFileSystemRegistered();
-#endif
+  EnsurePaimonBoltFileSystemRegistered();
 }
 
 } // namespace bytedance::bolt::connector::paimon

--- a/bolt/connectors/paimon/PaimonDataSource.cpp
+++ b/bolt/connectors/paimon/PaimonDataSource.cpp
@@ -130,6 +130,18 @@ std::vector<std::string> collectFieldNames(
   return fieldNames;
 }
 
+template <typename T, typename F>
+T queryOptionOrElse(
+    const core::QueryConfig& queryConfig,
+    const std::unordered_map<std::string, std::string>& queryConfigs,
+    const std::string& key,
+    F&& fallback) {
+  if (queryConfigs.contains(key)) {
+    return queryConfig.get<T>(key, T{});
+  }
+  return std::forward<F>(fallback)();
+}
+
 std::pair<std::shared_ptr<::paimon::Predicate>, core::TypedExprPtr> planFilter(
     const core::TypedExprPtr& expression,
     const RowTypePtr& rowType,
@@ -167,6 +179,66 @@ std::pair<std::shared_ptr<::paimon::Predicate>, core::TypedExprPtr> planFilter(
 }
 
 } // namespace
+
+PaimonDataSourceReadOptions resolvePaimonDataSourceReadOptions(
+    const core::QueryConfig& queryConfig,
+    const PaimonConfig& paimonConfig) {
+  const auto queryConfigs = queryConfig.rawConfigsCopy();
+  return {
+      .naturalReadSize = queryOptionOrElse<uint64_t>(
+          queryConfig,
+          queryConfigs,
+          PaimonConfig::kNaturalReadSize,
+          [&] { return paimonConfig.naturalReadSize(); }),
+      .coalesceReads = queryOptionOrElse<bool>(
+          queryConfig,
+          queryConfigs,
+          PaimonConfig::kCoalesceReads,
+          [&] { return paimonConfig.coalesceReads(); }),
+      .readTimestampUnit = queryOptionOrElse<uint8_t>(
+          queryConfig,
+          queryConfigs,
+          PaimonConfig::kReadTimestampUnit,
+          [&] { return paimonConfig.readTimestampUnit(); }),
+  };
+}
+
+std::map<std::string, std::string> resolvePaimonDataSourceOptions(
+    const std::unordered_map<std::string, std::string>& tableProperties,
+    const core::QueryConfig& queryConfig,
+    const PaimonConfig& paimonConfig) {
+  std::map<std::string, std::string> options;
+
+  // Connector configuration supplies filesystem defaults (credentials,
+  // endpoints and backend-specific settings). Table properties may override
+  // these defaults for a particular Paimon table.
+  for (const auto& [key, value] : paimonConfig.config()->rawConfigsCopy()) {
+    options.insert_or_assign(key, value);
+  }
+  for (const auto& [key, value] : tableProperties) {
+    options.insert_or_assign(key, value);
+  }
+
+  // Paimon's filesystem must always delegate to Bolt. Reader options are
+  // resolved last so query-level values take precedence over connector/table
+  // defaults.
+  options.insert_or_assign(::paimon::Options::FILE_SYSTEM, "bolt");
+  options.insert_or_assign(
+      ::paimon::Options::READ_BATCH_SIZE,
+      std::to_string(paimonConfig.readBatchSize()));
+  const auto readOptions =
+      resolvePaimonDataSourceReadOptions(queryConfig, paimonConfig);
+  options.insert_or_assign(
+      PaimonConfig::kNaturalReadSize,
+      std::to_string(readOptions.naturalReadSize));
+  options.insert_or_assign(
+      PaimonConfig::kCoalesceReads,
+      readOptions.coalesceReads ? "true" : "false");
+  options.insert_or_assign(
+      PaimonConfig::kReadTimestampUnit,
+      std::to_string(readOptions.readTimestampUnit));
+  return options;
+}
 
 PaimonDataSource::PaimonDataSource(
     const std::shared_ptr<const RowType>& outputType,
@@ -228,48 +300,13 @@ PaimonDataSource::PaimonDataSource(
         paimonConfig->rowToBatchThreadNumber());
   }
   ctxBuilder.WithMemoryPool(paimonPool_);
-  ctxBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local");
-
-#ifdef BOLT_ENABLE_HDFS
-  // Enable hdfs:// scheme resolution to Bolt-backed paimon filesystem.
-  ctxBuilder.WithFileSystemSchemeToIdentifierMap(
-      std::map<std::string, std::string>{{"hdfs", "bolt_hdfs"}});
-#endif
   for (const auto& [key, value] : tableHandle_->tableProperties()) {
-    ctxBuilder.AddOption(key, value);
     VLOG(1) << "Added table option <" << key << "=" << value << ">";
   }
-
-  // Pass read.batch-size through the options map so the paimon library uses
-  // it when creating FileBatchReaders.
-  ctxBuilder.AddOption(
-      ::paimon::Options::READ_BATCH_SIZE,
-      std::to_string(paimonConfig->readBatchSize()));
-
-  // Propagate I/O tuning options through paimon's options map so they reach
-  // PaimonReadFile (constructed deep inside paimon's internal reader pipeline).
-  // Query config overrides connector config; connector config provides
-  // defaults.
-  ctxBuilder.AddOption(
-      PaimonConfig::kNaturalReadSize,
-      std::to_string(queryConfig.get<uint64_t>(
-          PaimonConfig::kNaturalReadSize, paimonConfig->naturalReadSize())));
-  ctxBuilder.AddOption(
-      PaimonConfig::kCoalesceReads,
-      queryConfig.get<bool>(
-          PaimonConfig::kCoalesceReads, paimonConfig->coalesceReads())
-          ? "true"
-          : "false");
-
-  // Propagate timestamp read precision so PaimonParquetReader can set it on
-  // bolt's ParquetReader (ReaderOptions::setTimestampPrecision). This ensures
-  // the paimon connector truncates timestamps to the same precision as the hive
-  // connector for a given session property value.
-  ctxBuilder.AddOption(
-      PaimonConfig::kReadTimestampUnit,
-      std::to_string(queryConfig.get<uint8_t>(
-          PaimonConfig::kReadTimestampUnit,
-          paimonConfig->readTimestampUnit())));
+  for (const auto& [key, value] : resolvePaimonDataSourceOptions(
+           tableHandle_->tableProperties(), queryConfig, *paimonConfig)) {
+    ctxBuilder.AddOption(key, value);
+  }
 
   ctxBuilder.EnablePredicateFilter(paimonConfig->predicateFilterEnabled());
 
@@ -318,10 +355,9 @@ void PaimonDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   BOLT_CHECK_NOT_NULL(
       paimonConnectorSplit, "Split was not paimon connector split");
 
-  // Deserialize the split bytes into a ::paimon::Split
   auto paimonSplit = ::paimon::Split::Deserialize(
       paimonConnectorSplit->splitBytes_.data(),
-      paimonConnectorSplit->splitBytes_.length(),
+      paimonConnectorSplit->splitBytes_.size(),
       paimonPool_);
   BOLT_CHECK(
       paimonSplit.ok(),

--- a/bolt/connectors/paimon/PaimonDataSource.cpp
+++ b/bolt/connectors/paimon/PaimonDataSource.cpp
@@ -226,8 +226,11 @@ std::map<std::string, std::string> resolvePaimonDataSourceOptions(
   options.insert_or_assign(
       ::paimon::Options::READ_BATCH_SIZE,
       std::to_string(paimonConfig.readBatchSize()));
+  const PaimonConfig tableConfig(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>(
+          options.begin(), options.end())));
   const auto readOptions =
-      resolvePaimonDataSourceReadOptions(queryConfig, paimonConfig);
+      resolvePaimonDataSourceReadOptions(queryConfig, tableConfig);
   options.insert_or_assign(
       PaimonConfig::kNaturalReadSize,
       std::to_string(readOptions.naturalReadSize));

--- a/bolt/connectors/paimon/PaimonDataSource.h
+++ b/bolt/connectors/paimon/PaimonDataSource.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "bolt/connectors/Connector.h"
 #include "bolt/connectors/paimon/PaimonConfig.h"
 #include "bolt/connectors/paimon/PaimonConnectorSplit.h"
@@ -33,6 +35,21 @@ class MemoryPool;
 } // namespace paimon
 
 namespace bytedance::bolt::connector::paimon {
+
+struct PaimonDataSourceReadOptions {
+  uint64_t naturalReadSize;
+  bool coalesceReads;
+  uint8_t readTimestampUnit;
+};
+
+PaimonDataSourceReadOptions resolvePaimonDataSourceReadOptions(
+    const core::QueryConfig& queryConfig,
+    const PaimonConfig& paimonConfig);
+
+std::map<std::string, std::string> resolvePaimonDataSourceOptions(
+    const std::unordered_map<std::string, std::string>& tableProperties,
+    const core::QueryConfig& queryConfig,
+    const PaimonConfig& paimonConfig);
 
 class PaimonDataSource : public DataSource {
  public:

--- a/bolt/connectors/paimon/tests/CMakeLists.txt
+++ b/bolt/connectors/paimon/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(
   PaimonConfigTest.cpp
   PaimonFilterPushdownTest.cpp
   PaimonFilterTranslatorTest.cpp
+  PaimonFileSystemTest.cpp
   PaimonParquetReaderTest.cpp
 )
 
@@ -80,7 +81,6 @@ if(NOT BUILD_SHARED_LIBS AND BOLT_TEST_LINKAGE STREQUAL "static")
   list(
     APPEND PAIMON_CONNECTOR_TEST_REGISTRATION_LIBRARIES
     $<LINK_LIBRARY:WHOLE_ARCHIVE,paimon_avro_file_format>
-    $<LINK_LIBRARY:WHOLE_ARCHIVE,paimon_local_file_system>
   )
 endif()
 
@@ -105,3 +105,7 @@ target_link_libraries(
     Paimon::tbb
     Paimon::libavrocpp
 )
+
+if(BOLT_ENABLE_HDFS)
+  target_link_libraries(bolt_paimon_connector_test PRIVATE bolt_hdfs)
+endif()

--- a/bolt/connectors/paimon/tests/CMakeLists.txt
+++ b/bolt/connectors/paimon/tests/CMakeLists.txt
@@ -109,3 +109,12 @@ target_link_libraries(
 if(BOLT_ENABLE_HDFS)
   target_link_libraries(bolt_paimon_connector_test PRIVATE bolt_hdfs)
 endif()
+
+if(BOLT_ENABLE_GCS)
+  target_link_libraries(
+    bolt_paimon_connector_test
+    PRIVATE
+      bolt_gcs
+      GTest::gmock
+  )
+endif()

--- a/bolt/connectors/paimon/tests/PaimonConnectorTest.cpp
+++ b/bolt/connectors/paimon/tests/PaimonConnectorTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "bolt/connectors/paimon/PaimonConnector.h"
+#include <folly/Conv.h>
 #include <folly/Subprocess.h>
 #include <folly/json.h>
 #include <gtest/gtest.h>
@@ -25,8 +26,10 @@
 #include <paimon/table/source/table_scan.h>
 #include <cstdlib>
 #include "bolt/common/config/Config.h"
+#include "bolt/common/file/FileSystems.h"
 #include "bolt/common/memory/Memory.h"
 #include "bolt/connectors/paimon/BoltMemoryPool.h"
+#include "bolt/connectors/paimon/PaimonBoltFileSystem.h"
 #include "bolt/connectors/paimon/PaimonConfig.h"
 #include "bolt/connectors/paimon/PaimonConnectorSplit.h"
 #include "bolt/connectors/paimon/PaimonDataSource.h"
@@ -54,6 +57,8 @@ class PaimonConnectorTest
     : public bytedance::bolt::exec::test::OperatorTestBase {
  protected:
   static void SetUpTestCase() {
+    filesystems::registerLocalFileSystem();
+
     // Create a temporary directory for the test
     tempDir_ = exec::test::TempDirectoryPath::create();
     LOG(INFO) << "Test using temporary directory: " << tempDir_->path;
@@ -148,7 +153,7 @@ TEST_F(PaimonConnectorTest, TestTableScanBasic) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   std::unique_ptr<::paimon::TableScan> tableScan =
@@ -198,6 +203,8 @@ TEST_F(PaimonConnectorTest, TestTableScanBasic) {
 }
 
 TEST_F(PaimonConnectorTest, ReturnedVectorsCanOutliveReaderEof) {
+  EnsurePaimonBoltFileSystemRegistered();
+
   auto rootPool =
       memory::memoryManager()->addRootPool("PaimonDataSourceLifetimeTest");
   auto leafPool = rootPool->addLeafChild("leaf");
@@ -207,7 +214,7 @@ TEST_F(PaimonConnectorTest, ReturnedVectorsCanOutliveReaderEof) {
   std::string tablePath = "file:" + tempDir_->path + "/test_db.db/basic";
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
   auto scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   auto tableScan = ::paimon::TableScan::Create(std::move(scanContext)).value();
@@ -264,6 +271,129 @@ TEST_F(PaimonConnectorTest, ReturnedVectorsCanOutliveReaderEof) {
   outputs.clear();
 }
 
+TEST_F(
+    PaimonConnectorTest,
+    SessionPropertiesOverrideConnectorConfigWithBaseFallback) {
+  EnsurePaimonBoltFileSystemRegistered();
+
+  auto rootPool =
+      memory::memoryManager()->addRootPool("PaimonConnectorSessionConfigTest");
+  auto leafPool = rootPool->addLeafChild("leaf");
+  auto connectorPool = rootPool->addAggregateChild("connector");
+
+  auto rowType = ROW({"id"}, {BIGINT()});
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+      columnHandles;
+  columnHandles["id"] = std::make_shared<PaimonColumnHandle>("id", BIGINT());
+  auto tableHandle = std::make_shared<PaimonTableHandle>(
+      "paimon_session_config_test",
+      "test_table",
+      "file:" + tempDir_->path + "/test_db.db/basic",
+      std::unordered_map<std::string, std::string>{});
+
+  auto baseConfig = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kReadBatchSize, "invalid-base-value"}});
+  PaimonConnector paimonConnector(
+      "paimon_session_config_test", baseConfig, driverExecutor_.get());
+
+  auto overriddenSession = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kReadBatchSize, "1024"}});
+  auto overriddenQueryCtx = std::make_shared<connector::ConnectorQueryCtx>(
+      leafPool.get(),
+      connectorPool.get(),
+      overriddenSession.get(),
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      "query.PaimonConnectorSessionConfigTest.override",
+      "task.PaimonConnectorSessionConfigTest.override",
+      "planNodeId.PaimonConnectorSessionConfigTest.override",
+      0);
+  EXPECT_NO_THROW(paimonConnector.createDataSource(
+      rowType,
+      tableHandle,
+      columnHandles,
+      overriddenQueryCtx,
+      core::QueryConfig({})));
+
+  auto emptySession = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{});
+  auto fallbackQueryCtx = std::make_shared<connector::ConnectorQueryCtx>(
+      leafPool.get(),
+      connectorPool.get(),
+      emptySession.get(),
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      "query.PaimonConnectorSessionConfigTest.fallback",
+      "task.PaimonConnectorSessionConfigTest.fallback",
+      "planNodeId.PaimonConnectorSessionConfigTest.fallback",
+      0);
+  EXPECT_THROW(
+      paimonConnector.createDataSource(
+          rowType,
+          tableHandle,
+          columnHandles,
+          fallbackQueryCtx,
+          core::QueryConfig({})),
+      folly::ConversionError);
+}
+
+TEST_F(PaimonConnectorTest, QueryConfigOverridesPaimonDataSourceReadDefaults) {
+  const auto mergedConnectorConfig = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kNaturalReadSize, "10485760"},
+          {PaimonConfig::kCoalesceReads, "true"},
+          {PaimonConfig::kReadTimestampUnit, "3"}});
+  const PaimonConfig paimonConfig(mergedConnectorConfig);
+  const core::QueryConfig queryConfig({
+      {PaimonConfig::kNaturalReadSize, "20971520"},
+      {PaimonConfig::kCoalesceReads, "false"},
+      {PaimonConfig::kReadTimestampUnit, "6"},
+  });
+
+  const auto readOptions =
+      resolvePaimonDataSourceReadOptions(queryConfig, paimonConfig);
+
+  EXPECT_EQ(readOptions.naturalReadSize, 20971520);
+  EXPECT_FALSE(readOptions.coalesceReads);
+  EXPECT_EQ(readOptions.readTimestampUnit, 6);
+
+  const auto fallbackOptions =
+      resolvePaimonDataSourceReadOptions(core::QueryConfig({}), paimonConfig);
+  EXPECT_EQ(fallbackOptions.naturalReadSize, 10485760);
+  EXPECT_TRUE(fallbackOptions.coalesceReads);
+  EXPECT_EQ(fallbackOptions.readTimestampUnit, 3);
+}
+
+TEST_F(
+    PaimonConnectorTest,
+    QueryConfigOverrideDoesNotParseMalformedConnectorFallback) {
+  const auto malformedConnectorConfig = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kNaturalReadSize, "invalid-size"},
+          {PaimonConfig::kCoalesceReads, "invalid-bool"},
+          {PaimonConfig::kReadTimestampUnit, "invalid-unit"}});
+  const PaimonConfig paimonConfig(malformedConnectorConfig);
+  const core::QueryConfig queryConfig({
+      {PaimonConfig::kNaturalReadSize, "20971520"},
+      {PaimonConfig::kCoalesceReads, "false"},
+      {PaimonConfig::kReadTimestampUnit, "6"},
+  });
+
+  PaimonDataSourceReadOptions readOptions;
+  EXPECT_NO_THROW(
+      readOptions =
+          resolvePaimonDataSourceReadOptions(queryConfig, paimonConfig));
+  EXPECT_EQ(readOptions.naturalReadSize, 20971520);
+  EXPECT_FALSE(readOptions.coalesceReads);
+  EXPECT_EQ(readOptions.readTimestampUnit, 6);
+}
+
 TEST_F(PaimonConnectorTest, TestTableScanAppendOnlyMultipleAppend) {
   // Create Parquet data with unique id
   auto rootPool = memory::memoryManager()->addRootPool("PaimonConnectorTest");
@@ -286,7 +416,7 @@ TEST_F(PaimonConnectorTest, TestTableScanAppendOnlyMultipleAppend) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   std::unique_ptr<::paimon::TableScan> tableScan =
@@ -357,7 +487,7 @@ TEST_F(PaimonConnectorTest, TestTableScanPkNoOverwrite) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   std::unique_ptr<::paimon::TableScan> tableScan =
@@ -436,7 +566,7 @@ TEST_F(PaimonConnectorTest, TestTableScanPkWithOverwrite) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   std::unique_ptr<::paimon::TableScan> tableScan =
@@ -513,7 +643,7 @@ TEST_F(PaimonConnectorTest, TestTableScanDataEvolution) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .AddOption(::paimon::Options::ROW_TRACKING_ENABLED, "true")
           .AddOption(::paimon::Options::DATA_EVOLUTION_ENABLED, "true")
           .Finish()
@@ -603,7 +733,7 @@ TEST_F(PaimonConnectorTest, TestTableScanPartialUpdate) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   std::unique_ptr<::paimon::TableScan> tableScan =
@@ -682,7 +812,7 @@ TEST_F(PaimonConnectorTest, TestTableScanAggregate) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
   auto tableScanResult = ::paimon::TableScan::Create(std::move(scanContext));
@@ -770,7 +900,7 @@ TEST_F(PaimonConnectorTest, TestTableScanDeduplicate) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
 
   std::unique_ptr<::paimon::ScanContext> scanContext =
-      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local")
+      contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt")
           .Finish()
           .value();
 
@@ -847,7 +977,7 @@ static std::vector<std::shared_ptr<connector::ConnectorSplit>> makePaimonSplits(
     const std::shared_ptr<BoltPaimonMemoryPool>& paimonPool,
     const std::unordered_map<std::string, std::string>& extraOptions = {}) {
   ::paimon::ScanContextBuilder contextBuilder(tablePath);
-  contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "local");
+  contextBuilder.AddOption(::paimon::Options::FILE_SYSTEM, "bolt");
   for (const auto& [key, value] : extraOptions) {
     contextBuilder.AddOption(key, value);
   }
@@ -865,6 +995,35 @@ static std::vector<std::shared_ptr<connector::ConnectorSplit>> makePaimonSplits(
         "paimon_test", serialized.data(), serialized.length()));
   }
   return result;
+}
+
+TEST_F(PaimonConnectorTest, TablePropertyCannotOverrideBoltFileSystem) {
+  auto rootPool = memory::memoryManager()->addRootPool("Test");
+  auto leafPool = rootPool->addLeafChild("leaf");
+  auto paimonPool = std::make_shared<BoltPaimonMemoryPool>(leafPool.get());
+
+  auto rowType = ROW({"id"}, {BIGINT()});
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+      columnHandles;
+  columnHandles["id"] = std::make_shared<PaimonColumnHandle>("id", BIGINT());
+
+  std::string tablePath = "file:" + tempDir_->path + "/test_db.db/basic";
+  auto tableHandle = std::make_shared<PaimonTableHandle>(
+      "paimon_test",
+      "test_table",
+      tablePath,
+      std::unordered_map<std::string, std::string>{
+          {::paimon::Options::FILE_SYSTEM, "local"}});
+  auto plan = exec::test::PlanBuilder()
+                  .tableScan(rowType, tableHandle, columnHandles)
+                  .planNode();
+
+  bytedance::bolt::test::VectorMaker mk(leafPool.get());
+  auto allRows = mk.rowVector({mk.flatVector<int64_t>({1, 2, 3})});
+  createDuckDbTable("tmp", {allRows});
+
+  auto connectorSplits = makePaimonSplits(tablePath, paimonPool);
+  assertQuery(plan, connectorSplits, "SELECT c0 FROM tmp");
 }
 
 TEST_F(PaimonConnectorTest, FilterPushdownIntEquality) {

--- a/bolt/connectors/paimon/tests/PaimonFileSystemTest.cpp
+++ b/bolt/connectors/paimon/tests/PaimonFileSystemTest.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include <paimon/defs.h>
+
+#include "bolt/common/file/File.h"
+#include "bolt/common/file/FileSystems.h"
+#include "bolt/connectors/paimon/PaimonBoltFileSystem.h"
+#include "bolt/connectors/paimon/PaimonConfig.h"
+#include "bolt/connectors/paimon/PaimonDataSource.h"
+#include "bolt/exec/tests/utils/TempDirectoryPath.h"
+
+#include "paimon/fs/file_system_factory.h"
+
+namespace bytedance::bolt::connector::paimon {
+namespace {
+
+class FakeFileSystem final : public filesystems::FileSystem {
+ public:
+  FakeFileSystem(
+      std::shared_ptr<const config::ConfigBase> config,
+      std::string name,
+      int* renameCalls)
+      : FileSystem(std::move(config)),
+        name_(std::move(name)),
+        renameCalls_(renameCalls) {}
+
+  std::string name() const override {
+    return name_;
+  }
+
+  std::unique_ptr<ReadFile> openFileForRead(
+      std::string_view,
+      const filesystems::FileOptions&) override {
+    return std::make_unique<InMemoryReadFile>(std::string_view{"fake"});
+  }
+
+  std::unique_ptr<WriteFile> openFileForWrite(
+      std::string_view,
+      const filesystems::FileOptions&) override {
+    return nullptr;
+  }
+
+  void remove(std::string_view) override {}
+
+  void rename(std::string_view, std::string_view, bool) override {
+    ++*renameCalls_;
+  }
+
+  bool exists(std::string_view) override {
+    return true;
+  }
+
+  bool isDirectory(std::string_view) const override {
+    return false;
+  }
+
+  filesystems::FileInfo fileInfo(std::string_view) override {
+    return {.isDirectory = false, .size = 4, .modificationTimeMs = 1'234'000};
+  }
+
+  std::vector<std::string> list(std::string_view) override {
+    return {};
+  }
+
+  void mkdir(std::string_view) override {}
+
+  void rmdir(std::string_view) override {}
+
+ private:
+  std::string name_;
+  int* renameCalls_;
+};
+
+class PaimonFileSystemTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    filesystems::registerLocalFileSystem();
+    EnsurePaimonBoltFileSystemRegistered();
+
+    filesystems::registerFileSystem(
+        [](std::string_view path) { return path.rfind("first://", 0) == 0; },
+        [](std::shared_ptr<const config::ConfigBase> config, std::string_view) {
+          firstConfig_ = config->rawConfigsCopy();
+          return std::make_shared<FakeFileSystem>(
+              std::move(config), "first", &firstRenameCalls_);
+        });
+    filesystems::registerFileSystem(
+        [](std::string_view path) { return path.rfind("second://", 0) == 0; },
+        [](std::shared_ptr<const config::ConfigBase> config, std::string_view) {
+          return std::make_shared<FakeFileSystem>(
+              std::move(config), "second", &secondRenameCalls_);
+        });
+  }
+
+  static inline int firstRenameCalls_{0};
+  static inline int secondRenameCalls_{0};
+  static inline std::unordered_map<std::string, std::string> firstConfig_;
+};
+
+TEST_F(PaimonFileSystemTest, LocalRoundTripUsesBoltFileSystem) {
+  auto temp = exec::test::TempDirectoryPath::create();
+  const std::string dir = "file:" + temp->getPath() + "/dir";
+  const std::string file = dir + "/data";
+  const std::string renamed = dir + "/renamed";
+
+  auto result = ::paimon::FileSystemFactory::Get("bolt", file, {});
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+  auto fs = std::move(result).value();
+  ASSERT_TRUE(fs->Mkdirs(dir).ok());
+  auto output = fs->Create(file, true).value();
+  ASSERT_TRUE(output->Write("bolt", 4).ok());
+  ASSERT_TRUE(output->Close().ok());
+  const auto status = fs->GetFileStatus(file);
+  ASSERT_TRUE(status.ok()) << status.status().ToString();
+  EXPECT_EQ(status.value()->GetLen(), 4);
+  EXPECT_GT(status.value()->GetModificationTime(), 0);
+  ASSERT_TRUE(fs->Rename(file, renamed).ok());
+  ASSERT_TRUE(fs->Exists(renamed).value());
+  ASSERT_TRUE(fs->Delete(dir, true).ok());
+}
+
+TEST_F(PaimonFileSystemTest, FileStatusUsesGenericFileInfo) {
+  auto result = ::paimon::FileSystemFactory::Get("bolt", "first://file", {});
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+
+  auto status = result.value()->GetFileStatus("first://file");
+  ASSERT_TRUE(status.ok()) << status.status().ToString();
+  EXPECT_EQ(status.value()->GetLen(), 4);
+  EXPECT_EQ(status.value()->GetModificationTime(), 1'234'000);
+
+  std::vector<std::unique_ptr<::paimon::FileStatus>> statuses;
+  ASSERT_TRUE(result.value()->ListFileStatus("first://file", &statuses).ok());
+  ASSERT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses.front()->GetModificationTime(), 1'234'000);
+}
+
+TEST_F(PaimonFileSystemTest, ConnectorOptionsReachRegisteredFileSystem) {
+  firstConfig_.clear();
+  const auto connectorConfig = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {"test.fs.endpoint", "session-endpoint"},
+          {"test.fs.credential", "session-credential"},
+          {::paimon::Options::FILE_SYSTEM, "not-bolt"}});
+  const PaimonConfig paimonConfig(connectorConfig);
+  const auto options = resolvePaimonDataSourceOptions(
+      {{"test.fs.endpoint", "table-endpoint"}},
+      core::QueryConfig({}),
+      paimonConfig);
+
+  auto result =
+      ::paimon::FileSystemFactory::Get("bolt", "first://file", options);
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+  ASSERT_TRUE(result.value()->Exists("first://file").value());
+
+  EXPECT_EQ(firstConfig_.at("test.fs.endpoint"), "table-endpoint");
+  EXPECT_EQ(firstConfig_.at("test.fs.credential"), "session-credential");
+  EXPECT_EQ(firstConfig_.at(::paimon::Options::FILE_SYSTEM), "bolt");
+}
+
+TEST_F(PaimonFileSystemTest, RenameRejectsDifferentBoltFilesystems) {
+  auto result = ::paimon::FileSystemFactory::Get("bolt", "first://a", {});
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+
+  const auto status = result.value()->Rename("first://a", "second://b");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), ::paimon::StatusCode::Invalid);
+  EXPECT_EQ(firstRenameCalls_, 0);
+  EXPECT_EQ(secondRenameCalls_, 0);
+}
+
+TEST_F(PaimonFileSystemTest, RenameRejectsDifferentHdfsAuthorities) {
+  PaimonBoltFileSystem fs({});
+
+  const auto status =
+      fs.Rename("hdfs://cluster-a/path", "hdfs://cluster-b/path");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), ::paimon::StatusCode::Invalid);
+}
+
+TEST_F(PaimonFileSystemTest, UnregisteredSchemeReturnsIoErrorWithPath) {
+  auto result =
+      ::paimon::FileSystemFactory::Get("bolt", "unregistered://missing", {});
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+
+  const auto exists = result.value()->Exists("unregistered://missing");
+  ASSERT_FALSE(exists.ok());
+  EXPECT_EQ(exists.status().code(), ::paimon::StatusCode::IOError);
+  EXPECT_NE(
+      exists.status().ToString().find("unregistered://missing"),
+      std::string::npos);
+  EXPECT_NE(
+      exists.status().ToString().find("No registered file system"),
+      std::string::npos);
+}
+
+} // namespace
+} // namespace bytedance::bolt::connector::paimon

--- a/bolt/connectors/paimon/tests/PaimonFileSystemTest.cpp
+++ b/bolt/connectors/paimon/tests/PaimonFileSystemTest.cpp
@@ -30,10 +30,15 @@
 
 #include "paimon/fs/file_system_factory.h"
 
+#ifdef BOLT_ENABLE_GCS
+#include "bolt/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.h"
+#include "bolt/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h"
+#endif
+
 namespace bytedance::bolt::connector::paimon {
 namespace {
 
-class FakeFileSystem final : public filesystems::FileSystem {
+class FakeFileSystem : public filesystems::FileSystem {
  public:
   FakeFileSystem(
       std::shared_ptr<const config::ConfigBase> config,
@@ -49,14 +54,16 @@ class FakeFileSystem final : public filesystems::FileSystem {
 
   std::unique_ptr<ReadFile> openFileForRead(
       std::string_view,
-      const filesystems::FileOptions&) override {
+      const filesystems::FileOptions& options) override {
+    readOptions = options;
     return std::make_unique<InMemoryReadFile>(std::string_view{"fake"});
   }
 
   std::unique_ptr<WriteFile> openFileForWrite(
       std::string_view,
-      const filesystems::FileOptions&) override {
-    return nullptr;
+      const filesystems::FileOptions& options) override {
+    writeOptions = options;
+    return std::make_unique<InMemoryWriteFile>(&output);
   }
 
   void remove(std::string_view) override {}
@@ -85,9 +92,36 @@ class FakeFileSystem final : public filesystems::FileSystem {
 
   void rmdir(std::string_view) override {}
 
+  static inline filesystems::FileOptions readOptions;
+  static inline filesystems::FileOptions writeOptions;
+  static inline std::string output;
+
  private:
   std::string name_;
   int* renameCalls_;
+};
+
+class NonListingFileSystem final : public FakeFileSystem {
+ public:
+  using FakeFileSystem::FakeFileSystem;
+
+  filesystems::FileInfo fileInfo(std::string_view) override {
+    return {.isDirectory = true};
+  }
+
+  std::vector<std::string> list(std::string_view) override {
+    BOLT_FAIL("Directory listing is unavailable");
+  }
+
+  void remove(std::string_view path) override {
+    const auto localPath =
+        path.substr(std::string_view{"non-listing://"}.size());
+    filesystems::getFileSystem(localPath, nullptr)->remove(localPath);
+  }
+
+  void rmdir(std::string_view) override {
+    BOLT_FAIL("Recursive deletion must not be used");
+  }
 };
 
 class PaimonFileSystemTest : public testing::Test {
@@ -108,6 +142,14 @@ class PaimonFileSystemTest : public testing::Test {
         [](std::shared_ptr<const config::ConfigBase> config, std::string_view) {
           return std::make_shared<FakeFileSystem>(
               std::move(config), "second", &secondRenameCalls_);
+        });
+    filesystems::registerFileSystem(
+        [](std::string_view path) {
+          return path.rfind("non-listing://", 0) == 0;
+        },
+        [](std::shared_ptr<const config::ConfigBase> config, std::string_view) {
+          return std::make_shared<NonListingFileSystem>(
+              std::move(config), "non-listing", &firstRenameCalls_);
         });
   }
 
@@ -175,6 +217,165 @@ TEST_F(PaimonFileSystemTest, ConnectorOptionsReachRegisteredFileSystem) {
   EXPECT_EQ(firstConfig_.at("test.fs.credential"), "session-credential");
   EXPECT_EQ(firstConfig_.at(::paimon::Options::FILE_SYSTEM), "bolt");
 }
+
+TEST_F(PaimonFileSystemTest, ReaderOptionsRespectTableAndQueryPrecedence) {
+  const PaimonConfig config(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kNaturalReadSize, "1024"},
+          {PaimonConfig::kCoalesceReads, "true"},
+          {PaimonConfig::kReadTimestampUnit, "3"}}));
+  const std::unordered_map<std::string, std::string> tableProperties{
+      {PaimonConfig::kNaturalReadSize, "2048"},
+      {PaimonConfig::kCoalesceReads, "false"},
+      {PaimonConfig::kReadTimestampUnit, "6"}};
+  auto options = resolvePaimonDataSourceOptions(
+      tableProperties, core::QueryConfig({}), config);
+  EXPECT_EQ(options.at(PaimonConfig::kNaturalReadSize), "2048");
+  EXPECT_EQ(options.at(PaimonConfig::kCoalesceReads), "false");
+  EXPECT_EQ(options.at(PaimonConfig::kReadTimestampUnit), "6");
+
+  options = resolvePaimonDataSourceOptions(
+      tableProperties,
+      core::QueryConfig(std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kNaturalReadSize, "4096"}}),
+      config);
+  EXPECT_EQ(options.at(PaimonConfig::kNaturalReadSize), "4096");
+  EXPECT_EQ(options.at(PaimonConfig::kCoalesceReads), "false");
+  EXPECT_EQ(options.at(PaimonConfig::kReadTimestampUnit), "6");
+
+  options = resolvePaimonDataSourceOptions({}, core::QueryConfig({}), config);
+  EXPECT_EQ(options.at(PaimonConfig::kNaturalReadSize), "1024");
+  EXPECT_EQ(options.at(PaimonConfig::kCoalesceReads), "true");
+  EXPECT_EQ(options.at(PaimonConfig::kReadTimestampUnit), "3");
+}
+
+TEST_F(PaimonFileSystemTest, OpenOptionsReachReadAndWriteFiles) {
+  const std::map<std::string, std::string> options{
+      {"bolt.io.file.buffer.size", "4096"},
+      {"bolt.dfs.replication", "2"},
+      {"bolt.dfs.blocksize", "1048576"}};
+  PaimonBoltFileSystem fs(options);
+  FakeFileSystem::readOptions = {};
+  FakeFileSystem::writeOptions = {};
+  auto input = fs.Open("first://file");
+  ASSERT_TRUE(input.ok()) << input.status().ToString();
+  auto output = fs.Create("first://file", true);
+  ASSERT_TRUE(output.ok()) << output.status().ToString();
+  ASSERT_TRUE(output.value()->Close().ok());
+  for (const auto& [key, value] : options) {
+    EXPECT_EQ(FakeFileSystem::readOptions.values[key], value);
+    EXPECT_EQ(FakeFileSystem::writeOptions.values[key], value);
+  }
+  EXPECT_TRUE(FakeFileSystem::writeOptions.shouldCreateParentDirectories);
+  EXPECT_FALSE(FakeFileSystem::writeOptions.shouldThrowOnFileAlreadyExists);
+}
+
+TEST_F(PaimonFileSystemTest, QueryOverridesMalformedTableReaderOptions) {
+  const PaimonConfig config(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{}));
+  const auto options = resolvePaimonDataSourceOptions(
+      {{PaimonConfig::kNaturalReadSize, "invalid"},
+       {PaimonConfig::kCoalesceReads, "invalid"},
+       {PaimonConfig::kReadTimestampUnit, "invalid"}},
+      core::QueryConfig(
+          {{PaimonConfig::kNaturalReadSize, "4096"},
+           {PaimonConfig::kCoalesceReads, "false"},
+           {PaimonConfig::kReadTimestampUnit, "6"}}),
+      config);
+  EXPECT_EQ(options.at(PaimonConfig::kNaturalReadSize), "4096");
+  EXPECT_EQ(options.at(PaimonConfig::kCoalesceReads), "false");
+  EXPECT_EQ(options.at(PaimonConfig::kReadTimestampUnit), "6");
+}
+
+TEST_F(PaimonFileSystemTest, TableOverridesMalformedConnectorReaderOptions) {
+  const PaimonConfig config(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {PaimonConfig::kNaturalReadSize, "invalid"},
+          {PaimonConfig::kCoalesceReads, "invalid"},
+          {PaimonConfig::kReadTimestampUnit, "invalid"}}));
+  const auto options = resolvePaimonDataSourceOptions(
+      {{PaimonConfig::kNaturalReadSize, "4096"},
+       {PaimonConfig::kCoalesceReads, "false"},
+       {PaimonConfig::kReadTimestampUnit, "6"}},
+      core::QueryConfig({}),
+      config);
+  EXPECT_EQ(options.at(PaimonConfig::kNaturalReadSize), "4096");
+  EXPECT_EQ(options.at(PaimonConfig::kCoalesceReads), "false");
+  EXPECT_EQ(options.at(PaimonConfig::kReadTimestampUnit), "6");
+}
+
+TEST_F(PaimonFileSystemTest, NonRecursiveDeleteAllowsOnlyEmptyDirectories) {
+  auto temp = exec::test::TempDirectoryPath::create();
+  const auto dir = temp->getPath() + "/dir";
+  const auto file = dir + "/data";
+  PaimonBoltFileSystem fs({});
+  ASSERT_TRUE(fs.Mkdirs(dir).ok());
+  ASSERT_TRUE(fs.Delete(dir, false).ok());
+  EXPECT_FALSE(fs.Exists(dir).value());
+
+  ASSERT_TRUE(fs.Mkdirs(dir).ok());
+  auto output = fs.Create(file, false);
+  ASSERT_TRUE(output.ok());
+  ASSERT_TRUE(output.value()->Close().ok());
+  EXPECT_FALSE(fs.Delete(dir, false).ok());
+  EXPECT_TRUE(fs.Exists(file).value());
+  ASSERT_TRUE(fs.Delete(file, false).ok());
+  ASSERT_TRUE(fs.Delete(dir, false).ok());
+}
+
+TEST_F(PaimonFileSystemTest, NonRecursiveDeleteDoesNotRequireListing) {
+  auto temp = exec::test::TempDirectoryPath::create();
+  PaimonBoltFileSystem fs({});
+  EXPECT_TRUE(fs.Delete("non-listing://" + temp->getPath(), false).ok());
+  EXPECT_FALSE(filesystems::getFileSystem(temp->getPath(), nullptr)
+                   ->exists(temp->getPath()));
+}
+
+#ifdef BOLT_ENABLE_GCS
+void checkGcsDirectoryDeletionIsRejected(bool recursive) {
+  filesystems::GcsEmulator emulator;
+  emulator.bootstrap();
+  filesystems::registerGcsFileSystem();
+  const auto config = emulator.hiveConfig()->rawConfigsCopy();
+  PaimonBoltFileSystem fs(
+      std::map<std::string, std::string>(config.begin(), config.end()));
+  const auto root = gcsURI(emulator.preexistingBucketName(), "");
+  auto backend = filesystems::getFileSystem(root, emulator.hiveConfig());
+  ASSERT_TRUE(fs.Mkdirs(root + "dir/").ok());
+  for (const auto* key : {"dir/data", "virtual/data", "sibling"}) {
+    auto output = backend->openFileForWrite(root + key);
+    output->append("bolt");
+    output->close();
+  }
+
+  for (const auto* key : {"dir/", "dir", "virtual", "virtual/", ""}) {
+    SCOPED_TRACE(key);
+    const auto status = fs.Delete(root + key, recursive);
+    EXPECT_TRUE(status.IsNotImplemented()) << status.ToString();
+    for (const auto* retained :
+         {"dir/", "dir/data", "virtual/data", "sibling"}) {
+      const auto info = fs.GetFileStatus(root + retained);
+      EXPECT_TRUE(info.ok()) << info.status().ToString();
+    }
+    // fileInfo can synthesize a directory from its children even if its
+    // marker was deleted, so also check that the exact marker still exists.
+    EXPECT_NO_THROW(backend->openFileForRead(root + "dir/"));
+  }
+
+  // Rejecting directory deletion must not prevent ordinary file deletion.
+  ASSERT_TRUE(fs.Delete(root + "dir/data", recursive).ok());
+  EXPECT_FALSE(fs.GetFileStatus(root + "dir/data").ok());
+  EXPECT_TRUE(fs.GetFileStatus(root + "sibling").ok());
+}
+
+TEST_F(PaimonFileSystemTest, GcsRecursiveDirectoryDeletePreservesBucket) {
+  checkGcsDirectoryDeletionIsRejected(true);
+}
+
+TEST_F(PaimonFileSystemTest, GcsNonRecursiveDirectoryDeletePreservesChildren) {
+  checkGcsDirectoryDeletionIsRejected(false);
+}
+#endif
 
 TEST_F(PaimonFileSystemTest, RenameRejectsDifferentBoltFilesystems) {
   auto result = ::paimon::FileSystemFactory::Get("bolt", "first://a", {});

--- a/bolt/connectors/paimon/tests/PaimonHdfsFileSystemTest.cpp
+++ b/bolt/connectors/paimon/tests/PaimonHdfsFileSystemTest.cpp
@@ -34,7 +34,7 @@
 #include <sys/socket.h>
 
 #include "bolt/common/memory/Memory.h"
-#include "bolt/connectors/paimon/PaimonBoltHdfsFileSystem.h"
+#include "bolt/connectors/paimon/PaimonBoltFileSystem.h"
 #include "bolt/connectors/paimon/tests/HdfsContainerMiniCluster.h"
 
 #include "bolt/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
@@ -104,6 +104,9 @@ class PaimonHdfsFileSystemTest : public testing::Test {
       options.allocatorCapacity = 8L << 30;
       ::bytedance::bolt::memory::MemoryManager::testingSetInstance(options);
     }
+
+    filesystems::registerHdfsFileSystem();
+    EnsurePaimonBoltFileSystemRegistered();
 
     // Validate environment prerequisites.
     try {
@@ -186,7 +189,7 @@ TEST_F(PaimonHdfsFileSystemTest, CreateOpenGetStatusListAndDelete) {
   //   GTEST_SKIP() << "HDFS NameNode port 7878 not reachable on localhost";
   // }
 
-  EnsurePaimonBoltHdfsFileSystemRegistered();
+  EnsurePaimonBoltFileSystemRegistered();
 
   const std::string base = cluster_->namenodeUri() +
       std::string("/paimon_bolt_hdfs_fs_test_") + std::to_string(::getpid());
@@ -195,7 +198,7 @@ TEST_F(PaimonHdfsFileSystemTest, CreateOpenGetStatusListAndDelete) {
   const std::string renamed = dir + "/file2.txt";
 
   auto fsRes = ::paimon::FileSystemFactory::Get(
-      "bolt_hdfs", file, std::map<std::string, std::string>{});
+      "bolt", file, std::map<std::string, std::string>{});
   ASSERT_TRUE(fsRes.ok()) << fsRes.status().ToString();
   auto fs = std::move(fsRes).value();
 
@@ -242,7 +245,7 @@ TEST_F(PaimonHdfsFileSystemTest, RenameFile) {
   if (!clusterAvailable_) {
     GTEST_SKIP() << "CLASSPATH missing; libhdfs JNI cannot initialize";
   }
-  EnsurePaimonBoltHdfsFileSystemRegistered();
+  EnsurePaimonBoltFileSystemRegistered();
 
   const std::string base = cluster_->namenodeUri() +
       std::string("/paimon_bolt_hdfs_rename_test_") +
@@ -252,7 +255,7 @@ TEST_F(PaimonHdfsFileSystemTest, RenameFile) {
   const std::string renamed = dir + "/file2.txt";
 
   auto fsRes = ::paimon::FileSystemFactory::Get(
-      "bolt_hdfs", file, std::map<std::string, std::string>{});
+      "bolt", file, std::map<std::string, std::string>{});
   ASSERT_TRUE(fsRes.ok()) << fsRes.status().ToString();
   auto fs = std::move(fsRes).value();
 
@@ -303,7 +306,7 @@ TEST_F(PaimonHdfsFileSystemTest, WriteReadSeek) {
   if (!clusterAvailable_) {
     GTEST_SKIP() << "CLASSPATH missing; libhdfs JNI cannot initialize";
   }
-  EnsurePaimonBoltHdfsFileSystemRegistered();
+  EnsurePaimonBoltFileSystemRegistered();
 
   const std::string base = cluster_->namenodeUri() +
       std::string("/paimon_bolt_hdfs_rw_test_") + std::to_string(::getpid());
@@ -311,7 +314,7 @@ TEST_F(PaimonHdfsFileSystemTest, WriteReadSeek) {
   const std::string file = dir + "/data.bin";
 
   auto fsRes = ::paimon::FileSystemFactory::Get(
-      "bolt_hdfs", file, std::map<std::string, std::string>{});
+      "bolt", file, std::map<std::string, std::string>{});
   ASSERT_TRUE(fsRes.ok()) << fsRes.status().ToString();
   auto fs = std::move(fsRes).value();
 
@@ -376,7 +379,7 @@ TEST_F(PaimonHdfsFileSystemTest, OverwriteExistingFile) {
   if (!clusterAvailable_) {
     GTEST_SKIP() << "CLASSPATH missing; libhdfs JNI cannot initialize";
   }
-  EnsurePaimonBoltHdfsFileSystemRegistered();
+  EnsurePaimonBoltFileSystemRegistered();
 
   const std::string base = cluster_->namenodeUri() +
       std::string("/paimon_bolt_hdfs_overwrite_test_") +
@@ -385,7 +388,7 @@ TEST_F(PaimonHdfsFileSystemTest, OverwriteExistingFile) {
   const std::string file = dir + "/data.bin";
 
   auto fsRes = ::paimon::FileSystemFactory::Get(
-      "bolt_hdfs", file, std::map<std::string, std::string>{});
+      "bolt", file, std::map<std::string, std::string>{});
   ASSERT_TRUE(fsRes.ok()) << fsRes.status().ToString();
   auto fs = std::move(fsRes).value();
 
@@ -433,7 +436,7 @@ TEST_F(PaimonHdfsFileSystemTest, ListDirReturnsChildren) {
   if (!clusterAvailable_) {
     GTEST_SKIP() << "CLASSPATH missing; libhdfs JNI cannot initialize";
   }
-  EnsurePaimonBoltHdfsFileSystemRegistered();
+  EnsurePaimonBoltFileSystemRegistered();
 
   const std::string base = cluster_->namenodeUri() +
       std::string("/paimon_bolt_hdfs_list_test_") + std::to_string(::getpid());
@@ -442,7 +445,7 @@ TEST_F(PaimonHdfsFileSystemTest, ListDirReturnsChildren) {
   const std::string f2 = dir + "/b.txt";
 
   auto fsRes = ::paimon::FileSystemFactory::Get(
-      "bolt_hdfs", dir, std::map<std::string, std::string>{});
+      "bolt", dir, std::map<std::string, std::string>{});
   ASSERT_TRUE(fsRes.ok()) << fsRes.status().ToString();
   auto fs = std::move(fsRes).value();
 


### PR DESCRIPTION
### What problem does this PR solve?
The Paimon connector currently uses Paimon's local filesystem by default and provides a Bolt-backed adapter only for HDFS. As a result, Paimon cannot consistently reuse Bolt's registered filesystem implementations or propagate connector, session, and table-level filesystem options.

This PR introduces a generic Bolt-backed Paimon filesystem adapter so Paimon can access local, HDFS, and other registered storage backends through the same filesystem registry.

Issue Number: close #1009 

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Generalize `PaimonBoltHdfsFileSystem` into `PaimonBoltFileSystem` and register it using the `bolt` identifier.
- Resolve Paimon paths through Bolt's filesystem registry instead of relying on filesystem-specific Paimon implementations.
- Support open, create, mkdir, rename, delete, status, listing, and existence operations through the generic adapter.
- Add `FileSystem::fileInfo()` and implement it for local and HDFS filesystems to provide file type, size, and modification time.
- Reject rename operations across different Bolt filesystem implementations or different HDFS authorities.
- Propagate filesystem configuration using the following precedence:
  - session properties override connector defaults;
  - table properties override connector and session defaults;
  - query-level reader options override connector-level reader defaults.
- Always enforce `file-system=bolt` so table properties cannot bypass the Bolt filesystem adapter.
- Remove the Paimon connector's direct dependency on Paimon's local filesystem and Bolt's HDFS implementation.
- Add tests for local filesystem operations, generic file metadata, configuration propagation, rename validation, error handling, and existing HDFS behavior.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- add generic filesystem datasource support
- honor Paimon options and filesystem semantics
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [x] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Downstream binaries using FileSystem must be rebuilt.
    - Filesystem implementations used by Paimon should override fileInfo().
    - Existing source implementations remain compatible because the default method is non-pure virtual.
    ```
    </details>
