### PR TITLE
fix(parquet): report truncated definition levels

### DIFF
--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -181,6 +181,7 @@ void copyRawDataPageV1RepDefs(
 
 void makeDataPageV1RepDefDecoders(
     DataPageV1RepDefs repDefs,
+    int32_t numValues,
     int32_t maxRepeat,
     int32_t maxDefine,
     int32_t rowGroupOrdinal,
@@ -205,7 +206,8 @@ void makeDataPageV1RepDefDecoders(
           "definition-level",
           rowGroupOrdinal,
           columnOrdinal,
-          pageOrdinal);
+          pageOrdinal,
+          numValues);
     }
     wideDefineDecoder = std::make_unique<::arrow::util::RleDecoder>(
         reinterpret_cast<const uint8_t*>(repDefs.defineData),
@@ -543,6 +545,7 @@ void PageReader::prepareDataPageV1(
   } else {
     makeDataPageV1RepDefDecoders(
         repDefs,
+        numRepDefsInPage_,
         maxRepeat_,
         maxDefine_,
         cryptoCtx_.rowGroupOrdinal,
@@ -626,6 +629,7 @@ bool PageReader::tryPrepareDataPageV1RepDefOnly(
   } else {
     makeDataPageV1RepDefDecoders(
         repDefs,
+        numRepDefsInPage_,
         maxRepeat_,
         maxDefine_,
         cryptoCtx_.rowGroupOrdinal,
@@ -719,7 +723,8 @@ void PageReader::prepareDataPageV2(
         "definition-level",
         cryptoCtx_.rowGroupOrdinal,
         type_ ? static_cast<int32_t>(type_->column()) : -1,
-        pageOrdinal_);
+        pageOrdinal_,
+        numRepDefsInPage_);
     wideDefineDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
         reinterpret_cast<const uint8_t*>(pageData_ + repeatLength),
         defineLength,

--- a/bolt/dwio/parquet/reader/PageReader.cpp
+++ b/bolt/dwio/parquet/reader/PageReader.cpp
@@ -183,6 +183,9 @@ void makeDataPageV1RepDefDecoders(
     DataPageV1RepDefs repDefs,
     int32_t maxRepeat,
     int32_t maxDefine,
+    int32_t rowGroupOrdinal,
+    int32_t columnOrdinal,
+    int32_t pageOrdinal,
     std::unique_ptr<::arrow::util::RleDecoder>& repeatDecoder,
     std::unique_ptr<RleBpDecoder>& defineDecoder,
     std::unique_ptr<::arrow::util::RleDecoder>& wideDefineDecoder) {
@@ -198,7 +201,11 @@ void makeDataPageV1RepDefDecoders(
       defineDecoder = std::make_unique<RleBpDecoder>(
           repDefs.defineData,
           repDefs.defineData + repDefs.defineSize,
-          ::arrow::bit_util::NumRequiredBits(maxDefine));
+          ::arrow::bit_util::NumRequiredBits(maxDefine),
+          "definition-level",
+          rowGroupOrdinal,
+          columnOrdinal,
+          pageOrdinal);
     }
     wideDefineDecoder = std::make_unique<::arrow::util::RleDecoder>(
         reinterpret_cast<const uint8_t*>(repDefs.defineData),
@@ -538,6 +545,9 @@ void PageReader::prepareDataPageV1(
         repDefs,
         maxRepeat_,
         maxDefine_,
+        cryptoCtx_.rowGroupOrdinal,
+        type_ ? static_cast<int32_t>(type_->column()) : -1,
+        pageOrdinal_,
         repeatDecoder_,
         defineDecoder_,
         wideDefineDecoder_);
@@ -618,6 +628,9 @@ bool PageReader::tryPrepareDataPageV1RepDefOnly(
         repDefs,
         maxRepeat_,
         maxDefine_,
+        cryptoCtx_.rowGroupOrdinal,
+        type_ ? static_cast<int32_t>(type_->column()) : -1,
+        pageOrdinal_,
         repeatDecoder_,
         defineDecoder_,
         wideDefineDecoder_);
@@ -702,7 +715,11 @@ void PageReader::prepareDataPageV2(
     defineDecoder_ = std::make_unique<RleBpDecoder>(
         pageData_ + repeatLength,
         pageData_ + repeatLength + defineLength,
-        ::arrow::bit_util::NumRequiredBits(maxDefine_));
+        ::arrow::bit_util::NumRequiredBits(maxDefine_),
+        "definition-level",
+        cryptoCtx_.rowGroupOrdinal,
+        type_ ? static_cast<int32_t>(type_->column()) : -1,
+        pageOrdinal_);
     wideDefineDecoder_ = std::make_unique<::arrow::util::RleDecoder>(
         reinterpret_cast<const uint8_t*>(pageData_ + repeatLength),
         defineLength,
@@ -1390,7 +1407,12 @@ void PageReader::makeDecoder() {
     case Encoding::RLE_DICTIONARY:
     case Encoding::PLAIN_DICTIONARY:
       dictionaryIdDecoder_ = std::make_unique<RleBpDataDecoder>(
-          pageData_ + 1, pageData_ + encodedDataSize_, pageData_[0]);
+          pageData_ + 1,
+          pageData_ + encodedDataSize_,
+          pageData_[0],
+          cryptoCtx_.rowGroupOrdinal,
+          type_ ? static_cast<int32_t>(type_->column()) : -1,
+          pageOrdinal_);
       decoderSet_ = true;
       break;
     case Encoding::PLAIN:

--- a/bolt/dwio/parquet/reader/RleBpDataDecoder.h
+++ b/bolt/dwio/parquet/reader/RleBpDataDecoder.h
@@ -47,8 +47,18 @@ class RleBpDataDecoder : public bytedance::bolt::parquet::RleBpDecoder {
   RleBpDataDecoder(
       const char* FOLLY_NONNULL start,
       const char* FOLLY_NONNULL end,
-      uint8_t bitWidth)
-      : super::RleBpDecoder{start, end, bitWidth} {}
+      uint8_t bitWidth,
+      int32_t rowGroupOrdinal = -1,
+      int32_t columnOrdinal = -1,
+      int32_t pageOrdinal = -1)
+      : super::RleBpDecoder{
+            start,
+            end,
+            bitWidth,
+            "dictionary-id",
+            rowGroupOrdinal,
+            columnOrdinal,
+            pageOrdinal} {}
 
   template <bool hasNulls>
   inline void skip(
@@ -93,7 +103,7 @@ class RleBpDataDecoder : public bytedance::bolt::parquet::RleBpDecoder {
 
         // We are at a non-null value on a row to visit.
         if (!remainingValues_) {
-          readHeader();
+          readHeader(1);
         }
         if (repeating_) {
           toSkip = visitor.process(value_, atEnd);
@@ -295,7 +305,7 @@ class RleBpDataDecoder : public bytedance::bolt::parquet::RleBpDecoder {
           skip<false>(remainingValues_, -1, nullptr);
         }
       }
-      readHeader();
+      readHeader(numRows - rowIndex);
     }
   }
 

--- a/bolt/dwio/parquet/reader/RleBpDecoder.cpp
+++ b/bolt/dwio/parquet/reader/RleBpDecoder.cpp
@@ -43,6 +43,7 @@ void RleBpDecoder::skip(uint64_t numValues) {
     uint64_t count = std::min<int>(numValues, remainingValues_);
     remainingValues_ -= count;
     numValues -= count;
+    consumedValues_ += count;
     if (!repeating_) {
       auto numBits = bitWidth_ * count + bitOffset_;
       bufferStart_ += numBits >> 3;
@@ -74,6 +75,7 @@ void RleBpDecoder::readBits(
         // The whole read is covered by a RLE of ones and 'allOnes' is
         // provided, so we can shortcut the read.
         remainingValues_ -= toRead;
+        consumedValues_ += toRead;
         *allOnes = true;
         return;
       }
@@ -94,6 +96,7 @@ void RleBpDecoder::readBits(
     numWritten += consumed;
     toRead -= consumed;
     remainingValues_ -= consumed;
+    consumedValues_ += consumed;
   }
 }
 
@@ -109,6 +112,23 @@ void RleBpDecoder::readHeader(uint64_t requestedValues) {
   try {
     indicator = folly::decodeVarint(headerRange);
   } catch (const std::exception& error) {
+    if (expectedValues_ >= 0 && bufferStart_ == bufferEnd_ &&
+        consumedValues_ < static_cast<uint64_t>(expectedValues_)) {
+      BOLT_FAIL(
+          "PARQUET_INVALID_LEVEL_COUNT role={} row_group={} column={} "
+          "page={} encoded_values={} expected_values={} missing_values={} "
+          "buffer_offset={} requested_values={} bit_width={}",
+          role_,
+          rowGroupOrdinal_,
+          columnOrdinal_,
+          pageOrdinal_,
+          consumedValues_,
+          expectedValues_,
+          static_cast<uint64_t>(expectedValues_) - consumedValues_,
+          bufferStart_ - bufferBegin_,
+          requestedValues,
+          bitWidth_);
+    }
     BOLT_FAIL(
         "Parquet RLE/bit-pack decoder header failure: role={} "
         "row_group={} column={} page={} buffer_offset={} "

--- a/bolt/dwio/parquet/reader/RleBpDecoder.cpp
+++ b/bolt/dwio/parquet/reader/RleBpDecoder.cpp
@@ -30,13 +30,15 @@
 
 #include "bolt/dwio/parquet/reader/RleBpDecoder.h"
 
+#include <exception>
+
 #include <folly/Varint.h>
 namespace bytedance::bolt::parquet {
 
 void RleBpDecoder::skip(uint64_t numValues) {
   while (numValues > 0) {
     if (!remainingValues_) {
-      readHeader();
+      readHeader(numValues);
     }
     uint64_t count = std::min<int>(numValues, remainingValues_);
     remainingValues_ -= count;
@@ -62,7 +64,7 @@ void RleBpDecoder::readBits(
   }
   while (toRead) {
     if (!remainingValues_) {
-      readHeader();
+      readHeader(toRead);
     }
     auto consumed = std::min<int32_t>(toRead, remainingValues_);
 
@@ -95,7 +97,7 @@ void RleBpDecoder::readBits(
   }
 }
 
-void RleBpDecoder::readHeader() {
+void RleBpDecoder::readHeader(uint64_t requestedValues) {
   bitOffset_ = 0;
   auto maxVarIntLen = std::min<uint64_t>(
       (uint64_t)folly::kMaxVarintLength64, bufferEnd_ - bufferStart_);
@@ -103,7 +105,26 @@ void RleBpDecoder::readHeader() {
       reinterpret_cast<const unsigned char*>(bufferStart_),
       reinterpret_cast<const unsigned char*>(bufferStart_ + maxVarIntLen));
   // decodeVarint() would advance headerRange's begin pointer.
-  auto indicator = folly::decodeVarint(headerRange);
+  uint64_t indicator;
+  try {
+    indicator = folly::decodeVarint(headerRange);
+  } catch (const std::exception& error) {
+    BOLT_FAIL(
+        "Parquet RLE/bit-pack decoder header failure: role={} "
+        "row_group={} column={} page={} buffer_offset={} "
+        "buffer_remaining={} requested_values={} remaining_run_values={} "
+        "bit_width={} cause={}",
+        role_,
+        rowGroupOrdinal_,
+        columnOrdinal_,
+        pageOrdinal_,
+        bufferStart_ - bufferBegin_,
+        bufferEnd_ - bufferStart_,
+        requestedValues,
+        remainingValues_,
+        bitWidth_,
+        error.what());
+  }
   // Advance bufferStart_ to the position after where the varint is read
   bufferStart_ = reinterpret_cast<const char*>(headerRange.begin());
 

--- a/bolt/dwio/parquet/reader/RleBpDecoder.h
+++ b/bolt/dwio/parquet/reader/RleBpDecoder.h
@@ -40,13 +40,23 @@ class RleBpDecoder {
   RleBpDecoder(
       const char* FOLLY_NONNULL start,
       const char* FOLLY_NONNULL end,
-      uint8_t bitWidth)
+      uint8_t bitWidth,
+      const char* FOLLY_NONNULL role = "unspecified",
+      int32_t rowGroupOrdinal = -1,
+      int32_t columnOrdinal = -1,
+      int32_t pageOrdinal = -1)
       : bufferStart_(start),
+        bufferBegin_(start),
         bufferEnd_(end),
         bitWidth_(bitWidth),
         byteWidth_(bits::roundUp(bitWidth, 8) / 8),
         bitMask_(bits::lowMask(bitWidth)),
-        lastSafeWord_(end - sizeof(uint64_t)) {}
+        lastSafeWord_(
+            end - start >= sizeof(uint64_t) ? end - sizeof(uint64_t) : start),
+        role_(role),
+        rowGroupOrdinal_(rowGroupOrdinal),
+        columnOrdinal_(columnOrdinal),
+        pageOrdinal_(pageOrdinal) {}
 
   void skip(uint64_t numValues);
 
@@ -63,7 +73,7 @@ class RleBpDecoder {
         numValues -= numValuesToRead;
       } else {
         if (remainingValues_ == 0) {
-          readHeader();
+          readHeader(numValues);
         }
 
         auto numValuesToRead = std::min<uint32_t>(numValues, remainingValues_);
@@ -117,7 +127,7 @@ class RleBpDecoder {
       bool* FOLLY_NULLABLE allOnes = nullptr);
 
  protected:
-  void readHeader();
+  void readHeader(uint64_t requestedValues);
 
   template <typename T>
   inline void copyRemainingUnpackedValues(
@@ -137,11 +147,16 @@ class RleBpDecoder {
   }
 
   const char* FOLLY_NULLABLE bufferStart_;
+  const char* FOLLY_NULLABLE const bufferBegin_;
   const char* FOLLY_NULLABLE bufferEnd_;
   const int8_t bitWidth_;
   const int8_t byteWidth_;
   const uint64_t bitMask_;
   const char* FOLLY_NONNULL const lastSafeWord_;
+  const char* FOLLY_NONNULL const role_;
+  const int32_t rowGroupOrdinal_;
+  const int32_t columnOrdinal_;
+  const int32_t pageOrdinal_;
   uint64_t remainingValues_{0};
   int64_t value_;
   int8_t bitOffset_{0};

--- a/bolt/dwio/parquet/reader/RleBpDecoder.h
+++ b/bolt/dwio/parquet/reader/RleBpDecoder.h
@@ -44,7 +44,8 @@ class RleBpDecoder {
       const char* FOLLY_NONNULL role = "unspecified",
       int32_t rowGroupOrdinal = -1,
       int32_t columnOrdinal = -1,
-      int32_t pageOrdinal = -1)
+      int32_t pageOrdinal = -1,
+      int64_t expectedValues = -1)
       : bufferStart_(start),
         bufferBegin_(start),
         bufferEnd_(end),
@@ -56,7 +57,8 @@ class RleBpDecoder {
         role_(role),
         rowGroupOrdinal_(rowGroupOrdinal),
         columnOrdinal_(columnOrdinal),
-        pageOrdinal_(pageOrdinal) {}
+        pageOrdinal_(pageOrdinal),
+        expectedValues_(expectedValues) {}
 
   void skip(uint64_t numValues);
 
@@ -157,6 +159,8 @@ class RleBpDecoder {
   const int32_t rowGroupOrdinal_;
   const int32_t columnOrdinal_;
   const int32_t pageOrdinal_;
+  const int64_t expectedValues_;
+  uint64_t consumedValues_{0};
   uint64_t remainingValues_{0};
   int64_t value_;
   int8_t bitOffset_{0};

--- a/bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "bolt/dwio/common/BitPackDecoder.h"
+#include "bolt/dwio/parquet/reader/RleBpDecoder.h"
 
 #include <arrow/util/rle_encoding.h> // @manual
 #include <gtest/gtest.h>
@@ -36,6 +37,48 @@
 #include <random>
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::dwio::common;
+using bytedance::bolt::parquet::RleBpDecoder;
+
+TEST(RleBpDecoderDiagnosticTest, EmptyHeaderIncludesRoleAndBounds) {
+  const char input[] = {0};
+  RleBpDecoder decoder(
+      input, input, 1, "definition-level", 7, 11, 13);
+  uint64_t output = 0;
+
+  try {
+    decoder.readBits(1, &output);
+    FAIL() << "Expected an empty RLE header to fail";
+  } catch (const std::exception& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("role=definition-level"), std::string::npos);
+    EXPECT_NE(message.find("row_group=7"), std::string::npos);
+    EXPECT_NE(message.find("column=11"), std::string::npos);
+    EXPECT_NE(message.find("page=13"), std::string::npos);
+    EXPECT_NE(message.find("buffer_offset=0"), std::string::npos);
+    EXPECT_NE(message.find("buffer_remaining=0"), std::string::npos);
+    EXPECT_NE(message.find("requested_values=1"), std::string::npos);
+    EXPECT_NE(
+        message.find("Invalid varint value: too few bytes"),
+        std::string::npos);
+  }
+}
+
+TEST(RleBpDecoderDiagnosticTest, TruncatedHeaderIncludesDictionaryRole) {
+  const char input[] = {static_cast<char>(0x80)};
+  RleBpDecoder decoder(input, input + 1, 1, "dictionary-id", 2, 3, 5);
+  uint8_t output = 0;
+  auto* outputPtr = &output;
+
+  try {
+    decoder.next(outputPtr, 4);
+    FAIL() << "Expected a truncated RLE header to fail";
+  } catch (const std::exception& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("role=dictionary-id"), std::string::npos);
+    EXPECT_NE(message.find("buffer_remaining=1"), std::string::npos);
+    EXPECT_NE(message.find("requested_values=4"), std::string::npos);
+  }
+}
 
 template <typename T>
 class RleBpDecoderTest {

--- a/bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
@@ -80,6 +80,31 @@ TEST(RleBpDecoderDiagnosticTest, TruncatedHeaderIncludesDictionaryRole) {
   }
 }
 
+TEST(RleBpDecoderDiagnosticTest, ReportsTruncatedDefinitionLevelCount) {
+  // Two RLE runs encode 8 + 803 zero definition levels. The page header
+  // claims 827 values, so the final request exposes a 16-level shortfall.
+  const char input[] = {
+      0x10, 0x00, static_cast<char>(0xc6), 0x0c, 0x00};
+  RleBpDecoder decoder(
+      input, input + sizeof(input), 1, "definition-level", 0, 124, 1, 827);
+  std::vector<uint64_t> output(bits::nwords(827));
+
+  try {
+    decoder.readBits(827, output.data());
+    FAIL() << "Expected a short definition-level stream to fail";
+  } catch (const std::exception& error) {
+    const std::string message = error.what();
+    EXPECT_NE(
+        message.find("PARQUET_INVALID_LEVEL_COUNT"), std::string::npos);
+    EXPECT_NE(message.find("role=definition-level"), std::string::npos);
+    EXPECT_NE(message.find("column=124"), std::string::npos);
+    EXPECT_NE(message.find("page=1"), std::string::npos);
+    EXPECT_NE(message.find("encoded_values=811"), std::string::npos);
+    EXPECT_NE(message.find("expected_values=827"), std::string::npos);
+    EXPECT_NE(message.find("missing_values=16"), std::string::npos);
+  }
+}
+
 template <typename T>
 class RleBpDecoderTest {
  public:

--- a/bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
+++ b/bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
@@ -28,8 +28,8 @@
  * --------------------------------------------------------------------------
  */
 
-#include "bolt/dwio/common/BitPackDecoder.h"
 #include "bolt/dwio/parquet/reader/RleBpDecoder.h"
+#include "bolt/dwio/common/BitPackDecoder.h"
 
 #include <arrow/util/rle_encoding.h> // @manual
 #include <gtest/gtest.h>
@@ -41,8 +41,7 @@ using bytedance::bolt::parquet::RleBpDecoder;
 
 TEST(RleBpDecoderDiagnosticTest, EmptyHeaderIncludesRoleAndBounds) {
   const char input[] = {0};
-  RleBpDecoder decoder(
-      input, input, 1, "definition-level", 7, 11, 13);
+  RleBpDecoder decoder(input, input, 1, "definition-level", 7, 11, 13);
   uint64_t output = 0;
 
   try {
@@ -58,8 +57,7 @@ TEST(RleBpDecoderDiagnosticTest, EmptyHeaderIncludesRoleAndBounds) {
     EXPECT_NE(message.find("buffer_remaining=0"), std::string::npos);
     EXPECT_NE(message.find("requested_values=1"), std::string::npos);
     EXPECT_NE(
-        message.find("Invalid varint value: too few bytes"),
-        std::string::npos);
+        message.find("Invalid varint value: too few bytes"), std::string::npos);
   }
 }
 
@@ -83,8 +81,7 @@ TEST(RleBpDecoderDiagnosticTest, TruncatedHeaderIncludesDictionaryRole) {
 TEST(RleBpDecoderDiagnosticTest, ReportsTruncatedDefinitionLevelCount) {
   // Two RLE runs encode 8 + 803 zero definition levels. The page header
   // claims 827 values, so the final request exposes a 16-level shortfall.
-  const char input[] = {
-      0x10, 0x00, static_cast<char>(0xc6), 0x0c, 0x00};
+  const char input[] = {0x10, 0x00, static_cast<char>(0xc6), 0x0c, 0x00};
   RleBpDecoder decoder(
       input, input + sizeof(input), 1, "definition-level", 0, 124, 1, 827);
   std::vector<uint64_t> output(bits::nwords(827));
@@ -94,8 +91,7 @@ TEST(RleBpDecoderDiagnosticTest, ReportsTruncatedDefinitionLevelCount) {
     FAIL() << "Expected a short definition-level stream to fail";
   } catch (const std::exception& error) {
     const std::string message = error.what();
-    EXPECT_NE(
-        message.find("PARQUET_INVALID_LEVEL_COUNT"), std::string::npos);
+    EXPECT_NE(message.find("PARQUET_INVALID_LEVEL_COUNT"), std::string::npos);
     EXPECT_NE(message.find("role=definition-level"), std::string::npos);
     EXPECT_NE(message.find("column=124"), std::string::npos);
     EXPECT_NE(message.find("page=1"), std::string::npos);


### PR DESCRIPTION
### What problem does this PR solve?

When a malformed Parquet page declares more values than its bounded definition-level payload encodes, the RLE/bit-pack decoder reaches the end of the buffer and reports only a generic varint-header failure. Missing definition levels carry nullness and value alignment, so they cannot be reconstructed or padded safely.

Issue Number: close #980

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Track the number of values consumed by `RleBpDecoder`.
- Pass the declared definition-level count and page location into bounded definition-level decoders.
- Fail with `PARQUET_INVALID_LEVEL_COUNT` when the page data ends before the declared value count.
- Report the level role, row group, column, page, encoded, expected, and missing counts, buffer offset, requested count, and bit width.
- Preserve contextual diagnostics for other malformed RLE/bit-pack headers, including dictionary-ID streams.
- Add focused tests for empty headers, truncated dictionary-ID headers, and definition-level count mismatches.

The reader deliberately fails instead of padding missing levels or silently accepting corrupt input.

### Performance Impact

- [x] **No Impact**: The change adds decoder counters and error context; the new diagnostic branch is reached only for malformed input.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Validation

- Three focused `RleBpDecoder` regression tests passed in the original change environment.
- Eight self-contained Parquet reader regression tests passed in the original change environment.
- A malformed-input replay consistently failed fast with the expected encoded, expected, and missing counts.
- `pre-commit run --files bolt/dwio/parquet/reader/PageReader.cpp bolt/dwio/parquet/reader/RleBpDataDecoder.h bolt/dwio/parquet/reader/RleBpDecoder.cpp bolt/dwio/parquet/reader/RleBpDecoder.h bolt/dwio/parquet/tests/reader/RleBpDecoderTest.cpp` passed locally.
- `git diff --check upstream/main...HEAD` passed locally.
- A fresh local focused-test build was not completed because CMake generation in the existing checkout fails on an unrelated missing `duckdb::duckdb` target. GitHub build-and-test jobs provide the clean-environment validation.

### Release Note

```text
Release Note:
- Report a dedicated error with page context when a Parquet definition-level stream contains fewer values than the page declares.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
