### PR TITLE
fix: restore deprecated system root pool API

### DIFF
--- a/bolt/common/memory/Memory.h
+++ b/bolt/common/memory/Memory.h
@@ -298,6 +298,12 @@ class MemoryManager {
 
   std::string treeMemoryUsage() const;
 
+  /// Returns the memory manger's internal default root memory pool for testing
+  /// purpose and legacy use cases.
+  MemoryPool& deprecatedSysRootPool() const {
+    return *sysRoot_;
+  }
+
   /// Returns the process wide leaf memory pool used for disk spilling.
   MemoryPool* spillPool() {
     return spillPool_.get();

--- a/bolt/common/memory/tests/MemoryManagerTest.cpp
+++ b/bolt/common/memory/tests/MemoryManagerTest.cpp
@@ -67,6 +67,7 @@ TEST_F(MemoryManagerTest, ctor) {
     ASSERT_EQ(manager.numPools(), 3);
     ASSERT_EQ(manager.capacity(), kMaxMemory);
     ASSERT_EQ(0, manager.getTotalBytes());
+    ASSERT_EQ(&manager.deprecatedSysRootPool(), &systemRootPool(manager));
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMaxAlignment);
     ASSERT_EQ(systemRootPool(manager).alignment(), manager.alignment());
     ASSERT_EQ(systemRootPool(manager).capacity(), kMaxMemory);


### PR DESCRIPTION
### What problem does this PR solve?

PR #929 removed `MemoryManager::deprecatedSysRootPool()`. Some legacy callers still depend on this compatibility API to access the memory manager's internal system root pool.

Issue Number: N/A

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Restore `MemoryManager::deprecatedSysRootPool()` with its original signature and behavior. The method returns the existing internal `sysRoot_` pool and does not alter memory management behavior.

Add a focused regression assertion to verify that the restored compatibility API returns the same system root pool currently reached through the spill pool's parent.

### Performance Impact

- [x] **No Impact**: This is an inline compatibility getter and does not change the critical path.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
- Restored MemoryManager::deprecatedSysRootPool() for legacy callers.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local Release build.
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation performed:

```text
cmake --build --preset conan-release --target bolt_memory_test --parallel 16
env -u LD_LIBRARY_PATH _build/Release/bolt/common/memory/tests/bolt_memory_test --gtest_filter='MemoryManagerTest.*'
# 13 tests passed.
```

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)
