### PR TITLE
perf: enable LTO and bumpup to clang 22

### DIFF
--- a/.github/runners/requirements.txt
+++ b/.github/runners/requirements.txt
@@ -1,4 +1,4 @@
-conan==2.22.2
+conan==2.32.0
 pydot==2.0.0
 pre-commit==4.5.0
 clang-format==14.0.6

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,7 @@ endif
 endif
 export BOLT_TEST_LINKAGE
 
-# BOLT_LINKER overrides profile-aware automatic linker selection. An explicitly
-# empty value disables automatic selection.
+# Pass an explicitly selected linker to the Conan recipe.
 ifneq ($(origin BOLT_LINKER), undefined)
 export BOLT_LINKER
 endif
@@ -225,18 +224,9 @@ _conan_prepare:
 	mkdir -p _build/${BUILD_TYPE} && \
 	cd _build/${BUILD_TYPE} && \
 	set -f && \
-	$(PYTHON_EXECUTABLE) ../../scripts/select-conan-linker.py \
-	   --output conan-linker.options -- \
-	   conan profile show \
-	   $(CONAN_HOST_PROFILE_ARGS) \
-	   $(CONAN_BUILD_SETTINGS) \
-	   ${CONAN_OPTIONS} ${CONAN_OVERRIDE} ${CONAN_CONFIG} \
-	   --format=json && \
-	read CONAN_LINKER_OPTIONS < conan-linker.options && \
 	echo " \
 	$(CONAN_HOST_PROFILE_ARGS) \
-	${CONAN_OPTIONS} ${CONAN_OVERRIDE} \
-	$${CONAN_LINKER_OPTIONS}" > new_conan.options && \
+	${CONAN_OPTIONS} ${CONAN_OVERRIDE}" > new_conan.options && \
 	set -x && \
 	if [ -f conan.options ] && [ -f ../.build_type ] && cmp -s new_conan.options conan.options && [ "`cat ../.build_type`" = "${BUILD_TYPE}" ]; then \
 	  echo "Conan options and build type unchanged; preserving CMakeCache.txt"; \

--- a/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
+++ b/bolt/dwio/parquet/arrow/tests/CMakeLists.txt
@@ -45,19 +45,21 @@ add_executable(
 add_test(bolt_dwio_parquet_arrow_test bolt_dwio_parquet_arrow_test)
 target_link_libraries(bolt_dwio_parquet_arrow_test bolt_gtest_main)
 
-add_executable(
-  bolt_dwio_parquet_level_conversion_benchmark
-  LevelConversionBenchmark.cpp
-  ../LevelComparison.cpp
-  ../LevelComparisonAvx2.cpp
-  ../LevelConversion.cpp
-)
-target_link_libraries(
-  bolt_dwio_parquet_level_conversion_benchmark
-  PRIVATE
-    arrow::arrow
-    ${FOLLY_BENCHMARK}
-)
+if(BOLT_BUILD_BENCHMARKS)
+  add_executable(
+    bolt_dwio_parquet_level_conversion_benchmark
+    LevelConversionBenchmark.cpp
+    ../LevelComparison.cpp
+    ../LevelComparisonAvx2.cpp
+    ../LevelConversion.cpp
+  )
+  target_link_libraries(
+    bolt_dwio_parquet_level_conversion_benchmark
+    PRIVATE
+      arrow::arrow
+      ${FOLLY_BENCHMARK}
+  )
+endif()
 
 bolt_add_library(
   bolt_dwio_parquet_arrow_test_lib

--- a/bolt/type/tests/VariantTypeTest.cpp
+++ b/bolt/type/tests/VariantTypeTest.cpp
@@ -23,8 +23,8 @@ TEST(VariantTypeTest, Basic) {
   auto variantType = VARIANT();
   EXPECT_EQ(variantType->kind(), TypeKind::VARIANT);
   EXPECT_EQ(variantType->toString(), "VARIANT");
-  EXPECT_EQ(variantType->name(), "VARIANT");
-  EXPECT_EQ(variantType->kindName(), "VARIANT");
+  EXPECT_STREQ(variantType->name(), "VARIANT");
+  EXPECT_STREQ(variantType->kindName(), "VARIANT");
   // VARIANT is NOT a primitive type (it has composite storage via
   // VariantVector).
   EXPECT_FALSE(variantType->isPrimitiveType());

--- a/conanfile.py
+++ b/conanfile.py
@@ -435,9 +435,10 @@ class BoltConan(ConanFile):
             self.options[onetbb].tbbmalloc = False
             # self.options[onetbb].tbbproxy = False
 
+        self.options[folly].no_exception_tracer = True
+
         openssl = f"openssl{postfix}"
         if self.options.get_safe("ldb_build"):
-            self.options[folly].no_exception_tracer = True
             self.options[openssl].rand_seed = "devrandom"
             self.options[boost].filesystem_disable_statx = True
             self.options[boost].without_stacktrace = True
@@ -474,21 +475,32 @@ class BoltConan(ConanFile):
         tc.cache_variables["BOLT_TEST_LINKAGE"] = self._test_linkage()
         if bolt_linker:
             use_ld = f"-fuse-ld={bolt_linker}"
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = use_ld
-            tc.cache_variables["CMAKE_SHARED_LINKER_FLAGS"] = use_ld
+            tc.extra_exelinkflags.append(use_ld)
+            tc.extra_sharedlinkflags.append(use_ld)
             tc.cache_variables["CMAKE_MODULE_LINKER_FLAGS"] = use_ld
 
         if str(self.settings.arch) in ["x86", "x86_64"]:
             flags = (
                 f"{self.BOLT_GLOBAL_FLAGS} -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 "
             )
-            tc.cache_variables["CMAKE_CXX_FLAGS"] = flags
-            tc.cache_variables["CMAKE_C_FLAGS"] = flags
+            tc.extra_cxxflags.append(flags)
+            tc.extra_cflags.append(flags)
 
         if str(self.settings.arch) in ["armv8", "arm", "armv9"]:
             flags = self._get_arm_cpu_flags()
-            tc.cache_variables["CMAKE_CXX_FLAGS"] = flags
-            tc.cache_variables["CMAKE_C_FLAGS"] = flags
+            tc.extra_cxxflags.append(flags)
+            tc.extra_cflags.append(flags)
+
+        if str(self.settings.compiler) == "clang":
+            # ThinLTO needs bitcode inputs as well as the linker flag.
+            tc.extra_cflags.append("-flto=thin")
+            tc.extra_cxxflags.append("-flto=thin")
+            tc.extra_exelinkflags.append("-flto=thin")
+            tc.extra_sharedlinkflags.append("-flto=thin")
+            # Avoid incorrect dynamic_cast results across ThinLTO shared libraries.
+            # https://github.com/llvm/llvm-project/issues/71196
+            tc.extra_cxxflags.append("-fno-assume-unique-vtables")
+
         if (
             self.options.enable_torch is not None
             and self.options.enable_torch.value is not None
@@ -502,15 +514,15 @@ class BoltConan(ConanFile):
         )
 
         if self.options.enable_asan:
-            tc.cache_variables["CMAKE_CXX_FLAGS"] += " -fsanitize=address "
-            tc.cache_variables["CMAKE_C_FLAGS"] += " -fsanitize=address"
+            tc.extra_cxxflags.append("-fsanitize=address")
+            tc.extra_cflags.append("-fsanitize=address")
 
         if (
             str(self.settings.build_type) == "RelWithDebInfo"
             or self.options.enable_asan
         ):
-            tc.cache_variables["CMAKE_CXX_FLAGS"] += " -fno-omit-frame-pointer "
-            tc.cache_variables["CMAKE_C_FLAGS"] += " -fno-omit-frame-pointer "
+            tc.extra_cxxflags.append("-fno-omit-frame-pointer")
+            tc.extra_cflags.append("-fno-omit-frame-pointer")
 
         tc.cache_variables["TREAT_WARNINGS_AS_ERRORS"] = "OFF"
         tc.cache_variables["ENABLE_ALL_WARNINGS"] = "ON"

--- a/scripts/conan/bolt.profile
+++ b/scripts/conan/bolt.profile
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[tool_requires]
-cmake/3.31.10
+[replace_tool_requires]
+cmake/*: cmake/3.31.10

--- a/scripts/install-bolt-deps.sh
+++ b/scripts/install-bolt-deps.sh
@@ -15,105 +15,99 @@
 #
 set -euo pipefail
 
-CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
-cd "${CUR_DIR}"
+# Download the conan recipes for Bolt dependencies from the https://github.com/bytedance/conan-center-index.git.
+# And configure it as a local conan remote for building Bolt dependencies.
+#
+# For each Bolt release, a corresponding tag is created in bytedance/conan-center-index. This script downloads the Conan recipes from the tag matching the current Bolt version and configures them as a local Conan remote.
+# If the --branch argument is provided, it must be a valid branch or tag in the conan-center-index repository.
+# If the --repository argument is provided, it must point to a conan-center-index repository.
 
-CONAN_CENTER_COMMIT_ID="bad5c95b810e859c1c31553b92584246fe436d69"
-CCI_HOME="${CONAN_HOME:-$HOME/.conan2}/conan-center-index"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+readonly BOLT_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+readonly DEFAULT_CCI_REPOSITORY="https://github.com/bytedance/conan-center-index.git"
+readonly CCI_HOME="${CONAN_HOME:-${HOME}/.conan2}/conan-center-index"
 
-if ! command -v conan &> /dev/null; then
-  echo "❌ Error: 'conan' command not found."
+usage() {
+  echo "Usage: $0 [--branch <branch-or-tag>] [--repository <repository-url>]"
+}
+
+die() {
+  echo "❌ Error: $*" >&2
   exit 1
-fi
+}
 
-# Does a shallow checkout of conan-center-index at the given commit id in $1
-checkout_conan_center_index() {
-  local target_commit="$1"
-  local need_clone=true
+parse_args() {
+  CCI_REF=""
+  CCI_REPOSITORY="${DEFAULT_CCI_REPOSITORY}"
 
-  if [ -d "${CCI_HOME}/.git" ]; then
-    echo "ℹ️  Found existing conan-center-index cache..."
-    pushd "${CCI_HOME}" > /dev/null
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --branch)
+        [[ $# -ge 2 && -n "$2" ]] || die "--branch requires a value"
+        CCI_REF="$2"
+        shift 2
+        ;;
+      --repository)
+        [[ $# -ge 2 && -n "$2" ]] || die "--repository requires a value"
+        CCI_REPOSITORY="$2"
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        die "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
 
-    local current_commit
-    current_commit=$(git rev-parse HEAD 2> /dev/null || echo "")
-
-    if [ "${current_commit}" == "${target_commit}" ]; then
-      echo "✅ Cache hit: conan-center-index is already at ${target_commit}. Skipping download."
-      git reset --hard HEAD > /dev/null 2>&1
-      git clean -fd > /dev/null 2>&1
-      need_clone=false
-    else
-      echo "🔄 Cache outdated. Updating to ${target_commit}..."
-      if git fetch --depth 1 origin "${target_commit}" > /dev/null 2>&1; then
-        git checkout FETCH_HEAD > /dev/null 2>&1
-        need_clone=false
-      fi
-    fi
-    popd > /dev/null
+resolve_cci_ref() {
+  if [[ -n "${CCI_REF}" ]]; then
+    return
   fi
 
-  if $need_clone; then
-    echo "⬇️  Cloning conan-center-index (Commit: ${target_commit})..."
-    rm -rf "${CCI_HOME}"
-    mkdir -p "${CCI_HOME}"
-    pushd "${CCI_HOME}" > /dev/null
-    git init -q
-    git remote add origin https://github.com/conan-io/conan-center-index.git
-    git fetch --depth 1 origin "${target_commit}"
-    git checkout -q FETCH_HEAD
-    popd > /dev/null
-  fi
+  # Bolt release tags have matching tags in bytedance/conan-center-index.
+  CCI_REF="$(git -C "${BOLT_ROOT}" describe --exact-match --tags HEAD 2> /dev/null || true)"
+  CCI_REF="${CCI_REF:-main}"
+}
+
+download_conan_recipes() {
+  local cci_repository="$1"
+
+  echo "ℹ️  Cloning conan-center-index at ${CCI_REF} from ${cci_repository}..."
+  rm -rf "${CCI_HOME}"
+  git clone --quiet --depth 1 --branch "${CCI_REF}" "${cci_repository}" "${CCI_HOME}"
 }
 
 update_conan_remote() {
   local remote_name="$1"
   local remote_url="$2"
-  local remote_type="${3:-}"
+  local remote_index="$3"
+  local remote_type="${4:-}"
+
+  pip install --upgrade conan==2.32.0
 
   echo "⚙️  Configuring remote '${remote_name}'..."
   conan remote remove "${remote_name}" > /dev/null 2>&1 || true
 
-  if [ -n "$remote_type" ]; then
-    conan remote add -t "$remote_type" "${remote_name}" "${remote_url}" > /dev/null
+  if [[ -n "${remote_type}" ]]; then
+    conan remote add --index "${remote_index}" --type "${remote_type}" "${remote_name}" "${remote_url}" > /dev/null
   else
-    conan remote add "${remote_name}" "${remote_url}" > /dev/null
+    conan remote add --index "${remote_index}" "${remote_name}" "${remote_url}" > /dev/null
   fi
 }
 
-update_conan_remote "bolt-local" "${CUR_DIR}/conan" "local-recipes-index"
+main() {
+  parse_args "$@"
+  command -v conan > /dev/null 2>&1 || die "'conan' command not found"
+  resolve_cci_ref
+  download_conan_recipes "${CCI_REPOSITORY}"
+  update_conan_remote "bolt-cci-local" "${CCI_HOME}" 0 "local-recipes-index"
 
-checkout_conan_center_index "${CONAN_CENTER_COMMIT_ID}"
+  echo "🎉 All done! Conan remotes configured."
+}
 
-echo "🩹 Applying patches..."
-for patch_file in "${CUR_DIR}/conan/patches"/*.patch; do
-  if [ ! -f "$patch_file" ]; then
-    continue
-  fi
-  patch_name=$(basename "$patch_file")
-
-  if output=$(patch -p1 -f -N -d "${CCI_HOME}" -i "$patch_file" 2>&1); then
-    echo "✅ Applied: $patch_name"
-  else
-    if echo "$output" | grep -q "Reversed (or previously applied) patch detected"; then
-      echo "⚠️  Skipped: $patch_name (Already applied)"
-    else
-      echo "❌ Failed to apply $patch_name"
-      echo "--- Patch Output ---"
-      echo "$output"
-      echo "--------------------"
-      exit 1
-    fi
-  fi
-done
-
-update_conan_remote "bolt-cci-local" "${CCI_HOME}" "local-recipes-index"
-
-update_conan_remote "conancenter" "https://center2.conan.io"
-
-# Repository recipes and their patches must take precedence over cached remote
-# revisions. Keep the CI package remote ahead of conancenter for binary reuse.
-conan remote update bolt-local --index=0
-conan remote update bolt-cci-local --index=1
-
-echo "🎉 All done! Conan remotes configured."
+main "$@"


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #982

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Describe your changes in detail.
For complex logic, explain the "Why" and "How".

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [ ] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
