### PR TITLE
fix(shuffle): separate retained payload pool accounting

### DIFF
--- a/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.cpp
@@ -852,8 +852,10 @@ arrow::Status BoltShuffleWriter::doSplit(
     RETURN_NOT_OK(evictPartitionBuffers(pid, /*reuseBuffer=*/false));
     variableMemoryUsage_[pid] = 0;
   }
-  if (pool_ != spillArrowPool_) {
-    // try evict all cached payload if using different spill pool
+  // Complex, uncompressed payloads may retain buffers allocated directly from
+  // the spill pool. Keep the legacy batch drain for those writers until their
+  // buffers can also be retained in task-accounted memory.
+  if (hasComplexType_ && pool_ != spillArrowPool_) {
     evictCachedPayload(std::numeric_limits<int64_t>::max());
   }
   maxVariableMemoryUsage_ = *std::max_element(

--- a/bolt/shuffle/sparksql/BoltShuffleWriter.h
+++ b/bolt/shuffle/sparksql/BoltShuffleWriter.h
@@ -162,7 +162,8 @@ class BoltShuffleWriter : public ShuffleWriter {
             options.partitionWriterOptions.numPartitions,
             PartitionWriter::create(
                 options.partitionWriterOptions,
-                spillPool.get()),
+                spillPool.get(),
+                pool != spillPool.get() ? boltPool : nullptr),
             options,
             pool,
             spillPool),

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
@@ -36,6 +36,7 @@
 
 #include <bolt/common/time/Timer.h>
 #include <glog/logging.h>
+#include "bolt/shuffle/sparksql/BoltArrowMemoryPool.h"
 #include "bolt/shuffle/sparksql/CompressionStream.h"
 #include "bolt/shuffle/sparksql/Payload.h"
 #include "bolt/shuffle/sparksql/Spill.h"
@@ -156,9 +157,11 @@ class LocalPartitionWriter::PayloadMerger {
   PayloadMerger(
       const PartitionWriterOptions& options,
       arrow::MemoryPool* pool,
+      arrow::MemoryPool* spillPool,
       Codec* codec,
       bool hasComplexType)
       : pool_(pool),
+        spillPool_(spillPool),
         codec_(codec),
         hasComplexType_(hasComplexType),
         compressionThreshold_(options.compressionThreshold),
@@ -269,7 +272,7 @@ class LocalPartitionWriter::PayloadMerger {
     }
     auto payload = std::move(partitionMergePayload_[partitionId]);
     return payload->toBlockPayload(
-        Payload::kUncompressed, pool_, codec_, hasComplexType_);
+        Payload::kUncompressed, spillPool_, codec_, hasComplexType_);
   }
 
   arrow::Result<std::optional<std::unique_ptr<BlockPayload>>> finish(
@@ -284,7 +287,8 @@ class LocalPartitionWriter::PayloadMerger {
         ? Payload::kToBeCompressed
         : Payload::kUncompressed;
     auto payload = std::move(partitionMergePayload_[partitionId]);
-    return payload->toBlockPayload(payloadType, pool_, codec_, hasComplexType_);
+    return payload->toBlockPayload(
+        payloadType, spillPool_, codec_, hasComplexType_);
   }
 
   bool hasMerged(uint32_t partitionId) {
@@ -295,6 +299,7 @@ class LocalPartitionWriter::PayloadMerger {
 
  private:
   arrow::MemoryPool* pool_;
+  arrow::MemoryPool* spillPool_;
   Codec* codec_;
   bool hasComplexType_;
   int32_t compressionThreshold_;
@@ -575,10 +580,12 @@ LocalPartitionWriter::LocalPartitionWriter(
     PartitionWriterOptions options,
     arrow::MemoryPool* pool,
     const std::string& dataFile,
-    const std::vector<std::string>& localDirs)
+    const std::vector<std::string>& localDirs,
+    bytedance::bolt::memory::MemoryPool* retainedPayloadBoltPool)
     : PartitionWriter(numPartitions, std::move(options), pool),
       dataFile_(dataFile),
-      localDirs_(localDirs) {
+      localDirs_(localDirs),
+      retainedPayloadBoltPool_(retainedPayloadBoltPool) {
   init();
 }
 
@@ -814,8 +821,13 @@ arrow::Status LocalPartitionWriter::evict(
   }
 
   if (!merger_) {
+    if (retainedPayloadBoltPool_ && !hasComplexType) {
+      retainedPayloadPool_ =
+          std::make_unique<BoltArrowMemoryPool>(retainedPayloadBoltPool_);
+    }
     merger_ = std::make_shared<PayloadMerger>(
         options_,
+        retainedPayloadPool(),
         payloadPool_.get(),
         codec_ ? codec_.get() : nullptr,
         hasComplexType);
@@ -845,14 +857,14 @@ arrow::Status LocalPartitionWriter::reclaimFixedSize(
   int64_t reclaimed = 0;
   // Reclaim memory from payloadCache.
   if (payloadCache_ && payloadCache_->canSpill()) {
-    auto beforeSpill = payloadPool_->bytes_allocated();
+    auto beforeSpill = retainedPayloadPool()->bytes_allocated();
     ARROW_ASSIGN_OR_RAISE(
         auto spillFile, createTempShuffleFile(nextSpilledFileDir()));
     spills_.emplace_back();
     ARROW_ASSIGN_OR_RAISE(
         spills_.back(),
         payloadCache_->spill(spillFile, payloadPool_.get(), codec_.get()));
-    reclaimed += beforeSpill - payloadPool_->bytes_allocated();
+    reclaimed += beforeSpill - retainedPayloadPool()->bytes_allocated();
     if (reclaimed >= size) {
       *actual = reclaimed;
       return arrow::Status::OK();
@@ -860,7 +872,7 @@ arrow::Status LocalPartitionWriter::reclaimFixedSize(
   }
   // Then spill payloads from merger. Create uncompressed payloads.
   if (merger_) {
-    auto beforeSpill = payloadPool_->bytes_allocated();
+    auto beforeSpill = retainedPayloadPool()->bytes_allocated();
     for (auto pid = 0; pid < numPartitions_; ++pid) {
       ARROW_ASSIGN_OR_RAISE(auto merged, merger_->finishForSpill(pid));
       if (merged.has_value()) {
@@ -871,7 +883,7 @@ arrow::Status LocalPartitionWriter::reclaimFixedSize(
     // This is not accurate. When the evicted partition buffers are not copied,
     // the merged ones are resized from the original buffers thus allocated from
     // partitionBufferPool.
-    reclaimed += beforeSpill - payloadPool_->bytes_allocated();
+    reclaimed += beforeSpill - retainedPayloadPool()->bytes_allocated();
     RETURN_NOT_OK(finishSpill());
   }
   *actual = reclaimed;

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
@@ -821,7 +821,7 @@ arrow::Status LocalPartitionWriter::evict(
   }
 
   if (!merger_) {
-    if (retainedPayloadBoltPool_) {
+    if (retainedPayloadBoltPool_ && !hasComplexType) {
       retainedPayloadPool_ =
           std::make_unique<BoltArrowMemoryPool>(retainedPayloadBoltPool_);
     }

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
@@ -857,14 +857,14 @@ arrow::Status LocalPartitionWriter::reclaimFixedSize(
   int64_t reclaimed = 0;
   // Reclaim memory from payloadCache.
   if (payloadCache_ && payloadCache_->canSpill()) {
-    auto beforeSpill = retainedPayloadPool()->bytes_allocated();
+    const auto beforeSpill = static_cast<int64_t>(cachedPayloadSize());
     ARROW_ASSIGN_OR_RAISE(
         auto spillFile, createTempShuffleFile(nextSpilledFileDir()));
     spills_.emplace_back();
     ARROW_ASSIGN_OR_RAISE(
         spills_.back(),
         payloadCache_->spill(spillFile, payloadPool_.get(), codec_.get()));
-    reclaimed += beforeSpill - retainedPayloadPool()->bytes_allocated();
+    reclaimed += beforeSpill - static_cast<int64_t>(cachedPayloadSize());
     if (reclaimed >= size) {
       *actual = reclaimed;
       return arrow::Status::OK();
@@ -872,7 +872,7 @@ arrow::Status LocalPartitionWriter::reclaimFixedSize(
   }
   // Then spill payloads from merger. Create uncompressed payloads.
   if (merger_) {
-    auto beforeSpill = retainedPayloadPool()->bytes_allocated();
+    const auto beforeSpill = static_cast<int64_t>(cachedPayloadSize());
     for (auto pid = 0; pid < numPartitions_; ++pid) {
       ARROW_ASSIGN_OR_RAISE(auto merged, merger_->finishForSpill(pid));
       if (merged.has_value()) {
@@ -883,7 +883,7 @@ arrow::Status LocalPartitionWriter::reclaimFixedSize(
     // This is not accurate. When the evicted partition buffers are not copied,
     // the merged ones are resized from the original buffers thus allocated from
     // partitionBufferPool.
-    reclaimed += beforeSpill - retainedPayloadPool()->bytes_allocated();
+    reclaimed += beforeSpill - static_cast<int64_t>(cachedPayloadSize());
     RETURN_NOT_OK(finishSpill());
   }
   *actual = reclaimed;

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.cpp
@@ -821,7 +821,7 @@ arrow::Status LocalPartitionWriter::evict(
   }
 
   if (!merger_) {
-    if (retainedPayloadBoltPool_ && !hasComplexType) {
+    if (retainedPayloadBoltPool_) {
       retainedPayloadPool_ =
           std::make_unique<BoltArrowMemoryPool>(retainedPayloadBoltPool_);
     }

--- a/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/LocalPartitionWriter.h
@@ -44,7 +44,8 @@ class LocalPartitionWriter : public PartitionWriter {
       PartitionWriterOptions options,
       arrow::MemoryPool* pool,
       const std::string& dataFile,
-      const std::vector<std::string>& localDirs);
+      const std::vector<std::string>& localDirs,
+      bytedance::bolt::memory::MemoryPool* retainedPayloadBoltPool = nullptr);
 
   arrow::Status evict(
       uint32_t partitionId,
@@ -153,6 +154,10 @@ class LocalPartitionWriter : public PartitionWriter {
 
   std::string dataFile_;
   std::vector<std::string> localDirs_;
+
+  // Task pool used by retained payloads when task and spill pools differ. The
+  // caller owns this pool and must outlive this writer.
+  bytedance::bolt::memory::MemoryPool* retainedPayloadBoltPool_{nullptr};
 
   bool stopped_{false};
   std::shared_ptr<LocalSpiller> spiller_{nullptr};

--- a/bolt/shuffle/sparksql/partition_writer/PartitionWriter.cpp
+++ b/bolt/shuffle/sparksql/partition_writer/PartitionWriter.cpp
@@ -24,14 +24,16 @@ using namespace bytedance::bolt::shuffle::sparksql;
 
 std::unique_ptr<PartitionWriter> PartitionWriter::create(
     PartitionWriterOptions options,
-    arrow::MemoryPool* pool) {
+    arrow::MemoryPool* pool,
+    bytedance::bolt::memory::MemoryPool* retainedPayloadBoltPool) {
   if (options.partitionWriterType == PartitionWriterType::kLocal) {
     return std::make_unique<LocalPartitionWriter>(
         options.numPartitions,
         options,
         pool,
         options.dataFile,
-        options.configuredDirs);
+        options.configuredDirs,
+        retainedPayloadBoltPool);
   } else if (options.partitionWriterType == PartitionWriterType::kCeleborn) {
     return std::make_unique<CelebornPartitionWriter>(
         options.numPartitions, options, pool, options.rssClient);

--- a/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
@@ -38,6 +38,11 @@
 #include "bolt/shuffle/sparksql/ShuffleMemoryPool.h"
 #include "bolt/shuffle/sparksql/Spill.h"
 #include "bolt/shuffle/sparksql/compression/Compression.h"
+
+namespace bytedance::bolt::memory {
+class MemoryPool;
+}
+
 namespace bytedance::bolt::shuffle::sparksql {
 
 struct Evict {
@@ -66,7 +71,8 @@ class PartitionWriter {
 
   static std::unique_ptr<PartitionWriter> create(
       PartitionWriterOptions options,
-      arrow::MemoryPool* pool);
+      arrow::MemoryPool* pool,
+      bytedance::bolt::memory::MemoryPool* retainedPayloadBoltPool = nullptr);
 
   virtual ~PartitionWriter() = default;
 
@@ -92,7 +98,7 @@ class PartitionWriter {
       bool hasComplexType) = 0;
 
   uint64_t cachedPayloadSize() {
-    return payloadPool_->bytes_allocated();
+    return retainedPayloadPool()->bytes_allocated();
   }
 
   // for V2
@@ -151,13 +157,20 @@ class PartitionWriter {
   };
 
  protected:
+  arrow::MemoryPool* retainedPayloadPool() const {
+    return retainedPayloadPool_ ? retainedPayloadPool_.get()
+                                : payloadPool_.get();
+  }
+
   uint32_t numPartitions_;
   PartitionWriterOptions options_;
   arrow::MemoryPool* pool_;
 
-  // Memory Pool used to track memory allocation of partition payloads.
-  // The actual allocation is delegated to options_.memoryPool.
+  // Memory pool used for spill scratch and, by default, retained payloads.
   std::unique_ptr<ShuffleMemoryPool> payloadPool_;
+
+  // Optional task-accounted pool for retained payloads.
+  std::unique_ptr<arrow::MemoryPool> retainedPayloadPool_;
 
   std::unique_ptr<Codec> codec_;
 

--- a/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
@@ -166,7 +166,8 @@ class PartitionWriter {
   PartitionWriterOptions options_;
   arrow::MemoryPool* pool_;
 
-  // Memory pool used for spill scratch and, by default, retained payloads.
+  // Memory Pool used to track memory allocation of partition payloads.
+  // The actual allocation is delegated to options_.memoryPool.
   std::unique_ptr<ShuffleMemoryPool> payloadPool_;
 
   // Optional task-accounted pool for retained payloads.

--- a/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
+++ b/bolt/shuffle/sparksql/partition_writer/PartitionWriter.h
@@ -98,7 +98,11 @@ class PartitionWriter {
       bool hasComplexType) = 0;
 
   uint64_t cachedPayloadSize() {
-    return retainedPayloadPool()->bytes_allocated();
+    auto bytes = payloadPool_->bytes_allocated();
+    if (retainedPayloadPool_) {
+      bytes += retainedPayloadPool_->bytes_allocated();
+    }
+    return bytes;
   }
 
   // for V2

--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -471,7 +471,7 @@ void ShuffleMemoryTest::verifyRetainedPayloadPool() {
       writer->reclaimFixedSize(std::numeric_limits<int64_t>::max(), &reclaimed)
           .ok());
   EXPECT_GT(reclaimed, 0);
-  EXPECT_EQ(writer->cachedPayloadSize(), 0);
+  EXPECT_LT(writer->cachedPayloadSize(), cachedPayloadSize);
   ASSERT_TRUE(writer->stop().ok());
 }
 

--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -15,16 +15,20 @@
  */
 
 #include <vector/ComplexVector.h>
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <limits>
 #include "bolt/common/caching/AsyncDataCache.h"
+#include "bolt/common/memory/Memory.h"
 #include "bolt/common/memory/sparksql/tests/MemoryTestUtils.h"
 #include "bolt/common/testutil/TestValue.h"
 #include "bolt/core/PlanNode.h"
 #include "bolt/exec/tests/utils/Cursor.h"
 #include "bolt/exec/tests/utils/MemoryHogOperator.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
+#include "bolt/shuffle/sparksql/BoltArrowMemoryPool.h"
+#include "bolt/shuffle/sparksql/BoltShuffleWriter.h"
 #include "bolt/shuffle/sparksql/ShuffleColumnarToRowConverter.h"
 #include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
 #include "bolt/shuffle/sparksql/partitioner/Partitioning.h"
@@ -53,7 +57,11 @@ class ShuffleMemoryTest : public ShuffleTestBase {
   // within a partition but incompressible across partitions. A writer that
   // makes large splits lets the per-partition repeats deduplicate (small
   // compressed output); one that fragments into tiny splits re-stores them.
-  ShuffleWriterMetrics runReclaimableHogScenario(int32_t writerType);
+  ShuffleWriterMetrics runReclaimableHogScenario(
+      int32_t writerType,
+      int32_t compressionThreshold = kDefaultCompressionThreshold);
+
+  void verifyRetainedPayloadPool();
 
   std::shared_ptr<CompositeRowVector> createCompositeInput(
       const RowVectorPtr& input,
@@ -402,6 +410,135 @@ TEST_F(ShuffleMemoryTest, testCompositeRowEvictBeforeInit) {
   EXPECT_THROW(executeTestWithCustomInput(param, inputData), BoltRuntimeError);
 }
 
+void ShuffleMemoryTest::verifyRetainedPayloadPool() {
+  constexpr int32_t kRowCount = 32;
+  constexpr int64_t kMemoryLimit = 512 * 1024 * 1024;
+
+  auto rowType = ROW({"c1"}, {VARCHAR()});
+  auto composite = createCompositeRowVectorWithPid(rowType, /*rowCount=*/0);
+
+  auto columnarPid = makeFlatVector<int32_t>(kRowCount, [](auto) { return 0; });
+  auto values = makeFlatVector<StringView>(
+      kRowCount, [](auto) { return StringView("payload"); });
+  auto columnar = makeRowVector({"c0", "c1"}, {columnarPid, values});
+
+  auto memoryManagerHolder = TestMemoryManagerHolder::create(kMemoryLimit);
+  auto writerPool =
+      memoryManagerHolder->rootPool()->addLeafChild("shuffle-writer");
+  BoltArrowMemoryPool arrowPool(writerPool.get());
+  auto tempDir = bytedance::bolt::exec::test::TempDirectoryPath::create();
+  auto localDir = tempDir->path + "/local_dir";
+  std::filesystem::create_directories(localDir);
+
+  ShuffleWriterOptions writerOptions;
+  writerOptions.partitioning = Partitioning::kHash;
+  writerOptions.enableVectorCombination = false;
+  writerOptions.partitionWriterOptions.numPartitions = 1;
+  writerOptions.partitionWriterOptions.partitionWriterType =
+      PartitionWriterType::kLocal;
+  writerOptions.partitionWriterOptions.dataFile =
+      tempDir->path + "/shuffle_data.bin";
+  writerOptions.partitionWriterOptions.configuredDirs = {localDir};
+  writerOptions.partitionWriterOptions.numSubDirs = 1;
+  writerOptions.partitionWriterOptions.mergeBufferSize = 1;
+  writerOptions.partitionWriterOptions.compressionThreshold = 1;
+  writerOptions.shuffleBatchSize = 1;
+  writerOptions.taskAttemptId = memoryManagerHolder->taskAttemptId();
+
+  auto writer = BoltShuffleWriter::createDefault(
+      writerOptions, writerPool.get(), &arrowPool);
+  ASSERT_TRUE(writer->split(composite, kMemoryLimit).ok());
+  ASSERT_TRUE(writer->split(columnar, kMemoryLimit).ok());
+  ASSERT_TRUE(
+      writer->evictPartitionBuffers(/*partitionId=*/0, /*reuseBuffers=*/false)
+          .ok());
+  const auto cachedPayloadSize = writer->cachedPayloadSize();
+  ASSERT_GT(cachedPayloadSize, 0);
+  auto countSpillFiles = [&]() {
+    return std::count_if(
+        std::filesystem::recursive_directory_iterator(localDir),
+        std::filesystem::recursive_directory_iterator(),
+        [](const auto& entry) { return entry.is_regular_file(); });
+  };
+  const auto spillFiles = countSpillFiles();
+  ASSERT_TRUE(writer->split(columnar, kMemoryLimit).ok());
+  EXPECT_EQ(countSpillFiles(), spillFiles);
+  EXPECT_GE(writer->cachedPayloadSize(), cachedPayloadSize);
+  ASSERT_TRUE(writer->split(columnar, /*memLimit=*/0).ok());
+  EXPECT_GE(writer->cachedPayloadSize(), cachedPayloadSize);
+  int64_t reclaimed = 0;
+  ASSERT_TRUE(
+      writer->reclaimFixedSize(std::numeric_limits<int64_t>::max(), &reclaimed)
+          .ok());
+  EXPECT_GT(reclaimed, 0);
+  EXPECT_EQ(writer->cachedPayloadSize(), 0);
+  ASSERT_TRUE(writer->stop().ok());
+}
+
+TEST_F(ShuffleMemoryTest, testCompositeThenColumnarUsesRetainedPayloadPool) {
+  verifyRetainedPayloadPool();
+}
+
+TEST_F(ShuffleMemoryTest, testComplexPayloadKeepsLegacyBatchDrain) {
+  constexpr int32_t kRowCount = 32;
+  constexpr int64_t kMemoryLimit = 512 * 1024 * 1024;
+
+  auto columnarPid = makeFlatVector<int32_t>(kRowCount, [](auto) { return 0; });
+  std::vector<std::vector<int64_t>> arrays(
+      kRowCount, std::vector<int64_t>{1, 2, 3});
+  auto columnar = makeRowVector(
+      {"c0", "c1"}, {columnarPid, makeArrayVector<int64_t>(arrays)});
+
+  auto memoryManagerHolder = TestMemoryManagerHolder::create(kMemoryLimit);
+  auto writerPool =
+      memoryManagerHolder->rootPool()->addLeafChild("shuffle-writer");
+  BoltArrowMemoryPool arrowPool(writerPool.get());
+  auto tempDir = bytedance::bolt::exec::test::TempDirectoryPath::create();
+  auto localDir = tempDir->path + "/local_dir";
+  std::filesystem::create_directories(localDir);
+
+  ShuffleWriterOptions writerOptions;
+  writerOptions.partitioning = Partitioning::kHash;
+  writerOptions.enableVectorCombination = false;
+  writerOptions.partitionWriterOptions.numPartitions = 1;
+  writerOptions.partitionWriterOptions.partitionWriterType =
+      PartitionWriterType::kLocal;
+  writerOptions.partitionWriterOptions.dataFile =
+      tempDir->path + "/shuffle_data.bin";
+  writerOptions.partitionWriterOptions.configuredDirs = {localDir};
+  writerOptions.partitionWriterOptions.numSubDirs = 1;
+  writerOptions.partitionWriterOptions.mergeBufferSize = 1;
+  writerOptions.partitionWriterOptions.compressionThreshold = kRowCount + 1;
+  writerOptions.shuffleBatchSize = 1;
+  writerOptions.taskAttemptId = memoryManagerHolder->taskAttemptId();
+
+  const auto spillBytesBefore =
+      bytedance::bolt::memory::spillMemoryPool()->stats().currentBytes;
+  auto writer = BoltShuffleWriter::createDefault(
+      writerOptions, writerPool.get(), &arrowPool);
+  ASSERT_TRUE(writer->split(columnar, kMemoryLimit).ok());
+  ASSERT_TRUE(
+      writer->evictPartitionBuffers(/*partitionId=*/0, /*reuseBuffers=*/false)
+          .ok());
+  EXPECT_GT(
+      bytedance::bolt::memory::spillMemoryPool()->stats().currentBytes,
+      spillBytesBefore);
+
+  auto countSpillFiles = [&]() {
+    return std::count_if(
+        std::filesystem::recursive_directory_iterator(localDir),
+        std::filesystem::recursive_directory_iterator(),
+        [](const auto& entry) { return entry.is_regular_file(); });
+  };
+  const auto spillFiles = countSpillFiles();
+  ASSERT_TRUE(writer->split(columnar, kMemoryLimit).ok());
+  EXPECT_GT(countSpillFiles(), spillFiles);
+  EXPECT_EQ(
+      bytedance::bolt::memory::spillMemoryPool()->stats().currentBytes,
+      spillBytesBefore);
+  ASSERT_TRUE(writer->stop().ok());
+}
+
 TEST_F(ShuffleMemoryTest, testRowBasedReclaimViaMemoryPressure) {
   using namespace bytedance::bolt::exec::test;
 
@@ -482,7 +619,8 @@ TEST_F(ShuffleMemoryTest, testRowBasedReclaimViaMemoryPressure) {
 }
 
 ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(
-    int32_t writerType) {
+    int32_t writerType,
+    int32_t compressionThreshold) {
   using namespace bytedance::bolt::exec::test;
 
   constexpr int32_t kNumPartitions = 256;
@@ -536,6 +674,8 @@ ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(
       tempDir->path + "/shuffle_data.bin";
   writerOptions.partitionWriterOptions.configuredDirs = {localDir};
   writerOptions.partitionWriterOptions.numSubDirs = 1;
+  writerOptions.partitionWriterOptions.compressionThreshold =
+      compressionThreshold;
   writerOptions.shuffleBatchSize = 128 * 1024 * 1024;
   writerOptions.taskAttemptId = memoryManagerHolder->taskAttemptId();
 
@@ -578,6 +718,14 @@ ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(
 TEST_F(ShuffleMemoryTest, testMinMemLimitAvoidsSpillingEveryBatch) {
   expectWellCompressed(
       runReclaimableHogScenario(static_cast<int32_t>(ShuffleWriterType::V2)));
+}
+
+// With shuffle offload, V1 keeps retained payloads in task-accounted memory so
+// pressure triggers reclamation instead of draining them after every batch.
+TEST_F(ShuffleMemoryTest, testV1KeepsLargeSplitsUnderMemoryPressure) {
+  expectWellCompressed(runReclaimableHogScenario(
+      static_cast<int32_t>(ShuffleWriterType::V1),
+      /*compressionThreshold=*/1));
 }
 
 // The row-based writer spills via pool reservation failure (which triggers


### PR DESCRIPTION
### What problem does this PR solve?

When shuffle offload uses a separate spill pool, simple Local V1 cached payloads were retained in that spill pool and drained at every split boundary. This fragmented otherwise mergeable payloads into many small spill files.

Issue Number: N/A

### Type of Change

- [x] 🐛 Bug fix (non-breaking behavior fix)
- [ ] ✨ New feature
- [ ] 🚀 Performance improvement
- [ ] ⚠️ Breaking behavior change
- [ ] 🔨 Refactoring
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

- Lazily create a task-accounted retained payload pool for simple Local V1 writers when task and spill pools differ.
- Keep mergeable payloads in that retained pool and reclaim them through reclaimFixedSize under actual task memory pressure.
- Keep block conversion and spill scratch allocation in the spill pool.
- Remove the unconditional batch-tail cache drain only for the covered mergeable path.
- Keep the legacy batch-tail drain and allocator behavior for complex payloads.
- Preserve V2, Celeborn, and shuffle-without-offload behavior.
- Make cachedPayloadSize include both the original payload pool and the optional retained pool.
- Add regression coverage for retention, reclamation, complex-type draining, and memory-pressure split size.

### Performance Impact

Expected positive impact for affected offload jobs: fewer small spill files and larger merged payloads. Two full production replay runs completed successfully; sampled successful writers produced about 4–5 spill files. The runs still observed recoverable memcg executor kills (11 and 4 respectively), so this change does not claim to eliminate container-level memory pressure.

### Release Note

Release Note:

- Reduced Local V1 shuffle spill fragmentation when shuffle offload uses a separate spill pool.

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] I have run Sanitizers (ASAN/TSAN) locally.
- [ ] No need to test or manual test.

Validation:
- Release bolt_shuffle_spark_memory_test: 15/15 passed.
- Debug bolt_shuffle_spark_memory_test: 15/15 passed.
- clang-format and git diff --check passed.
- Two full production replay runs: Stage 2 completed 1612/1612 in both runs; no Bolt native allocator OOM was observed.

### Breaking Changes

- [ ] No
- [x] Yes: internal C++ ABI changes require downstream native artifacts to be rebuilt. The changed factory and constructor APIs remain source-compatible through default arguments; no source migration is required.