### PR TITLE
fix(shuffle): account external reclaims separately from shuffle write time

### DIFF
--- a/bolt/shuffle/sparksql/CMakeLists.txt
+++ b/bolt/shuffle/sparksql/CMakeLists.txt
@@ -54,6 +54,7 @@ bolt_add_library(
   partitioner/Partitioning.cpp
   partitioner/RoundRobinPartitioner.cpp
   partitioner/SinglePartitioner.cpp
+  Options.cpp
   Payload.cpp
   ShuffleColumnarToRowConverter.cpp
   ShuffleMemoryPool.cpp

--- a/bolt/shuffle/sparksql/Options.cpp
+++ b/bolt/shuffle/sparksql/Options.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) ByteDance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bolt/shuffle/sparksql/Options.h"
+
+#include <fmt/format.h>
+#include <folly/String.h>
+
+#include "bolt/common/base/SuccinctPrinter.h"
+
+namespace bytedance::bolt::shuffle::sparksql {
+
+namespace {
+
+// Partitioning and row format names, matching the names used by the
+// configuration (see toPartitioning() and row::RowFormat).
+const char* partitioningName(Partitioning partitioning) {
+  switch (partitioning) {
+    case Partitioning::kSingle:
+      return "single";
+    case Partitioning::kRoundRobin:
+      return "rr";
+    case Partitioning::kHash:
+      return "hash";
+    case Partitioning::kRange:
+      return "range";
+  }
+  return "unknown";
+}
+
+const char* rowFormatName(row::RowFormat format) {
+  switch (format) {
+    case row::RowFormat::DENSE:
+      return "dense";
+    case row::RowFormat::COMPACT:
+      return "compact";
+  }
+  return "unknown";
+}
+
+} // namespace
+
+std::string ShuffleReaderOptions::toString() const {
+  return fmt::format(
+      "compressionType={} codecBackend={} batchSize={} "
+      "shuffleBatchByteSize={} shuffleBufferSize={} numPartitions={} "
+      "partitionShortName={} forceShuffleWriterType={} rowFormat={} "
+      "rowBasedShuffleThreshold={} checksumEnabled={} "
+      "reuseBufferedInputStream={} reuseColumnBuffer={}",
+      arrow::util::Codec::GetCodecAsString(compressionType),
+      codecBackend,
+      batchSize,
+      shuffleBatchByteSize,
+      shuffleBufferSize,
+      numPartitions,
+      partitionShortName,
+      forceShuffleWriterType,
+      rowFormatName(rowFormat),
+      rowBasedShuffleThreshold,
+      checksumEnabled,
+      reuseBufferedInputStream,
+      reuseColumnBuffer);
+}
+
+std::string PartitionWriterOptions::toString() const {
+  return fmt::format(
+      "numPartitions={} partitionWriterType={} dataFile={} numSubDirs={} "
+      "configuredDirs=[{}] compressionType={} codecBackend={} "
+      "compressionLevel={} compressionMode={} compressionThreshold={} "
+      "mergeBufferSize={} mergeThreshold={} bufferedWrite={} "
+      "bufferedSpillWrite={} pushBufferMaxSize={} shuffleBufferSize={} "
+      "rowvectorModeCompressionMinColumns={} "
+      "rowvectorModeCompressionMaxBufferSize={} checksumEnabled={} "
+      "rssClient={}",
+      numPartitions,
+      partitionWriterType,
+      dataFile,
+      numSubDirs,
+      folly::join(",", configuredDirs),
+      arrow::util::Codec::GetCodecAsString(compressionType),
+      codecBackend,
+      compressionLevel,
+      compressionMode,
+      compressionThreshold,
+      mergeBufferSize,
+      mergeThreshold,
+      bufferedWrite,
+      bufferedSpillWrite,
+      pushBufferMaxSize,
+      shuffleBufferSize,
+      rowvectorModeCompressionMinColumns,
+      rowvectorModeCompressionMaxBufferSize,
+      checksumEnabled,
+      rssClient ? "set" : "unset");
+}
+
+std::string ShuffleWriterOptions::toString() const {
+  return fmt::format(
+      "partitioning={} taskAttemptId={} startPartitionId={} bufferSize={} "
+      "bufferReallocThreshold={} shuffleBatchSize={} "
+      "forceShuffleWriterType={} useV2PreallocSizeThreshold={} "
+      "enableVectorCombination={} accumulateBatchMaxColumns={} "
+      "accumulateBatchMaxBatches={} recommendedColumn2RowSize={} "
+      "rowFormat={} rowBasedShuffleThreshold={} shuffleCheckRatio={} "
+      "shuffleCheckMaxColumns={} rowvectorModeCompressionMinColumns={} "
+      "rowvectorModeCompressionMaxBufferSize={} partitionWriterOptions=[{}]",
+      partitioningName(partitioning),
+      taskAttemptId,
+      startPartitionId,
+      bufferSize,
+      bufferReallocThreshold,
+      shuffleBatchSize,
+      forceShuffleWriterType,
+      useV2PreallocSizeThreshold,
+      enableVectorCombination,
+      accumulateBatchMaxColumns,
+      accumulateBatchMaxBatches,
+      recommendedColumn2RowSize,
+      rowFormatName(rowFormat),
+      rowBasedShuffleThreshold,
+      shuffleCheckRatio,
+      shuffleCheckMaxColumns,
+      rowvectorModeCompressionMinColumns,
+      rowvectorModeCompressionMaxBufferSize,
+      partitionWriterOptions.toString());
+}
+
+std::string ShuffleWriterMetrics::toString() const {
+  const auto asMillis = [](int64_t nanos) {
+    return fmt::format("{:.3f}ms", static_cast<double>(nanos) / 1'000'000);
+  };
+  int64_t totalPartitionLengths{0};
+  int64_t totalRawPartitionLengths{0};
+  for (auto length : partitionLengths) {
+    totalPartitionLengths += length;
+  }
+  for (auto length : rawPartitionLengths) {
+    totalRawPartitionLengths += length;
+  }
+  return fmt::format(
+      "totalInputRowNumber={} totalInputBatches={} totalBytesWritten={} "
+      "totalBytesEvicted={} totalWriteTime={} totalEvictTime={} "
+      "totalCompressTime={} splitTime={} convertTime={} flattenTime={} "
+      "computePidTime={} shuffleWriteTime={} externalReclaimTime={} "
+      "maxPartitionBufferSize={} avgPreallocSize={} dataSize={} peakBytes={} "
+      "useV2={} useRowBased={} rowVectorModeCompress={} "
+      "combinedVectorNumber={} combineVectorTimes={} combineVectorCost={} "
+      "numPartitions={} totalPartitionLengths={} totalRawPartitionLengths={}",
+      totalInputRowNumber,
+      totalInputBatches,
+      succinctBytes(totalBytesWritten),
+      succinctBytes(totalBytesEvicted),
+      asMillis(totalWriteTime),
+      asMillis(totalEvictTime),
+      asMillis(totalCompressTime),
+      asMillis(splitTime),
+      asMillis(convertTime),
+      asMillis(flattenTime),
+      asMillis(computePidTime),
+      asMillis(shuffleWriteTime),
+      asMillis(externalReclaimTime),
+      succinctBytes(maxPartitionBufferSize),
+      succinctBytes(avgPreallocSize),
+      succinctBytes(dataSize),
+      succinctBytes(peakBytes),
+      useV2,
+      useRowBased,
+      rowVectorModeCompress,
+      combinedVectorNumber,
+      combineVectorTimes,
+      asMillis(combineVectorCost),
+      partitionLengths.size(),
+      succinctBytes(totalPartitionLengths),
+      succinctBytes(totalRawPartitionLengths));
+}
+
+} // namespace bytedance::bolt::shuffle::sparksql

--- a/bolt/shuffle/sparksql/Options.h
+++ b/bolt/shuffle/sparksql/Options.h
@@ -36,6 +36,7 @@
 #include <bolt/common/base/Exceptions.h>
 #include <fmt/format.h>
 #include <cstdint>
+#include <string>
 #include "bolt/row/RowFormat.h"
 #include "bolt/shuffle/sparksql/compression/Codec.h"
 #include "bolt/shuffle/sparksql/partition_writer/rss/RssClient.h"
@@ -127,6 +128,9 @@ struct ShuffleReaderOptions {
   bool reuseBufferedInputStream = kDefaultReuseBufferedInputStream;
 
   bool reuseColumnBuffer = kDefaultReuseColumnBuffer;
+
+  /// Returns the options in a human readable form.
+  std::string toString() const;
 };
 
 struct PartitionWriterOptions {
@@ -165,6 +169,9 @@ struct PartitionWriterOptions {
 
   // Enable checksum in codec for shuffle data corruption detection
   bool checksumEnabled = true;
+
+  /// Returns the options in a human readable form.
+  std::string toString() const;
 };
 
 struct ShuffleWriterOptions {
@@ -189,6 +196,9 @@ struct ShuffleWriterOptions {
   row::RowFormat rowFormat = row::RowFormat::COMPACT;
   int64_t rowBasedShuffleThreshold = kDefaultRowBasedShuffleThreshold;
   PartitionWriterOptions partitionWriterOptions{};
+
+  /// Returns the options in a human readable form.
+  std::string toString() const;
 };
 
 struct ShuffleWriterMetrics {
@@ -213,10 +223,17 @@ struct ShuffleWriterMetrics {
   int64_t computePidTime{0};
   // total time for shuffle write, including split, evict, write, compress
   int64_t shuffleWriteTime{0};
+  // Total wall time of reclaims triggered from outside this operator, i.e. not
+  // covered by shuffleWriteTime.
+  int64_t externalReclaimTime{0};
   int64_t dataSize{0};
   int64_t peakBytes{0};
   std::vector<int64_t> partitionLengths{};
   std::vector<int64_t> rawPartitionLengths{}; // Uncompressed size.
+
+  /// Returns all metrics in a human readable form; per-partition lengths are
+  /// summarized.
+  std::string toString() const;
 };
 
 // Only partitioning that has pid support adaptive shuffle writer, otherwise

--- a/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleReaderNode.cpp
@@ -50,6 +50,8 @@ SparkShuffleReader::SparkShuffleReader(
           outputType_,
           pool(),
           shuffleReaderOptions_.rowFormat)) {
+  VLOG(1) << "Spark shuffle reader options: "
+          << shuffleReaderOptions_.toString();
   isValidityBuffer_.reserve(outputType_->size());
   for (size_t i = 0; i < outputType_->size(); ++i) {
     switch (outputType_->childAt(i)->kind()) {

--- a/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.cpp
@@ -14,16 +14,41 @@
  * limitations under the License.
  */
 
-#include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
+#include <folly/String.h>
+#include <optional>
+
 #include "bolt/common/memory/sparksql/ExecutionMemoryPool.h"
 #include "bolt/shuffle/sparksql/BoltArrowMemoryPool.h"
 #include "bolt/shuffle/sparksql/BoltRowBasedSortShuffleWriter.h"
 #include "bolt/shuffle/sparksql/BoltShuffleWriter.h"
 #include "bolt/shuffle/sparksql/BoltShuffleWriterV2.h"
+#include "bolt/shuffle/sparksql/ShuffleWriterNode.h"
 using namespace bytedance::bolt::shuffle::sparksql;
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec;
 using namespace bytedance::bolt::memory::sparksql;
+
+namespace {
+// Times a shuffle write section and keeps it marked active while timed, so a
+// reclaim nested in the section is not timed twice (see reclaim()).
+class ShuffleWriteSection {
+ public:
+  ShuffleWriteSection(uint64_t* writeTime, std::atomic<bool>* inSection)
+      : inSection_(inSection), timer_(writeTime) {
+    inSection_->store(true);
+  }
+
+  ~ShuffleWriteSection() {
+    // Stop timing before the section stops being active.
+    timer_.reset();
+    inSection_->store(false);
+  }
+
+ private:
+  std::atomic<bool>* inSection_;
+  std::optional<bytedance::bolt::NanosecondTimer> timer_;
+};
+} // namespace
 
 SparkShuffleWriter::SparkShuffleWriter(
     int32_t operatorId,
@@ -39,7 +64,10 @@ SparkShuffleWriter::SparkShuffleWriter(
       // shuffle writer memory limit should at least hold one max shuffle batch
       minMemLimit_(shuffleWriterOptions_.shuffleBatchSize),
       reportShuffleStatusCallback_(
-          shuffleWriterNode->getReportShuffleStatusCallback()) {}
+          shuffleWriterNode->getReportShuffleStatusCallback()) {
+  VLOG(1) << "Spark shuffle writer options: "
+          << shuffleWriterOptions_.toString();
+}
 
 void SparkShuffleWriter::init(const bytedance::bolt::RowVectorPtr& rv) {
   arrowPool_ = std::make_unique<BoltArrowMemoryPool>(pool());
@@ -59,7 +87,7 @@ void SparkShuffleWriter::init(const bytedance::bolt::RowVectorPtr& rv) {
 }
 
 void SparkShuffleWriter::addInput(RowVectorPtr input) {
-  bytedance::bolt::NanosecondTimer shuffleWriteTimer(&shuffleWriteTime_);
+  ShuffleWriteSection section(&shuffleWriteTime_, &inShuffleSection_);
   Operator::ReclaimableSectionGuard guard(this);
   std::call_once(initOnceFlag_, [this, &input]() { this->init(input); });
   auto freeMem = ExecutionMemoryPool::getMinimumFreeMemoryForTask(
@@ -92,7 +120,7 @@ void SparkShuffleWriter::noMoreInput() {
   if (shuffleWriter_) {
     arrow::Status status;
     {
-      bytedance::bolt::NanosecondTimer shuffleWriteTimer(&shuffleWriteTime_);
+      ShuffleWriteSection section(&shuffleWriteTime_, &inShuffleSection_);
       status = shuffleWriter_->stop();
     }
     BOLT_CHECK(
@@ -111,6 +139,13 @@ void SparkShuffleWriter::noMoreInput() {
   }
 
   metrics.shuffleWriteTime = shuffleWriteTime_;
+  metrics.externalReclaimTime = externalReclaimTime_;
+
+  VLOG(1) << "Shuffle writer metrics: " << metrics.toString();
+  VLOG(1) << "Shuffle writer partition lengths: "
+          << folly::join(",", metrics.partitionLengths)
+          << ", raw partition lengths: "
+          << folly::join(",", metrics.rawPartitionLengths);
 
   reportShuffleStatusCallback_(metrics);
 }
@@ -127,9 +162,17 @@ void SparkShuffleWriter::reclaim(
     memory::MemoryReclaimer::Stats& stats) {
   int64_t evictedSize;
   if (shuffleWriter_) {
-    bytedance::bolt::NanosecondTimer shuffleWriteTimer(&shuffleWriteTime_);
-    auto status = shuffleWriter_->reclaimFixedSize(targetBytes, &evictedSize);
-    BOLT_CHECK(status.ok(), "(shuffle) nativeEvict: evict failed");
+    const auto doReclaim = [&]() {
+      return shuffleWriter_->reclaimFixedSize(targetBytes, &evictedSize);
+    };
+    if (inShuffleSection_.load()) {
+      // Nested in a timed section: already covered by shuffleWriteTime_.
+      BOLT_CHECK(doReclaim().ok(), "(shuffle) nativeEvict: evict failed");
+    } else {
+      // External reclaim: not covered by shuffleWriteTime_.
+      bytedance::bolt::NanosecondTimer timer(&externalReclaimTime_);
+      BOLT_CHECK(doReclaim().ok(), "(shuffle) nativeEvict: evict failed");
+    }
   } else {
     LOG(INFO) << "ShuffleWriter is null when reclaim";
   }

--- a/bolt/shuffle/sparksql/ShuffleWriterNode.h
+++ b/bolt/shuffle/sparksql/ShuffleWriterNode.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include "bolt/exec/Driver.h"
 #include "bolt/exec/Operator.h"
@@ -134,6 +135,12 @@ class SparkShuffleWriter : public bytedance::bolt::exec::Operator {
   // Total wall time spent inside the shuffle write operator, covering init,
   // addInput (split), reclaim (spill) and stop.
   uint64_t shuffleWriteTime_{0};
+  // Wall time of reclaims triggered from outside this operator, i.e. not
+  // covered by shuffleWriteTime_.
+  uint64_t externalReclaimTime_{0};
+  // True while addInput()/noMoreInput() is timed, so that a reclaim nested in
+  // it is not timed twice.
+  std::atomic<bool> inShuffleSection_{false};
   std::unique_ptr<BoltArrowMemoryPool> arrowPool_;
   std::shared_ptr<BoltShuffleWriter> shuffleWriter_;
   bool finished_ = false;

--- a/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
+++ b/bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp
@@ -479,6 +479,9 @@ TEST_F(ShuffleMemoryTest, testRowBasedReclaimViaMemoryPressure) {
     while (cursor->moveNext()) {
     }
   });
+  // The hog reclaims the idle writer outside the timed sections.
+  EXPECT_GT(metrics.externalReclaimTime, 0);
+  EXPECT_GT(metrics.shuffleWriteTime, 0);
 }
 
 ShuffleWriterMetrics ShuffleMemoryTest::runReclaimableHogScenario(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A — found while investigating a production metrics anomaly.

The reported shuffle write time could exceed the wall-clock duration of the task
that produced it. In one observed case a single task reported `shuffle total
write time` of 45.7 minutes while the task itself ran for 35.994 minutes (+27%),
and stage-wide shuffle write time (1,382.54 task-hours) exceeded the total
executor runtime of all attempts (1,325.67 task-hours).

Root cause: #783 (`refactor: measure splitTime in doSplit and shuffleWriteTime at
operator level`, commit 5cb127fe19) moved the `shuffleWriteTime` measurement to
the operator and added a third `NanosecondTimer` in
`SparkShuffleWriter::reclaim()` on the same counter that `addInput()` and
`noMoreInput()` (around `stop()`) already time. A reclaim caused by this
operator's own memory pressure runs *nested* inside those sections — the driver
thread is suspended inside `split()` while the arbitration and the eviction run
— so its wall time was accumulated twice. `NanosecondTimer` only performs
`counter += elapsed`, nothing de-duplicates overlapping intervals. Before #783
the split/stop time was measured at writer level and a nested reclaim was
covered exactly once by the enclosing split interval.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

`SparkShuffleWriter::reclaim()` no longer adds its wall time to
`shuffleWriteTime`:

* A reclaim that is nested in a timed `addInput()`/`stop()` section is already
  part of that section's wall time, so `shuffleWriteTime` now accounts for it
  exactly once. As a result `shuffleWriteTime` can no longer exceed the duration
  of the task that reported it.
* Reclaims that are *not* covered by a timed section — those are triggered by
  memory pressure from outside this operator, e.g. another operator allocating
  while the writer is idle, or a shrink requested from another task — are timed
  into the new `externalReclaimTime` metric, so that cost stays visible without
  being double counted.

Telling the two cases apart requires knowing whether a timed section is active,
so `addInput()` and the `stop()` section scope a small `ShuffleWriteSection`
helper that times the section and keeps the `inShuffleSection_` flag set for
exactly that window. The flag is atomic because the reclaim callback can run on
another thread while the driver thread is suspended inside the timed section.

`ShuffleWriterMetrics` gains `externalReclaimTime` (additive field, existing
consumers keep working) and a `toString()` that formats every metric in a
human-readable way. `SparkShuffleWriter::noMoreInput()` logs these metrics at
`VLOG(1)` when the writer stops (per-partition arrays on a separate `VLOG(1)`
line), which makes this class of anomaly visible without a debugger or a custom
build.

The shuffle writer and reader operators also log their options when they are
constructed (`SparkShuffleWriter` / `SparkShuffleReader`), so the shuffle
configuration a task actually ran with is in the executor log (`VLOG(1)`)
next to the metrics. `ShuffleWriterOptions`, `ShuffleReaderOptions` and
`PartitionWriterOptions` get a `toString()` for that (formatters for the
partitioning, row format and codec names included); the implementations live in
`Options.cpp`.

Validation:

* `clang-format` 14.0.6 (the CI version) is clean on all touched C++ files.
* In the project devcontainer (Linux aarch64, gcc 12.5.0) the changed
  translation units `bolt/shuffle/sparksql/ShuffleWriterNode.cpp` and
  `bolt/shuffle/sparksql/Options.cpp` compile with the real Release flags taken
  from the build's `compile_commands.json`, and
  `bolt/shuffle/sparksql/tests/ShuffleMemoryTest.cpp` passes a syntax check.
* Not done locally: a full `make release_with_test` and running the gtest. The
  local conan cache has no `llvm-core` package for the current recipe revision,
  so conan would rebuild LLVM from source first. CI covers it: `lint`,
  `build-test (release)`, `build-test (release_spark)` (both run
  `make ctest_release`) and `build-only (debug_spark_with_test)` all pass on
  this head.

### Performance Impact
- [x] **No Impact**: This is instrumentation only. The change adds two atomic
  stores per `addInput()`/`stop()` call and one clock read per reclaim that is
  not covered by a timed section; the split/spill hot path is untouched. The
  added log line is emitted once per shuffle writer (at `stop()`).

### Release Note

```text
Release Note:
- Fixed shuffle write time being double counted when a memory reclaim ran inside
  a timed shuffle write call, which could report more time than the task itself took.
- Added an external reclaim time metric to the shuffle writer metrics and log all
  shuffle writer metrics when the writer stops.
- Log the shuffle writer and reader options when the operators are constructed.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
      Partial: the changed TU and the test TU compile in the devcontainer, see
      Validation above; a full build needs the missing conan LLVM package.
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes

- [x] No
