### PR TITLE
fix: register newly initialized dictionary memos

### DIFF
--- a/bolt/expression/Expr.cpp
+++ b/bolt/expression/Expr.cpp
@@ -1248,7 +1248,6 @@ void Expr::evalWithMemo(
 
     // stop updating dictionary if retained memory is too large
     if (!context.exprSet()->dictionaryCacheSizeExceedLimit()) {
-      context.exprSet()->addToMemo(this);
       auto newCacheSize = uncached->end();
 
       // dictionaryCache_ is valid only for cachedDictionaryIndices_. Hence, a

--- a/bolt/expression/Expr.cpp
+++ b/bolt/expression/Expr.cpp
@@ -1205,6 +1205,7 @@ void Expr::evalWithMemo(
 
   if (baseOfDictionaryRepeats_ == 1) {
     evalWithNulls(rows, context, result);
+    context.exprSet()->addToMemo(this);
     baseOfDictionary_ = base;
     dictionaryCache_ = result;
     dictionaryCacheSize_ = dictionaryCache_->retainedSize();

--- a/bolt/expression/tests/ExprTest.cpp
+++ b/bolt/expression/tests/ExprTest.cpp
@@ -2224,6 +2224,43 @@ TEST_F(ExprTest, memo) {
   BOLT_CHECK(base.use_count() == 1);
 }
 
+TEST_F(ExprTest, clearNewlyInitializedMemo) {
+  constexpr vector_size_t kSize = 22;
+  const auto bytesBefore = pool_->currentBytes();
+  auto base = makeFlatVector<StringView>(kSize, [](auto row) {
+    return StringView(row % 2 == 0 ? "growth" : "mature");
+  });
+  auto indices = makeIndices(kSize, [](auto row) { return row; });
+  auto rowType = ROW({"c0"}, {VARCHAR()});
+  auto exprSet = compileExpression("coalesce(c0, 'unknown')", rowType);
+
+  auto evaluateBatch = [&]() {
+    auto result = evaluate(
+        exprSet.get(), makeRowVector({wrapInDictionary(indices, kSize, base)}));
+    auto* values = result->as<SimpleVector<StringView>>();
+    BOLT_CHECK_NOT_NULL(values);
+    for (vector_size_t row = 0; row < kSize; ++row) {
+      EXPECT_EQ(row % 2 == 0 ? "growth" : "mature", values->valueAt(row));
+    }
+    return result;
+  };
+
+  auto result = evaluateBatch();
+  result.reset();
+  ASSERT_TRUE(base.unique());
+
+  // The second encounter with the same dictionary base initializes the memo.
+  result = evaluateBatch();
+  result.reset();
+  ASSERT_FALSE(base.unique());
+  base.reset();
+  indices.reset();
+  EXPECT_GT(pool_->currentBytes(), bytesBefore);
+
+  exprSet->clear();
+  EXPECT_EQ(bytesBefore, pool_->currentBytes());
+}
+
 // This test triggers the situation when peelEncodings() produces an empty
 // selectivity vector, which if passed to evalWithMemo() causes the latter to
 // produce null Expr::dictionaryCache_, which leads to a crash in evaluation


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #989

When evaluation ends immediately after a dictionary memo is initialized, `ExprSet::clear()` misses its retained vectors because the expression has not been registered for cleanup. The regression leaves 512 B allocated on the unmodified implementation in both Release and Debug.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Register the expression at memo initialization, after successful evaluation and before taking strong references. `ExprSet::clear()` can then release the memo even if there is no later cache expansion. The expression remains registered for subsequent cache updates, so initialization is the only registration site.

Add a regression that evaluates the same dictionary base twice, verifies the values, drops external references, and checks that `clear()` returns the pool to its baseline allocation. Expression results and cache eligibility remain unchanged.

### Performance Impact

- [ ] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
- [x] **Negative Impact**: Explained below (e.g., trade-off for correctness).

Registration occurs at memo initialization, with at most one tracked pointer per expression. This setup cost is paid even if the cache is never expanded. Cache expansion avoids redundant set insertions; per-row evaluation and cache-hit logic are unchanged. No performance benchmark was run.

### Release Note

```text
Release Note:
- Release newly initialized dictionary memos during expression-set cleanup.
```

### Checklist (For Author)

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

Validation used GCC 13.4.0 on Linux x86_64 with AVX2, shared test linkage, test utilities, DuckDB and JIT enabled, and `BOLT_ENABLE_SPARK_COMPATIBLE=OFF`.

- Regression on the original implementation: fails with 512 B retained in both Release and Debug.
- Patched Release expression suite: 1250 passed, 4 skipped, 1 disabled.
- An earlier full Debug expression run had 1250 passed, 4 skipped, and 1 failed (`EvalSimplifiedTest.strings`). Removing only the memo fix and rebuilding reproduced the same `FlatVector::setNoCopy` / `StringViewStats` assertion for `lower(upper(c0))`; this is a baseline failure.
- Final revision: the full Release expression suite passed as above; Debug `ExprTest.*` and `ExprTest/ParameterizedExprTest.memoNulls/*` passed all 9 tests, covering initialization cleanup, cache expansion, and null handling.
- All applicable pre-commit hooks passed. Spark-compatible mode and sanitizers were not run locally.

```bash
CCACHE_READONLY=1 CCACHE_TEMPDIR=/tmp/bolt-ccache-temp \
  cmake --build _build/Release --target bolt_expression_test -j16
CCACHE_READONLY=1 CCACHE_TEMPDIR=/tmp/bolt-ccache-temp \
  cmake --build _build/Debug --target bolt_expression_test -j16
./_build/Release/bolt/expression/tests/bolt_expression_test
./_build/Debug/bolt/expression/tests/bolt_expression_test
./_build/Release/bolt/expression/tests/bolt_expression_test \
  --gtest_filter='ExprTest.*:ExprTest/ParameterizedExprTest.memoNulls/*'
./_build/Debug/bolt/expression/tests/bolt_expression_test \
  --gtest_filter='ExprTest.*:ExprTest/ParameterizedExprTest.memoNulls/*'
GOCACHE=/tmp/bolt-go-cache pre-commit run \
  --files bolt/expression/Expr.cpp bolt/expression/tests/ExprTest.cpp
```

Local setup retries corrected missing test-utils/DuckDB and CPU/JIT configuration, regenerated Debug Conan dependencies, and used a writable Go cache for the license hook. Both builds then completed.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

