### PR TITLE
refactor: simplify radix sort internals

### DIFF
--- a/bolt/exec/SpillFile.h
+++ b/bolt/exec/SpillFile.h
@@ -303,6 +303,13 @@ class SpillInputStream : public ByteInputStream {
     }
   }
 
+  uint64_t remainingFileBytes() const {
+    const auto& range = ranges()[0];
+    const auto provided =
+        spillUringEnabled_ && file_->uringEnabled() ? completed_ : offset_;
+    return size_ - provided + range.size - range.position;
+  }
+
   void reuse() {
     offset_ = 0;
   }
@@ -360,6 +367,10 @@ class SpillReadFileInput {
 
   bool inputAtEnd() const {
     return input_ == nullptr || input_->atEnd();
+  }
+
+  uint64_t inputRemainingFileBytes() const {
+    return input_ == nullptr ? 0 : input_->remainingFileBytes();
   }
 
   void prefetchInput() {

--- a/bolt/exec/benchmarks/RadixSortAlgorithmBenchmark.cpp
+++ b/bolt/exec/benchmarks/RadixSortAlgorithmBenchmark.cpp
@@ -21,19 +21,16 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
-#include <cstring>
 #include <numeric>
 #include <vector>
 
 #include "bolt/common/base/CompareFlags.h"
 #include "bolt/exec/HybridSorter.h"
 #include "bolt/exec/RowContainer.h"
-#include "bolt/exec/radixsort/RadixSortKey.h"
-#include "bolt/exec/radixsort/RadixSortRunSorter.h"
-#include "bolt/exec/radixsort/RadixSortRunStorage.h"
-#include "bolt/exec/radixsort/RadixSortUtils.h"
+#include "bolt/exec/radixsort/RadixSortRun.h"
 #include "bolt/jit/CompiledModule.h"
 #include "bolt/jit/RowContainer/RowContainerCodeGenerator.h"
+#include "bolt/vector/FlatVector.h"
 
 using namespace bytedance::bolt;
 using namespace bytedance::bolt::exec;
@@ -70,7 +67,6 @@ constexpr std::array<Scenario, 14> kScenarios{{
     {"low_cardinality_w8_10m", 10'000'000, 8, DataPattern::kLowCardinality},
 }};
 
-std::shared_ptr<memory::MemoryPool> pool;
 std::atomic<uint64_t> adaptivePoolSequence{0};
 
 uint64_t randomBits(uint64_t value) {
@@ -88,19 +84,6 @@ uint64_t keyWord(const Scenario& scenario, uint64_t row, uint32_t word) {
       return randomBits(row + word * 257);
   }
   BOLT_UNREACHABLE("Unsupported radix sort benchmark data pattern");
-}
-
-std::vector<uint64_t> makeInput(const Scenario& scenario) {
-  std::vector<uint64_t> data(
-      static_cast<uint64_t>(scenario.rows) * scenario.words);
-  for (uint32_t row = 0; row < scenario.rows; ++row) {
-    for (uint32_t word = 0; word < scenario.words; ++word) {
-      const auto value = keyWord(scenario, row, word);
-      data[static_cast<uint64_t>(row) * scenario.words + word] =
-          byteSwap<uint64_t>(value);
-    }
-  }
-  return data;
 }
 
 uint64_t unsignedKeyWordForSignedCompare(const uint64_t word) {
@@ -182,47 +165,28 @@ void legacyAdaptiveSort(unsigned iterations, uint32_t scenarioIndex) {
   }
 }
 
-RadixSortKeyLayout layoutForWords(uint32_t words) {
-  switch (words) {
-    case 1:
-      return RadixSortKeyLayout::fromKind(
-          RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-    case 2:
-      return RadixSortKeyLayout::fromKind(
-          RadixSortKeyLayoutKind::kKeyOnlyFixed16);
-    case 3:
-      return RadixSortKeyLayout::fromKind(
-          RadixSortKeyLayoutKind::kKeyOnlyFixed24);
-    case 4:
-      return RadixSortKeyLayout::fromKind(
-          RadixSortKeyLayoutKind::kKeyOnlyFixed32);
-    default:
-      return RadixSortKeyLayout::fromKind(
-          RadixSortKeyLayoutKind::kKeyOnlyVariable32);
+RowVectorPtr makeRadixInput(
+    const Scenario& scenario,
+    memory::MemoryPool* sortPool) {
+  std::vector<VectorPtr> children;
+  children.reserve(scenario.words);
+  for (uint32_t word = 0; word < scenario.words; ++word) {
+    auto values = BaseVector::create<FlatVector<int64_t>>(
+        BIGINT(), scenario.rows, sortPool);
+    for (uint32_t row = 0; row < scenario.rows; ++row) {
+      values->set(
+          row,
+          static_cast<int64_t>(
+              unsignedKeyWordForSignedCompare(keyWord(scenario, row, word))));
+    }
+    children.push_back(std::move(values));
   }
-}
-
-void appendToStorage(
-    RadixSortRunStorage& storage,
-    const uint64_t* data,
-    const Scenario& scenario) {
-  if (scenario.words <= 4) {
-    storage.appendKeyBlocks(
-        scenario.rows,
-        [&](vector_size_t source, vector_size_t count, char* out) {
-          std::memcpy(
-              out,
-              data + static_cast<uint64_t>(source) * scenario.words,
-              static_cast<size_t>(count) * scenario.words * sizeof(uint64_t));
-        });
-    return;
-  }
-  for (uint32_t row = 0; row < scenario.rows; ++row) {
-    storage.append(std::string_view(
-        reinterpret_cast<const char*>(
-            data + static_cast<uint64_t>(row) * scenario.words),
-        static_cast<size_t>(scenario.words) * sizeof(uint64_t)));
-  }
+  return std::make_shared<RowVector>(
+      sortPool,
+      ROW(bigintKeyTypes(scenario.words)),
+      nullptr,
+      scenario.rows,
+      std::move(children));
 }
 
 void radixRunSort(unsigned iterations, uint32_t scenarioIndex) {
@@ -231,17 +195,22 @@ void radixRunSort(unsigned iterations, uint32_t scenarioIndex) {
   for (unsigned iteration = 0; iteration < iterations; ++iteration) {
     auto sortPool = memory::memoryManager()->addLeafPool(fmt::format(
         "radix-sort-algorithm-benchmark-{}-{}", scenarioIndex, iteration));
-    RadixSortRunStorage storage(
-        sortPool.get(),
-        layoutForWords(scenario.words),
-        RadixSortRunStorage::kTestingRowsPerBlock,
-        64 * 1024);
-    auto data = makeInput(scenario);
-    appendToStorage(storage, data.data(), scenario);
-    RadixSortRunSorter sorter(storage);
+    auto input = makeRadixInput(scenario, sortPool.get());
+    const auto rowType = std::static_pointer_cast<const RowType>(input->type());
+    std::vector<column_index_t> keyChannels(scenario.words);
+    std::iota(keyChannels.begin(), keyChannels.end(), 0);
+    const std::vector<CompareFlags> flags(
+        scenario.words,
+        CompareFlags{
+            .nullsFirst = true,
+            .ascending = true,
+            .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue});
+    auto run = RadixSortRun::create(
+        sortPool.get(), rowType, rowType, flags, keyChannels, {});
+    run->append(*input);
     suspender.dismiss();
-    sorter.sort();
-    folly::doNotOptimizeAway(storage.keyDataAt(0));
+    run->finalize();
+    folly::doNotOptimizeAway(run->storage()->keyRangeAt(0, 1).data);
     suspender.rehire();
   }
 }
@@ -273,7 +242,6 @@ SORT_ALGORITHM_BENCHMARKS(low_cardinality_w8_10m, 13);
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
-  pool = memory::memoryManager()->addLeafPool("sort-algorithm-inputs");
   folly::runBenchmarks();
   return 0;
 }

--- a/bolt/exec/benchmarks/RadixSortSpillBenchmark.cpp
+++ b/bolt/exec/benchmarks/RadixSortSpillBenchmark.cpp
@@ -803,17 +803,18 @@ PointerFreeValidationResult runPointerFreeValidation(uint32_t scenario) {
 
   const auto inputStage =
       addAndSpillInputStage(buffer, fixture.data.inputs, split, runs);
-  const auto inputDiskRuns = buffer.testingSpilledRunCount();
+  const auto inputSpillStats = buffer.spilledStats();
+  BOLT_CHECK(inputSpillStats.has_value());
+  const auto inputDiskRuns = inputSpillStats->spillRuns;
   BOLT_CHECK_EQ(inputDiskRuns, runs);
   for (uint32_t index = inputStage.split; index < fixture.data.inputs.size();
        ++index) {
     buffer.addInput(fixture.data.inputs[index]);
   }
   buffer.noMoreInput();
-  const auto mergeStreams = buffer.testingMergeStreamCount();
   const auto expectedResidentStreams =
       inputStage.split < fixture.data.inputs.size() ? 1 : 0;
-  BOLT_CHECK_EQ(mergeStreams, inputDiskRuns + expectedResidentStreams);
+  const auto mergeStreams = inputDiskRuns + expectedResidentStreams;
   const auto preOutputReadStats =
       buffer.spillReadStats().value_or(common::SpillReadStats{});
 

--- a/bolt/exec/benchmarks/RadixSortWideKeyBenchmark.cpp
+++ b/bolt/exec/benchmarks/RadixSortWideKeyBenchmark.cpp
@@ -20,7 +20,6 @@
 #include <gflags/gflags.h>
 #include <time.h>
 #include <algorithm>
-#include <array>
 #include <chrono>
 #include <cstdio>
 #include <filesystem>
@@ -37,8 +36,7 @@
 #include "bolt/exec/SortBuffer.h"
 #include "bolt/exec/Task.h"
 #include "bolt/exec/radixsort/RadixSortBuffer.h"
-#include "bolt/exec/radixsort/RadixSortKey.h"
-#include "bolt/exec/radixsort/RadixSortUtils.h"
+#include "bolt/exec/radixsort/RadixSortRun.h"
 #include "bolt/functions/prestosql/types/HyperLogLogType.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
 #include "bolt/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -96,15 +94,10 @@ DEFINE_uint32(
     4,
     "In-process repetitions including a warmup.");
 DEFINE_bool(bolt_benchmark_wide_jit, true, "Enable legacy comparator JIT.");
-DEFINE_bool(
-    bolt_benchmark_wide_known_nulls,
-    true,
-    "Pass observed top-level nullability to the decoder.");
-DEFINE_bool(
-    bolt_benchmark_wide_mask_alternate,
-    false,
-    "Skip alternate columns where codec supports selective decode.");
-DEFINE_string(bolt_benchmark_wide_mode, "codec", "codec or buffer.");
+DEFINE_string(
+    bolt_benchmark_wide_mode,
+    "run",
+    "Production in-memory run or complete sort buffer.");
 DEFINE_uint32(
     bolt_benchmark_wide_spill_every,
     0,
@@ -492,116 +485,146 @@ void addStringStorage(const VectorPtr& vector, StringStorage& storage) {
   }
 }
 
-void runCodec(
-    uint32_t trial,
-    const RowTypePtr& type,
+int32_t compareInputRows(
     const std::vector<RowVectorPtr>& inputs,
-    const std::vector<CompareFlags>& flags) {
-  auto root = memory::memoryManager()->addRootPool();
-  auto pool = root->addLeafChild("codec");
-  std::unique_ptr<RadixSortKeyCodec> codec;
-  RadixSortKeyCodec::bind(type->children(), flags, codec);
-  EncodedKeyBatch keys;
-  BufferPtr cursorScratch;
-  RowVectorPtr output;
-  uint64_t encodeUs = 0;
-  uint64_t decodeUs = 0;
-  uint64_t encodeAllocs = 0;
-  uint64_t decodeAllocs = 0;
-  uint64_t encodedBytes = 0;
-  StringStorage strings;
-  for (const auto& input : inputs) {
-    auto before = pool->stats().numAllocs;
-    auto start = cpuUs();
-    codec->encode(*input, pool.get(), keys);
-    encodeUs += cpuUs() - start;
-    encodeAllocs += pool->stats().numAllocs - before;
-
-    std::vector<std::array<char, sizeof(uint64_t)>> fixed;
-    std::vector<EncodedKeyView> views(input->size());
-    if (keys.format() == EncodedKeyFormat::kFixed64) {
-      fixed.resize(input->size());
-      for (vector_size_t row = 0; row < input->size(); ++row) {
-        storeUnaligned<uint64_t>(
-            fixed[row].data(), toBigEndian(keys.fixedKeyAt(row)));
-        views[row] = {std::string_view(fixed[row].data(), sizeof(uint64_t))};
-      }
-      encodedBytes += input->size() * sizeof(uint64_t);
-    } else {
-      for (vector_size_t row = 0; row < input->size(); ++row) {
-        views[row] = {keys.variableKeyAt(row)};
-        encodedBytes += views[row].bytes.size();
-      }
-    }
-    before = pool->stats().numAllocs;
-    std::vector<uint8_t> decodedColumns;
-    if (FLAGS_bolt_benchmark_wide_mask_alternate) {
-      decodedColumns.resize(type->size());
-      for (uint32_t column = 0; column < type->size(); ++column)
-        decodedColumns[column] = column % 2 == 0;
-    }
-    std::vector<uint8_t> mayHaveNulls;
-    if (FLAGS_bolt_benchmark_wide_known_nulls) {
-      for (const auto& child : input->children())
-        mayHaveNulls.push_back(child->mayHaveNulls());
-    }
-    start = cpuUs();
-    codec->decode(
-        views, decodedColumns, mayHaveNulls, pool.get(), cursorScratch, output);
-    decodeUs += cpuUs() - start;
-    decodeAllocs += pool->stats().numAllocs - before;
-    addStringStorage(output, strings);
-    if (FLAGS_bolt_benchmark_wide_verify) {
-      for (column_index_t column = 0; column < type->size(); ++column) {
-        if (output->childAt(column) == nullptr)
-          continue;
-        for (vector_size_t row = 0; row < input->size(); ++row) {
-          BOLT_CHECK(
-              output->childAt(column)->equalValueAt(
-                  input->childAt(column).get(), row, row),
-              "Codec mismatch column {} row {}",
-              column,
-              row);
-        }
-      }
-      auto compareRows = [&](vector_size_t left, vector_size_t right) {
-        for (column_index_t column = 0; column < type->size(); ++column) {
-          const auto result =
-              input->childAt(column)
-                  ->compare(
-                      input->childAt(column).get(), left, right, flags[column])
-                  .value();
-          if (result != 0)
-            return result;
-        }
-        return 0;
-      };
-      for (vector_size_t row = 1; row < input->size(); ++row) {
-        const auto expected = compareRows(row - 1, row);
-        const auto actual = keys.format() == EncodedKeyFormat::kFixed64
-            ? (keys.fixedKeyAt(row - 1) > keys.fixedKeyAt(row)) -
-                (keys.fixedKeyAt(row - 1) < keys.fixedKeyAt(row))
-            : views[row - 1].bytes.compare(views[row].bytes);
-        BOLT_CHECK_EQ(
-            (actual > 0) - (actual < 0), (expected > 0) - (expected < 0));
-      }
+    const std::vector<CompareFlags>& flags,
+    uint64_t left,
+    uint64_t right) {
+  const auto& leftInput = inputs[left / FLAGS_bolt_benchmark_wide_batch];
+  const auto& rightInput = inputs[right / FLAGS_bolt_benchmark_wide_batch];
+  for (column_index_t column = 0; column < flags.size(); ++column) {
+    const auto result = leftInput->childAt(column)
+                            ->compare(
+                                rightInput->childAt(column).get(),
+                                left % FLAGS_bolt_benchmark_wide_batch,
+                                right % FLAGS_bolt_benchmark_wide_batch,
+                                flags[column])
+                            .value();
+    if (result != 0) {
+      return result;
     }
   }
+  return 0;
+}
+
+void runRadixRun(
+    uint32_t trial,
+    const RowTypePtr& keyType,
+    const RowTypePtr& outputType,
+    const std::vector<RowVectorPtr>& sourceInputs,
+    const std::vector<RowVectorPtr>& inputs,
+    const std::vector<CompareFlags>& flags,
+    const std::vector<column_index_t>& channels) {
+  auto root = memory::memoryManager()->addRootPool();
+  auto pool = root->addLeafChild("radix-run");
+
+  const auto before = pool->stats();
+  auto start = cpuUs();
+  auto run = RadixSortRun::create(
+      pool.get(), outputType, keyType, flags, channels, RadixSortRunOptions{});
+  const auto createUs = cpuUs() - start;
+  const auto afterCreate = pool->stats();
+
+  start = cpuUs();
+  for (const auto& input : inputs) {
+    run->append(*input);
+  }
+  const auto appendUs = cpuUs() - start;
+  const auto afterAppend = pool->stats();
+  const auto retainedBytes = run->retainedBytes();
+  const auto estimatedOutputBytes = run->estimatedOutputBytes();
+
+  start = cpuUs();
+  run->finalize();
+  const auto finalizeUs = cpuUs() - start;
+  const auto afterFinalize = pool->stats();
+
+  uint64_t outputUs = 0;
+  uint64_t rows = 0;
+  uint64_t previousRowId = 0;
+  bool hasPreviousRow = false;
+  std::vector<uint8_t> seen;
+  if (FLAGS_bolt_benchmark_wide_verify) {
+    seen.resize(FLAGS_bolt_benchmark_wide_rows, 0);
+  }
+  StringStorage strings;
+  RowVectorPtr output;
+  while (true) {
+    start = cpuUs();
+    auto result =
+        run->getOutput(FLAGS_bolt_benchmark_wide_output, pool.get(), output);
+    outputUs += cpuUs() - start;
+    if (result == nullptr) {
+      break;
+    }
+    addStringStorage(result, strings);
+    if (FLAGS_bolt_benchmark_wide_verify) {
+      auto* rowIds =
+          result->childAt(keyType->size())->as<SimpleVector<int64_t>>();
+      BOLT_CHECK_NOT_NULL(rowIds);
+      for (vector_size_t row = 0; row < result->size(); ++row) {
+        const auto signedRowId = rowIds->valueAt(row);
+        BOLT_CHECK_GE(signedRowId, 0);
+        const auto rowId = static_cast<uint64_t>(signedRowId);
+        BOLT_CHECK_LT(rowId, FLAGS_bolt_benchmark_wide_rows);
+        BOLT_CHECK_EQ(
+            seen[rowId], 0, "Duplicate output row identity {}", rowId);
+        seen[rowId] = 1;
+        if (hasPreviousRow) {
+          BOLT_CHECK_LE(
+              compareInputRows(sourceInputs, flags, previousRowId, rowId),
+              0,
+              "Output order mismatch at row {}",
+              rows + row);
+        }
+        previousRowId = rowId;
+        hasPreviousRow = true;
+        const auto& source =
+            sourceInputs[rowId / FLAGS_bolt_benchmark_wide_batch];
+        const auto sourceRow = rowId % FLAGS_bolt_benchmark_wide_batch;
+        for (column_index_t column = 0; column < keyType->size(); ++column) {
+          BOLT_CHECK(
+              result->childAt(column)->equalValueAt(
+                  source->childAt(column).get(), row, sourceRow),
+              "Output value mismatch at row {} column {} for identity {}",
+              rows + row,
+              column,
+              rowId);
+        }
+      }
+    }
+    rows += result->size();
+  }
+  BOLT_CHECK_EQ(rows, FLAGS_bolt_benchmark_wide_rows);
+  if (FLAGS_bolt_benchmark_wide_verify) {
+    BOLT_CHECK(
+        std::all_of(
+            seen.begin(), seen.end(), [](uint8_t value) { return value != 0; }),
+        "Missing output row identity");
+  }
+  const auto afterOutput = pool->stats();
   std::printf(
-      "RESULT impl=codec trial=%u type=%s columns=%u rows=%u encode=%.3f decode=%.3f "
-      "total=%.3f encodeAllocs=%llu decodeAllocs=%llu peak=%lld encodedBytes=%llu "
+      "RESULT impl=run trial=%u type=%s columns=%u rows=%llu create=%.3f append=%.3f "
+      "finalize=%.3f output=%.3f total=%.3f createAllocs=%llu appendAllocs=%llu "
+      "finalizeAllocs=%llu outputAllocs=%llu peak=%lld retainedBytes=%lld "
+      "estimatedOutputBytes=%llu "
       "stringUsed=%llu stringCapacity=%llu verified=%d\n",
       trial,
       FLAGS_bolt_benchmark_wide_type.c_str(),
       FLAGS_bolt_benchmark_wide_columns,
-      FLAGS_bolt_benchmark_wide_rows,
-      encodeUs / 1000.0,
-      decodeUs / 1000.0,
-      (encodeUs + decodeUs) / 1000.0,
-      (unsigned long long)encodeAllocs,
-      (unsigned long long)decodeAllocs,
-      (long long)pool->peakBytes(),
-      (unsigned long long)encodedBytes,
+      (unsigned long long)rows,
+      createUs / 1000.0,
+      appendUs / 1000.0,
+      finalizeUs / 1000.0,
+      outputUs / 1000.0,
+      (createUs + appendUs + finalizeUs + outputUs) / 1000.0,
+      (unsigned long long)(afterCreate.numAllocs - before.numAllocs),
+      (unsigned long long)(afterAppend.numAllocs - afterCreate.numAllocs),
+      (unsigned long long)(afterFinalize.numAllocs - afterAppend.numAllocs),
+      (unsigned long long)(afterOutput.numAllocs - afterFinalize.numAllocs),
+      (long long)afterOutput.peakBytes,
+      (long long)retainedBytes,
+      (unsigned long long)estimatedOutputBytes,
       (unsigned long long)strings.used,
       (unsigned long long)strings.capacity,
       FLAGS_bolt_benchmark_wide_verify);
@@ -812,9 +835,33 @@ void mainBenchmark() {
     inputs.push_back(std::make_shared<RowVector>(
         source.get(), type, nullptr, count, std::move(children)));
   }
-  if (FLAGS_bolt_benchmark_wide_mode == "codec") {
+  if (FLAGS_bolt_benchmark_wide_mode == "run") {
+    auto outputNames = type->names();
+    outputNames.push_back("__row_id");
+    auto outputTypes = type->children();
+    outputTypes.push_back(BIGINT());
+    const auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
+    std::vector<RowVectorPtr> runInputs;
+    runInputs.reserve(inputs.size());
+    uint64_t offset = 0;
+    for (const auto& input : inputs) {
+      auto children = input->children();
+      auto rowIds = BaseVector::create<FlatVector<int64_t>>(
+          BIGINT(), input->size(), source.get());
+      for (vector_size_t row = 0; row < input->size(); ++row) {
+        rowIds->set(row, offset + row);
+      }
+      children.push_back(std::move(rowIds));
+      runInputs.push_back(std::make_shared<RowVector>(
+          source.get(),
+          outputType,
+          nullptr,
+          input->size(),
+          std::move(children)));
+      offset += input->size();
+    }
     for (uint32_t trial = 0; trial < FLAGS_bolt_benchmark_wide_runs; ++trial) {
-      runCodec(trial, type, inputs, flags);
+      runRadixRun(trial, type, outputType, inputs, runInputs, flags, channels);
     }
     return;
   }

--- a/bolt/exec/radixsort/PayloadRow.cpp
+++ b/bolt/exec/radixsort/PayloadRow.cpp
@@ -1683,7 +1683,7 @@ bool shouldClearPayloadSlots(const RowVector& input) {
 }
 
 template <typename T>
-void writeFixedFlatColumn(
+void writeFixedFlatColumnTyped(
     const PayloadRowColumnLayout& column,
     const BaseVector& vector,
     char* const* rows,
@@ -1702,7 +1702,7 @@ void writeFixedFlatColumn(
 }
 
 template <>
-void writeFixedFlatColumn<bool>(
+void writeFixedFlatColumnTyped<bool>(
     const PayloadRowColumnLayout& column,
     const BaseVector& vector,
     char* const* rows,
@@ -1721,56 +1721,42 @@ void writeFixedFlatColumn<bool>(
   }
 }
 
+template <TypeKind Kind>
+void writeFixedFlatColumnByKind(
+    const PayloadRowColumnLayout& column,
+    const BaseVector& vector,
+    char* const* rows,
+    vector_size_t begin,
+    vector_size_t end) {
+  if constexpr (Kind == TypeKind::UNKNOWN) {
+    for (vector_size_t row = begin; row < end; ++row) {
+      setNull(rows[row], column);
+    }
+  } else if constexpr (
+      Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+    BOLT_FAIL(
+        "Sort fixed payload fast path is not implemented for ",
+        column.type->toString());
+  } else {
+    using T = typename TypeTraits<Kind>::NativeType;
+    writeFixedFlatColumnTyped<T>(column, vector, rows, begin, end);
+  }
+}
+
 void writeFixedFlatColumn(
     const PayloadRowColumnLayout& column,
     const BaseVector& vector,
     char* const* rows,
     vector_size_t begin,
     vector_size_t end) {
-  if (column.type->isShortDecimal()) {
-    writeFixedFlatColumn<int64_t>(column, vector, rows, begin, end);
-    return;
-  }
-  if (column.type->isLongDecimal() ||
-      column.type->kind() == TypeKind::HUGEINT) {
-    writeFixedFlatColumn<int128_t>(column, vector, rows, begin, end);
-    return;
-  }
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN:
-      writeFixedFlatColumn<bool>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::TINYINT:
-      writeFixedFlatColumn<int8_t>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::SMALLINT:
-      writeFixedFlatColumn<int16_t>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::INTEGER:
-      writeFixedFlatColumn<int32_t>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::BIGINT:
-      writeFixedFlatColumn<int64_t>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::REAL:
-      writeFixedFlatColumn<float>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::DOUBLE:
-      writeFixedFlatColumn<double>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::TIMESTAMP:
-      writeFixedFlatColumn<Timestamp>(column, vector, rows, begin, end);
-      return;
-    case TypeKind::UNKNOWN:
-      for (vector_size_t row = begin; row < end; ++row) {
-        setNull(rows[row], column);
-      }
-      return;
-    default:
-      BOLT_FAIL(
-          "Sort fixed payload fast path is not implemented for ",
-          column.type->toString());
-  }
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      writeFixedFlatColumnByKind,
+      column.type->kind(),
+      column,
+      vector,
+      rows,
+      begin,
+      end);
 }
 
 void writeFlatStringValue(
@@ -1801,7 +1787,7 @@ void writeFlatStringValue(
 }
 
 template <typename T>
-void writeFixedDecodedColumn(
+void writeFixedDecodedColumnTyped(
     const PayloadRowColumnLayout& column,
     DecodedVector& decoded,
     char* const* rows,
@@ -1840,82 +1826,68 @@ void writeFixedDecodedColumn(
   }
 }
 
+template <TypeKind Kind>
+void writeFixedDecodedColumnByKind(
+    const PayloadRowColumnLayout& column,
+    DecodedVector& decoded,
+    char* const* rows,
+    vector_size_t begin,
+    vector_size_t end) {
+  if constexpr (Kind == TypeKind::BOOLEAN) {
+    if (decoded.isConstantMapping()) {
+      const bool isNull = decoded.isNullAt(0);
+      const auto value =
+          isNull ? uint8_t{0} : static_cast<uint8_t>(decoded.valueAt<bool>(0));
+      for (vector_size_t row = begin; row < end; ++row) {
+        if (isNull) {
+          setNull(rows[row], column);
+        } else {
+          storeUnaligned<uint8_t>(rows[row] + column.offset, value);
+        }
+      }
+      return;
+    }
+    const auto* values = decoded.data<uint64_t>();
+    const auto* indices = decoded.indices();
+    const auto* nulls = decoded.nulls();
+    for (vector_size_t row = begin; row < end; ++row) {
+      if (nulls != nullptr && bits::isBitNull(nulls, row)) {
+        setNull(rows[row], column);
+      } else {
+        storeUnaligned<uint8_t>(
+            rows[row] + column.offset,
+            static_cast<uint8_t>(bits::isBitSet(values, indices[row])));
+      }
+    }
+  } else if constexpr (Kind == TypeKind::UNKNOWN) {
+    for (vector_size_t row = begin; row < end; ++row) {
+      setNull(rows[row], column);
+    }
+  } else if constexpr (
+      Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+    BOLT_FAIL(
+        "Sort fixed payload column is not implemented for ",
+        column.type->toString());
+  } else {
+    using T = typename TypeTraits<Kind>::NativeType;
+    writeFixedDecodedColumnTyped<T>(column, decoded, rows, begin, end);
+  }
+}
+
 void writeFixedDecodedColumn(
     const PayloadRowColumnLayout& column,
     DecodedVector& decoded,
     char* const* rows,
     vector_size_t begin,
     vector_size_t end) {
-  if (column.type->isShortDecimal()) {
-    writeFixedDecodedColumn<int64_t>(column, decoded, rows, begin, end);
-    return;
-  }
-  if (column.type->isLongDecimal() ||
-      column.type->kind() == TypeKind::HUGEINT) {
-    writeFixedDecodedColumn<int128_t>(column, decoded, rows, begin, end);
-    return;
-  }
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN: {
-      if (decoded.isConstantMapping()) {
-        const bool isNull = decoded.isNullAt(0);
-        const auto value = isNull
-            ? uint8_t{0}
-            : static_cast<uint8_t>(decoded.valueAt<bool>(0));
-        for (vector_size_t row = begin; row < end; ++row) {
-          if (isNull) {
-            setNull(rows[row], column);
-          } else {
-            storeUnaligned<uint8_t>(rows[row] + column.offset, value);
-          }
-        }
-        return;
-      }
-      const auto* values = decoded.data<uint64_t>();
-      const auto* indices = decoded.indices();
-      const auto* nulls = decoded.nulls();
-      for (vector_size_t row = begin; row < end; ++row) {
-        if (nulls != nullptr && bits::isBitNull(nulls, row)) {
-          setNull(rows[row], column);
-        } else {
-          storeUnaligned<uint8_t>(
-              rows[row] + column.offset,
-              static_cast<uint8_t>(bits::isBitSet(values, indices[row])));
-        }
-      }
-      return;
-    }
-    case TypeKind::TINYINT:
-      writeFixedDecodedColumn<int8_t>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::SMALLINT:
-      writeFixedDecodedColumn<int16_t>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::INTEGER:
-      writeFixedDecodedColumn<int32_t>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::BIGINT:
-      writeFixedDecodedColumn<int64_t>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::REAL:
-      writeFixedDecodedColumn<float>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::DOUBLE:
-      writeFixedDecodedColumn<double>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::TIMESTAMP:
-      writeFixedDecodedColumn<Timestamp>(column, decoded, rows, begin, end);
-      return;
-    case TypeKind::UNKNOWN:
-      for (vector_size_t row = begin; row < end; ++row) {
-        setNull(rows[row], column);
-      }
-      return;
-    default:
-      BOLT_FAIL(
-          "Sort fixed payload column is not implemented for ",
-          column.type->toString());
-  }
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      writeFixedDecodedColumnByKind,
+      column.type->kind(),
+      column,
+      decoded,
+      rows,
+      begin,
+      end);
 }
 
 void writeFixedDecodedColumn(

--- a/bolt/exec/radixsort/RadixSortBuffer.cpp
+++ b/bolt/exec/radixsort/RadixSortBuffer.cpp
@@ -100,31 +100,18 @@ void appendSpillRun(
   spillRuns.back().files.swap(files);
 }
 
-std::vector<std::string> copySpillFilePaths(
-    const std::vector<RadixSortSpillFile>& files) {
-  std::vector<std::string> paths;
-  paths.reserve(files.size());
-  for (const auto& file : files) {
-    paths.push_back(file.path);
-  }
-  return paths;
-}
-
-void cleanupSpillFilePathsNoThrow(
-    const std::vector<std::string>& paths) noexcept {
-  for (const auto& path : paths) {
-    cleanupSpillFileNoThrow(path);
-  }
-}
-
-uint64_t fixedWidthValueBytes(const Type& type, vector_size_t rows) {
-  if (type.kind() == TypeKind::UNKNOWN) {
+template <TypeKind KIND>
+uint64_t fixedWidthValueBytes(vector_size_t rows) {
+  if constexpr (KIND == TypeKind::UNKNOWN) {
     return 0;
-  }
-  if (type.kind() == TypeKind::BOOLEAN) {
+  } else if constexpr (KIND == TypeKind::BOOLEAN) {
     return BaseVector::byteSize<bool>(rows);
+  } else if constexpr (TypeTraits<KIND>::isFixedWidth) {
+    return checkedByteSize(
+        rows, sizeof(typename TypeTraits<KIND>::NativeType), "output value");
+  } else {
+    BOLT_FAIL("Expected a fixed-width scalar type");
   }
-  return checkedByteSize(rows, type.cppSizeInBytes(), "output value");
 }
 
 uint64_t spillReadBytesPerRun(common::CompressionKind compressionKind) {
@@ -293,7 +280,8 @@ bool RadixSortBuffer::canReuseOutput(vector_size_t batchSize) const {
       return false;
     }
 
-    const auto valueBytes = fixedWidthValueBytes(*childType, batchSize);
+    const auto valueBytes = BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        fixedWidthValueBytes, childType->kind(), batchSize);
     if (valueBytes != 0 &&
         (child->values() == nullptr ||
          child->values()->capacity() < valueBytes)) {
@@ -429,8 +417,7 @@ void RadixSortBuffer::ensureMergeRowPointerBuffers(vector_size_t count) {
 std::optional<common::SortStats> RadixSortBuffer::sortStats() const {
   const auto& metrics = run_->metrics();
   common::SortStats stats;
-  stats.sortColToRowTimeUs = encodeTimeUs_ + appendTimeUs_ +
-      metrics.encodeTimeUs + metrics.appendTimeUs;
+  stats.sortColToRowTimeUs = appendTimeUs_ + metrics.appendTimeUs;
   stats.sortInSortTimeUs = sortTimeUs_ + metrics.sortTimeUs;
   stats.sortOutputTimeUs = outputTimeUs_ + metrics.outputTimeUs;
   return stats;
@@ -593,7 +580,7 @@ void RadixSortBuffer::reserveOutputForCurrentState(vector_size_t batchSize) {
 }
 
 std::unique_ptr<RadixSortRun> RadixSortBuffer::makeRun() const {
-  auto options = runOptions_;
+  RadixSortRunOptions options;
   options.initialKeyMayHaveNulls = keyMayHaveNulls_;
   options.initialPayloadMayHaveNulls = payloadMayHaveNulls_;
   options.initialVariableKeysFitRadixPrefix = variableKeysFitRadixPrefix_;
@@ -690,7 +677,6 @@ void RadixSortBuffer::spillBuildingRun() {
   const auto spillBegin = std::chrono::steady_clock::now();
   run_->finalize();
   const auto metrics = run_->metrics();
-  encodeTimeUs_ += metrics.encodeTimeUs;
   appendTimeUs_ += metrics.appendTimeUs;
   sortTimeUs_ += metrics.sortTimeUs;
   const auto mergeNullability = [](auto& target, const auto& source) {
@@ -774,6 +760,10 @@ void RadixSortBuffer::spillMemoryRun() {
     pool_->release();
     return;
   }
+  std::optional<memory::NonReclaimableSectionGuard> nonReclaimableGuard;
+  if (nonReclaimableSection_ != nullptr) {
+    nonReclaimableGuard.emplace(nonReclaimableSection_);
+  }
 
   const auto end = run_->size();
   uint64_t begin;
@@ -800,12 +790,8 @@ void RadixSortBuffer::spillMemoryRun() {
   const auto writeBegin = std::chrono::steady_clock::now();
   auto files = writer.writeRun(*run_->storage(), payloadLayout.get(), begin);
   const auto writeEnd = std::chrono::steady_clock::now();
-  auto cleanupReturnedFiles =
+  auto cleanupUncommittedFiles =
       folly::makeGuard([&files]() { cleanupSpillFilesNoThrow(files); });
-  auto cleanupFiles = copySpillFilePaths(files);
-  auto cleanupUncommittedFiles = folly::makeGuard(
-      [&cleanupFiles]() { cleanupSpillFilePathsNoThrow(cleanupFiles); });
-  cleanupReturnedFiles.dismiss();
   auto serializationTimeUs =
       std::chrono::duration_cast<std::chrono::microseconds>(
           writeEnd - writeBegin)
@@ -833,16 +819,25 @@ void RadixSortBuffer::spillMemoryRun() {
     prepareMerge();
     cleanupUncommittedFiles.dismiss();
   } else {
-    merger_->replaceMemory(
-        RadixSortSpillRun{std::move(files)},
-        RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get()),
-        pool_,
-        spillConfig_->spillUringEnabled);
+    auto meta =
+        RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
+    try {
+      merger_->replaceMemory(
+          RadixSortSpillRun{std::move(files)},
+          std::move(meta),
+          pool_,
+          spillConfig_->spillUringEnabled,
+          [this]() noexcept {
+            mergeKeyRows_.reset();
+            mergePayloadRows_.reset();
+            output_.reset();
+            run_->clear();
+          });
+    } catch (...) {
+      merger_.reset();
+      throw;
+    }
     cleanupUncommittedFiles.dismiss();
-    mergeKeyRows_.reset();
-    mergePayloadRows_.reset();
-    output_.reset();
-    run_->clear();
   }
 
   bool firstSpilledPartition;

--- a/bolt/exec/radixsort/RadixSortBuffer.h
+++ b/bolt/exec/radixsort/RadixSortBuffer.h
@@ -79,14 +79,6 @@ class RadixSortBuffer : public SortBufferBase {
                                 : std::make_optional(std::move(stats));
   }
 
-  size_t testingSpilledRunCount() const {
-    return spilledRuns_.size();
-  }
-
-  size_t testingMergeStreamCount() const {
-    return merger_ == nullptr ? 0 : merger_->testingNumStreams();
-  }
-
   std::optional<common::SpillReadStats> spillReadStats() const override;
 
   size_t numInputRows() const override;
@@ -141,7 +133,6 @@ class RadixSortBuffer : public SortBufferBase {
   std::vector<column_index_t> directKeyChannels_;
   std::vector<uint8_t> keyMayHaveNulls_;
   std::vector<uint8_t> payloadMayHaveNulls_;
-  RadixSortRunOptions runOptions_;
   const common::SpillConfig* spillConfig_{nullptr};
   uint64_t spillMemoryThreshold_{0};
   OperatorCtx* operatorCtx_{nullptr};
@@ -159,7 +150,6 @@ class RadixSortBuffer : public SortBufferBase {
   uint64_t storedRows_{0};
   uint64_t storedBytes_{0};
   bool variableKeysFitRadixPrefix_{true};
-  uint64_t encodeTimeUs_{0};
   uint64_t appendTimeUs_{0};
   uint64_t sortTimeUs_{0};
   uint64_t outputTimeUs_{0};

--- a/bolt/exec/radixsort/RadixSortKey.cpp
+++ b/bolt/exec/radixsort/RadixSortKey.cpp
@@ -17,24 +17,10 @@
 #include "bolt/exec/radixsort/RadixSortKey.h"
 
 #include <algorithm>
-#include <cstring>
-
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/exec/radixsort/RadixSortUtils.h"
 
 namespace bytedance::bolt::exec::radixsort {
-namespace {
-
-uint64_t fromEncodedWord(const char* data) {
-  auto word = loadUnaligned<uint64_t>(data);
-  if constexpr (std::endian::native == std::endian::little) {
-    word = byteSwap(word);
-  }
-  return word;
-}
-
-} // namespace
-
 void checkCompactPointerRange(const void* data, uint64_t size) {
   if (size == 0) {
     return;
@@ -127,144 +113,6 @@ RadixSortKeyLayout RadixSortKeyLayout::select(
         "Fixed radix sort key layout cannot have a heap offset");
   }
   return layout;
-}
-
-uint64_t RadixSortKeyLayout::heapSize(uint64_t encodedSize) const {
-  if (!isVariable()) {
-    return 0;
-  }
-  BOLT_DCHECK_LE(heapKeyOffset_, inlineCapacity_);
-  BOLT_DCHECK_LE(heapKeyOffset_, encodedSize);
-  return encodedSize - heapKeyOffset_;
-}
-
-void RadixSortKey::construct(
-    std::string_view encodedKey,
-    char* overflowData,
-    char* payload) const {
-  if (layout_->isVariable()) {
-    std::memset(mutableData_, 0, layout_->inlineCapacity());
-    std::memcpy(
-        mutableData_,
-        encodedKey.data(),
-        std::min<size_t>(encodedKey.size(), layout_->inlineCapacity()));
-  } else {
-    RadixSortInlineKeyBuffer inlineBytes{};
-    std::memcpy(
-        inlineBytes.data(),
-        encodedKey.data(),
-        std::min<size_t>(encodedKey.size(), layout_->inlineCapacity()));
-    for (uint32_t word = 0; word < layout_->inlineWordCount(); ++word) {
-      storeUnaligned(
-          mutableData_ + word * sizeof(uint64_t),
-          fromEncodedWord(inlineBytes.data() + word * sizeof(uint64_t)));
-    }
-    std::memcpy(
-        mutableData_ + layout_->inlineWordBytes(),
-        inlineBytes.data() + layout_->inlineWordBytes(),
-        layout_->inlineTailBytes());
-  }
-
-  if (layout_->isVariable()) {
-    BOLT_DCHECK_GT(
-        encodedKey.size(),
-        layout_->heapKeyOffset(),
-        "Variable radix sort key must contain a suffix column");
-    storeUnaligned<uint64_t>(
-        mutableData_ + *layout_->sizeOffset(), encodedKey.size());
-    const auto heapSize = layout_->heapSize(encodedKey.size());
-    BOLT_DCHECK_GT(heapSize, 0);
-    BOLT_DCHECK_NOT_NULL(overflowData);
-    std::memcpy(
-        overflowData, encodedKey.data() + layout_->heapKeyOffset(), heapSize);
-    storeCompactPointer(mutableData_ + *layout_->dataOffset(), overflowData);
-  }
-  if (layout_->hasPayload()) {
-    storeCompactPointer(mutableData_ + *layout_->payloadOffset(), payload);
-  }
-}
-
-int32_t RadixSortKey::compare(const RadixSortKey& other) const {
-  if (!layout_->isVariable()) {
-    for (uint32_t word = 0; word < layout_->inlineWordCount(); ++word) {
-      const auto left = inlineWord(word);
-      const auto right = other.inlineWord(word);
-      if (left != right) {
-        return (left > right) - (left < right);
-      }
-    }
-    const auto tailResult = std::memcmp(
-        data_ + layout_->inlineWordBytes(),
-        other.data_ + layout_->inlineWordBytes(),
-        layout_->inlineTailBytes());
-    if (tailResult != 0) {
-      return (tailResult > 0) - (tailResult < 0);
-    }
-    return 0;
-  }
-
-  const auto leftSize = storedSize();
-  const auto rightSize = other.storedSize();
-  const auto prefixSize =
-      std::min<uint64_t>({leftSize, rightSize, layout_->inlineCapacity()});
-  const auto result = std::memcmp(data_, other.data_, prefixSize);
-  if (result != 0) {
-    return (result > 0) - (result < 0);
-  }
-  if (prefixSize < layout_->inlineCapacity()) {
-    return (leftSize > rightSize) - (leftSize < rightSize);
-  }
-
-  const auto heapOffset = layout_->heapKeyOffset();
-  BOLT_DCHECK_LE(heapOffset, layout_->inlineCapacity());
-  const auto* leftData = loadCompactPointer(data_ + *layout_->dataOffset());
-  const auto* rightData =
-      loadCompactPointer(other.data_ + *layout_->dataOffset());
-  const auto suffixResult = std::memcmp(
-      leftData + layout_->inlineCapacity() - heapOffset,
-      rightData + layout_->inlineCapacity() - heapOffset,
-      std::min(leftSize, rightSize) - layout_->inlineCapacity());
-  if (suffixResult != 0) {
-    return (suffixResult > 0) - (suffixResult < 0);
-  }
-  return (leftSize > rightSize) - (leftSize < rightSize);
-}
-
-uint64_t RadixSortKey::heapSize() const {
-  if (!layout_->isVariable()) {
-    return 0;
-  }
-  return layout_->heapSize(storedSize());
-}
-
-std::string_view RadixSortKey::heapKey() const {
-  const auto size = heapSize();
-  return std::string_view(
-      size == 0 ? nullptr : loadCompactPointer(data_ + *layout_->dataOffset()),
-      size);
-}
-
-char* RadixSortKey::heapKeyData() const {
-  BOLT_DCHECK(layout_->isVariable());
-  return loadCompactPointer(data_ + *layout_->dataOffset());
-}
-
-char* RadixSortKey::payload() const {
-  if (!layout_->hasPayload()) {
-    return nullptr;
-  }
-  return loadCompactPointer(data_ + *layout_->payloadOffset());
-}
-
-uint64_t RadixSortKey::inlineWord(uint32_t index) const {
-  return loadUnaligned<uint64_t>(data_ + index * sizeof(uint64_t));
-}
-
-uint64_t RadixSortKey::storedSize() const {
-  if (!layout_->isVariable()) {
-    return 0;
-  }
-  return loadUnaligned<uint64_t>(data_ + *layout_->sizeOffset());
 }
 
 } // namespace bytedance::bolt::exec::radixsort

--- a/bolt/exec/radixsort/RadixSortKey.h
+++ b/bolt/exec/radixsort/RadixSortKey.h
@@ -131,8 +131,6 @@ class RadixSortKeyLayout {
     return heapKeyOffset_;
   }
 
-  uint64_t heapSize(uint64_t encodedSize) const;
-
   bool isVariable() const {
     return variable_;
   }
@@ -486,10 +484,6 @@ class RadixSortKeyOps {
  public:
   using Traits = RadixSortKeyTraits<KIND>;
 
-  static int32_t compare(const char* left, const char* right) {
-    return compare(left, right, 0);
-  }
-
   static int32_t
   compare(const char* left, const char* right, uint32_t heapKeyOffset) {
     if constexpr (!Traits::kVariable) {
@@ -560,16 +554,8 @@ class RadixSortKeyOps {
 
 class RadixSortKey {
  public:
-  RadixSortKey(const RadixSortKeyLayout& layout, char* data)
-      : layout_(&layout), data_(data), mutableData_(data) {}
-
   RadixSortKey(const RadixSortKeyLayout& layout, const char* data)
       : layout_(&layout), data_(data) {}
-
-  void construct(
-      std::string_view encodedKey,
-      char* overflowData,
-      char* payload = nullptr) const;
 
   FOLLY_ALWAYS_INLINE void deconstruct(
       RadixSortInlineKeyBuffer& inlineBuffer,
@@ -594,24 +580,9 @@ class RadixSortKey {
         std::string_view(inlineBuffer.data(), layout_->inlineCapacity())};
   }
 
-  int32_t compare(const RadixSortKey& other) const;
-
-  uint64_t heapSize() const;
-
-  std::string_view heapKey() const;
-
-  char* heapKeyData() const;
-
-  char* payload() const;
-
  private:
-  uint64_t inlineWord(uint32_t index) const;
-
-  uint64_t storedSize() const;
-
   const RadixSortKeyLayout* layout_;
   const char* data_;
-  char* mutableData_{nullptr};
 };
 
 } // namespace bytedance::bolt::exec::radixsort

--- a/bolt/exec/radixsort/RadixSortKeyCodec.cpp
+++ b/bolt/exec/radixsort/RadixSortKeyCodec.cpp
@@ -117,7 +117,6 @@ void buildMetadata(
 
   metadata.type = type;
   metadata.flags = flags;
-  metadata.encodeDecodeSupported = supportsType(*type);
   auto bodySize = fixedBodySize(*type);
   if (bodySize.has_value()) {
     metadata.maximumEncodedSize = *bodySize + 1;
@@ -229,6 +228,54 @@ uint64_t encodeDouble(double value) {
   return (bits & (uint64_t{1} << 63)) == 0 ? bits | (uint64_t{1} << 63) : ~bits;
 }
 
+template <TypeKind KIND>
+FOLLY_ALWAYS_INLINE void encodeFixedScalarValue(
+    typename TypeTraits<KIND>::NativeType value,
+    char* output,
+    bool descending) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  if constexpr (KIND == TypeKind::BOOLEAN) {
+    const auto byte = static_cast<uint8_t>(value);
+    output[0] =
+        static_cast<char>(descending ? static_cast<uint8_t>(~byte) : byte);
+  } else if constexpr (
+      KIND == TypeKind::TINYINT || KIND == TypeKind::SMALLINT ||
+      KIND == TypeKind::INTEGER || KIND == TypeKind::BIGINT) {
+    encodeSignedWord<T>(value, output, descending);
+  } else if constexpr (KIND == TypeKind::HUGEINT) {
+    encodeSignedWord<int64_t>(
+        static_cast<int64_t>(HugeInt::upper(value)), output, descending);
+    encodeUnsignedWord<uint64_t>(
+        HugeInt::lower(value), output + sizeof(int64_t), descending);
+  } else if constexpr (KIND == TypeKind::REAL) {
+    encodeUnsignedWord<uint32_t>(encodeFloat(value), output, descending);
+  } else if constexpr (KIND == TypeKind::DOUBLE) {
+    encodeUnsignedWord<uint64_t>(encodeDouble(value), output, descending);
+  } else if constexpr (KIND == TypeKind::TIMESTAMP) {
+    encodeSignedWord<int64_t>(value.getSeconds(), output, descending);
+    encodeUnsignedWord<uint64_t>(
+        value.getNanos(), output + sizeof(int64_t), descending);
+  } else {
+    BOLT_FAIL(
+        "Fixed radix sort key encoding is not implemented for {}",
+        TypeTraits<KIND>::name);
+  }
+}
+
+template <TypeKind KIND>
+FOLLY_ALWAYS_INLINE uint64_t
+encodeFixed64Value(typename TypeTraits<KIND>::NativeType value) {
+  if constexpr (KIND == TypeKind::BIGINT) {
+    return static_cast<uint64_t>(value) ^ (uint64_t{1} << 63);
+  } else if constexpr (KIND == TypeKind::DOUBLE) {
+    return encodeDouble(value);
+  } else {
+    BOLT_FAIL(
+        "64-bit radix sort key encoding is not implemented for {}",
+        TypeTraits<KIND>::name);
+  }
+}
+
 template <typename T>
 T valueAt(const BaseVector& vector, vector_size_t row) {
   const auto* base = vector.wrappedVector();
@@ -239,212 +286,6 @@ T valueAt(const BaseVector& vector, vector_size_t row) {
 bool isFixedScalarColumn(const RadixSortKeyColumn& column) {
   return column.type->kind() != TypeKind::UNKNOWN &&
       fixedBodySize(*column.type).has_value();
-}
-
-template <typename T, typename EncodeBody>
-void encodeSingleFixedFlat(
-    const RadixSortKeyColumn& column,
-    const FlatVector<T>& input,
-    vector_size_t size,
-    EncodedKeyFormat format,
-    uint64_t* words,
-    const uint64_t* offsets,
-    char* data,
-    EncodeBody encodeBody) {
-  const auto* nulls = input.rawNulls();
-  const bool descending = !column.flags.ascending;
-
-  if (format == EncodedKeyFormat::kFixed64) {
-    for (vector_size_t row = 0; row < size; ++row) {
-      std::array<char, sizeof(uint64_t)> bytes{};
-      if (nulls != nullptr && bits::isBitNull(nulls, row)) {
-        bytes[0] = static_cast<char>(nullMarker(column.flags));
-      } else {
-        bytes[0] = static_cast<char>(validMarker(column.flags));
-        encodeBody(input, row, bytes.data() + 1, descending);
-      }
-      auto word = loadUnaligned<uint64_t>(bytes.data());
-      if constexpr (std::endian::native == std::endian::little) {
-        word = byteSwap(word);
-      }
-      words[row] = word;
-    }
-    return;
-  }
-
-  for (vector_size_t row = 0; row < size; ++row) {
-    auto* output = data + offsets[row];
-    if (nulls != nullptr && bits::isBitNull(nulls, row)) {
-      output[0] = static_cast<char>(nullMarker(column.flags));
-    } else {
-      output[0] = static_cast<char>(validMarker(column.flags));
-      encodeBody(input, row, output + 1, descending);
-    }
-  }
-}
-
-template <typename T, typename EncodeBody>
-void encodeSingleVariableFixedFlat(
-    const RadixSortKeyColumn& column,
-    const FlatVector<T>& input,
-    vector_size_t size,
-    const uint64_t* offsets,
-    char* data,
-    EncodeBody encodeBody) {
-  const auto* nulls = input.rawNulls();
-  const bool descending = !column.flags.ascending;
-  for (vector_size_t row = 0; row < size; ++row) {
-    auto* output = data + offsets[row];
-    if (nulls != nullptr && bits::isBitNull(nulls, row)) {
-      output[0] = static_cast<char>(nullMarker(column.flags));
-    } else {
-      output[0] = static_cast<char>(validMarker(column.flags));
-      encodeBody(input, row, output + 1, descending);
-    }
-  }
-}
-
-void encodeSingleFixedFlat(
-    const RadixSortKeyColumn& column,
-    const BaseVector& input,
-    vector_size_t size,
-    EncodedKeyFormat format,
-    uint64_t* words,
-    const uint64_t* offsets,
-    char* data) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    const auto* flat = input.asUnchecked<FlatVector<int64_t>>();
-    if (format == EncodedKeyFormat::kVariableBinary) {
-      encodeSingleVariableFixedFlat(
-          column,
-          *flat,
-          size,
-          offsets,
-          data,
-          [](const auto& values, auto row, auto* output, bool descending) {
-            encodeSignedWord<int64_t>(
-                values.rawValues()[row], output, descending);
-          });
-      return;
-    }
-    encodeSingleFixedFlat(
-        column,
-        *flat,
-        size,
-        format,
-        words,
-        offsets,
-        data,
-        [](const auto& values, auto row, auto* output, bool descending) {
-          encodeSigned<int64_t>(values.rawValues()[row], output, descending);
-        });
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    const auto* flat = input.asUnchecked<FlatVector<int128_t>>();
-    encodeSingleFixedFlat(
-        column,
-        *flat,
-        size,
-        format,
-        words,
-        offsets,
-        data,
-        [](const auto& values, auto row, auto* output, bool descending) {
-          const auto value = values.rawValues()[row];
-          encodeSigned<int64_t>(
-              static_cast<int64_t>(HugeInt::upper(value)), output, descending);
-          encodeUnsigned<uint64_t>(
-              HugeInt::lower(value), output + sizeof(int64_t), descending);
-        });
-    return;
-  }
-  if (format == EncodedKeyFormat::kVariableBinary &&
-      column.type->kind() == TypeKind::DOUBLE) {
-    const auto* flat = input.asUnchecked<FlatVector<double>>();
-    encodeSingleVariableFixedFlat(
-        column,
-        *flat,
-        size,
-        offsets,
-        data,
-        [](const auto& values, auto row, auto* output, bool descending) {
-          encodeUnsignedWord<uint64_t>(
-              encodeDouble(values.rawValues()[row]), output, descending);
-        });
-    return;
-  }
-
-#define BOLT_ENCODE_FIXED_FLAT(kind, cppType, expression)                 \
-  case TypeKind::kind: {                                                  \
-    const auto* flat = input.asUnchecked<FlatVector<cppType>>();          \
-    encodeSingleFixedFlat(                                                \
-        column,                                                           \
-        *flat,                                                            \
-        size,                                                             \
-        format,                                                           \
-        words,                                                            \
-        offsets,                                                          \
-        data,                                                             \
-        [](const auto& values, auto row, auto* output, bool descending) { \
-          expression;                                                     \
-        });                                                               \
-    return;                                                               \
-  }
-
-  switch (column.type->kind()) {
-    BOLT_ENCODE_FIXED_FLAT(
-        BOOLEAN,
-        bool,
-        const auto value = static_cast<uint8_t>(values.valueAtFast(row));
-        output[0] = static_cast<char>(
-            descending ? static_cast<uint8_t>(~value) : value))
-    BOLT_ENCODE_FIXED_FLAT(
-        TINYINT,
-        int8_t,
-        encodeSignedWord<int8_t>(values.rawValues()[row], output, descending))
-    BOLT_ENCODE_FIXED_FLAT(
-        SMALLINT,
-        int16_t,
-        encodeSignedWord<int16_t>(values.rawValues()[row], output, descending))
-    BOLT_ENCODE_FIXED_FLAT(
-        INTEGER,
-        int32_t,
-        encodeSignedWord<int32_t>(values.rawValues()[row], output, descending))
-    BOLT_ENCODE_FIXED_FLAT(
-        BIGINT,
-        int64_t,
-        encodeSigned<int64_t>(values.rawValues()[row], output, descending))
-    BOLT_ENCODE_FIXED_FLAT(
-        REAL,
-        float,
-        encodeUnsignedWord<uint32_t>(
-            encodeFloat(values.rawValues()[row]), output, descending))
-    BOLT_ENCODE_FIXED_FLAT(
-        DOUBLE,
-        double,
-        encodeUnsigned<uint64_t>(
-            encodeDouble(values.rawValues()[row]), output, descending))
-    BOLT_ENCODE_FIXED_FLAT(
-        TIMESTAMP, Timestamp, const auto value = values.rawValues()[row];
-        encodeSigned<int64_t>(value.getSeconds(), output, descending);
-        encodeUnsigned<uint64_t>(
-            value.getNanos(), output + sizeof(int64_t), descending))
-    default:
-      BOLT_FAIL(
-          "Single fixed sort key fast path is not implemented for {}",
-          column.type->toString());
-  }
-#undef BOLT_ENCODE_FIXED_FLAT
-}
-
-bool canEncodeSingleFixedFlatVector(
-    const std::vector<RadixSortKeyColumn>& columns,
-    const RowVector& input) {
-  return columns.size() == 1 && input.childAt(0) != nullptr &&
-      input.childAt(0)->encoding() == VectorEncoding::Simple::FLAT &&
-      input.childAt(0)->type()->kind() != TypeKind::UNKNOWN &&
-      fixedBodySize(*input.childAt(0)->type()).has_value();
 }
 
 template <
@@ -633,142 +474,78 @@ void appendSingleFixed64Flat(
   }
 }
 
+template <TypeKind KIND>
+void appendSingleFixedFlatByKind(
+    const RadixSortKeyColumn& column,
+    const BaseVector& input,
+    vector_size_t size,
+    RadixSortRunStorage& arena,
+    std::span<char* const> payloads) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  if constexpr (KIND == TypeKind::BIGINT || KIND == TypeKind::DOUBLE) {
+    appendSingleFixed64Flat(
+        column,
+        *input.asUnchecked<FlatVector<T>>(),
+        size,
+        arena,
+        payloads,
+        [](T value) { return encodeFixed64Value<KIND>(value); });
+  } else if constexpr (
+      KIND == TypeKind::HUGEINT || KIND == TypeKind::TIMESTAMP) {
+    appendSingleFixedFlat<
+        RadixSortKeyLayoutKind::kKeyOnlyFixed24,
+        RadixSortKeyLayoutKind::kKeyWithPayloadFixed24>(
+        column,
+        *input.asUnchecked<FlatVector<T>>(),
+        size,
+        arena,
+        payloads,
+        [](const auto& values, auto row, auto* output, bool descending) {
+          encodeFixedScalarValue<KIND>(
+              values.rawValues()[row], output, descending);
+        });
+  } else if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::REAL) {
+    appendSingleFixedFlat<
+        RadixSortKeyLayoutKind::kKeyOnlyFixed8,
+        RadixSortKeyLayoutKind::kKeyWithPayloadFixed16>(
+        column,
+        *input.asUnchecked<FlatVector<T>>(),
+        size,
+        arena,
+        payloads,
+        [](const auto& values, auto row, auto* output, bool descending) {
+          if constexpr (KIND == TypeKind::BOOLEAN) {
+            encodeFixedScalarValue<KIND>(
+                values.valueAtFast(row), output, descending);
+          } else {
+            encodeFixedScalarValue<KIND>(
+                values.rawValues()[row], output, descending);
+          }
+        });
+  } else {
+    BOLT_FAIL(
+        "Direct fixed sort key encoder is not implemented for {}",
+        column.type->toString());
+  }
+}
+
 void appendSingleFixedFlat(
     const RadixSortKeyColumn& column,
     const BaseVector& input,
     vector_size_t size,
     RadixSortRunStorage& arena,
     std::span<char* const> payloads) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    appendSingleFixed64Flat(
-        column,
-        *input.asUnchecked<FlatVector<int64_t>>(),
-        size,
-        arena,
-        payloads,
-        [](int64_t value) {
-          return static_cast<uint64_t>(value) ^ (uint64_t{1} << 63);
-        });
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    appendSingleFixedFlat<
-        RadixSortKeyLayoutKind::kKeyOnlyFixed24,
-        RadixSortKeyLayoutKind::kKeyWithPayloadFixed24>(
-        column,
-        *input.asUnchecked<FlatVector<int128_t>>(),
-        size,
-        arena,
-        payloads,
-        [](const auto& values, auto row, auto* output, bool descending) {
-          const auto value = values.rawValues()[row];
-          encodeSignedWord<int64_t>(
-              static_cast<int64_t>(HugeInt::upper(value)), output, descending);
-          encodeUnsignedWord<uint64_t>(
-              HugeInt::lower(value), output + sizeof(int64_t), descending);
-        });
-    return;
-  }
-
-#define BOLT_APPEND_FIXED_FLAT(                                           \
-    kind, cppType, noPayloadKind, payloadKind, expression)                \
-  case TypeKind::kind:                                                    \
-    appendSingleFixedFlat<                                                \
-        RadixSortKeyLayoutKind::noPayloadKind,                            \
-        RadixSortKeyLayoutKind::payloadKind>(                             \
-        column,                                                           \
-        *input.asUnchecked<FlatVector<cppType>>(),                        \
-        size,                                                             \
-        arena,                                                            \
-        payloads,                                                         \
-        [](const auto& values, auto row, auto* output, bool descending) { \
-          expression;                                                     \
-        });                                                               \
-    return;
-
-  switch (column.type->kind()) {
-    BOLT_APPEND_FIXED_FLAT(
-        BOOLEAN,
-        bool,
-        kKeyOnlyFixed8,
-        kKeyWithPayloadFixed16,
-        const auto value = static_cast<uint8_t>(values.valueAtFast(row));
-        output[0] = static_cast<char>(
-            descending ? static_cast<uint8_t>(~value) : value))
-    BOLT_APPEND_FIXED_FLAT(
-        TINYINT,
-        int8_t,
-        kKeyOnlyFixed8,
-        kKeyWithPayloadFixed16,
-        encodeSignedWord<int8_t>(values.rawValues()[row], output, descending))
-    BOLT_APPEND_FIXED_FLAT(
-        SMALLINT,
-        int16_t,
-        kKeyOnlyFixed8,
-        kKeyWithPayloadFixed16,
-        encodeSignedWord<int16_t>(values.rawValues()[row], output, descending))
-    BOLT_APPEND_FIXED_FLAT(
-        INTEGER,
-        int32_t,
-        kKeyOnlyFixed8,
-        kKeyWithPayloadFixed16,
-        encodeSignedWord<int32_t>(values.rawValues()[row], output, descending))
-    case TypeKind::BIGINT:
-      appendSingleFixed64Flat(
-          column,
-          *input.asUnchecked<FlatVector<int64_t>>(),
-          size,
-          arena,
-          payloads,
-          [](int64_t value) {
-            return static_cast<uint64_t>(value) ^ (uint64_t{1} << 63);
-          });
-      return;
-      BOLT_APPEND_FIXED_FLAT(
-          REAL,
-          float,
-          kKeyOnlyFixed8,
-          kKeyWithPayloadFixed16,
-          encodeUnsignedWord<uint32_t>(
-              encodeFloat(values.rawValues()[row]), output, descending))
-    case TypeKind::DOUBLE:
-      appendSingleFixed64Flat(
-          column,
-          *input.asUnchecked<FlatVector<double>>(),
-          size,
-          arena,
-          payloads,
-          [](double value) { return encodeDouble(value); });
-      return;
-      BOLT_APPEND_FIXED_FLAT(
-          TIMESTAMP,
-          Timestamp,
-          kKeyOnlyFixed24,
-          kKeyWithPayloadFixed24,
-          const auto value = values.rawValues()[row];
-          encodeSignedWord<int64_t>(value.getSeconds(), output, descending);
-          encodeUnsignedWord<uint64_t>(
-              value.getNanos(), output + sizeof(int64_t), descending))
-    default:
-      BOLT_FAIL(
-          "Direct fixed sort key encoder is not implemented for {}",
-          column.type->toString());
-  }
-#undef BOLT_APPEND_FIXED_FLAT
-}
-
-void stringEncodedSize(
-    const BaseVector& vector,
-    vector_size_t row,
-    uint64_t& size) {
-  const auto value = valueAt<StringView>(vector, row);
-  uint64_t escaped = 0;
-  for (uint32_t index = 0; index < value.size(); ++index) {
-    if (static_cast<uint8_t>(value.data()[index]) <= kBlobEscape) {
-      ++escaped;
-    }
-  }
-  size = static_cast<uint64_t>(value.size()) + escaped + 1;
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      appendSingleFixedFlatByKind,
+      column.type->kind(),
+      column,
+      input,
+      size,
+      arena,
+      payloads);
 }
 
 uint64_t encodedStringBodySize(StringView value);
@@ -789,6 +566,17 @@ class DecodedKeyVectors {
   std::unordered_map<const BaseVector*, std::unique_ptr<DecodedVector>>
       vectors_;
 };
+
+DecodedVector& decodeInput(
+    const BaseVector& vector,
+    DecodedVector& local,
+    DecodedKeyVectors* cache) {
+  if (cache != nullptr) {
+    return cache->get(vector);
+  }
+  local.decode(vector);
+  return local;
+}
 
 struct RangeSizeMetadata {
   std::optional<uint64_t> fixedElementSize;
@@ -1131,9 +919,7 @@ void encodedSize(
   }
   if (column.type->kind() == TypeKind::VARCHAR ||
       column.type->kind() == TypeKind::VARBINARY) {
-    uint64_t bodySize;
-    stringEncodedSize(vector, row, bodySize);
-    size = 1 + bodySize;
+    size = 1 + encodedStringBodySize(valueAt<StringView>(vector, row));
     return;
   }
   auto bodySize = fixedBodySize(*column.type);
@@ -1203,6 +989,40 @@ scalarValueAt(const BaseVector& vector, vector_size_t row) {
   return valueAt<T>(vector, row);
 }
 
+template <TypeKind KIND>
+FOLLY_ALWAYS_INLINE void encodeBytesFixedScalarValue(
+    typename TypeTraits<KIND>::NativeType value,
+    char* output,
+    bool descending) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  if constexpr (KIND == TypeKind::BOOLEAN) {
+    const auto byte = static_cast<uint8_t>(value);
+    output[0] =
+        static_cast<char>(descending ? static_cast<uint8_t>(~byte) : byte);
+  } else if constexpr (
+      KIND == TypeKind::TINYINT || KIND == TypeKind::SMALLINT ||
+      KIND == TypeKind::INTEGER || KIND == TypeKind::BIGINT) {
+    encodeSigned<T>(value, output, descending);
+  } else if constexpr (KIND == TypeKind::HUGEINT) {
+    encodeSigned<int64_t>(
+        static_cast<int64_t>(HugeInt::upper(value)), output, descending);
+    encodeUnsigned<uint64_t>(
+        HugeInt::lower(value), output + sizeof(int64_t), descending);
+  } else if constexpr (KIND == TypeKind::REAL) {
+    encodeUnsigned<uint32_t>(encodeFloat(value), output, descending);
+  } else if constexpr (KIND == TypeKind::DOUBLE) {
+    encodeUnsigned<uint64_t>(encodeDouble(value), output, descending);
+  } else if constexpr (KIND == TypeKind::TIMESTAMP) {
+    encodeSigned<int64_t>(value.getSeconds(), output, descending);
+    encodeUnsigned<uint64_t>(
+        value.getNanos(), output + sizeof(int64_t), descending);
+  } else {
+    BOLT_FAIL(
+        "Fixed radix sort key byte encoding is not implemented for {}",
+        TypeTraits<KIND>::name);
+  }
+}
+
 template <typename T, typename EncodeBody>
 uint64_t encodeFixedScalarArrayElements(
     const RadixSortKeyColumn& column,
@@ -1210,7 +1030,6 @@ uint64_t encodeFixedScalarArrayElements(
     vector_size_t offset,
     vector_size_t count,
     char* output,
-    uint64_t /*outputSize*/,
     EncodeBody encodeBody,
     DecodedKeyVectors& decodedVectors) {
   const auto bodySize = *fixedBodySize(*column.type);
@@ -1278,89 +1097,54 @@ uint64_t encodeFixedScalarArrayElements(
   return written;
 }
 
+template <TypeKind KIND>
+uint64_t encodeFixedScalarArrayElementsByKind(
+    const RadixSortKeyColumn& column,
+    const BaseVector& elements,
+    vector_size_t offset,
+    vector_size_t count,
+    char* output,
+    DecodedKeyVectors& decodedVectors) {
+  if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT ||
+      KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE ||
+      KIND == TypeKind::TIMESTAMP) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    return encodeFixedScalarArrayElements<T>(
+        column,
+        elements,
+        offset,
+        count,
+        output,
+        [](T value, char* out, bool descending) {
+          encodeBytesFixedScalarValue<KIND>(value, out, descending);
+        },
+        decodedVectors);
+  } else {
+    BOLT_FAIL(
+        "Radix sort fixed array element encoding is not implemented for {}",
+        column.type->toString());
+  }
+}
+
 uint64_t encodeFixedScalarArrayElements(
     const RadixSortKeyColumn& column,
     const BaseVector& elements,
     vector_size_t offset,
     vector_size_t count,
     char* output,
-    uint64_t outputSize,
     DecodedKeyVectors& decodedVectors) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    return encodeFixedScalarArrayElements<int64_t>(
-        column,
-        elements,
-        offset,
-        count,
-        output,
-        outputSize,
-        [](auto value, auto* out, bool descending) {
-          encodeSigned<int64_t>(value, out, descending);
-        },
-        decodedVectors);
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    return encodeFixedScalarArrayElements<int128_t>(
-        column,
-        elements,
-        offset,
-        count,
-        output,
-        outputSize,
-        [](auto value, auto* out, bool descending) {
-          encodeSigned<int64_t>(
-              static_cast<int64_t>(HugeInt::upper(value)), out, descending);
-          encodeUnsigned<uint64_t>(
-              HugeInt::lower(value), out + sizeof(int64_t), descending);
-        },
-        decodedVectors);
-  }
-
-#define BOLT_ENCODE_ARRAY_FIXED_SCALAR(kind, cppType, expression)      \
-  case TypeKind::kind:                                                 \
-    return encodeFixedScalarArrayElements<cppType>(                    \
-        column,                                                        \
-        elements,                                                      \
-        offset,                                                        \
-        count,                                                         \
-        output,                                                        \
-        outputSize,                                                    \
-        [](cppType value, char* out, bool descending) { expression; }, \
-        decodedVectors)
-
-  switch (column.type->kind()) {
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        BOOLEAN, bool, const auto byte = static_cast<uint8_t>(value);
-        out[0] =
-            static_cast<char>(descending ? static_cast<uint8_t>(~byte) : byte));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        TINYINT, int8_t, encodeSigned<int8_t>(value, out, descending));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        SMALLINT, int16_t, encodeSigned<int16_t>(value, out, descending));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        INTEGER, int32_t, encodeSigned<int32_t>(value, out, descending));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        BIGINT, int64_t, encodeSigned<int64_t>(value, out, descending));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        REAL,
-        float,
-        encodeUnsigned<uint32_t>(encodeFloat(value), out, descending));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        DOUBLE,
-        double,
-        encodeUnsigned<uint64_t>(encodeDouble(value), out, descending));
-    BOLT_ENCODE_ARRAY_FIXED_SCALAR(
-        TIMESTAMP,
-        Timestamp,
-        encodeSigned<int64_t>(value.getSeconds(), out, descending);
-        encodeUnsigned<uint64_t>(
-            value.getNanos(), out + sizeof(int64_t), descending));
-    default:
-      BOLT_FAIL(
-          "Radix sort fixed array element encoding is not implemented for {}",
-          column.type->toString());
-  }
-#undef BOLT_ENCODE_ARRAY_FIXED_SCALAR
+  return BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      encodeFixedScalarArrayElementsByKind,
+      column.type->kind(),
+      column,
+      elements,
+      offset,
+      count,
+      output,
+      decodedVectors);
 }
 
 class MapKeyIndexScratch {
@@ -1468,12 +1252,39 @@ class MapKeyIndexScratch {
   size_t depth_{0};
 };
 
+template <TypeKind KIND>
+void encodeScalarValue(
+    const BaseVector& vector,
+    vector_size_t row,
+    char* output,
+    bool descending,
+    uint64_t& written) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT ||
+      KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE ||
+      KIND == TypeKind::TIMESTAMP) {
+    encodeBytesFixedScalarValue<KIND>(
+        scalarValueAt<T>(vector, row), output, descending);
+    written = 1 + sizeof(T);
+  } else if constexpr (
+      KIND == TypeKind::VARCHAR || KIND == TypeKind::VARBINARY) {
+    written = 1 +
+        encodeStringValue(valueAt<StringView>(vector, row), output, descending);
+  } else {
+    BOLT_FAIL(
+        "Radix sort key encoding is not implemented for {}",
+        TypeTraits<KIND>::name);
+  }
+}
+
 void encodeValue(
     const RadixSortKeyColumn& column,
     const BaseVector& vector,
     vector_size_t row,
     char* output,
-    uint64_t /*outputSize*/,
     uint64_t& written,
     MapKeyIndexScratch& mapIndices,
     DecodedKeyVectors& decodedVectors) {
@@ -1501,7 +1312,6 @@ void encodeValue(
           *rowVector->childAt(child),
           wrappedRow,
           output + offset,
-          0,
           childWritten,
           mapIndices,
           decodedVectors);
@@ -1519,13 +1329,7 @@ void encodeValue(
     const auto& elements = *arrayVector->elements();
     if (isFixedScalarColumn(child)) {
       const auto childWritten = encodeFixedScalarArrayElements(
-          child,
-          elements,
-          arrayOffset,
-          count,
-          output + offset,
-          0,
-          decodedVectors);
+          child, elements, arrayOffset, count, output + offset, decodedVectors);
       addWritten(offset, childWritten);
     } else {
       for (vector_size_t index = 0; index < count; ++index) {
@@ -1535,7 +1339,6 @@ void encodeValue(
             elements,
             arrayOffset + index,
             output + offset,
-            0,
             childWritten,
             mapIndices,
             decodedVectors);
@@ -1570,7 +1373,6 @@ void encodeValue(
                 *mapVector->mapKeys(),
                 indexAt(entry),
                 output + offset,
-                0,
                 childWritten,
                 mapIndices,
                 decodedVectors);
@@ -1584,7 +1386,6 @@ void encodeValue(
                 *mapVector->mapValues(),
                 indexAt(entry),
                 output + offset,
-                0,
                 childWritten,
                 mapIndices,
                 decodedVectors);
@@ -1594,78 +1395,22 @@ void encodeValue(
         });
     written = offset;
     return;
-  } else if (column.type->kind() == TypeKind::BIGINT) {
-    encodeSigned<int64_t>(
-        scalarValueAt<int64_t>(vector, row), body, descending);
-    written = 1 + sizeof(int64_t);
+  } else if (
+      column.type->isPrimitiveType() &&
+      column.type->kind() != TypeKind::UNKNOWN) {
+    BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        encodeScalarValue,
+        column.type->kind(),
+        vector,
+        row,
+        body,
+        descending,
+        written);
     return;
-  } else if (column.type->kind() == TypeKind::HUGEINT) {
-    const auto value = scalarValueAt<int128_t>(vector, row);
-    encodeSigned<int64_t>(
-        static_cast<int64_t>(HugeInt::upper(value)), body, descending);
-    encodeUnsigned<uint64_t>(
-        HugeInt::lower(value), body + sizeof(int64_t), descending);
-    written = 1 + sizeof(int128_t);
-    return;
-  } else {
-    switch (column.type->kind()) {
-      case TypeKind::BOOLEAN: {
-        auto value = static_cast<uint8_t>(scalarValueAt<bool>(vector, row));
-        body[0] = static_cast<char>(
-            descending ? static_cast<uint8_t>(~value) : value);
-        written = 2;
-        return;
-      }
-      case TypeKind::TINYINT:
-        encodeSigned<int8_t>(
-            scalarValueAt<int8_t>(vector, row), body, descending);
-        written = 2;
-        return;
-      case TypeKind::SMALLINT:
-        encodeSigned<int16_t>(
-            scalarValueAt<int16_t>(vector, row), body, descending);
-        written = 1 + sizeof(int16_t);
-        return;
-      case TypeKind::INTEGER:
-        encodeSigned<int32_t>(
-            scalarValueAt<int32_t>(vector, row), body, descending);
-        written = 1 + sizeof(int32_t);
-        return;
-      case TypeKind::BIGINT:
-        encodeSigned<int64_t>(
-            scalarValueAt<int64_t>(vector, row), body, descending);
-        written = 1 + sizeof(int64_t);
-        return;
-      case TypeKind::REAL:
-        encodeUnsigned<uint32_t>(
-            encodeFloat(scalarValueAt<float>(vector, row)), body, descending);
-        written = 1 + sizeof(uint32_t);
-        return;
-      case TypeKind::DOUBLE:
-        encodeUnsigned<uint64_t>(
-            encodeDouble(scalarValueAt<double>(vector, row)), body, descending);
-        written = 1 + sizeof(uint64_t);
-        return;
-      case TypeKind::TIMESTAMP: {
-        const auto value = scalarValueAt<Timestamp>(vector, row);
-        encodeSigned<int64_t>(value.getSeconds(), body, descending);
-        encodeUnsigned<uint64_t>(
-            value.getNanos(), body + sizeof(int64_t), descending);
-        written = 1 + sizeof(int64_t) + sizeof(uint64_t);
-        return;
-      }
-      case TypeKind::VARCHAR:
-      case TypeKind::VARBINARY: {
-        const auto value = valueAt<StringView>(vector, row);
-        written = 1 + encodeStringValue(value, body, descending);
-        return;
-      }
-      default:
-        BOLT_FAIL(
-            "Radix sort key encoding is not implemented for {}",
-            column.type->toString());
-    }
   }
+  BOLT_FAIL(
+      "Radix sort key encoding is not implemented for {}",
+      column.type->toString());
 }
 
 template <typename ValueAt, typename IsNullAt>
@@ -1851,24 +1596,6 @@ void initializeVariableKeySizes(
   }
 }
 
-class ContiguousEncodeOutput {
- public:
-  ContiguousEncodeOutput(char* data, uint64_t* cursors)
-      : data_(data), cursors_(cursors) {}
-
-  char* current(vector_size_t row) const {
-    return data_ + cursors_[row];
-  }
-
-  void advance(vector_size_t row, uint64_t bytes) const {
-    cursors_[row] += bytes;
-  }
-
- private:
-  char* data_;
-  uint64_t* cursors_;
-};
-
 class StridedEncodeOutput {
  public:
   StridedEncodeOutput(char* data, uint32_t stride, uint32_t offset)
@@ -2000,7 +1727,8 @@ void encodeFixedColumn(
     vector_size_t size,
     const Output& output,
     EncodeBody encodeBody,
-    bool fixedWidthNulls) {
+    bool fixedWidthNulls,
+    DecodedKeyVectors* decodedInputs) {
   if (vector.encoding() == VectorEncoding::Simple::FLAT) {
     const auto* flat = vector.asUnchecked<FlatVector<T>>();
     const auto* nulls = flat->rawNulls();
@@ -2076,7 +1804,8 @@ void encodeFixedColumn(
     return;
   }
 
-  DecodedVector decoded(vector);
+  DecodedVector local;
+  auto& decoded = decodeInput(vector, local, decodedInputs);
   const auto* values = decoded.data<T>();
   const auto* indices = decoded.indices();
   const auto* nulls = decoded.nulls();
@@ -2114,6 +1843,45 @@ void encodeFixedColumn(
       fixedWidthNulls);
 }
 
+template <TypeKind KIND, typename Output>
+void encodeFixedColumnByKind(
+    const RadixSortKeyColumn& column,
+    const BaseVector& vector,
+    vector_size_t source,
+    vector_size_t size,
+    const Output& output,
+    DecodedKeyVectors* decodedInputs = nullptr,
+    bool fixedWidthNulls = false) {
+  if constexpr (KIND == TypeKind::UNKNOWN) {
+    for (vector_size_t row = 0; row < size; ++row) {
+      output.current(row)[0] = static_cast<char>(nullMarker(column.flags));
+      output.advance(row, 1);
+    }
+  } else if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT ||
+      KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE ||
+      KIND == TypeKind::TIMESTAMP) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    encodeFixedColumn<T>(
+        column,
+        vector,
+        source,
+        size,
+        output,
+        [](T value, char* output, bool descending) {
+          encodeFixedScalarValue<KIND>(value, output, descending);
+        },
+        fixedWidthNulls,
+        decodedInputs);
+  } else {
+    BOLT_FAIL(
+        "Sort fixed key column is not implemented for {}",
+        column.type->toString());
+  }
+}
+
 template <typename Output>
 void encodeFixedColumn(
     const RadixSortKeyColumn& column,
@@ -2121,90 +1889,14 @@ void encodeFixedColumn(
     vector_size_t source,
     vector_size_t size,
     const Output& output,
+    DecodedKeyVectors* decodedInputs = nullptr,
     bool fixedWidthNulls = false) {
-  if (column.type->kind() == TypeKind::UNKNOWN) {
-    DecodedVector decoded(vector);
-    for (vector_size_t row = 0; row < size; ++row) {
-      output.current(row)[0] = static_cast<char>(nullMarker(column.flags));
-      output.advance(row, 1);
-    }
-    return;
-  }
-  if (column.type->kind() == TypeKind::BIGINT) {
-    encodeFixedColumn<int64_t>(
-        column,
-        vector,
-        source,
-        size,
-        output,
-        [](int64_t value, char* output, bool descending) {
-          encodeSignedWord<int64_t>(value, output, descending);
-        },
-        fixedWidthNulls);
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    encodeFixedColumn<int128_t>(
-        column,
-        vector,
-        source,
-        size,
-        output,
-        [](int128_t value, char* output, bool descending) {
-          encodeSignedWord<int64_t>(
-              static_cast<int64_t>(HugeInt::upper(value)), output, descending);
-          encodeUnsignedWord<uint64_t>(
-              HugeInt::lower(value), output + sizeof(int64_t), descending);
-        },
-        fixedWidthNulls);
-    return;
-  }
-
-#define BOLT_ENCODE_COLUMN(kind, cppType, expression)                     \
-  case TypeKind::kind:                                                    \
-    encodeFixedColumn<cppType>(                                           \
-        column,                                                           \
-        vector,                                                           \
-        source,                                                           \
-        size,                                                             \
-        output,                                                           \
-        [](cppType value, char* output, bool descending) { expression; }, \
-        fixedWidthNulls);                                                 \
-    return;
-
-  switch (column.type->kind()) {
-    BOLT_ENCODE_COLUMN(
-        BOOLEAN, bool, const auto byte = static_cast<uint8_t>(value);
-        output[0] =
-            static_cast<char>(descending ? static_cast<uint8_t>(~byte) : byte))
-    BOLT_ENCODE_COLUMN(
-        TINYINT, int8_t, encodeSignedWord<int8_t>(value, output, descending))
-    BOLT_ENCODE_COLUMN(
-        SMALLINT, int16_t, encodeSignedWord<int16_t>(value, output, descending))
-    BOLT_ENCODE_COLUMN(
-        INTEGER, int32_t, encodeSignedWord<int32_t>(value, output, descending))
-    BOLT_ENCODE_COLUMN(
-        BIGINT, int64_t, encodeSignedWord<int64_t>(value, output, descending))
-    BOLT_ENCODE_COLUMN(
-        REAL,
-        float,
-        encodeUnsignedWord<uint32_t>(encodeFloat(value), output, descending))
-    BOLT_ENCODE_COLUMN(
-        DOUBLE,
-        double,
-        encodeUnsignedWord<uint64_t>(encodeDouble(value), output, descending))
-    BOLT_ENCODE_COLUMN(
-        TIMESTAMP,
-        Timestamp,
-        encodeSignedWord<int64_t>(value.getSeconds(), output, descending);
-        encodeUnsignedWord<uint64_t>(
-            value.getNanos(), output + sizeof(int64_t), descending))
-    default:
-      BOLT_FAIL(
-          "Sort fixed key column is not implemented for {}",
-          column.type->toString());
-  }
-#undef BOLT_ENCODE_COLUMN
+  const auto dispatch = [&]<TypeKind KIND>() {
+    encodeFixedColumnByKind<KIND>(
+        column, vector, source, size, output, decodedInputs, fixedWidthNulls);
+  };
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      dispatch.template operator(), column.type->kind());
 }
 
 template <typename Output, typename ValueAt, typename IsNullAt>
@@ -2237,7 +1929,8 @@ void encodeStringColumn(
     const BaseVector& vector,
     vector_size_t source,
     vector_size_t size,
-    const Output& output) {
+    const Output& output,
+    DecodedKeyVectors* decodedInputs) {
   if (vector.encoding() == VectorEncoding::Simple::FLAT) {
     const auto* flat = vector.asUnchecked<FlatVector<StringView>>();
     const auto* values = flat->rawValues();
@@ -2267,7 +1960,8 @@ void encodeStringColumn(
     return;
   }
 
-  DecodedVector decoded(vector);
+  DecodedVector local;
+  auto& decoded = decodeInput(vector, local, decodedInputs);
   const auto* values = decoded.data<StringView>();
   const auto* indices = decoded.indices();
   const auto* nulls = decoded.nulls();
@@ -2289,20 +1983,25 @@ void encodeVariableColumn(
     vector_size_t source,
     vector_size_t size,
     const Output& output,
+    DecodedKeyVectors* decodedInputs = nullptr,
     bool fixedWidthNulls = false) {
   if (column.type->kind() == TypeKind::VARCHAR ||
       column.type->kind() == TypeKind::VARBINARY) {
-    encodeStringColumn(column, vector, source, size, output);
+    encodeStringColumn(column, vector, source, size, output, decodedInputs);
     return;
   }
   if (fixedBodySize(*column.type).has_value()) {
-    encodeFixedColumn(column, vector, source, size, output, fixedWidthNulls);
+    encodeFixedColumn(
+        column, vector, source, size, output, decodedInputs, fixedWidthNulls);
     return;
   }
 
-  DecodedVector decoded(vector);
+  DecodedVector local;
+  auto& decoded = decodeInput(vector, local, decodedInputs);
   MapKeyIndexScratch mapIndices;
-  DecodedKeyVectors decodedVectors;
+  DecodedKeyVectors localDecodedInputs;
+  auto& decodedVectors =
+      decodedInputs == nullptr ? localDecodedInputs : *decodedInputs;
   for (vector_size_t row = 0; row < size; ++row) {
     const auto inputRow = source + row;
     auto* destination = output.current(row);
@@ -2317,7 +2016,6 @@ void encodeVariableColumn(
         *decoded.base(),
         decoded.index(inputRow),
         destination,
-        0,
         written,
         mapIndices,
         decodedVectors);
@@ -2335,6 +2033,7 @@ void encodeAndAppendInlineLayout(
   using Traits = RadixSortKeyTraits<KIND>;
   static_assert(!Traits::kVariable);
 
+  DecodedKeyVectors decodedInputs;
   storage.appendKeyBlocks(
       input.size(),
       [&](vector_size_t source, vector_size_t count, char* records) {
@@ -2345,7 +2044,12 @@ void encodeAndAppendInlineLayout(
             records, Traits::kWidth, cursors.data());
         for (uint32_t column = 0; column < columns.size(); ++column) {
           encodeVariableColumn(
-              columns[column], *input.childAt(column), source, count, output);
+              columns[column],
+              *input.childAt(column),
+              source,
+              count,
+              output,
+              &decodedInputs);
         }
 
         for (vector_size_t row = 0; row < count; ++row) {
@@ -2478,7 +2182,7 @@ uint8_t physicalEncodedByte(
 }
 
 template <bool HostOrderWords, typename T>
-T decodePhysicalUnsigned(
+FOLLY_ALWAYS_INLINE T decodePhysicalUnsigned(
     const char* key,
     bool descending,
     uint32_t offset,
@@ -2527,7 +2231,7 @@ T decodePhysicalUnsigned(
 }
 
 template <bool HostOrderWords, typename T>
-T decodePhysicalSigned(
+FOLLY_ALWAYS_INLINE T decodePhysicalSigned(
     const char* key,
     bool descending,
     uint32_t offset,
@@ -2802,6 +2506,107 @@ void decodeSinglePhysicalBooleanColumn(
   }
 }
 
+template <bool HostOrderWords, TypeKind KIND, typename Source, typename... Args>
+void decodeSinglePhysicalColumnByKind(
+    const RadixSortKeyColumn& column,
+    const Source& source,
+    bool mayHaveNulls,
+    const VectorPtr& result,
+    uint32_t encodedOffset,
+    uint32_t inlineWordBytes,
+    Args... args) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  using SourceType = std::remove_cv_t<std::remove_reference_t<Source>>;
+  constexpr bool kPointerSpan =
+      std::is_same_v<SourceType, std::span<const char* const>>;
+  const auto decode = [&](auto decodeValue) {
+    if constexpr (kPointerSpan) {
+      decodeSinglePhysicalColumn<HostOrderWords, T>(
+          column,
+          source,
+          mayHaveNulls,
+          result,
+          encodedOffset,
+          inlineWordBytes,
+          args...,
+          decodeValue);
+    } else {
+      decodeSinglePhysicalColumn<HostOrderWords, T>(
+          column,
+          source,
+          args...,
+          mayHaveNulls,
+          result,
+          encodedOffset,
+          inlineWordBytes,
+          decodeValue);
+    }
+  };
+  if constexpr (KIND == TypeKind::BOOLEAN) {
+    if constexpr (kPointerSpan) {
+      decodeSinglePhysicalBooleanColumn<HostOrderWords>(
+          column,
+          source,
+          mayHaveNulls,
+          result,
+          encodedOffset,
+          inlineWordBytes,
+          args...);
+    } else {
+      decodeSinglePhysicalBooleanColumn<HostOrderWords>(
+          column,
+          source,
+          args...,
+          mayHaveNulls,
+          result,
+          encodedOffset,
+          inlineWordBytes);
+    }
+  } else if constexpr (
+      KIND == TypeKind::TINYINT || KIND == TypeKind::SMALLINT ||
+      KIND == TypeKind::INTEGER || KIND == TypeKind::BIGINT) {
+    decode(
+        [](const char* key, bool descending, uint32_t offset, uint32_t words) {
+          return decodePhysicalSigned<HostOrderWords, T>(
+              key, descending, offset, words);
+        });
+  } else if constexpr (KIND == TypeKind::HUGEINT) {
+    decode(
+        [](const char* key, bool descending, uint32_t offset, uint32_t words) {
+          const auto upper = decodePhysicalSigned<HostOrderWords, int64_t>(
+              key, descending, offset, words);
+          const auto lower = decodePhysicalUnsigned<HostOrderWords, uint64_t>(
+              key, descending, offset + sizeof(int64_t), words);
+          return HugeInt::build(static_cast<uint64_t>(upper), lower);
+        });
+  } else if constexpr (KIND == TypeKind::REAL) {
+    decode(
+        [](const char* key, bool descending, uint32_t offset, uint32_t words) {
+          return decodeFloat(decodePhysicalUnsigned<HostOrderWords, uint32_t>(
+              key, descending, offset, words));
+        });
+  } else if constexpr (KIND == TypeKind::DOUBLE) {
+    decode(
+        [](const char* key, bool descending, uint32_t offset, uint32_t words) {
+          return decodeDouble(decodePhysicalUnsigned<HostOrderWords, uint64_t>(
+              key, descending, offset, words));
+        });
+  } else if constexpr (KIND == TypeKind::TIMESTAMP) {
+    decode(
+        [](const char* key, bool descending, uint32_t offset, uint32_t words) {
+          return Timestamp(
+              decodePhysicalSigned<HostOrderWords, int64_t>(
+                  key, descending, offset, words),
+              decodePhysicalUnsigned<HostOrderWords, uint64_t>(
+                  key, descending, offset + sizeof(int64_t), words));
+        });
+  } else {
+    BOLT_FAIL(
+        "Single fixed radix sort key decode is not implemented for {}",
+        column.type->toString());
+  }
+}
+
 template <bool HostOrderWords>
 void decodeSinglePhysicalColumn(
     const RadixSortKeyColumn& column,
@@ -2812,8 +2617,8 @@ void decodeSinglePhysicalColumn(
     uint32_t encodedOffset = 0,
     vector_size_t outputOffset = 0,
     bool offsetWrite = false) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    decodeSinglePhysicalColumn<HostOrderWords, int64_t>(
+  const auto dispatch = [&]<TypeKind KIND>() {
+    decodeSinglePhysicalColumnByKind<HostOrderWords, KIND>(
         column,
         keys,
         mayHaveNulls,
@@ -2821,165 +2626,10 @@ void decodeSinglePhysicalColumn(
         encodedOffset,
         inlineWordBytes,
         outputOffset,
-        offsetWrite,
-        [](const char* key,
-           bool descending,
-           uint32_t bodyOffset,
-           uint32_t wordBytes) {
-          return decodePhysicalSigned<HostOrderWords, int64_t>(
-              key, descending, bodyOffset, wordBytes);
-        });
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    decodeSinglePhysicalColumn<HostOrderWords, int128_t>(
-        column,
-        keys,
-        mayHaveNulls,
-        result,
-        encodedOffset,
-        inlineWordBytes,
-        outputOffset,
-        offsetWrite,
-        [](const char* key,
-           bool descending,
-           uint32_t bodyOffset,
-           uint32_t wordBytes) {
-          const auto upper = decodePhysicalSigned<HostOrderWords, int64_t>(
-              key, descending, bodyOffset, wordBytes);
-          const auto lower = decodePhysicalUnsigned<HostOrderWords, uint64_t>(
-              key, descending, bodyOffset + sizeof(int64_t), wordBytes);
-          return HugeInt::build(static_cast<uint64_t>(upper), lower);
-        });
-    return;
-  }
-
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN:
-      decodeSinglePhysicalBooleanColumn<HostOrderWords>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite);
-      return;
-    case TypeKind::TINYINT:
-      decodeSinglePhysicalColumn<HostOrderWords, int8_t>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int8_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::SMALLINT:
-      decodeSinglePhysicalColumn<HostOrderWords, int16_t>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int16_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::INTEGER:
-      decodeSinglePhysicalColumn<HostOrderWords, int32_t>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int32_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::BIGINT:
-      decodeSinglePhysicalColumn<HostOrderWords, int64_t>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int64_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::REAL:
-      decodeSinglePhysicalColumn<HostOrderWords, float>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodeFloat(decodePhysicalUnsigned<HostOrderWords, uint32_t>(
-                key, desc, offset, wordBytes));
-          });
-      return;
-    case TypeKind::DOUBLE:
-      decodeSinglePhysicalColumn<HostOrderWords, double>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodeDouble(
-                decodePhysicalUnsigned<HostOrderWords, uint64_t>(
-                    key, desc, offset, wordBytes));
-          });
-      return;
-    case TypeKind::TIMESTAMP:
-      decodeSinglePhysicalColumn<HostOrderWords, Timestamp>(
-          column,
-          keys,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          outputOffset,
-          offsetWrite,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return Timestamp(
-                decodePhysicalSigned<HostOrderWords, int64_t>(
-                    key, desc, offset, wordBytes),
-                decodePhysicalUnsigned<HostOrderWords, uint64_t>(
-                    key, desc, offset + sizeof(int64_t), wordBytes));
-          });
-      return;
-    default:
-      BOLT_FAIL(
-          "Single fixed radix sort key decode is not implemented for {}",
-          column.type->toString());
-  }
+        offsetWrite);
+  };
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      dispatch.template operator(), column.type->kind());
 }
 
 template <bool HostOrderWords>
@@ -2992,174 +2642,19 @@ void decodeSinglePhysicalColumn(
     const VectorPtr& result,
     uint32_t inlineWordBytes,
     uint32_t encodedOffset = 0) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    decodeSinglePhysicalColumn<HostOrderWords, int64_t>(
+  const auto dispatch = [&]<TypeKind KIND>() {
+    decodeSinglePhysicalColumnByKind<HostOrderWords, KIND>(
         column,
         arena,
-        begin,
-        count,
         mayHaveNulls,
         result,
         encodedOffset,
         inlineWordBytes,
-        [](const char* key,
-           bool descending,
-           uint32_t bodyOffset,
-           uint32_t wordBytes) {
-          return decodePhysicalSigned<HostOrderWords, int64_t>(
-              key, descending, bodyOffset, wordBytes);
-        });
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    decodeSinglePhysicalColumn<HostOrderWords, int128_t>(
-        column,
-        arena,
         begin,
-        count,
-        mayHaveNulls,
-        result,
-        encodedOffset,
-        inlineWordBytes,
-        [](const char* key,
-           bool descending,
-           uint32_t bodyOffset,
-           uint32_t wordBytes) {
-          const auto upper = decodePhysicalSigned<HostOrderWords, int64_t>(
-              key, descending, bodyOffset, wordBytes);
-          const auto lower = decodePhysicalUnsigned<HostOrderWords, uint64_t>(
-              key, descending, bodyOffset + sizeof(int64_t), wordBytes);
-          return HugeInt::build(static_cast<uint64_t>(upper), lower);
-        });
-    return;
-  }
-
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN:
-      decodeSinglePhysicalBooleanColumn<HostOrderWords>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes);
-      return;
-    case TypeKind::TINYINT:
-      decodeSinglePhysicalColumn<HostOrderWords, int8_t>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int8_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::SMALLINT:
-      decodeSinglePhysicalColumn<HostOrderWords, int16_t>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int16_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::INTEGER:
-      decodeSinglePhysicalColumn<HostOrderWords, int32_t>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int32_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::BIGINT:
-      decodeSinglePhysicalColumn<HostOrderWords, int64_t>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodePhysicalSigned<HostOrderWords, int64_t>(
-                key, desc, offset, wordBytes);
-          });
-      return;
-    case TypeKind::REAL:
-      decodeSinglePhysicalColumn<HostOrderWords, float>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodeFloat(decodePhysicalUnsigned<HostOrderWords, uint32_t>(
-                key, desc, offset, wordBytes));
-          });
-      return;
-    case TypeKind::DOUBLE:
-      decodeSinglePhysicalColumn<HostOrderWords, double>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return decodeDouble(
-                decodePhysicalUnsigned<HostOrderWords, uint64_t>(
-                    key, desc, offset, wordBytes));
-          });
-      return;
-    case TypeKind::TIMESTAMP:
-      decodeSinglePhysicalColumn<HostOrderWords, Timestamp>(
-          column,
-          arena,
-          begin,
-          count,
-          mayHaveNulls,
-          result,
-          encodedOffset,
-          inlineWordBytes,
-          [](const char* key, bool desc, uint32_t offset, uint32_t wordBytes) {
-            return Timestamp(
-                decodePhysicalSigned<HostOrderWords, int64_t>(
-                    key, desc, offset, wordBytes),
-                decodePhysicalUnsigned<HostOrderWords, uint64_t>(
-                    key, desc, offset + sizeof(int64_t), wordBytes));
-          });
-      return;
-    default:
-      BOLT_FAIL(
-          "Single fixed radix sort key decode is not implemented for {}",
-          column.type->toString());
-  }
+        count);
+  };
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      dispatch.template operator(), column.type->kind());
 }
 
 template <typename DecodeColumn>
@@ -3268,6 +2763,47 @@ void decodeString(
       row, StringView(output, static_cast<int32_t>(decodedSize)));
 }
 
+template <TypeKind KIND>
+FOLLY_ALWAYS_INLINE typename TypeTraits<KIND>::NativeType
+decodeFixedScalarValue(EncodedKeyReader& input, bool descending) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  if constexpr (KIND == TypeKind::BOOLEAN) {
+    uint8_t value;
+    input.readBodyByte(descending, value);
+    return value != 0;
+  } else if constexpr (
+      KIND == TypeKind::TINYINT || KIND == TypeKind::SMALLINT ||
+      KIND == TypeKind::INTEGER || KIND == TypeKind::BIGINT) {
+    T value;
+    decodeSigned(input, descending, value);
+    return value;
+  } else if constexpr (KIND == TypeKind::HUGEINT) {
+    int64_t upper;
+    uint64_t lower;
+    decodeSigned(input, descending, upper);
+    decodeUnsigned(input, descending, lower);
+    return HugeInt::build(static_cast<uint64_t>(upper), lower);
+  } else if constexpr (KIND == TypeKind::REAL) {
+    uint32_t value;
+    decodeUnsigned(input, descending, value);
+    return decodeFloat(value);
+  } else if constexpr (KIND == TypeKind::DOUBLE) {
+    uint64_t value;
+    decodeUnsigned(input, descending, value);
+    return decodeDouble(value);
+  } else if constexpr (KIND == TypeKind::TIMESTAMP) {
+    int64_t seconds;
+    uint64_t nanos;
+    decodeSigned(input, descending, seconds);
+    decodeUnsigned(input, descending, nanos);
+    return Timestamp(seconds, nanos);
+  } else {
+    BOLT_FAIL(
+        "Fixed radix sort key decoding is not implemented for {}",
+        TypeTraits<KIND>::name);
+  }
+}
+
 template <typename T, typename Decode>
 void decodeFixedScalarArrayElements(
     const RadixSortKeyColumn& column,
@@ -3309,105 +2845,64 @@ void decodeFixedScalarArrayElements(
   reader.checkedReadByte(delimiter);
 }
 
+template <TypeKind KIND>
+void decodeFixedScalarArrayElementsByKind(
+    const RadixSortKeyColumn& column,
+    EncodedKeyReader& reader,
+    const VectorPtr& result,
+    vector_size_t start) {
+  if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT ||
+      KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE ||
+      KIND == TypeKind::TIMESTAMP) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    decodeFixedScalarArrayElements<T>(
+        column, reader, result, start, decodeFixedScalarValue<KIND>);
+  } else {
+    BOLT_FAIL(
+        "Radix sort fixed array element decoding is not implemented for {}",
+        column.type->toString());
+  }
+}
+
 void decodeFixedScalarArrayElements(
     const RadixSortKeyColumn& column,
     EncodedKeyReader& reader,
     const VectorPtr& result,
     vector_size_t start) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    decodeFixedScalarArrayElements<int64_t>(
-        column, reader, result, start, [](auto& input, bool descending) {
-          int64_t value;
-          decodeSigned(input, descending, value);
-          return value;
-        });
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    decodeFixedScalarArrayElements<int128_t>(
-        column, reader, result, start, [](auto& input, bool descending) {
-          int64_t upper;
-          uint64_t lower;
-          decodeSigned(input, descending, upper);
-          decodeUnsigned(input, descending, lower);
-          return HugeInt::build(static_cast<uint64_t>(upper), lower);
-        });
-    return;
-  }
+  BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      decodeFixedScalarArrayElementsByKind,
+      column.type->kind(),
+      column,
+      reader,
+      result,
+      start);
+}
 
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN:
-      decodeFixedScalarArrayElements<bool>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            uint8_t value;
-            input.readBodyByte(descending, value);
-            return value != 0;
-          });
-      return;
-    case TypeKind::TINYINT:
-      decodeFixedScalarArrayElements<int8_t>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            int8_t value;
-            decodeSigned(input, descending, value);
-            return value;
-          });
-      return;
-    case TypeKind::SMALLINT:
-      decodeFixedScalarArrayElements<int16_t>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            int16_t value;
-            decodeSigned(input, descending, value);
-            return value;
-          });
-      return;
-    case TypeKind::INTEGER:
-      decodeFixedScalarArrayElements<int32_t>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            int32_t value;
-            decodeSigned(input, descending, value);
-            return value;
-          });
-      return;
-    case TypeKind::BIGINT:
-      decodeFixedScalarArrayElements<int64_t>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            int64_t value;
-            decodeSigned(input, descending, value);
-            return value;
-          });
-      return;
-    case TypeKind::REAL:
-      decodeFixedScalarArrayElements<float>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            uint32_t value;
-            decodeUnsigned(input, descending, value);
-            const auto decoded = decodeFloat(value);
-            return decoded;
-          });
-      return;
-    case TypeKind::DOUBLE:
-      decodeFixedScalarArrayElements<double>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            uint64_t value;
-            decodeUnsigned(input, descending, value);
-            const auto decoded = decodeDouble(value);
-            return decoded;
-          });
-      return;
-    case TypeKind::TIMESTAMP:
-      decodeFixedScalarArrayElements<Timestamp>(
-          column, reader, result, start, [](auto& input, bool descending) {
-            int64_t seconds;
-            uint64_t nanos;
-            decodeSigned(input, descending, seconds);
-            decodeUnsigned(input, descending, nanos);
-            return Timestamp(seconds, nanos);
-          });
-      return;
-    default:
-      BOLT_FAIL(
-          "Radix sort fixed array element decoding is not implemented for {}",
-          column.type->toString());
+template <TypeKind KIND>
+void decodeScalarValue(
+    EncodedKeyReader& reader,
+    bool descending,
+    const VectorPtr& result,
+    vector_size_t row,
+    vector_size_t endRow) {
+  if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT ||
+      KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE ||
+      KIND == TypeKind::TIMESTAMP) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    setValue<T>(result, row, decodeFixedScalarValue<KIND>(reader, descending));
+  } else if constexpr (
+      KIND == TypeKind::VARCHAR || KIND == TypeKind::VARBINARY) {
+    decodeString(reader, descending, result, row, endRow);
+  } else {
+    BOLT_FAIL(
+        "Radix sort key decoding is not implemented for {}",
+        TypeTraits<KIND>::name);
   }
 }
 
@@ -3519,84 +3014,21 @@ void decodeValue(
     mapResult->setOffsetAndSize(row, start, count);
     return;
   }
-  if (column.type->kind() == TypeKind::BIGINT) {
-    int64_t value;
-    decodeSigned(reader, descending, value);
-    setValue<int64_t>(result, row, value);
+  if (column.type->isPrimitiveType() &&
+      column.type->kind() != TypeKind::UNKNOWN) {
+    BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        decodeScalarValue,
+        column.type->kind(),
+        reader,
+        descending,
+        result,
+        row,
+        endRow);
     return;
   }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    int64_t upper;
-    uint64_t lower;
-    decodeSigned(reader, descending, upper);
-    decodeUnsigned(reader, descending, lower);
-    setValue<int128_t>(
-        result, row, HugeInt::build(static_cast<uint64_t>(upper), lower));
-    return;
-  }
-
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN: {
-      uint8_t value;
-      reader.readBodyByte(descending, value);
-      setValue<bool>(result, row, value != 0);
-      return;
-    }
-    case TypeKind::TINYINT: {
-      int8_t value;
-      decodeSigned(reader, descending, value);
-      setValue<int8_t>(result, row, value);
-      return;
-    }
-    case TypeKind::SMALLINT: {
-      int16_t value;
-      decodeSigned(reader, descending, value);
-      setValue<int16_t>(result, row, value);
-      return;
-    }
-    case TypeKind::INTEGER: {
-      int32_t value;
-      decodeSigned(reader, descending, value);
-      setValue<int32_t>(result, row, value);
-      return;
-    }
-    case TypeKind::BIGINT: {
-      int64_t value;
-      decodeSigned(reader, descending, value);
-      setValue<int64_t>(result, row, value);
-      return;
-    }
-    case TypeKind::REAL: {
-      uint32_t value;
-      decodeUnsigned(reader, descending, value);
-      const auto decoded = decodeFloat(value);
-      setValue<float>(result, row, decoded);
-      return;
-    }
-    case TypeKind::DOUBLE: {
-      uint64_t value;
-      decodeUnsigned(reader, descending, value);
-      const auto decoded = decodeDouble(value);
-      setValue<double>(result, row, decoded);
-      return;
-    }
-    case TypeKind::TIMESTAMP: {
-      int64_t seconds;
-      uint64_t nanos;
-      decodeSigned(reader, descending, seconds);
-      decodeUnsigned(reader, descending, nanos);
-      setValue<Timestamp>(result, row, Timestamp(seconds, nanos));
-      return;
-    }
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY:
-      decodeString(reader, descending, result, row, endRow);
-      return;
-    default:
-      BOLT_FAIL(
-          "Radix sort key decoding is not implemented for {}",
-          column.type->toString());
-  }
+  BOLT_FAIL(
+      "Radix sort key decoding is not implemented for {}",
+      column.type->toString());
 }
 
 void prepareDecodedResult(
@@ -3608,8 +3040,7 @@ void prepareDecodedResult(
     std::span<const uint8_t> mayHaveNulls,
     RowVectorPtr& result) {
   const auto shouldDecode = [&](uint32_t column) {
-    return decodedColumns.empty() || decodedColumns[column] != 0 ||
-        !fixedBodySize(*columns[column].type).has_value();
+    return decodedColumns.empty() || decodedColumns[column] != 0;
   };
   if (result != nullptr && result->pool() == pool &&
       result->type()->equivalent(*rowType)) {
@@ -3708,11 +3139,6 @@ void bindPreparedDecodeScratch(
   scratch.cursors = scratch.words;
 }
 
-bool isLayeredFixedColumn(const RadixSortKeyColumn& column) {
-  return column.type->kind() != TypeKind::UNKNOWN &&
-      fixedBodySize(*column.type).has_value();
-}
-
 bool isStringColumn(const RadixSortKeyColumn& column) {
   return column.type->kind() == TypeKind::VARCHAR ||
       column.type->kind() == TypeKind::VARBINARY;
@@ -3723,21 +3149,18 @@ uint64_t calculateDecodeScratchWordsPerRow(
     std::span<const uint8_t> decodedColumns,
     std::span<const uint8_t> mayHaveNulls,
     uint32_t firstColumn,
-    uint32_t endColumn,
-    bool skipMaskedVariableColumns) {
+    uint32_t endColumn) {
   BOLT_DCHECK_LT(firstColumn, endColumn);
   BOLT_DCHECK_LE(endColumn, columns.size());
   uint64_t extraBlocks = 0;
   for (uint32_t column = firstColumn; column < endColumn; ++column) {
     const bool masked = !decodedColumns.empty() && decodedColumns[column] == 0;
-    if (masked &&
-        (skipMaskedVariableColumns ||
-         fixedBodySize(*columns[column].type).has_value())) {
+    if (masked) {
       continue;
     }
     const bool columnMayHaveNulls =
         mayHaveNulls.empty() || mayHaveNulls[column] != 0;
-    if (isLayeredFixedColumn(columns[column])) {
+    if (isFixedScalarColumn(columns[column])) {
       const auto bodyWords = (*fixedBodySize(*columns[column].type) + 7) / 8;
       extraBlocks =
           std::max<uint64_t>(extraBlocks, bodyWords + columnMayHaveNulls);
@@ -3747,20 +3170,6 @@ uint64_t calculateDecodeScratchWordsPerRow(
     }
   }
   return 1 + extraBlocks;
-}
-
-uint64_t decodeScratchWordsPerRow(
-    const std::vector<RadixSortKeyColumn>& columns,
-    std::span<const uint8_t> decodedColumns,
-    std::span<const uint8_t> mayHaveNulls,
-    uint32_t firstColumn) {
-  return calculateDecodeScratchWordsPerRow(
-      columns,
-      decodedColumns,
-      mayHaveNulls,
-      firstColumn,
-      columns.size(),
-      false);
 }
 
 FOLLY_ALWAYS_INLINE void readMarker(
@@ -4549,6 +3958,77 @@ void decodeStringColumnLayered(
   });
 }
 
+template <TypeKind KIND, bool FirstColumn, bool MayHaveNulls>
+void decodeScalarColumnLayered(
+    const RadixSortKeyColumn& column,
+    std::span<const EncodedKeyView> keys,
+    DecodeScratch& scratch,
+    const VectorPtr& result,
+    vector_size_t outputOffset) {
+  if constexpr (KIND == TypeKind::BOOLEAN) {
+    decodeBooleanLayered<FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (
+      KIND == TypeKind::TINYINT || KIND == TypeKind::SMALLINT ||
+      KIND == TypeKind::INTEGER || KIND == TypeKind::BIGINT) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    decodeSignedFixedLayered<FirstColumn, MayHaveNulls, T>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (KIND == TypeKind::HUGEINT) {
+    decodeInt128Layered<FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (KIND == TypeKind::REAL) {
+    decodeFloatLayered<FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (KIND == TypeKind::DOUBLE) {
+    decodeDoubleLayered<FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (KIND == TypeKind::TIMESTAMP) {
+    decodeTimestampLayered<FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else {
+    BOLT_FAIL(
+        "Layered radix sort key decoding is not implemented for {}",
+        column.type->toString());
+  }
+}
+
+template <TypeKind KIND, bool FirstColumn, bool MayHaveNulls>
+void decodePrimitiveColumnLayered(
+    const RadixSortKeyColumn& column,
+    std::span<const EncodedKeyView> keys,
+    uint64_t* cursors,
+    const VectorPtr& result,
+    DecodeScratch& scratch,
+    vector_size_t outputOffset) {
+  if constexpr (
+      KIND == TypeKind::BOOLEAN || KIND == TypeKind::TINYINT ||
+      KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
+      KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT ||
+      KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE ||
+      KIND == TypeKind::TIMESTAMP) {
+    decodeScalarColumnLayered<KIND, FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (
+      KIND == TypeKind::VARCHAR || KIND == TypeKind::VARBINARY) {
+    decodeStringColumnLayered<FirstColumn, MayHaveNulls>(
+        column, keys, scratch, result, outputOffset);
+  } else if constexpr (KIND == TypeKind::UNKNOWN) {
+    const auto null = nullMarker(column.flags);
+    for (vector_size_t row = 0; row < keys.size(); ++row) {
+      auto cursor = FirstColumn ? uint64_t{0} : cursors[row];
+      bool isNull;
+      readMarker(keys[row], cursor, null, isNull);
+      cursors[row] = cursor;
+      result->setNull(outputOffset + row, true);
+    }
+  } else {
+    BOLT_FAIL(
+        "Layered radix sort key decoding is not implemented for {}",
+        column.type->toString());
+  }
+}
+
 template <bool FirstColumn, bool MayHaveNulls>
 void decodeColumn(
     const RadixSortKeyColumn& column,
@@ -4557,77 +4037,23 @@ void decodeColumn(
     const VectorPtr& result,
     DecodeScratch& scratch,
     vector_size_t outputOffset = 0) {
-  if (column.type->kind() == TypeKind::BIGINT) {
-    decodeSignedFixedLayered<FirstColumn, MayHaveNulls, int64_t>(
-        column, keys, scratch, result, outputOffset);
-    return;
-  }
-  if (column.type->kind() == TypeKind::HUGEINT) {
-    decodeInt128Layered<FirstColumn, MayHaveNulls>(
-        column, keys, scratch, result, outputOffset);
+  if (column.type->isPrimitiveType()) {
+    const auto dispatch = [&]<TypeKind KIND>() {
+      decodePrimitiveColumnLayered<KIND, FirstColumn, MayHaveNulls>(
+          column, keys, cursors, result, scratch, outputOffset);
+    };
+    BOLT_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        dispatch.template operator(), column.type->kind());
     return;
   }
 
-  switch (column.type->kind()) {
-    case TypeKind::BOOLEAN:
-      decodeBooleanLayered<FirstColumn, MayHaveNulls>(
-          column, keys, scratch, result, outputOffset);
-      return;
-#define BOLT_DECODE_SIGNED_COLUMN(kind, cppType)                  \
-  case TypeKind::kind:                                            \
-    decodeSignedFixedLayered<FirstColumn, MayHaveNulls, cppType>( \
-        column, keys, scratch, result, outputOffset);             \
-    return
-      BOLT_DECODE_SIGNED_COLUMN(TINYINT, int8_t);
-      BOLT_DECODE_SIGNED_COLUMN(SMALLINT, int16_t);
-      BOLT_DECODE_SIGNED_COLUMN(INTEGER, int32_t);
-    case TypeKind::BIGINT:
-      decodeSignedFixedLayered<FirstColumn, MayHaveNulls, int64_t>(
-          column, keys, scratch, result, outputOffset);
-      return;
-#undef BOLT_DECODE_SIGNED_COLUMN
-    case TypeKind::REAL:
-      decodeFloatLayered<FirstColumn, MayHaveNulls>(
-          column, keys, scratch, result, outputOffset);
-      return;
-    case TypeKind::DOUBLE:
-      decodeDoubleLayered<FirstColumn, MayHaveNulls>(
-          column, keys, scratch, result, outputOffset);
-      return;
-    case TypeKind::TIMESTAMP:
-      decodeTimestampLayered<FirstColumn, MayHaveNulls>(
-          column, keys, scratch, result, outputOffset);
-      return;
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY:
-      decodeStringColumnLayered<FirstColumn, MayHaveNulls>(
-          column, keys, scratch, result, outputOffset);
-      return;
-    case TypeKind::UNKNOWN: {
-      const auto null = nullMarker(column.flags);
-      for (vector_size_t row = 0; row < keys.size(); ++row) {
-        auto cursor = FirstColumn ? uint64_t{0} : cursors[row];
-        bool isNull;
-        readMarker(keys[row], cursor, null, isNull);
-        cursors[row] = cursor;
-        result->setNull(outputOffset + row, true);
-      }
-      return;
-    }
-    default:
-      for (vector_size_t row = 0; row < keys.size(); ++row) {
-        auto cursor = FirstColumn ? uint64_t{0} : cursors[row];
-        EncodedKeyReader reader(
-            keys[row].bytes.data() + cursor, keys[row].bytes.size() - cursor);
-        decodeValue(
-            column,
-            reader,
-            result,
-            outputOffset + row,
-            outputOffset + keys.size());
-        cursors[row] = cursor + reader.position();
-      }
-      return;
+  for (vector_size_t row = 0; row < keys.size(); ++row) {
+    auto cursor = FirstColumn ? uint64_t{0} : cursors[row];
+    EncodedKeyReader reader(
+        keys[row].bytes.data() + cursor, keys[row].bytes.size() - cursor);
+    decodeValue(
+        column, reader, result, outputOffset + row, outputOffset + keys.size());
+    cursors[row] = cursor + reader.position();
   }
 }
 
@@ -4653,8 +4079,8 @@ void decodeColumns(
   prepareDecodeScratch(
       static_cast<vector_size_t>(keys.size()),
       pool,
-      decodeScratchWordsPerRow(
-          columns, decodedColumns, mayHaveNulls, firstColumn),
+      calculateDecodeScratchWordsPerRow(
+          columns, decodedColumns, mayHaveNulls, firstColumn, columns.size()),
       cursorScratch,
       scratch);
   auto* cursors = scratch.cursors;
@@ -4677,16 +4103,22 @@ void decodeColumns(
     }
   };
 
-  if (!decodedColumns.empty() && decodedColumns[firstColumn] == 0 &&
-      fixedBodySize(*columns[firstColumn].type).has_value()) {
-    skipFixedColumn<true>(columns[firstColumn], keys, cursors);
+  if (!decodedColumns.empty() && decodedColumns[firstColumn] == 0) {
+    if (fixedBodySize(*columns[firstColumn].type).has_value()) {
+      skipFixedColumn<true>(columns[firstColumn], keys, cursors);
+    } else {
+      skipColumn<true>(columns[firstColumn], keys, cursors);
+    }
   } else {
     decodeFirstColumn(firstColumn);
   }
   for (uint32_t column = firstColumn + 1; column < columns.size(); ++column) {
-    if (!decodedColumns.empty() && decodedColumns[column] == 0 &&
-        fixedBodySize(*columns[column].type).has_value()) {
-      skipFixedColumn<false>(columns[column], keys, cursors);
+    if (!decodedColumns.empty() && decodedColumns[column] == 0) {
+      if (fixedBodySize(*columns[column].type).has_value()) {
+        skipFixedColumn<false>(columns[column], keys, cursors);
+      } else {
+        skipColumn<false>(columns[column], keys, cursors);
+      }
     } else {
       decodeNextColumn(column);
     }
@@ -4741,7 +4173,7 @@ void decodeColumnsWithOffsetImpl(
 
   if (decodedColumns[firstColumn] != 0) {
     decode(firstColumn, true);
-  } else if (isLayeredFixedColumn(columns[firstColumn])) {
+  } else if (isFixedScalarColumn(columns[firstColumn])) {
     skipCheckedFixedColumn<true>(columns[firstColumn], keys, cursors);
   } else {
     skipColumn<true>(columns[firstColumn], keys, cursors);
@@ -4749,45 +4181,12 @@ void decodeColumnsWithOffsetImpl(
   for (uint32_t column = firstColumn + 1; column < endColumn; ++column) {
     if (decodedColumns[column] != 0) {
       decode(column, false);
-    } else if (isLayeredFixedColumn(columns[column])) {
+    } else if (isFixedScalarColumn(columns[column])) {
       skipCheckedFixedColumn<false>(columns[column], keys, cursors);
     } else {
       skipColumn<false>(columns[column], keys, cursors);
     }
   }
-}
-
-void decodeColumnsWithOffset(
-    const std::vector<RadixSortKeyColumn>& columns,
-    std::span<const EncodedKeyView> keys,
-    std::span<const uint8_t> decodedColumns,
-    std::span<const uint8_t> mayHaveNulls,
-    vector_size_t outputOffset,
-    memory::MemoryPool* pool,
-    BufferPtr& cursorScratch,
-    RowVector& output,
-    std::span<const column_index_t> directKeyChannels,
-    uint64_t scratchWordsPerRow,
-    uint32_t firstColumn) {
-  auto bindScratch = [&](DecodeScratch& scratch) {
-    prepareDecodeScratch(
-        static_cast<vector_size_t>(keys.size()),
-        pool,
-        scratchWordsPerRow,
-        cursorScratch,
-        scratch);
-  };
-  decodeColumnsWithOffsetImpl(
-      columns,
-      keys,
-      decodedColumns,
-      mayHaveNulls,
-      outputOffset,
-      output,
-      directKeyChannels,
-      firstColumn,
-      columns.size(),
-      bindScratch);
 }
 
 void decodeColumnsWithOffsetAndPreparedScratch(
@@ -4847,18 +4246,6 @@ std::vector<uint32_t> makeLeadingSkippableValidityOffsets(
 
 } // namespace
 
-uint64_t EncodedKeyBatch::fixedKeyAt(vector_size_t row) const {
-  return fixedKeys_->as<uint64_t>()[row];
-}
-
-std::string_view EncodedKeyBatch::variableKeyAt(vector_size_t row) const {
-  const auto* offsets = offsets_->as<uint64_t>();
-  const auto begin = offsets[row];
-  const auto end = offsets[row + 1];
-  return std::string_view(
-      data_ == nullptr ? nullptr : data_->as<char>() + begin, end - begin);
-}
-
 bool RadixSortKeyCodec::supportsEncodeDecode(const Type& type) {
   return supportsType(type);
 }
@@ -4877,13 +4264,16 @@ void RadixSortKeyCodec::bind(
 
   std::vector<RadixSortKeyColumn> columns;
   columns.reserve(types.size());
-  bool canEncodeDecode = true;
   std::optional<uint64_t> maximumEncodedSize = 0;
   bool maximumEncodedSizeValid = true;
   std::optional<uint64_t> fixedPrefixSize = 0;
   for (uint32_t column = 0; column < types.size(); ++column) {
     RadixSortKeyColumn metadata;
     buildMetadata(types[column], flags[column], metadata);
+    BOLT_CHECK(
+        supportsType(*types[column]),
+        "Radix sort key type is not supported: {}",
+        types[column]->toString());
     if (fixedPrefixSize.has_value() && isFixedScalarColumn(metadata)) {
       metadata.fixedPrefixOffset = static_cast<uint32_t>(*fixedPrefixSize);
       fixedPrefixSize =
@@ -4891,7 +4281,6 @@ void RadixSortKeyCodec::bind(
     } else {
       fixedPrefixSize = std::nullopt;
     }
-    canEncodeDecode &= metadata.encodeDecodeSupported;
     if (maximumEncodedSize.has_value() &&
         metadata.maximumEncodedSize.has_value()) {
       auto total =
@@ -4906,19 +4295,13 @@ void RadixSortKeyCodec::bind(
   BOLT_CHECK(
       maximumEncodedSizeValid, "Radix sort key maximum encoded size overflows");
 
-  const auto format =
-      maximumEncodedSize.has_value() && *maximumEncodedSize <= sizeof(uint64_t)
-      ? EncodedKeyFormat::kFixed64
-      : EncodedKeyFormat::kVariableBinary;
-  codec = std::unique_ptr<RadixSortKeyCodec>(new RadixSortKeyCodec(
-      std::move(columns), format, maximumEncodedSize, canEncodeDecode));
+  codec = std::unique_ptr<RadixSortKeyCodec>(
+      new RadixSortKeyCodec(std::move(columns), maximumEncodedSize));
 }
 
 RadixSortKeyCodec::RadixSortKeyCodec(
     std::vector<RadixSortKeyColumn> columns,
-    EncodedKeyFormat format,
-    std::optional<uint64_t> maximumEncodedSize,
-    bool canEncodeDecode)
+    std::optional<uint64_t> maximumEncodedSize)
     : columns_(std::move(columns)),
       rowType_([&]() {
         std::vector<TypePtr> types;
@@ -4928,9 +4311,7 @@ RadixSortKeyCodec::RadixSortKeyCodec(
         }
         return ROW(std::move(types));
       }()),
-      format_(format),
-      maximumEncodedSize_(maximumEncodedSize),
-      canEncodeDecode_(canEncodeDecode) {}
+      maximumEncodedSize_(maximumEncodedSize) {}
 
 std::vector<uint32_t> RadixSortKeyCodec::leadingSkippableValidityOffsets(
     std::span<const uint8_t> keyMayHaveNulls,
@@ -4968,126 +4349,7 @@ uint32_t RadixSortKeyCodec::fixedPrefixColumnCount(
   return count;
 }
 
-void RadixSortKeyCodec::encodeSingleFixedFlat(
-    const RowVector& input,
-    memory::MemoryPool* pool,
-    EncodedKeyBatch& result) const {
-  result.format_ = format_;
-  result.size_ = input.size();
-
-  uint64_t* words = nullptr;
-  const uint64_t* offsets = nullptr;
-  char* data = nullptr;
-  if (format_ == EncodedKeyFormat::kFixed64) {
-    words =
-        prepareReusableBuffer<uint64_t>(result.fixedKeys_, input.size(), pool);
-    std::fill(words, words + input.size(), uint64_t{0});
-  } else {
-    auto* mutableOffsets = prepareReusableBuffer<uint64_t>(
-        result.offsets_, input.size() + 1, pool);
-    mutableOffsets[0] = 0;
-    const auto* nulls = input.childAt(0)->rawNulls();
-    const auto bodySize = *fixedBodySize(*columns_[0].type);
-    for (vector_size_t row = 0; row < input.size(); ++row) {
-      mutableOffsets[row + 1] = mutableOffsets[row] +
-          ((nulls != nullptr && bits::isBitNull(nulls, row)) ? 1
-                                                             : bodySize + 1);
-    }
-    offsets = mutableOffsets;
-    if (mutableOffsets[input.size()] > 0) {
-      result.data_ =
-          AlignedBuffer::allocate<char>(mutableOffsets[input.size()], pool);
-      data = result.data_->asMutable<char>();
-    }
-  }
-
-  radixsort::encodeSingleFixedFlat(
-      columns_[0],
-      *input.childAt(0),
-      input.size(),
-      format_,
-      words,
-      offsets,
-      data);
-}
-
-void RadixSortKeyCodec::encode(
-    const RowVector& input,
-    memory::MemoryPool* pool,
-    EncodedKeyBatch& result) const {
-  BOLT_CHECK_NOT_NULL(pool, "Radix sort key memory pool must not be null");
-
-  result.format_ = format_;
-  result.size_ = input.size();
-  result.data_.reset();
-  if (format_ == EncodedKeyFormat::kFixed64) {
-    result.offsets_.reset();
-  } else {
-    result.fixedKeys_.reset();
-  }
-
-  if (canEncodeSingleFixedFlatVector(columns_, input)) {
-    encodeSingleFixedFlat(input, pool, result);
-    return;
-  }
-
-  if (format_ == EncodedKeyFormat::kFixed64) {
-    auto* words =
-        prepareReusableBuffer<uint64_t>(result.fixedKeys_, input.size(), pool);
-    std::fill(words, words + input.size(), uint64_t{0});
-    encodeCursorScratch_.resize(input.size());
-    auto* cursors = encodeCursorScratch_.data();
-    for (vector_size_t row = 0; row < input.size(); ++row) {
-      cursors[row] = static_cast<uint64_t>(row) * sizeof(uint64_t);
-    }
-    auto* data = reinterpret_cast<char*>(words);
-    ContiguousEncodeOutput output(data, cursors);
-    for (uint32_t column = 0; column < columns_.size(); ++column) {
-      encodeVariableColumn(
-          columns_[column], *input.childAt(column), 0, input.size(), output);
-    }
-    for (vector_size_t row = 0; row < input.size(); ++row) {
-      const auto rowEnd = static_cast<uint64_t>(row + 1) * sizeof(uint64_t);
-      auto word = words[row];
-      if constexpr (std::endian::native == std::endian::little) {
-        word = byteSwap(word);
-      }
-      words[row] = word;
-    }
-    return;
-  }
-
-  auto offsetCount = static_cast<uint64_t>(input.size()) + 1;
-  auto* offsets = prepareReusableBuffer<uint64_t>(
-      result.offsets_, static_cast<size_t>(offsetCount), pool);
-  initializeVariableKeySizes(columns_, input, 0, offsets);
-
-  uint64_t totalBytes = 0;
-  for (vector_size_t row = 0; row < input.size(); ++row) {
-    const auto rowSize = offsets[row];
-    offsets[row] = totalBytes;
-    totalBytes += rowSize;
-  }
-  offsets[input.size()] = totalBytes;
-
-  if (totalBytes > 0) {
-    result.data_ = AlignedBuffer::allocate<char>(totalBytes, pool);
-  }
-  auto* data =
-      result.data_ == nullptr ? nullptr : result.data_->asMutable<char>();
-  ContiguousEncodeOutput output(data, offsets);
-  for (uint32_t column = 0; column < columns_.size(); ++column) {
-    encodeVariableColumn(
-        columns_[column], *input.childAt(column), 0, input.size(), output);
-  }
-
-  for (vector_size_t row = input.size(); row > 0; --row) {
-    offsets[row] = offsets[row - 1];
-  }
-  offsets[0] = 0;
-}
-
-uint64_t RadixSortKeyCodec::encodeAndAppendVariable(
+uint64_t RadixSortKeyCodec::appendVariable(
     const RowVector& input,
     RadixSortRunStorage& arena,
     std::span<char* const> payloads,
@@ -5103,6 +4365,7 @@ uint64_t RadixSortKeyCodec::encodeAndAppendVariable(
       prepareReusableBuffer<uint64_t>(sizeScratch, input.size(), arena.pool());
   initializeVariableKeySizes(columns_, input, firstSuffixColumn, heapSizes);
 
+  DecodedKeyVectors decodedInputs;
   return arena.appendVariableKeyBatch(
       std::span<const uint64_t>(heapSizes, input.size()),
       payloads,
@@ -5116,6 +4379,7 @@ uint64_t RadixSortKeyCodec::encodeAndAppendVariable(
               source,
               count,
               output,
+              &decodedInputs,
               true);
         }
 
@@ -5126,7 +4390,12 @@ uint64_t RadixSortKeyCodec::encodeAndAppendVariable(
         for (uint32_t column = firstSuffixColumn; column < columns_.size();
              ++column) {
           encodeVariableColumn(
-              columns_[column], *input.childAt(column), source, count, output);
+              columns_[column],
+              *input.childAt(column),
+              source,
+              count,
+              output,
+              &decodedInputs);
         }
 
         const auto crossingPrefixSize =
@@ -5171,21 +4440,29 @@ bool RadixSortKeyCodec::tryAppendSingleFixedFlat(
   return true;
 }
 
-void RadixSortKeyCodec::encodeAndAppendInline(
+uint64_t RadixSortKeyCodec::append(
     const RowVector& input,
     RadixSortRunStorage& storage,
-    std::span<char* const> payloads) const {
-  BOLT_DCHECK(!storage.layout().isVariable());
+    std::span<char* const> payloads,
+    BufferPtr& sizeScratch) const {
   BOLT_DCHECK_EQ(input.childrenSize(), columns_.size());
   BOLT_DCHECK(
       storage.layout().hasPayload()
           ? payloads.size() == static_cast<size_t>(input.size())
           : payloads.empty());
+  if (storage.layout().isVariable()) {
+    return appendVariable(
+        input,
+        storage,
+        payloads,
+        fixedPrefixColumnCount(storage.layout().heapKeyOffset()),
+        sizeScratch);
+  }
 
   if (input.childrenSize() == 1 &&
       tryAppendSingleFixedFlat(
           *input.childAt(0), input.size(), storage, payloads)) {
-    return;
+    return *maximumEncodedSize_;
   }
 
   const auto append = [&]<RadixSortKeyLayoutKind KIND>() {
@@ -5194,32 +4471,35 @@ void RadixSortKeyCodec::encodeAndAppendInline(
   };
   switch (storage.layout().kind()) {
     case RadixSortKeyLayoutKind::kKeyOnlyFixed8:
-      return append
-          .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed8>();
+      append.template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed8>();
+      break;
     case RadixSortKeyLayoutKind::kKeyOnlyFixed16:
-      return append
-          .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed16>();
+      append.template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed16>();
+      break;
     case RadixSortKeyLayoutKind::kKeyOnlyFixed24:
-      return append
-          .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed24>();
+      append.template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed24>();
+      break;
     case RadixSortKeyLayoutKind::kKeyOnlyFixed32:
-      return append
-          .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed32>();
+      append.template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed32>();
+      break;
     case RadixSortKeyLayoutKind::kKeyWithPayloadFixed16:
-      return append.template
+      append.template
       operator()<RadixSortKeyLayoutKind::kKeyWithPayloadFixed16>();
+      break;
     case RadixSortKeyLayoutKind::kKeyWithPayloadFixed24:
-      return append.template
+      append.template
       operator()<RadixSortKeyLayoutKind::kKeyWithPayloadFixed24>();
+      break;
     case RadixSortKeyLayoutKind::kKeyWithPayloadFixed32:
-      return append.template
+      append.template
       operator()<RadixSortKeyLayoutKind::kKeyWithPayloadFixed32>();
+      break;
     case RadixSortKeyLayoutKind::kInvalid:
     case RadixSortKeyLayoutKind::kKeyOnlyVariable32:
     case RadixSortKeyLayoutKind::kKeyWithPayloadVariable32:
       BOLT_FAIL("Unsupported inline radix sort key layout");
   }
-  BOLT_UNREACHABLE();
+  return *maximumEncodedSize_;
 }
 
 bool RadixSortKeyCodec::canDecodeSingleFixedColumn() const {
@@ -5325,49 +4605,13 @@ uint64_t RadixSortKeyCodec::decodeScratchWordsPerRowWithMask(
     std::span<const uint8_t> decodedColumns,
     std::span<const uint8_t> mayHaveNulls,
     uint32_t firstColumn,
-    uint32_t endColumn,
-    bool skipMaskedVariableColumns) const {
+    uint32_t endColumn) const {
   BOLT_DCHECK_EQ(decodedColumns.size(), columns_.size());
   BOLT_DCHECK_EQ(mayHaveNulls.size(), columns_.size());
   BOLT_DCHECK_LT(firstColumn, columns_.size());
   BOLT_DCHECK_LE(endColumn, columns_.size());
   return calculateDecodeScratchWordsPerRow(
-      columns_,
-      decodedColumns,
-      mayHaveNulls,
-      firstColumn,
-      endColumn,
-      skipMaskedVariableColumns);
-}
-
-void RadixSortKeyCodec::decodeSuffixAt(
-    std::span<const EncodedKeyView> keys,
-    std::span<const uint8_t> decodedColumns,
-    std::span<const uint8_t> mayHaveNulls,
-    vector_size_t outputOffset,
-    memory::MemoryPool* scratchPool,
-    BufferPtr& cursorScratch,
-    RowVector& output,
-    std::span<const column_index_t> directKeyChannels,
-    uint64_t scratchWordsPerRow,
-    uint32_t firstColumn) const {
-  BOLT_DCHECK_NOT_NULL(scratchPool);
-  BOLT_DCHECK_GE(outputOffset, 0);
-  BOLT_DCHECK_LE(outputOffset, output.size());
-  BOLT_DCHECK_LE(
-      keys.size(), static_cast<size_t>(output.size() - outputOffset));
-  decodeColumnsWithOffset(
-      columns_,
-      keys,
-      decodedColumns,
-      mayHaveNulls,
-      outputOffset,
-      scratchPool,
-      cursorScratch,
-      output,
-      directKeyChannels,
-      scratchWordsPerRow,
-      firstColumn);
+      columns_, decodedColumns, mayHaveNulls, firstColumn, endColumn);
 }
 
 void RadixSortKeyCodec::decodeSuffixAtWithPreparedScratch(

--- a/bolt/exec/radixsort/RadixSortKeyCodec.h
+++ b/bolt/exec/radixsort/RadixSortKeyCodec.h
@@ -18,7 +18,6 @@
 
 #include <optional>
 #include <span>
-#include <string_view>
 #include <vector>
 
 #include "bolt/buffer/Buffer.h"
@@ -27,68 +26,21 @@
 #include "bolt/vector/ComplexVector.h"
 
 namespace bytedance::bolt::exec::radixsort {
-namespace test {
-class RadixSortKeyCodecTestHelper;
-}
-
 class RadixSortRun;
 class RadixSortRunStorage;
 struct EncodedKeyView;
 enum class RadixSortKeyLayoutKind : uint8_t;
-
-enum class EncodedKeyFormat : uint8_t {
-  kFixed64,
-  kVariableBinary,
-};
 
 struct RadixSortKeyColumn {
   TypePtr type;
   CompareFlags flags;
   std::optional<uint64_t> maximumEncodedSize;
   std::optional<uint32_t> fixedPrefixOffset;
-  bool encodeDecodeSupported;
   std::vector<RadixSortKeyColumn> children;
-};
-
-class EncodedKeyBatch {
- public:
-  EncodedKeyFormat format() const {
-    return format_;
-  }
-
-  vector_size_t size() const {
-    return size_;
-  }
-
-  uint64_t fixedKeyAt(vector_size_t row) const;
-
-  std::string_view variableKeyAt(vector_size_t row) const;
-
-  const BufferPtr& fixedKeys() const {
-    return fixedKeys_;
-  }
-
-  const BufferPtr& offsets() const {
-    return offsets_;
-  }
-
-  const BufferPtr& data() const {
-    return data_;
-  }
-
- private:
-  friend class RadixSortKeyCodec;
-
-  EncodedKeyFormat format_{EncodedKeyFormat::kVariableBinary};
-  vector_size_t size_{0};
-  BufferPtr fixedKeys_;
-  BufferPtr offsets_;
-  BufferPtr data_;
 };
 
 class RadixSortKeyCodec {
   friend class RadixSortRun;
-  friend class test::RadixSortKeyCodecTestHelper;
 
  public:
   static bool supportsEncodeDecode(const Type& type);
@@ -102,10 +54,6 @@ class RadixSortKeyCodec {
     return maximumEncodedSize_;
   }
 
-  bool canEncodeDecode() const {
-    return canEncodeDecode_;
-  }
-
   std::vector<uint32_t> leadingSkippableValidityOffsets(
       std::span<const uint8_t> keyMayHaveNulls,
       uint32_t radixWidth) const;
@@ -113,11 +61,6 @@ class RadixSortKeyCodec {
   uint32_t heapKeyOffsetForVariableLayout(uint32_t inlineCapacity) const;
 
   uint32_t fixedPrefixColumnCount(uint32_t heapKeyOffset) const;
-
-  void encode(
-      const RowVector& input,
-      memory::MemoryPool* pool,
-      EncodedKeyBatch& result) const;
 
   void decode(
       std::span<const EncodedKeyView> keys,
@@ -129,16 +72,9 @@ class RadixSortKeyCodec {
       uint32_t firstColumn = 0) const;
 
  private:
-  void encodeSingleFixedFlat(
-      const RowVector& input,
-      memory::MemoryPool* pool,
-      EncodedKeyBatch& result) const;
-
   RadixSortKeyCodec(
       std::vector<RadixSortKeyColumn> columns,
-      EncodedKeyFormat format,
-      std::optional<uint64_t> maximumEncodedSize,
-      bool canEncodeDecode);
+      std::optional<uint64_t> maximumEncodedSize);
 
   bool canAppendSingleFixedFlat(
       const BaseVector& input,
@@ -150,10 +86,11 @@ class RadixSortKeyCodec {
       RadixSortRunStorage& arena,
       std::span<char* const> payloads) const;
 
-  void encodeAndAppendInline(
+  uint64_t append(
       const RowVector& input,
       RadixSortRunStorage& storage,
-      std::span<char* const> payloads) const;
+      std::span<char* const> payloads,
+      BufferPtr& sizeScratch) const;
 
   bool canDecodeSingleFixedColumn() const;
 
@@ -179,20 +116,7 @@ class RadixSortKeyCodec {
       std::span<const uint8_t> decodedColumns,
       std::span<const uint8_t> mayHaveNulls,
       uint32_t firstColumn,
-      uint32_t endColumn,
-      bool skipMaskedVariableColumns) const;
-
-  void decodeSuffixAt(
-      std::span<const EncodedKeyView> keys,
-      std::span<const uint8_t> decodedColumns,
-      std::span<const uint8_t> mayHaveNulls,
-      vector_size_t outputOffset,
-      memory::MemoryPool* scratchPool,
-      BufferPtr& cursorScratch,
-      RowVector& output,
-      std::span<const column_index_t> directKeyChannels,
-      uint64_t scratchWordsPerRow,
-      uint32_t firstColumn) const;
+      uint32_t endColumn) const;
 
   void decodeSuffixAtWithPreparedScratch(
       std::span<const EncodedKeyView> keys,
@@ -221,7 +145,7 @@ class RadixSortKeyCodec {
       RowVector& output,
       std::span<const column_index_t> directKeyChannels) const;
 
-  uint64_t encodeAndAppendVariable(
+  uint64_t appendVariable(
       const RowVector& input,
       RadixSortRunStorage& arena,
       std::span<char* const> payloads,
@@ -239,9 +163,7 @@ class RadixSortKeyCodec {
 
   std::vector<RadixSortKeyColumn> columns_;
   RowTypePtr rowType_;
-  EncodedKeyFormat format_;
   std::optional<uint64_t> maximumEncodedSize_;
-  bool canEncodeDecode_;
   mutable std::vector<uint64_t> encodeCursorScratch_;
 };
 

--- a/bolt/exec/radixsort/RadixSortRun.cpp
+++ b/bolt/exec/radixsort/RadixSortRun.cpp
@@ -18,6 +18,7 @@
 
 #include "bolt/common/base/Exceptions.h"
 #include "bolt/exec/radixsort/PayloadRow.h"
+#include "bolt/exec/radixsort/RadixSortRunSorter.h"
 #include "bolt/exec/radixsort/RadixSortUtils.h"
 
 namespace bytedance::bolt::exec::radixsort {
@@ -249,14 +250,8 @@ std::unique_ptr<RadixSortRun> RadixSortRun::create(
         projection->hasPayload(),
         keyCodec->heapKeyOffsetForVariableLayout(keyLayout.inlineCapacity()));
   }
-  auto arena = std::make_unique<RadixSortRunStorage>(
-      pool,
-      keyLayout,
-      options.keysPerBlock,
-      options.preferredKeyHeapGroupBytes,
-      payloadLayout,
-      options.payloadRowsPerBlock,
-      options.preferredPayloadHeapGroupBytes);
+  auto arena =
+      std::make_unique<RadixSortRunStorage>(pool, keyLayout, payloadLayout);
   return std::unique_ptr<RadixSortRun>(new RadixSortRun(
       pool,
       std::move(projection),
@@ -294,19 +289,15 @@ void RadixSortRun::append(const RowVector& input) {
     currentRunKeyMayHaveNulls_[column] |= mayHaveNulls;
   }
 
-  const bool directVariableKey = keyLayout_.isVariable();
   const auto appendKeys = [&](std::span<char* const> payloads) {
-    if (directVariableKey) {
-      const auto batchMaximumEncodedKeySize =
-          keyCodec_->encodeAndAppendVariable(
-              keys, *storage_, payloads, firstSuffixColumn_, keySizeScratch_);
+    const auto batchMaximumEncodedKeySize =
+        keyCodec_->append(keys, *storage_, payloads, keySizeScratch_);
+    if (keyLayout_.isVariable()) {
       currentRunMaximumEncodedKeySize_ = std::max(
           currentRunMaximumEncodedKeySize_, batchMaximumEncodedKeySize);
       variableKeysFitRadixPrefix_ &=
           batchMaximumEncodedKeySize <= keyLayout_.inlineCapacity();
-      return;
     }
-    keyCodec_->encodeAndAppendInline(keys, *storage_, payloads);
   };
 
   if (projection_->hasPayload()) {
@@ -365,13 +356,6 @@ void RadixSortRun::finalize() {
   }
   metrics_.sortTimeUs += elapsedUs(begin);
   state_ = RadixSortRunState::kSortedInMemory;
-}
-
-RowVectorPtr RadixSortRun::getOutput(
-    vector_size_t maxRows,
-    memory::MemoryPool* outputPool) {
-  RowVectorPtr output;
-  return getOutput(maxRows, outputPool, output);
 }
 
 RowVectorPtr RadixSortRun::getOutput(
@@ -458,19 +442,14 @@ void RadixSortRun::ensureMergeDecodePlan() {
   if (!plan.singleFixedWordBytes.has_value()) {
     if (!keyLayout_.isVariable() || plan.decodeEndColumn > firstSuffixColumn_) {
       plan.scratchWords = keyCodec_->decodeScratchWordsPerRowWithMask(
-          decodedKeyMask,
-          keyMayHaveNulls_,
-          firstColumn,
-          plan.decodeEndColumn,
-          /*skipMaskedVariableColumns=*/true);
+          decodedKeyMask, keyMayHaveNulls_, firstColumn, plan.decodeEndColumn);
     }
 
     plan.directScratchWords = keyCodec_->decodeScratchWordsPerRowWithMask(
         decodedKeyMask,
         keyMayHaveNulls_,
         firstColumn,
-        static_cast<uint32_t>(decodedKeyMask.size()),
-        /*skipMaskedVariableColumns=*/false);
+        static_cast<uint32_t>(decodedKeyMask.size()));
   }
   mergeDecodePlan_.emplace(std::move(plan));
 }

--- a/bolt/exec/radixsort/RadixSortRun.h
+++ b/bolt/exec/radixsort/RadixSortRun.h
@@ -21,7 +21,8 @@
 #include <optional>
 
 #include "bolt/exec/radixsort/PayloadRow.h"
-#include "bolt/exec/radixsort/RadixSortRunSorter.h"
+#include "bolt/exec/radixsort/RadixSortKeyCodec.h"
+#include "bolt/exec/radixsort/RadixSortRunStorage.h"
 
 namespace bytedance::bolt::exec::radixsort {
 namespace test {
@@ -44,10 +45,6 @@ class RadixSortOutputProjection {
       const RowTypePtr& outputType,
       const RowTypePtr& keyType,
       const std::vector<column_index_t>& directKeyChannels);
-
-  const RowTypePtr& outputType() const {
-    return outputType_;
-  }
 
   const RowTypePtr& keyType() const {
     return keyType_;
@@ -141,7 +138,6 @@ enum class RadixSortRunState : uint8_t {
 struct RadixSortRunStats {
   uint64_t inputRows{0};
   uint64_t outputRows{0};
-  uint64_t encodeTimeUs{0};
   uint64_t appendTimeUs{0};
   uint64_t sortTimeUs{0};
   uint64_t outputTimeUs{0};
@@ -151,12 +147,6 @@ struct RadixSortRunOptions {
   std::vector<uint8_t> initialKeyMayHaveNulls;
   std::vector<uint8_t> initialPayloadMayHaveNulls;
   bool initialVariableKeysFitRadixPrefix{true};
-  uint32_t keysPerBlock{RadixSortRunStorage::kAutoRowsPerBlock};
-  uint64_t preferredKeyHeapGroupBytes{
-      RadixSortRunStorage::kDefaultHeapGroupBytes};
-  uint32_t payloadRowsPerBlock{RadixSortRunStorage::kAutoRowsPerBlock};
-  uint64_t preferredPayloadHeapGroupBytes{
-      RadixSortRunStorage::kDefaultHeapGroupBytes};
 };
 
 class RadixSortRun {
@@ -217,19 +207,9 @@ class RadixSortRun {
     return variableKeysFitRadixPrefix_;
   }
 
-  uint64_t maximumEncodedKeySize() const {
-    return currentRunMaximumEncodedKeySize_;
-  }
-
-  bool decodesVariableKeysFromInline() const {
-    return decodeVariableKeysFromInline_;
-  }
-
   void append(const RowVector& input);
 
   void finalize();
-
-  RowVectorPtr getOutput(vector_size_t maxRows, memory::MemoryPool* outputPool);
 
   RowVectorPtr getOutput(
       vector_size_t maxRows,

--- a/bolt/exec/radixsort/RadixSortRunSorter.cpp
+++ b/bolt/exec/radixsort/RadixSortRunSorter.cpp
@@ -758,7 +758,7 @@ class RadixSortRunSorterKernel {
     auto nextPasses = effectivePasses;
     if constexpr (!CompletePrefixRadix) {
       const auto bucketCount = static_cast<uint32_t>(remainingEnd - remaining);
-      nextPasses += bucketCount > kFreeRadixPassBucketLimit;
+      nextPasses += isEffectiveRadixPass(bucketCount);
       if (nextPasses > kEffectiveRadixPassLimit) {
         fullSort(begin, end);
         return;

--- a/bolt/exec/radixsort/RadixSortRunStorage.cpp
+++ b/bolt/exec/radixsort/RadixSortRunStorage.cpp
@@ -17,104 +17,32 @@
 #include "bolt/exec/radixsort/RadixSortRunStorage.h"
 
 #include <algorithm>
-#include <array>
-#include <limits>
 #include <utility>
 
-#include "bolt/common/base/BitUtil.h"
 #include "bolt/common/base/Exceptions.h"
-#include "bolt/exec/radixsort/RadixSortUtils.h"
 
 namespace bytedance::bolt::exec::radixsort {
 
-namespace {
-
 constexpr uint64_t kMaxPayloadFixedBlockBytes = 64 * 1024;
-
-template <RadixSortKeyLayoutKind KIND>
-void appendInlineVariableKeys(
-    const EncodedKeyBatch& encodedKeys,
-    std::span<char* const> payloads,
-    RadixSortKeyBlock& block,
-    vector_size_t source,
-    vector_size_t count) {
-  using Traits = RadixSortKeyTraits<KIND>;
-  static_assert(!Traits::kVariable);
-  const auto* offsets = encodedKeys.offsets()->as<uint64_t>();
-  const auto* data = encodedKeys.data()->as<char>();
-  auto* destination =
-      block.base + static_cast<uint64_t>(block.count) * Traits::kWidth;
-  for (vector_size_t row = 0; row < count; ++row) {
-    const auto inputRow = source + row;
-    const auto begin = offsets[inputRow];
-    const auto size = offsets[inputRow + 1] - begin;
-    auto* record = destination + static_cast<uint64_t>(row) * Traits::kWidth;
-    std::array<char, Traits::kInlineCapacity> inlineBytes{};
-    std::memcpy(
-        inlineBytes.data(),
-        data + begin,
-        std::min<uint64_t>(size, Traits::kInlineCapacity));
-    storeFixedKeyPrefix<Traits>(inlineBytes.data(), record);
-    if constexpr (Traits::kHasPayload) {
-      storeCompactPointer(
-          record + Traits::kPayloadOffset,
-          payloads.empty() ? nullptr : payloads[inputRow]);
-    }
-  }
-}
-
-} // namespace
-
-char* PayloadRowBatch::rowAt(vector_size_t row) const {
-  return rows_->as<char*>()[row];
-}
 
 char* PayloadRowBatch::heapAt(vector_size_t row) const {
   return heaps_ == nullptr ? nullptr : heaps_->as<char*>()[row];
 }
 
-uint64_t PayloadRowBatch::heapSizeAt(vector_size_t row) const {
-  return heapSizes_ == nullptr ? 0 : heapSizes_->as<uint64_t>()[row];
-}
-
 RadixSortRunStorage::RadixSortRunStorage(
     memory::MemoryPool* pool,
     RadixSortKeyLayout layout,
-    uint32_t keysPerBlock,
-    uint64_t preferredHeapGroupBytes,
-    std::shared_ptr<const PayloadRowLayout> payloadLayout,
-    uint32_t payloadRowsPerBlock,
-    uint64_t preferredPayloadHeapGroupBytes)
+    std::shared_ptr<const PayloadRowLayout> payloadLayout)
     : pool_(pool),
       layout_(std::move(layout)),
-      keysPerBlock_(normalizeKeysPerBlock(keysPerBlock, layout_)),
-      preferredHeapGroupBytes_(preferredHeapGroupBytes),
+      keysPerBlock_(static_cast<uint32_t>(
+          std::max<uint64_t>(1, kDefaultBlockBytes / layout_.width()))),
       payloadLayout_(std::move(payloadLayout)),
-      payloadRowsPerBlock_(payloadRowsPerBlock),
-      preferredPayloadHeapGroupBytes_(preferredPayloadHeapGroupBytes),
       allocationPool_(pool_),
       keyBlocks_(memory::StlAllocator<RadixSortKeyBlock>(pool_)),
       keyHeapGroups_(memory::StlAllocator<RadixSortKeyOverflowBlock>(pool_)),
       payloadFixedBlocks_(memory::StlAllocator<PayloadRowFixedBlock>(pool_)),
       payloadHeapGroups_(memory::StlAllocator<PayloadRowHeapBlock>(pool_)) {}
-
-uint32_t RadixSortRunStorage::normalizeKeysPerBlock(
-    uint32_t keysPerBlock,
-    const RadixSortKeyLayout& layout) {
-  if (keysPerBlock != kAutoRowsPerBlock) {
-    return keysPerBlock;
-  }
-  return static_cast<uint32_t>(std::max<uint64_t>(
-      1, bits::divRoundUp(kDefaultKeyBlockBytes, layout.width())));
-}
-
-RadixSortKey RadixSortRunStorage::keyAt(uint64_t index) {
-  return RadixSortKey(layout_, keyDataAt(index));
-}
-
-RadixSortKey RadixSortRunStorage::keyAt(uint64_t index) const {
-  return RadixSortKey(layout_, keyDataAt(index));
-}
 
 uint64_t RadixSortRunStorage::estimatedOutputBytes() const {
   uint64_t bytes = 0;
@@ -138,20 +66,6 @@ uint64_t RadixSortRunStorage::estimatedOutputBytes() const {
   return bytes;
 }
 
-char* RadixSortRunStorage::keyDataAt(uint64_t index) {
-  const auto blockIndex = index / keysPerBlock_;
-  const auto indexInBlock = index % keysPerBlock_;
-  auto& block = keyBlocks_[blockIndex];
-  return block.base + indexInBlock * layout_.width();
-}
-
-const char* RadixSortRunStorage::keyDataAt(uint64_t index) const {
-  const auto blockIndex = index / keysPerBlock_;
-  const auto indexInBlock = index % keysPerBlock_;
-  const auto& block = keyBlocks_[blockIndex];
-  return block.base + indexInBlock * layout_.width();
-}
-
 RadixSortKeyRange RadixSortRunStorage::keyRangeAt(
     uint64_t index,
     vector_size_t maxCount) const {
@@ -167,210 +81,11 @@ RadixSortKeyRange RadixSortRunStorage::keyRangeAt(
       std::min(maxCount, available)};
 }
 
-void RadixSortRunStorage::append(
-    std::string_view encodedKey,
-    char* payload,
-    uint64_t* index) {
-  ensureKeyBlock();
-  char* overflowData = nullptr;
-  const auto heapSize = layout_.heapSize(encodedKey.size());
-  if (heapSize > 0) {
-    allocateOverflow(heapSize, overflowData);
-  }
-
-  auto& block = keyBlocks_.back();
-  auto key = RadixSortKey(layout_, block.base + block.count * layout_.width());
-  key.construct(encodedKey, overflowData, payload);
-
-  if (index != nullptr) {
-    *index = size_;
-  }
-  ++block.count;
-  ++size_;
-}
-
-void RadixSortRunStorage::appendBatch(
-    std::span<const std::string_view> encodedKeys,
-    std::span<char* const> payloads) {
-  for (uint64_t index = 0; index < encodedKeys.size(); ++index) {
-    append(encodedKeys[index], payloads.empty() ? nullptr : payloads[index]);
-  }
-}
-
-void RadixSortRunStorage::appendBatch(
-    const EncodedKeyBatch& encodedKeys,
-    std::span<char* const> payloads) {
-  if (encodedKeys.format() == EncodedKeyFormat::kFixed64 &&
-      (layout_.kind() == RadixSortKeyLayoutKind::kKeyOnlyFixed8 ||
-       layout_.kind() == RadixSortKeyLayoutKind::kKeyWithPayloadFixed16)) {
-    const auto* keys = encodedKeys.fixedKeys() == nullptr
-        ? nullptr
-        : encodedKeys.fixedKeys()->as<uint64_t>();
-    vector_size_t source = 0;
-    while (source < encodedKeys.size()) {
-      ensureKeyBlock();
-      auto& block = keyBlocks_.back();
-      const auto count = static_cast<vector_size_t>(std::min<uint32_t>(
-          block.capacity - block.count, encodedKeys.size() - source));
-      auto* destination =
-          block.base + static_cast<uint64_t>(block.count) * layout_.width();
-      if (layout_.kind() == RadixSortKeyLayoutKind::kKeyOnlyFixed8) {
-        std::memcpy(
-            destination,
-            keys + source,
-            static_cast<uint64_t>(count) * sizeof(uint64_t));
-      } else {
-        auto* records =
-            reinterpret_cast<KeyWithPayloadFixed16Record*>(destination);
-        for (vector_size_t row = 0; row < count; ++row) {
-          auto& record = records[row];
-          record.part0 = keys[source + row];
-          record.tail = {};
-          storeCompactPointer(
-              &record.payload,
-              payloads.empty() ? nullptr : payloads[source + row]);
-        }
-      }
-      block.count += count;
-      size_ += count;
-      source += count;
-    }
-    return;
-  }
-
-  if (encodedKeys.format() == EncodedKeyFormat::kVariableBinary &&
-      !layout_.isVariable()) {
-    if (encodedKeys.offsets() == nullptr || encodedKeys.data() == nullptr) {
-      BOLT_FAIL("Variable encoded key buffers must not be null");
-    }
-    const auto appendFixed = [&]<RadixSortKeyLayoutKind KIND>() {
-      vector_size_t source = 0;
-      while (source < encodedKeys.size()) {
-        ensureKeyBlock();
-        auto& block = keyBlocks_.back();
-        const auto count = static_cast<vector_size_t>(std::min<uint32_t>(
-            block.capacity - block.count, encodedKeys.size() - source));
-        appendInlineVariableKeys<KIND>(
-            encodedKeys, payloads, block, source, count);
-        block.count += count;
-        size_ += count;
-        source += count;
-      }
-    };
-    switch (layout_.kind()) {
-      case RadixSortKeyLayoutKind::kKeyWithPayloadFixed16:
-        return appendFixed.template
-        operator()<RadixSortKeyLayoutKind::kKeyWithPayloadFixed16>();
-      case RadixSortKeyLayoutKind::kKeyOnlyFixed16:
-        return appendFixed
-            .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed16>();
-      case RadixSortKeyLayoutKind::kKeyOnlyFixed24:
-        return appendFixed
-            .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed24>();
-      case RadixSortKeyLayoutKind::kKeyOnlyFixed32:
-        return appendFixed
-            .template operator()<RadixSortKeyLayoutKind::kKeyOnlyFixed32>();
-      case RadixSortKeyLayoutKind::kKeyWithPayloadFixed24:
-        return appendFixed.template
-        operator()<RadixSortKeyLayoutKind::kKeyWithPayloadFixed24>();
-      case RadixSortKeyLayoutKind::kKeyWithPayloadFixed32:
-        return appendFixed.template
-        operator()<RadixSortKeyLayoutKind::kKeyWithPayloadFixed32>();
-      default:
-        BOLT_FAIL("Unsupported fixed radix sort key layout");
-    }
-  }
-
-  if (encodedKeys.format() == EncodedKeyFormat::kVariableBinary &&
-      layout_.isVariable()) {
-    if (encodedKeys.offsets() == nullptr || encodedKeys.data() == nullptr) {
-      BOLT_FAIL("Variable encoded key buffers must not be null");
-    }
-    const auto* offsets = encodedKeys.offsets()->as<uint64_t>();
-    const auto* data = encodedKeys.data()->as<char>();
-    const auto appendVariable = [&]<RadixSortKeyLayoutKind KIND>() {
-      using Traits = RadixSortKeyTraits<KIND>;
-      static_assert(Traits::kVariable);
-      vector_size_t source = 0;
-      while (source < encodedKeys.size()) {
-        ensureKeyBlock();
-        auto& block = keyBlocks_.back();
-        const auto count = static_cast<vector_size_t>(std::min<uint32_t>(
-            block.capacity - block.count, encodedKeys.size() - source));
-        auto* destination =
-            block.base + static_cast<uint64_t>(block.count) * Traits::kWidth;
-        for (vector_size_t row = 0; row < count; ++row) {
-          const auto inputRow = source + row;
-          const auto begin = offsets[inputRow];
-          const auto size = offsets[inputRow + 1] - begin;
-          auto* record =
-              destination + static_cast<uint64_t>(row) * Traits::kWidth;
-          std::memset(record, 0, Traits::kInlineCapacity);
-          std::memcpy(
-              record,
-              data + begin,
-              std::min<uint64_t>(size, Traits::kInlineCapacity));
-          storeUnaligned<uint64_t>(record + Traits::kSizeOffset, size);
-          const auto heapSize = layout_.heapSize(size);
-          BOLT_DCHECK_GT(heapSize, 0);
-          char* overflow;
-          allocateOverflow(heapSize, overflow);
-          std::memcpy(
-              overflow, data + begin + layout_.heapKeyOffset(), heapSize);
-          storeCompactPointer(record + Traits::kDataOffset, overflow);
-          if constexpr (Traits::kHasPayload) {
-            storeCompactPointer(
-                record + Traits::kPayloadOffset,
-                payloads.empty() ? nullptr : payloads[inputRow]);
-          }
-        }
-        block.count += count;
-        size_ += count;
-        source += count;
-      }
-    };
-
-    switch (layout_.kind()) {
-      case RadixSortKeyLayoutKind::kKeyOnlyVariable32:
-        return appendVariable
-            .template operator()<RadixSortKeyLayoutKind::kKeyOnlyVariable32>();
-      case RadixSortKeyLayoutKind::kKeyWithPayloadVariable32:
-        return appendVariable.template
-        operator()<RadixSortKeyLayoutKind::kKeyWithPayloadVariable32>();
-      default:
-        BOLT_FAIL("Unsupported variable radix sort key layout");
-    }
-  }
-
-  for (vector_size_t row = 0; row < encodedKeys.size(); ++row) {
-    std::array<char, sizeof(uint64_t)> fixedBytes{};
-    std::string_view key;
-    if (encodedKeys.format() == EncodedKeyFormat::kFixed64) {
-      auto word = encodedKeys.fixedKeyAt(row);
-      if constexpr (std::endian::native == std::endian::little) {
-        word = byteSwap(word);
-      }
-      storeUnaligned(fixedBytes.data(), word);
-      key = std::string_view(fixedBytes.data(), fixedBytes.size());
-    } else {
-      key = encodedKeys.variableKeyAt(row);
-    }
-    append(key, payloads.empty() ? nullptr : payloads[row]);
-  }
-}
-
-void RadixSortRunStorage::allocatePayloadRowBatch(
-    std::span<const uint64_t> heapSizes,
-    PayloadRowBatch& batch) {
-  allocatePayloadRowBatch(heapSizes, nullptr, batch);
-}
-
 void RadixSortRunStorage::allocatePayloadRowBatch(
     std::span<const uint64_t> heapSizes,
     const BufferPtr& sizeStorage,
     PayloadRowBatch& batch) {
   const auto count = static_cast<vector_size_t>(heapSizes.size());
-  batch.size_ = count;
   if (count == 0) {
     if (batch.rows_ != nullptr && batch.rows_->isMutable()) {
       batch.rows_->setSize(0);
@@ -411,29 +126,26 @@ void RadixSortRunStorage::allocatePayloadRowBatch(
         continue;
       }
       if (groupSize > 0 &&
-          (heapSizes[groupEnd] > preferredPayloadHeapGroupBytes_ ||
-           groupSize > preferredPayloadHeapGroupBytes_ - heapSizes[groupEnd])) {
+          (heapSizes[groupEnd] > kDefaultBlockBytes ||
+           groupSize > kDefaultBlockBytes - heapSizes[groupEnd])) {
         break;
       }
       groupSize += heapSizes[groupEnd];
       ++groupEnd;
-      if (groupSize >= preferredPayloadHeapGroupBytes_) {
+      if (groupSize >= kDefaultBlockBytes) {
         break;
       }
     }
     auto* groupBase = allocationPool_.allocateFixed(groupSize, 1);
     uint64_t offset = 0;
-    uint64_t heapRowCount = 0;
     for (auto groupRow = groupStart; groupRow < groupEnd; ++groupRow) {
       if (heapSizes[groupRow] == 0) {
         continue;
       }
       heaps[groupRow] = groupBase + offset;
       offset += heapSizes[groupRow];
-      ++heapRowCount;
     }
-    payloadHeapGroups_.push_back(
-        PayloadRowHeapBlock{groupBase, groupSize, groupSize, heapRowCount});
+    payloadHeapGroups_.push_back(PayloadRowHeapBlock{groupSize});
     row = groupEnd;
   }
 }
@@ -441,7 +153,6 @@ void RadixSortRunStorage::allocatePayloadRowBatch(
 void RadixSortRunStorage::allocateFixedPayloadRowBatch(
     vector_size_t count,
     PayloadRowBatch& batch) {
-  batch.size_ = count;
   batch.heaps_.reset();
   batch.heapSizes_.reset();
   if (count == 0) {
@@ -471,7 +182,6 @@ void RadixSortRunStorage::allocatePayloadRowPointers(
           row + static_cast<uint64_t>(index) * payloadLayout_->rowWidth();
     }
     block.count += blockCount;
-    payloadSize_ += blockCount;
     outputRow += blockCount;
   }
 }
@@ -492,7 +202,6 @@ void RadixSortRunStorage::clear() {
   }
   allocationPool_.clear();
   size_ = 0;
-  payloadSize_ = 0;
 }
 
 void RadixSortRunStorage::ensureKeyBlock() {
@@ -514,11 +223,7 @@ void RadixSortRunStorage::ensurePayloadFixedBlock() {
   const auto rowWidth = payloadLayout_->rowWidth();
   const auto byteLimitedCapacity =
       std::max<uint64_t>(1, kMaxPayloadFixedBlockBytes / rowWidth);
-  const auto rowLimitedCapacity = payloadRowsPerBlock_ == kAutoRowsPerBlock
-      ? byteLimitedCapacity
-      : payloadRowsPerBlock_;
-  const auto capacity = static_cast<uint32_t>(
-      std::min<uint64_t>(rowLimitedCapacity, byteLimitedCapacity));
+  const auto capacity = static_cast<uint32_t>(byteLimitedCapacity);
   const auto bytes = static_cast<uint64_t>(capacity) * rowWidth;
   auto* base = allocationPool_.allocateFixed(bytes, alignof(uint64_t));
   checkCompactPointerRange(base, bytes);
@@ -528,15 +233,14 @@ void RadixSortRunStorage::ensurePayloadFixedBlock() {
 void RadixSortRunStorage::allocateOverflow(uint64_t size, char*& data) {
   if (keyHeapGroups_.empty() ||
       keyHeapGroups_.back().capacity - keyHeapGroups_.back().used < size) {
-    const auto capacity = std::max(preferredHeapGroupBytes_, size);
+    const auto capacity = std::max(kDefaultBlockBytes, size);
     auto* base = allocationPool_.allocateFixed(capacity, 1);
     checkCompactPointerRange(base, capacity);
-    keyHeapGroups_.push_back(RadixSortKeyOverflowBlock{base, capacity, 0, 0});
+    keyHeapGroups_.push_back(RadixSortKeyOverflowBlock{base, capacity, 0});
   }
   auto& group = keyHeapGroups_.back();
   data = group.base + group.used;
   group.used += size;
-  ++group.keyCount;
 }
 
 } // namespace bytedance::bolt::exec::radixsort

--- a/bolt/exec/radixsort/RadixSortRunStorage.h
+++ b/bolt/exec/radixsort/RadixSortRunStorage.h
@@ -26,7 +26,6 @@
 #include "bolt/common/memory/AllocationPool.h"
 #include "bolt/exec/radixsort/PayloadRow.h"
 #include "bolt/exec/radixsort/RadixSortKey.h"
-#include "bolt/exec/radixsort/RadixSortKeyCodec.h"
 
 namespace bytedance::bolt::exec::radixsort {
 
@@ -40,7 +39,6 @@ struct RadixSortKeyOverflowBlock {
   char* base;
   uint64_t capacity;
   uint64_t used;
-  uint64_t keyCount;
 };
 
 struct PayloadRowFixedBlock {
@@ -50,10 +48,7 @@ struct PayloadRowFixedBlock {
 };
 
 struct PayloadRowHeapBlock {
-  char* base;
-  uint64_t capacity;
   uint64_t used;
-  uint64_t rowCount;
 };
 
 struct RadixSortKeyRange {
@@ -63,33 +58,16 @@ struct RadixSortKeyRange {
 
 class PayloadRowBatch {
  public:
-  vector_size_t size() const {
-    return size_;
-  }
-
-  char* rowAt(vector_size_t row) const;
-
   char* heapAt(vector_size_t row) const;
-
-  uint64_t heapSizeAt(vector_size_t row) const;
 
   const BufferPtr& rows() const {
     return rows_;
-  }
-
-  const BufferPtr& heaps() const {
-    return heaps_;
-  }
-
-  const BufferPtr& heapSizes() const {
-    return heapSizes_;
   }
 
  private:
   friend class RadixSortRunStorage;
   friend class PayloadRowWriter;
 
-  vector_size_t size_{0};
   BufferPtr rows_;
   BufferPtr heaps_;
   BufferPtr heapSizes_;
@@ -97,19 +75,10 @@ class PayloadRowBatch {
 
 class RadixSortRunStorage {
  public:
-  static constexpr uint32_t kAutoRowsPerBlock = 0;
-  static constexpr uint32_t kTestingRowsPerBlock = 2048;
-  static constexpr uint64_t kDefaultKeyBlockBytes = 64 * 1024;
-  static constexpr uint64_t kDefaultHeapGroupBytes = 64 * 1024;
-
   RadixSortRunStorage(
       memory::MemoryPool* pool,
       RadixSortKeyLayout layout,
-      uint32_t keysPerBlock = kAutoRowsPerBlock,
-      uint64_t preferredHeapGroupBytes = kDefaultHeapGroupBytes,
-      std::shared_ptr<const PayloadRowLayout> payloadLayout = nullptr,
-      uint32_t payloadRowsPerBlock = kAutoRowsPerBlock,
-      uint64_t preferredPayloadHeapGroupBytes = kDefaultHeapGroupBytes);
+      std::shared_ptr<const PayloadRowLayout> payloadLayout = nullptr);
 
   const RadixSortKeyLayout& layout() const {
     return layout_;
@@ -131,24 +100,8 @@ class RadixSortRunStorage {
     return keyBlocks_;
   }
 
-  const auto& keyHeapGroups() const {
-    return keyHeapGroups_;
-  }
-
   const std::shared_ptr<const PayloadRowLayout>& payloadLayout() const {
     return payloadLayout_;
-  }
-
-  uint64_t payloadSize() const {
-    return payloadSize_;
-  }
-
-  const auto& payloadFixedBlocks() const {
-    return payloadFixedBlocks_;
-  }
-
-  const auto& payloadHeapGroups() const {
-    return payloadHeapGroups_;
   }
 
   int64_t allocatedBytes() const {
@@ -157,32 +110,7 @@ class RadixSortRunStorage {
 
   uint64_t estimatedOutputBytes() const;
 
-  int32_t numRanges() const {
-    return allocationPool_.numRanges();
-  }
-
-  RadixSortKey keyAt(uint64_t index);
-
-  RadixSortKey keyAt(uint64_t index) const;
-
-  char* keyDataAt(uint64_t index);
-
-  const char* keyDataAt(uint64_t index) const;
-
   RadixSortKeyRange keyRangeAt(uint64_t index, vector_size_t maxCount) const;
-
-  void append(
-      std::string_view encodedKey,
-      char* payload = nullptr,
-      uint64_t* index = nullptr);
-
-  void appendBatch(
-      std::span<const std::string_view> encodedKeys,
-      std::span<char* const> payloads = {});
-
-  void appendBatch(
-      const EncodedKeyBatch& encodedKeys,
-      std::span<char* const> payloads = {});
 
   template <typename Append>
   void appendKeyBlocks(vector_size_t count, Append append) {
@@ -203,10 +131,6 @@ class RadixSortRunStorage {
 
   void allocatePayloadRowBatch(
       std::span<const uint64_t> heapSizes,
-      PayloadRowBatch& batch);
-
-  void allocatePayloadRowBatch(
-      std::span<const uint64_t> heapSizes,
       const BufferPtr& sizeStorage,
       PayloadRowBatch& batch);
 
@@ -218,6 +142,8 @@ class RadixSortRunStorage {
 
  private:
   friend class RadixSortKeyCodec;
+
+  static constexpr uint64_t kDefaultBlockBytes = 64 * 1024;
 
   template <typename Encode>
   uint64_t appendVariableKeyBatch(
@@ -273,10 +199,6 @@ class RadixSortRunStorage {
 
   void ensurePayloadFixedBlock();
 
-  static uint32_t normalizeKeysPerBlock(
-      uint32_t keysPerBlock,
-      const RadixSortKeyLayout& layout);
-
   void allocatePayloadRowPointers(vector_size_t count, char** rows);
 
   void allocateOverflow(uint64_t size, char*& data);
@@ -284,17 +206,13 @@ class RadixSortRunStorage {
   memory::MemoryPool* pool_;
   RadixSortKeyLayout layout_;
   uint32_t keysPerBlock_;
-  uint64_t preferredHeapGroupBytes_;
   std::shared_ptr<const PayloadRowLayout> payloadLayout_;
-  uint32_t payloadRowsPerBlock_;
-  uint64_t preferredPayloadHeapGroupBytes_;
   memory::AllocationPool allocationPool_;
   BlockVector keyBlocks_;
   HeapGroupVector keyHeapGroups_;
   PayloadFixedBlockVector payloadFixedBlocks_;
   PayloadHeapGroupVector payloadHeapGroups_;
   uint64_t size_{0};
-  uint64_t payloadSize_{0};
 };
 
 } // namespace bytedance::bolt::exec::radixsort

--- a/bolt/exec/radixsort/RadixSortSpill.cpp
+++ b/bolt/exec/radixsort/RadixSortSpill.cpp
@@ -252,8 +252,7 @@ std::vector<RadixSortSpillFile> RadixSortSpillWriter::finish() {
   std::vector<RadixSortSpillFile> files;
   files.reserve(spillFiles.size());
   for (auto& file : spillFiles) {
-    files.push_back(RadixSortSpillFile{
-        file.id, file.path, file.size, file.rowCount, file.compressionKind});
+    files.push_back(RadixSortSpillFile{file.path, file.compressionKind});
   }
   cleanupFilesOnError.dismiss();
   finished_ = true;
@@ -380,10 +379,10 @@ void RadixSortSpillWriter::flush() {
     payloadFixedCursor +=
         static_cast<uint64_t>(range.rowCount) * meta_.payloadFixedSize;
   }
-  BOLT_DCHECK_EQ(keyRecordsCursor, keyRecords + keyRecordBytes);
-  BOLT_DCHECK_EQ(keyHeapCursor, keyHeap + keyHeapBytes);
-  BOLT_DCHECK_EQ(payloadFixedCursor, payloadFixed + payloadFixedBytes);
-  BOLT_DCHECK_EQ(payloadHeapCursor, payloadHeap + payloadHeapBytes);
+  BOLT_DCHECK(keyRecordsCursor == keyRecords + keyRecordBytes);
+  BOLT_DCHECK(keyHeapCursor == keyHeap + keyHeapBytes);
+  BOLT_DCHECK(payloadFixedCursor == payloadFixed + payloadFixedBytes);
+  BOLT_DCHECK(payloadHeapCursor == payloadHeap + payloadHeapBytes);
 
   inputBytes_ += uncompressedBytes;
 
@@ -460,6 +459,10 @@ std::optional<RadixSortSpillBlockView> RadixSortSpillReader::nextBatch() {
   }
 
   MicrosecondTimer readTimer(&spillReadTimeUs_);
+  BOLT_CHECK_GE(
+      inputRemainingFileBytes(),
+      kBlockHeaderSize,
+      "Radix sort spill header is truncated");
   RadixSortSpillBlockHeader header;
   input_->readBytes(reinterpret_cast<char*>(&header), sizeof(header));
   BOLT_CHECK_EQ(
@@ -517,6 +520,10 @@ std::optional<RadixSortSpillBlockView> RadixSortSpillReader::nextBatch() {
       header.payloadHeapBytes);
   BOLT_CHECK_EQ(
       static_cast<uint64_t>(uncompressedSize), expectedUncompressedSize);
+  BOLT_CHECK_LE(
+      static_cast<uint64_t>(storedSize),
+      inputRemainingFileBytes(),
+      "Radix sort spill body is truncated");
   if (serializedBuffer_ != nullptr &&
       (serializedBuffer_->size() > kRadixSortSpillBufferSize ||
        serializedBuffer_->capacity() < uncompressedSize)) {
@@ -816,7 +823,7 @@ class RadixSortFixedSpillMergeStream final
   bool tryAdvance() override {
     BOLT_DCHECK_NOT_NULL(key_);
     const auto* nextKey = key_ + recordStride_;
-    BOLT_DCHECK_LE(nextKey, keyRecordsEnd_);
+    BOLT_DCHECK(nextKey <= keyRecordsEnd_);
     if (nextKey == keyRecordsEnd_) {
       return false;
     }
@@ -829,7 +836,7 @@ class RadixSortFixedSpillMergeStream final
 
   void advanceAfterFlush() override {
     BOLT_DCHECK_NOT_NULL(key_);
-    BOLT_DCHECK_EQ(key_ + recordStride_, keyRecordsEnd_);
+    BOLT_DCHECK(key_ + recordStride_ == keyRecordsEnd_);
     loadBatch();
   }
 
@@ -859,7 +866,7 @@ class RadixSortFixedSpillMergeStream final
         clearCursor();
         return;
       }
-      BOLT_DCHECK_LT(block->keyRecordsBegin, block->keyHeapBegin);
+      BOLT_DCHECK(block->keyRecordsBegin < block->keyHeapBegin);
       keyRecordsEnd_ = block->keyHeapBegin;
       if constexpr (HasPayload) {
         payload_ = block->payloadFixedBegin;
@@ -915,7 +922,7 @@ class RadixSortVariableSpillMergeStream final
   bool tryAdvance() override {
     BOLT_DCHECK_NOT_NULL(key_);
     const auto* nextKey = key_ + recordStride_;
-    BOLT_DCHECK_LE(nextKey, keyRecordsEnd_);
+    BOLT_DCHECK(nextKey <= keyRecordsEnd_);
     if (nextKey == keyRecordsEnd_) {
       return false;
     }
@@ -931,10 +938,10 @@ class RadixSortVariableSpillMergeStream final
 
   void advanceAfterFlush() override {
     BOLT_DCHECK_NOT_NULL(key_);
-    BOLT_DCHECK_EQ(key_ + recordStride_, keyRecordsEnd_);
-    BOLT_CHECK_EQ(
-        encodedSuffix_.bytes.data() + encodedSuffix_.bytes.size(),
-        keyHeapEnd_,
+    BOLT_DCHECK(key_ + recordStride_ == keyRecordsEnd_);
+    BOLT_CHECK(
+        encodedSuffix_.bytes.data() + encodedSuffix_.bytes.size() ==
+            keyHeapEnd_,
         "Radix sort spill key heap is not consumed exactly");
     loadBatch();
   }
@@ -953,7 +960,7 @@ class RadixSortVariableSpillMergeStream final
 
  private:
   void prepareCurrent(const char* record, const char* keyHeap, char* payload) {
-    BOLT_DCHECK_LE(keyHeap, keyHeapEnd_);
+    BOLT_DCHECK(keyHeap <= keyHeapEnd_);
     const auto encodedSize =
         loadUnaligned<uint64_t>(record + Traits::kSizeOffset);
     BOLT_CHECK_GT(
@@ -1126,22 +1133,35 @@ void RadixSortMerger::replaceMemory(
     RadixSortSpillRun run,
     RadixSortSpillSectionMeta meta,
     memory::MemoryPool* pool,
-    bool spillUringEnabled) {
+    bool spillUringEnabled,
+    folly::FunctionRef<void()> releaseMemory) {
+  auto cleanupFilesOnError =
+      folly::makeGuard([&run]() { cleanupSpillFilesNoThrow(run.files); });
   BOLT_CHECK(memoryIndex_.has_value(), "Missing radix memory merge stream");
   BOLT_CHECK(!run.files.empty(), "Radix sort spill run has no files");
   BOLT_CHECK(
       meta.keyLayout.kind() == keyLayout_.kind(),
       "Radix sort replacement stream layout mismatch");
 
-  auto replacement = makeRadixSortSpillMergeStream(
-      std::move(run),
-      std::move(meta),
-      pool,
-      spillUringEnabled,
-      bufferCache_.get());
-  streams_[*memoryIndex_] = std::move(replacement);
+  const auto index = *memoryIndex_;
+  streams_[index].reset();
   memoryIndex_.reset();
-  resetSelection();
+  try {
+    releaseMemory();
+    streams_[index] = makeRadixSortSpillMergeStream(
+        std::move(run),
+        std::move(meta),
+        pool,
+        spillUringEnabled,
+        bufferCache_.get());
+    resetSelection();
+  } catch (...) {
+    streams_.clear();
+    losers_.clear();
+    lastIndex_ = kEmpty;
+    throw;
+  }
+  cleanupFilesOnError.dismiss();
 }
 
 void RadixSortMerger::removeMemory() {

--- a/bolt/exec/radixsort/RadixSortSpill.h
+++ b/bolt/exec/radixsort/RadixSortSpill.h
@@ -37,10 +37,7 @@ constexpr uint64_t kRadixSortSpillBufferSize =
 constexpr uint32_t kCurrentRadixSortSpillFormat = 2;
 
 struct RadixSortSpillFile {
-  uint32_t id;
   std::string path;
-  uint64_t size{0};
-  uint64_t rowCount{0};
   common::CompressionKind compressionKind{common::CompressionKind_NONE};
 };
 
@@ -362,13 +359,10 @@ class RadixSortMerger {
       RadixSortSpillRun run,
       RadixSortSpillSectionMeta meta,
       memory::MemoryPool* pool,
-      bool spillUringEnabled);
+      bool spillUringEnabled,
+      folly::FunctionRef<void()> releaseMemory);
 
   void removeMemory();
-
-  size_t testingNumStreams() const {
-    return streams_.size();
-  }
 
  private:
   using StreamIndex = uint16_t;

--- a/bolt/exec/radixsort/RadixSortSpillSections.cpp
+++ b/bolt/exec/radixsort/RadixSortSpillSections.cpp
@@ -295,7 +295,7 @@ void copyRowsToSectionsForLayout(
       const auto keyHeapSize = encodedSize - meta.keyHeapOffset;
       // keyHeapBytes is the sizing snapshot for this range. Source records
       // must remain immutable until this delayed copy completes.
-      BOLT_DCHECK_LE(keyHeap, keyHeapEnd);
+      BOLT_DCHECK(keyHeap <= keyHeapEnd);
       BOLT_DCHECK_LE(keyHeapSize, static_cast<uint64_t>(keyHeapEnd - keyHeap));
       std::memcpy(
           keyHeap,
@@ -317,10 +317,10 @@ void copyRowsToSectionsForLayout(
     destinationKey += kWireKeyRecordSize;
   }
   if constexpr (kHasKeyHeap) {
-    BOLT_DCHECK_EQ(keyHeap, keyHeapEnd);
+    BOLT_DCHECK(keyHeap == keyHeapEnd);
   }
   if constexpr (HasPayloadHeap) {
-    BOLT_DCHECK_EQ(payloadHeap, payloadHeapStart + payloadHeapBytes);
+    BOLT_DCHECK(payloadHeap == payloadHeapStart + payloadHeapBytes);
   }
 }
 

--- a/bolt/exec/radixsort/RadixSortUtils.h
+++ b/bolt/exec/radixsort/RadixSortUtils.h
@@ -31,11 +31,6 @@ static_assert(
     std::endian::native == std::endian::little ||
     std::endian::native == std::endian::big);
 
-enum class NativeEndianness : uint8_t {
-  kLittle = 1,
-  kBig = 2,
-};
-
 template <typename T>
 T loadUnaligned(const void* source) {
   static_assert(std::is_trivially_copyable_v<T>);
@@ -119,26 +114,6 @@ T* prepareReusableBuffer(
 }
 
 template <typename T>
-std::optional<T> checkedAlignUp(T value, T alignment) {
-  static_assert(std::is_unsigned_v<T>);
-  if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
-    return std::nullopt;
-  }
-  auto adjusted = checkedAdd(value, alignment - 1);
-  if (!adjusted.has_value()) {
-    return std::nullopt;
-  }
-  return *adjusted & ~(alignment - 1);
-}
-
-constexpr NativeEndianness nativeEndianness() {
-  if constexpr (std::endian::native == std::endian::little) {
-    return NativeEndianness::kLittle;
-  }
-  return NativeEndianness::kBig;
-}
-
-template <typename T>
 constexpr T byteSwap(T value) {
   static_assert(std::is_unsigned_v<T>);
   if constexpr (sizeof(T) == 1) {
@@ -165,22 +140,6 @@ constexpr T toBigEndian(T value) {
 template <typename T>
 constexpr T fromBigEndian(T value) {
   return toBigEndian(value);
-}
-
-inline bool isValidRecordRelativeRange(
-    uint64_t recordSize,
-    uint64_t offset,
-    uint64_t length,
-    uint64_t minimumOffset = 1,
-    bool allowZeroOffset = false) {
-  if (offset == 0) {
-    return allowZeroOffset && length == 0;
-  }
-  if (offset < minimumOffset || offset >= recordSize) {
-    return false;
-  }
-  auto end = checkedAdd(offset, length);
-  return end.has_value() && *end <= recordSize;
 }
 
 } // namespace bytedance::bolt::exec::radixsort

--- a/bolt/exec/tests/RadixPayloadRowTest.cpp
+++ b/bolt/exec/tests/RadixPayloadRowTest.cpp
@@ -85,6 +85,8 @@ class PayloadRowReaderTestHelper {
 
 namespace {
 
+constexpr uint32_t kTestingRowsPerBlock = 2048;
+
 class FixedSizeStreamArena final : public StreamArena {
  public:
   explicit FixedSizeStreamArena(char* buffer)
@@ -480,28 +482,50 @@ class RadixPayloadRowTest : public testing::Test {
     }
   }
 
-  static std::vector<char*> rowPointers(const PayloadRowBatch& batch) {
-    std::vector<char*> rows(batch.size());
-    for (vector_size_t row = 0; row < batch.size(); ++row) {
-      rows[row] = batch.rowAt(row);
+  static std::span<char* const> batchRows(
+      const PayloadRowBatch& batch,
+      vector_size_t size) {
+    if (size == 0) {
+      return {};
     }
-    return rows;
+    BOLT_CHECK_NOT_NULL(batch.rows());
+    return {batch.rows()->as<char*>(), static_cast<size_t>(size)};
+  }
+
+  static std::vector<char*> rowPointers(
+      const PayloadRowBatch& batch,
+      vector_size_t size) {
+    const auto rows = batchRows(batch, size);
+    return {rows.begin(), rows.end()};
   }
 
   static void gatherPayloadBatch(
       const PayloadRowLayout& layout,
       const PayloadRowBatch& batch,
+      vector_size_t size,
       memory::MemoryPool* pool,
       RowVectorPtr& result) {
-    auto rows = rowPointers(batch);
-    PayloadRowReader::gather(
-        layout, std::span<char* const>(rows), pool, result);
+    PayloadRowReader::gather(layout, batchRows(batch, size), pool, result);
   }
 
-  static uint64_t totalHeapSize(const PayloadRowBatch& batch) {
+  static uint64_t payloadHeapSize(
+      const PayloadRowLayout& layout,
+      const char* row) {
     uint64_t size = 0;
-    for (vector_size_t row = 0; row < batch.size(); ++row) {
-      const auto next = checkedAdd(size, batch.heapSizeAt(row));
+    for (const auto& column : layout.variableColumns()) {
+      const auto isNull =
+          (static_cast<uint8_t>(row[column.nullByte]) & column.nullMask) == 0;
+      if (isNull) {
+        continue;
+      }
+      const auto fieldSize = column.complex
+          ? loadUnaligned<PayloadVarlenRef>(row + column.offset).size
+          : [&]() {
+              const auto value = loadUnaligned<StringView>(row + column.offset);
+              return value.isInline() ? uint64_t{0}
+                                      : static_cast<uint64_t>(value.size());
+            }();
+      const auto next = checkedAdd(size, fieldSize);
       BOLT_CHECK(next.has_value());
       size = *next;
     }
@@ -519,18 +543,25 @@ class RadixPayloadRowTest : public testing::Test {
       verifyPayloadHeapLayout(*input, *arena.payloadLayout(), batch);
     }
     RowVectorPtr output;
-    gatherPayloadBatch(*arena.payloadLayout(), batch, pool_.get(), output);
+    gatherPayloadBatch(
+        *arena.payloadLayout(), batch, input->size(), pool_.get(), output);
     expectEquivalent(*input, *output);
     return output;
   }
 
   void poisonHeap(
-      const RadixSortRunStorage& arena,
+      const PayloadRowLayout& layout,
+      const PayloadRowBatch& batch,
+      vector_size_t size,
       uint8_t byte,
       const RowVector& input,
       const RowVector& output) {
-    for (const auto& group : arena.payloadHeapGroups()) {
-      std::memset(group.base, byte, group.used);
+    const auto rows = batchRows(batch, size);
+    for (vector_size_t row = 0; row < size; ++row) {
+      const auto heapSize = payloadHeapSize(layout, rows[row]);
+      if (heapSize > 0) {
+        std::memset(batch.heapAt(row), byte, heapSize);
+      }
     }
     expectEquivalent(input, output);
   }
@@ -539,7 +570,6 @@ class RadixPayloadRowTest : public testing::Test {
       const RadixSortRunStorage& arena,
       const memory::MemoryPool& pool) {
     EXPECT_EQ(arena.allocatedBytes(), 0);
-    EXPECT_EQ(arena.numRanges(), 0);
     EXPECT_EQ(pool.currentBytes(), 0);
   }
 
@@ -549,9 +579,9 @@ class RadixPayloadRowTest : public testing::Test {
       vector_size_t rows) {
     PayloadRowBatch used;
     arena.allocateFixedPayloadRowBatch(rows, used);
-    BOLT_CHECK(!arena.payloadFixedBlocks().empty());
-    auto* next = arena.payloadFixedBlocks().front().base +
-        static_cast<uint64_t>(used.size()) * layout.rowWidth();
+    const auto usedRows = batchRows(used, rows);
+    auto* next =
+        usedRows.front() + static_cast<uint64_t>(rows) * layout.rowWidth();
     std::memset(next, 0xa5, static_cast<uint64_t>(rows) * layout.rowWidth());
     return next;
   }
@@ -570,30 +600,29 @@ class RadixPayloadRowTest : public testing::Test {
       const RowVector& input,
       const PayloadRowLayout& layout,
       const PayloadRowBatch& batch) {
-    ASSERT_EQ(input.size(), batch.size());
     ASSERT_EQ(input.childrenSize(), layout.columns().size());
+    const auto rows = batchRows(batch, input.size());
     for (vector_size_t row = 0; row < input.size(); ++row) {
       auto* cursor = batch.heapAt(row);
       for (uint32_t column = 0; column < layout.columns().size(); ++column) {
         const auto& metadata = layout.columns()[column];
         const auto isNull = input.childAt(column)->isNullAt(row);
         EXPECT_EQ(
-            (static_cast<uint8_t>(batch.rowAt(row)[metadata.nullByte]) &
+            (static_cast<uint8_t>(rows[row][metadata.nullByte]) &
              metadata.nullMask) == 0,
             isNull)
             << "row=" << row << ", column=" << column;
         if (isNull) {
           for (uint32_t byte = 0; byte < metadata.width; ++byte) {
             EXPECT_EQ(
-                static_cast<uint8_t>(batch.rowAt(row)[metadata.offset + byte]),
-                0)
+                static_cast<uint8_t>(rows[row][metadata.offset + byte]), 0)
                 << "row=" << row << ", column=" << column << ", byte=" << byte;
           }
         }
         if (!metadata.variable) {
           continue;
         }
-        const auto* slot = batch.rowAt(row) + metadata.offset;
+        const auto* slot = rows[row] + metadata.offset;
         if (isNull) {
           if (metadata.complex) {
             const auto value = loadUnaligned<PayloadVarlenRef>(slot);
@@ -626,8 +655,10 @@ class RadixPayloadRowTest : public testing::Test {
           cursor,
           batch.heapAt(row) == nullptr
               ? nullptr
-              : batch.heapAt(row) + batch.heapSizeAt(row));
-      EXPECT_EQ(batch.heapAt(row) == nullptr, batch.heapSizeAt(row) == 0);
+              : batch.heapAt(row) + payloadHeapSize(layout, rows[row]));
+      EXPECT_EQ(
+          batch.heapAt(row) == nullptr,
+          payloadHeapSize(layout, rows[row]) == 0);
     }
   }
 };
@@ -744,34 +775,31 @@ TEST_F(RadixPayloadRowTest, scalarStringRoundTripAndDeepCopy) {
        makeUnknownVector(4)});
   auto layout = payloadLayout(asRowType(input->type()));
   auto arenaPool = rootPool_->addLeafChild("payload-roundtrip-arena");
-  RadixSortRunStorage arena(
-      arenaPool.get(), keyLayout(), 4, 64, layout, 2, 512);
+  RadixSortRunStorage arena(arenaPool.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  ASSERT_EQ(batch.size(), input->size());
-  ASSERT_EQ(arena.payloadSize(), input->size());
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 2);
 
   verifyPayloadHeapLayout(*input, *layout, batch);
-  EXPECT_EQ(batch.heapSizeAt(0), 0);
-  EXPECT_EQ(batch.heapSizeAt(1), 0);
-  EXPECT_EQ(batch.heapSizeAt(2), longA.size() + longB.size());
-  EXPECT_EQ(batch.heapSizeAt(3), 0);
+  const auto rows = batchRows(batch, input->size());
+  EXPECT_EQ(payloadHeapSize(*layout, rows[0]), 0);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[1]), 0);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[2]), longA.size() + longB.size());
+  EXPECT_EQ(payloadHeapSize(*layout, rows[3]), 0);
   ASSERT_NE(batch.heapAt(2), nullptr);
   const auto firstString =
-      loadUnaligned<StringView>(batch.rowAt(2) + layout->columns()[11].offset);
+      loadUnaligned<StringView>(rows[2] + layout->columns()[11].offset);
   const auto secondString =
-      loadUnaligned<StringView>(batch.rowAt(2) + layout->columns()[12].offset);
+      loadUnaligned<StringView>(rows[2] + layout->columns()[12].offset);
   EXPECT_EQ(firstString.data(), batch.heapAt(2));
   EXPECT_EQ(secondString.data(), batch.heapAt(2) + longA.size());
   EXPECT_EQ(
       secondString.data() + secondString.size(),
-      batch.heapAt(2) + batch.heapSizeAt(2));
+      batch.heapAt(2) + payloadHeapSize(*layout, rows[2]));
 
   auto outputPool = rootPool_->addLeafChild("payload-roundtrip-output");
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, batch, outputPool.get(), output);
+  gatherPayloadBatch(*layout, batch, input->size(), outputPool.get(), output);
   expectEquivalent(*input, *output);
 
   const auto outputFloat =
@@ -789,7 +817,7 @@ TEST_F(RadixPayloadRowTest, scalarStringRoundTripAndDeepCopy) {
   EXPECT_TRUE(std::signbit(
       output->childAt(7)->asUnchecked<SimpleVector<double>>()->valueAt(0)));
 
-  std::memset(batch.heapAt(2), 'z', batch.heapSizeAt(2));
+  std::memset(batch.heapAt(2), 'z', payloadHeapSize(*layout, rows[2]));
   expectEquivalent(*input, *output);
   batch = PayloadRowBatch{};
   arena.clear();
@@ -819,7 +847,7 @@ TEST_F(RadixPayloadRowTest, complexRoundTripAndContiguousHeap) {
     EXPECT_EQ(column.width, sizeof(PayloadVarlenRef));
   }
 
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   auto output = roundTrip(input, arena, batch, true);
   const auto* outputMaps = output->childAt(2)->asUnchecked<MapVector>();
@@ -838,7 +866,7 @@ TEST_F(RadixPayloadRowTest, complexRoundTripAndContiguousHeap) {
     }
   }
 
-  poisonHeap(arena, 0xa5, *input, *output);
+  poisonHeap(*layout, batch, input->size(), 0xa5, *input, *output);
 }
 
 TEST_F(RadixPayloadRowTest, stringBoundaryRoundTrip) {
@@ -856,17 +884,17 @@ TEST_F(RadixPayloadRowTest, stringBoundaryRoundTrip) {
       {makeStringVector(VARCHAR(), values),
        makeStringVector(VARBINARY(), values)});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 16 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   roundTrip(input, arena, batch);
-  EXPECT_EQ(batch.heapSizeAt(0), 0);
-  EXPECT_EQ(batch.heapSizeAt(1), 0);
-  EXPECT_EQ(batch.heapSizeAt(2), 26);
-  EXPECT_EQ(batch.heapSizeAt(3), 8192);
-  EXPECT_EQ(batch.heapSizeAt(4), 0);
-  EXPECT_EQ(batch.heapSizeAt(5), 0);
-  EXPECT_EQ(batch.heapSizeAt(6), 0);
+  const auto rows = batchRows(batch, input->size());
+  EXPECT_EQ(payloadHeapSize(*layout, rows[0]), 0);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[1]), 0);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[2]), 26);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[3]), 8192);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[4]), 0);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[5]), 0);
+  EXPECT_EQ(payloadHeapSize(*layout, rows[6]), 0);
 }
 
 TEST_F(RadixPayloadRowTest, multiColumnStringRoundTrip) {
@@ -896,18 +924,17 @@ TEST_F(RadixPayloadRowTest, multiColumnStringRoundTrip) {
        makeStringVector(VARCHAR(), nullableMixed),
        makeStringVector(VARBINARY(), nonNullLong)});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 32, 4096, layout, 32, 32 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  auto rows = rowPointers(batch);
+  auto rows = rowPointers(batch, input->size());
   const std::array<uint8_t, 4> mayHaveNulls{1, 0, 1, 0};
   RowVectorPtr output;
   PayloadRowReader::gather(*layout, rows, pool_.get(), output, mayHaveNulls);
   expectEquivalent(*input, *output);
 
-  poisonHeap(arena, 0, *input, *output);
+  poisonHeap(*layout, batch, input->size(), 0, *input, *output);
 }
 
 TEST_F(RadixPayloadRowTest, mixedStringAndComplexPayloadHeapOrder) {
@@ -931,7 +958,7 @@ TEST_F(RadixPayloadRowTest, mixedStringAndComplexPayloadHeapOrder) {
   ASSERT_TRUE(layout->hasVariableFields());
   ASSERT_EQ(layout->columns().size(), 4);
 
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   roundTrip(input, arena, batch, true);
 }
@@ -939,12 +966,11 @@ TEST_F(RadixPayloadRowTest, mixedStringAndComplexPayloadHeapOrder) {
 TEST_F(RadixPayloadRowTest, allSupportedPayloadTypesRoundTrip) {
   auto input = makeRows(makeSupportedValues());
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 16 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   auto output = roundTrip(input, arena, batch);
 
-  poisonHeap(arena, 0x3c, *input, *output);
+  poisonHeap(*layout, batch, input->size(), 0x3c, *input, *output);
 }
 
 TEST_F(RadixPayloadRowTest, gatherResultReuse) {
@@ -961,20 +987,21 @@ TEST_F(RadixPayloadRowTest, gatherResultReuse) {
             std::nullopt,
             std::string(112, 'c')})});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 8, 64, layout, 8, 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
 
   RowVectorPtr output;
-  auto rows = rowPointers(batch);
+  auto rows = rowPointers(batch, input->size());
   PayloadRowReader::gather(*layout, rows, pool_.get(), output);
   ASSERT_NE(output, nullptr);
   ASSERT_EQ(output->size(), input->size());
   ASSERT_NE(output->childAt(0)->rawNulls(), nullptr);
   ASSERT_NE(output->childAt(1)->rawNulls(), nullptr);
 
-  rows = {batch.rowAt(2), batch.rowAt(3), batch.rowAt(4)};
+  const auto encodedRows = batchRows(batch, input->size());
+  rows = {encodedRows[2], encodedRows[3], encodedRows[4]};
   PayloadRowReader::gather(*layout, rows, pool_.get(), output);
   ASSERT_NE(output, nullptr);
   ASSERT_EQ(output->size(), 3);
@@ -1005,13 +1032,12 @@ TEST_F(RadixPayloadRowTest, gatherResultReuse) {
       {makeVector<int64_t>(BIGINT(), first),
        makeVector<double>(DOUBLE(), second)});
   auto bitmapLayout = payloadLayout(asRowType(bitmapInput->type()));
-  RadixSortRunStorage bitmapArena(
-      pool_.get(), keyLayout(), 64, 1024, bitmapLayout, 64, 64);
+  RadixSortRunStorage bitmapArena(pool_.get(), keyLayout(), bitmapLayout);
   PayloadRowBatch bitmapBatch;
   PayloadRowWriter bitmapWriter;
   bitmapWriter.append(*bitmapInput, bitmapArena, bitmapBatch);
 
-  auto bitmapRows = rowPointers(bitmapBatch);
+  auto bitmapRows = rowPointers(bitmapBatch, bitmapInput->size());
   RowVectorPtr bitmapOutput;
   PayloadRowReader::gather(
       *bitmapLayout,
@@ -1033,11 +1059,8 @@ TEST_F(RadixPayloadRowTest, gatherResultReuse) {
 
 TEST_F(RadixPayloadRowTest, flatNullFreeWriteDoesNotDependOnClearedRows) {
   auto layout = payloadLayout(ROW({"first", "second"}, {BIGINT(), INTEGER()}));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 8, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   auto* nextRows = poisonNextRows(arena, *layout, 4);
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 1);
-  ASSERT_EQ(arena.payloadFixedBlocks()[0].capacity, 8);
-  ASSERT_EQ(arena.payloadFixedBlocks()[0].count, 4);
 
   auto input = makeRows(
       {makeVector<int64_t>(BIGINT(), {11, 22, 33, 44}),
@@ -1045,14 +1068,15 @@ TEST_F(RadixPayloadRowTest, flatNullFreeWriteDoesNotDependOnClearedRows) {
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  EXPECT_EQ(batch.rowAt(0), nextRows);
+  const auto rows = batchRows(batch, input->size());
+  EXPECT_EQ(rows[0], nextRows);
   for (vector_size_t row = 0; row < input->size(); ++row) {
-    EXPECT_EQ(static_cast<uint8_t>(batch.rowAt(row)[0]), 0xff);
+    EXPECT_EQ(static_cast<uint8_t>(rows[row][0]), 0xff);
     EXPECT_EQ(
-        loadUnaligned<int64_t>(batch.rowAt(row) + layout->columns()[0].offset),
+        loadUnaligned<int64_t>(rows[row] + layout->columns()[0].offset),
         11 * (row + 1));
     EXPECT_EQ(
-        loadUnaligned<int32_t>(batch.rowAt(row) + layout->columns()[1].offset),
+        loadUnaligned<int32_t>(rows[row] + layout->columns()[1].offset),
         row + 1);
   }
 }
@@ -1067,18 +1091,18 @@ TEST_F(RadixPayloadRowTest, decodedFixedDispatch) {
            nullptr, booleanIndices, kRows, booleanBase),
        BaseVector::createNullConstant(BIGINT(), kRows, pool_.get())});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 8, 64, layout, 2 * kRows, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   auto* nextRows = poisonNextRows(arena, *layout, kRows);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  ASSERT_EQ(batch.rowAt(0), nextRows);
+  const auto rows = batchRows(batch, input->size());
+  ASSERT_EQ(rows[0], nextRows);
 
   const std::array<std::optional<bool>, kRows> expected{
       false, true, std::nullopt, true, false, std::nullopt, true};
   for (vector_size_t row = 0; row < kRows; ++row) {
-    const auto* payload = batch.rowAt(row);
+    const auto* payload = rows[row];
     EXPECT_EQ(
         (static_cast<uint8_t>(payload[layout->columns()[0].nullByte]) &
          layout->columns()[0].nullMask) == 0,
@@ -1098,7 +1122,7 @@ TEST_F(RadixPayloadRowTest, decodedFixedDispatch) {
   }
 
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, batch, pool_.get(), output);
+  gatherPayloadBatch(*layout, batch, input->size(), pool_.get(), output);
   expectEquivalent(*input, *output);
 }
 
@@ -1112,16 +1136,19 @@ TEST_F(RadixPayloadRowTest, decodedStringNullInlineAndHeap) {
   auto input =
       makeRows({BaseVector::wrapInDictionary(nullptr, indices, kRows, base)});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 8, 64, layout, 8, 512);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
   verifyPayloadHeapLayout(*input, *layout, batch);
+  const auto rows = batchRows(batch, input->size());
   for (vector_size_t row = 0; row < kRows; ++row) {
     const auto source = indices->as<vector_size_t>()[row];
-    EXPECT_EQ(batch.heapSizeAt(row), source == 2 ? heapValue.size() : 0);
-    const auto value = loadUnaligned<StringView>(
-        batch.rowAt(row) + layout->columns()[0].offset);
+    EXPECT_EQ(
+        payloadHeapSize(*layout, rows[row]),
+        source == 2 ? heapValue.size() : 0);
+    const auto value =
+        loadUnaligned<StringView>(rows[row] + layout->columns()[0].offset);
     if (source == 0) {
       EXPECT_EQ(value.size(), 0);
     } else if (source == 1) {
@@ -1135,7 +1162,7 @@ TEST_F(RadixPayloadRowTest, decodedStringNullInlineAndHeap) {
   }
 
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, batch, pool_.get(), output);
+  gatherPayloadBatch(*layout, batch, input->size(), pool_.get(), output);
   expectEquivalent(*input, *output);
 }
 
@@ -1157,8 +1184,7 @@ TEST_F(RadixPayloadRowTest, multiLayerDictionaryStringPayload) {
       nullptr, makeBuffer(pool_.get(), outerIndices), kRows, inner);
   auto input = makeRows(std::vector<VectorPtr>{outer});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 8, 64, layout, 2 * kRows, 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
 
@@ -1166,16 +1192,19 @@ TEST_F(RadixPayloadRowTest, multiLayerDictionaryStringPayload) {
   writer.append(*input, arena, batch);
 
   DecodedVector decoded(*outer);
+  const auto rows = batchRows(batch, input->size());
   for (vector_size_t row = 0; row < kRows; ++row) {
     if (decoded.isNullAt(row)) {
-      EXPECT_EQ(batch.heapSizeAt(row), 0);
+      EXPECT_EQ(payloadHeapSize(*layout, rows[row]), 0);
       continue;
     }
     const auto value = decoded.valueAt<StringView>(row);
-    EXPECT_EQ(batch.heapSizeAt(row), value.isInline() ? 0 : value.size())
+    EXPECT_EQ(
+        payloadHeapSize(*layout, rows[row]),
+        value.isInline() ? 0 : value.size())
         << "row=" << row;
-    const auto stored = loadUnaligned<StringView>(
-        batch.rowAt(row) + layout->columns()[0].offset);
+    const auto stored =
+        loadUnaligned<StringView>(rows[row] + layout->columns()[0].offset);
     EXPECT_EQ(stored.str(), value.str());
     if (!stored.isInline()) {
       EXPECT_EQ(stored.data(), batch.heapAt(row));
@@ -1183,7 +1212,7 @@ TEST_F(RadixPayloadRowTest, multiLayerDictionaryStringPayload) {
   }
 
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, batch, pool_.get(), output);
+  gatherPayloadBatch(*layout, batch, input->size(), pool_.get(), output);
   expectEquivalent(*input, *output);
 }
 
@@ -1191,24 +1220,24 @@ TEST_F(RadixPayloadRowTest, singleStringNullFreeGatherClearsReusedOutput) {
   auto nullableInput = makeRows({makeStringVector(
       VARCHAR(), {std::string(80, 'n'), std::nullopt, std::string("short")})});
   auto layout = payloadLayout(asRowType(nullableInput->type()));
-  RadixSortRunStorage nullableArena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 1024);
+  RadixSortRunStorage nullableArena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch nullableBatch;
   PayloadRowWriter writer;
   writer.append(*nullableInput, nullableArena, nullableBatch);
 
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, nullableBatch, pool_.get(), output);
+  gatherPayloadBatch(
+      *layout, nullableBatch, nullableInput->size(), pool_.get(), output);
   ASSERT_NE(output->childAt(0)->rawNulls(), nullptr);
   EXPECT_TRUE(output->childAt(0)->isNullAt(1));
 
   auto nullFreeInput = makeRows({makeStringVector(
       VARCHAR(), {std::string(96, 'a'), "inline", std::string(72, 'b')})});
-  RadixSortRunStorage nullFreeArena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 1024);
+  RadixSortRunStorage nullFreeArena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch nullFreeBatch;
   writer.append(*nullFreeInput, nullFreeArena, nullFreeBatch);
-  gatherPayloadBatch(*layout, nullFreeBatch, pool_.get(), output);
+  gatherPayloadBatch(
+      *layout, nullFreeBatch, nullFreeInput->size(), pool_.get(), output);
 
   expectEquivalent(*nullFreeInput, *output);
   for (vector_size_t row = 0; row < output->size(); ++row) {
@@ -1273,14 +1302,12 @@ TEST_F(RadixPayloadRowTest, wrappedComplexPayloads) {
   columns.push_back(makeUnknownVector(kRows));
   auto input = makeRows(columns);
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 4, 64, layout, 8, 16 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   auto* nextRows = poisonNextRows(arena, *layout, kRows);
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 1);
   PayloadRowBatch batch;
   auto output = roundTrip(input, arena, batch, true);
-  EXPECT_EQ(batch.rowAt(0), nextRows);
-  poisonHeap(arena, 0x7f, *input, *output);
+  EXPECT_EQ(batchRows(batch, input->size())[0], nextRows);
+  poisonHeap(*layout, batch, input->size(), 0x7f, *input, *output);
 
   auto allNullColumns = makeNullConstants(
       kRows,
@@ -1293,14 +1320,14 @@ TEST_F(RadixPayloadRowTest, wrappedComplexPayloads) {
   allNullColumns.push_back(makeUnknownVector(kRows));
   auto allNull = makeRows(allNullColumns);
   auto allNullLayout = payloadLayout(asRowType(allNull->type()));
-  RadixSortRunStorage allNullArena(
-      pool_.get(), keyLayout(), 4, 64, allNullLayout, 4, 64);
+  RadixSortRunStorage allNullArena(pool_.get(), keyLayout(), allNullLayout);
   PayloadRowBatch allNullBatch;
   PayloadRowWriter allNullWriter;
   allNullWriter.append(*allNull, allNullArena, allNullBatch);
   verifyPayloadHeapLayout(*allNull, *allNullLayout, allNullBatch);
+  const auto allNullRows = batchRows(allNullBatch, allNull->size());
   for (vector_size_t row = 0; row < kRows; ++row) {
-    EXPECT_EQ(allNullBatch.heapSizeAt(row), 0);
+    EXPECT_EQ(payloadHeapSize(*allNullLayout, allNullRows[row]), 0);
     EXPECT_EQ(allNullBatch.heapAt(row), nullptr);
   }
 }
@@ -1311,13 +1338,12 @@ TEST_F(RadixPayloadRowTest, complexGatherReusesOutputAcrossRows) {
   auto rows = makeNestedRows();
   auto input = makeRows({arrays, maps, rows});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 16 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
 
-  auto firstRows = rowPointers(batch);
+  auto firstRows = rowPointers(batch, input->size());
   RowVectorPtr output;
   PayloadRowReader::gather(*layout, firstRows, pool_.get(), output);
   expectEquivalent(*input, *output);
@@ -1325,53 +1351,34 @@ TEST_F(RadixPayloadRowTest, complexGatherReusesOutputAcrossRows) {
   const std::vector<vector_size_t> rawIndices{2, 0, 1};
   auto indices = makeBuffer(pool_.get(), rawIndices);
   auto expected = makeRows(wrapDictionaries({arrays, maps, rows}, indices, 3));
-  std::vector<char*> subsetRows{batch.rowAt(2), batch.rowAt(0), batch.rowAt(1)};
+  const auto encodedRows = batchRows(batch, input->size());
+  std::vector<char*> subsetRows{encodedRows[2], encodedRows[0], encodedRows[1]};
   PayloadRowReader::gather(
       *layout, std::span<char* const>(subsetRows), pool_.get(), output);
   expectEquivalent(*expected, *output);
 }
 
-TEST_F(RadixPayloadRowTest, writerReuseAndBatchCopyOnWrite) {
+TEST_F(RadixPayloadRowTest, writerReusePreservesRetainedOutput) {
   auto input = makeRows({makeArrays(), makeMaps()});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 32, 4096, layout, 32, 16 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowWriter writer;
   PayloadRowBatch batch;
 
   writer.append(*input, arena, batch);
-  ASSERT_NE(batch.rows(), nullptr);
-  ASSERT_NE(batch.heaps(), nullptr);
-  ASSERT_NE(batch.heapSizes(), nullptr);
-  EXPECT_EQ(
-      batch.heapSizes()->size(),
-      static_cast<uint64_t>(input->size()) * sizeof(uint64_t));
-  const auto* rowsBuffer = batch.rows().get();
-  const auto* heapsBuffer = batch.heaps().get();
-  const auto* sizesBuffer = batch.heapSizes().get();
-
-  writer.append(*input, arena, batch);
-  EXPECT_EQ(batch.rows().get(), rowsBuffer);
-  EXPECT_EQ(batch.heaps().get(), heapsBuffer);
-  EXPECT_EQ(batch.heapSizes().get(), sizesBuffer);
-
   const auto retained = batch;
-  std::vector<uint64_t> retainedHeapSizes(retained.size());
-  for (vector_size_t row = 0; row < retained.size(); ++row) {
-    retainedHeapSizes[row] = retained.heapSizeAt(row);
-  }
+  RowVectorPtr retainedOutput;
+  gatherPayloadBatch(
+      *layout, retained, input->size(), pool_.get(), retainedOutput);
 
   writer.append(*input, arena, batch);
-  EXPECT_NE(batch.rows().get(), retained.rows().get());
-  EXPECT_NE(batch.heaps().get(), retained.heaps().get());
-  EXPECT_NE(batch.heapSizes().get(), retained.heapSizes().get());
-  for (vector_size_t row = 0; row < retained.size(); ++row) {
-    EXPECT_EQ(retained.heapSizeAt(row), retainedHeapSizes[row]);
-  }
+  writer.append(*input, arena, batch);
+
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, retained, pool_.get(), output);
+  gatherPayloadBatch(*layout, retained, input->size(), pool_.get(), output);
   expectEquivalent(*input, *output);
-  gatherPayloadBatch(*layout, batch, pool_.get(), output);
+  expectEquivalent(*input, *retainedOutput);
+  gatherPayloadBatch(*layout, batch, input->size(), pool_.get(), output);
   expectEquivalent(*input, *output);
 }
 
@@ -1398,8 +1405,7 @@ TEST_F(RadixPayloadRowTest, writerAndBatchReuseAcrossSizesAndClear) {
   auto empty = makeInput(0, 32);
   auto larger = makeInput(131, 80);
   auto layout = payloadLayout(asRowType(large->type()));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 64, 4096, layout, 64, 16 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowWriter writer;
   PayloadRowBatch batch;
   std::vector<std::pair<RowVectorPtr, RowVectorPtr>> retained;
@@ -1408,30 +1414,23 @@ TEST_F(RadixPayloadRowTest, writerAndBatchReuseAcrossSizesAndClear) {
     writer.append(*input, arena, batch);
     verifyPayloadHeapLayout(*input, *layout, batch);
     RowVectorPtr output;
-    gatherPayloadBatch(*layout, batch, pool_.get(), output);
+    gatherPayloadBatch(*layout, batch, input->size(), pool_.get(), output);
     expectEquivalent(*input, *output);
     retained.emplace_back(input, output);
   };
 
   appendAndRetain(large);
-  ASSERT_NE(batch.heapSizes(), nullptr);
-  const auto heapSizeCapacity = batch.heapSizes()->capacity();
   appendAndRetain(small);
-  ASSERT_NE(batch.heapSizes(), nullptr);
-  EXPECT_GE(batch.heapSizes()->capacity(), heapSizeCapacity);
 
   writer.append(*empty, arena, batch);
-  EXPECT_EQ(batch.size(), 0);
   RowVectorPtr emptyOutput;
-  gatherPayloadBatch(*layout, batch, pool_.get(), emptyOutput);
+  gatherPayloadBatch(*layout, batch, empty->size(), pool_.get(), emptyOutput);
   expectEquivalent(*empty, *emptyOutput);
 
   appendAndRetain(larger);
   batch = PayloadRowBatch{};
   arena.clear();
-  EXPECT_EQ(arena.payloadSize(), 0);
-  EXPECT_TRUE(arena.payloadFixedBlocks().empty());
-  EXPECT_TRUE(arena.payloadHeapGroups().empty());
+  EXPECT_EQ(arena.allocatedBytes(), 0);
   for (const auto& [expected, actual] : retained) {
     expectEquivalent(*expected, *actual);
   }
@@ -1439,7 +1438,6 @@ TEST_F(RadixPayloadRowTest, writerAndBatchReuseAcrossSizesAndClear) {
   auto afterClear = makeInput(17, 56);
   appendAndRetain(afterClear);
   expectEquivalent(*afterClear, *retained.back().second);
-  EXPECT_EQ(arena.payloadSize(), afterClear->size());
 }
 
 TEST_F(RadixPayloadRowTest, logPatternPayloadRoundTrip) {
@@ -1497,12 +1495,16 @@ TEST_F(RadixPayloadRowTest, logPatternPayloadRoundTrip) {
   ASSERT_EQ(layout->columns().size(), 9);
   ASSERT_TRUE(layout->hasVariableFields());
 
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout(), 64, 4096, layout, 64, 64 * 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   roundTrip(input, arena, batch);
 
-  EXPECT_GT(totalHeapSize(batch), 8 * 1024);
+  const auto rows = batchRows(batch, input->size());
+  uint64_t heapBytes = 0;
+  for (const auto* row : rows) {
+    heapBytes += payloadHeapSize(*layout, row);
+  }
+  EXPECT_GT(heapBytes, 8 * 1024);
 }
 
 TEST_F(RadixPayloadRowTest, fixedSeedRoundTripProperty) {
@@ -1552,8 +1554,7 @@ TEST_F(RadixPayloadRowTest, fixedSeedRoundTripProperty) {
          makeStringVector(VARCHAR(), strings),
          makeStringVector(VARBINARY(), binaries)});
     auto layout = payloadLayout(asRowType(input->type()));
-    RadixSortRunStorage arena(
-        pool_.get(), keyLayout(), 127, 4096, layout, 127, 4096);
+    RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
     PayloadRowBatch batch;
     roundTrip(input, arena, batch);
   }
@@ -1567,20 +1568,21 @@ TEST_F(RadixPayloadRowTest, nullBitmapAndNullSlots) {
   }
   auto input = makeRows(children);
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
 
-  const auto* allNull = reinterpret_cast<const uint8_t*>(batch.rowAt(0));
+  const auto rows = batchRows(batch, input->size());
+  const auto* allNull = reinterpret_cast<const uint8_t*>(rows[0]);
   EXPECT_EQ(allNull[0], 0);
   EXPECT_EQ(allNull[1], 0xfc);
   for (const auto& column : layout->columns()) {
     for (uint32_t byte = 0; byte < column.width; ++byte) {
-      EXPECT_EQ(batch.rowAt(0)[column.offset + byte], 0);
+      EXPECT_EQ(rows[0][column.offset + byte], 0);
     }
   }
-  const auto* noNull = reinterpret_cast<const uint8_t*>(batch.rowAt(1));
+  const auto* noNull = reinterpret_cast<const uint8_t*>(rows[1]);
   EXPECT_EQ(noNull[0], 0xff);
   EXPECT_EQ(noNull[1], 0xff);
 }
@@ -1593,27 +1595,25 @@ TEST_F(RadixPayloadRowTest, fixedOnlyAndEmptyInputHaveNoHeap) {
            TIMESTAMP(), {Timestamp(0, 1), Timestamp(0, 2), Timestamp(0, 3)})});
   auto layout = payloadLayout(asRowType(fixedInput->type()));
   ASSERT_FALSE(layout->hasVariableFields());
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   roundTrip(fixedInput, arena, batch);
-  EXPECT_TRUE(arena.payloadHeapGroups().empty());
-  EXPECT_EQ(batch.rowAt(1) - batch.rowAt(0), layout->rowWidth());
-  EXPECT_EQ(batch.rowAt(2) - batch.rowAt(1), layout->rowWidth());
+  const auto rows = batchRows(batch, fixedInput->size());
+  EXPECT_EQ(rows[1] - rows[0], layout->rowWidth());
+  EXPECT_EQ(rows[2] - rows[1], layout->rowWidth());
   EXPECT_EQ(batch.heapAt(0), nullptr);
   EXPECT_EQ(batch.heapAt(1), nullptr);
   EXPECT_EQ(batch.heapAt(2), nullptr);
   for (vector_size_t row = 0; row < fixedInput->size(); ++row) {
+    EXPECT_EQ(static_cast<uint8_t>(rows[row][0]), static_cast<uint8_t>(0xff));
     EXPECT_EQ(
-        static_cast<uint8_t>(batch.rowAt(row)[0]), static_cast<uint8_t>(0xff));
-    EXPECT_EQ(
-        loadUnaligned<int8_t>(batch.rowAt(row) + layout->columns()[0].offset),
+        loadUnaligned<int8_t>(rows[row] + layout->columns()[0].offset),
         row + 1);
     EXPECT_EQ(
-        loadUnaligned<int64_t>(batch.rowAt(row) + layout->columns()[1].offset),
+        loadUnaligned<int64_t>(rows[row] + layout->columns()[1].offset),
         row + 4);
     EXPECT_EQ(
-        loadUnaligned<Timestamp>(
-            batch.rowAt(row) + layout->columns()[2].offset),
+        loadUnaligned<Timestamp>(rows[row] + layout->columns()[2].offset),
         Timestamp(0, row + 1));
   }
 
@@ -1626,14 +1626,10 @@ TEST_F(RadixPayloadRowTest, fixedOnlyAndEmptyInputHaveNoHeap) {
           BaseVector::create(TINYINT(), 0, pool_.get()),
           BaseVector::create(BIGINT(), 0, pool_.get()),
           BaseVector::create(TIMESTAMP(), 0, pool_.get())});
-  RadixSortRunStorage emptyArena(
-      pool_.get(), keyLayout(), 4, 64, layout, 2, 64);
+  RadixSortRunStorage emptyArena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch emptyBatch;
   PayloadRowWriter emptyWriter;
   emptyWriter.append(*emptyInput, emptyArena, emptyBatch);
-  EXPECT_EQ(emptyBatch.size(), 0);
-  EXPECT_TRUE(emptyArena.payloadFixedBlocks().empty());
-  EXPECT_TRUE(emptyArena.payloadHeapGroups().empty());
   EXPECT_EQ(emptyArena.allocatedBytes(), 0);
 }
 
@@ -1648,17 +1644,14 @@ TEST_F(RadixPayloadRowTest, emptyVariableInputRoundTrip) {
           BaseVector::create(ARRAY(INTEGER()), 0, pool_.get())});
   auto layout = payloadLayout(asRowType(input->type()));
   ASSERT_TRUE(layout->hasVariableFields());
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  EXPECT_EQ(batch.size(), 0);
-  EXPECT_TRUE(arena.payloadFixedBlocks().empty());
-  EXPECT_TRUE(arena.payloadHeapGroups().empty());
   EXPECT_EQ(arena.allocatedBytes(), 0);
 
   RowVectorPtr output;
-  gatherPayloadBatch(*layout, batch, pool_.get(), output);
+  gatherPayloadBatch(*layout, batch, input->size(), pool_.get(), output);
   ASSERT_NE(output, nullptr);
   EXPECT_EQ(output->size(), 0);
   EXPECT_TRUE(output->type()->equivalent(*input->type()));
@@ -1689,11 +1682,11 @@ TEST_F(RadixPayloadRowTest, reversedUnalignedBigintGather) {
   ASSERT_NE(layout->columns()[1].offset % alignof(int64_t), 0);
   ASSERT_NE(layout->columns()[2].offset % alignof(int64_t), 0);
   ASSERT_NE(layout->columns()[3].offset % alignof(int64_t), 0);
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  auto rows = rowPointers(batch);
+  auto rows = rowPointers(batch, input->size());
   std::reverse(rows.begin(), rows.end());
 
   RowVectorPtr output;
@@ -1735,11 +1728,11 @@ TEST_F(RadixPayloadRowTest, fusedFixed64GatherWithExplicitNullHints) {
        makeVector<double>(DOUBLE(), doubles),
        makeVector<int64_t>(DECIMAL(18, 2), decimals)});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 64, 1024, layout, 64, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter writer;
   writer.append(*input, arena, batch);
-  auto rows = rowPointers(batch);
+  auto rows = rowPointers(batch, input->size());
 
   RowVectorPtr output;
   const std::array<uint8_t, 3> mayHaveNulls{0, 1, 0};
@@ -1773,81 +1766,35 @@ TEST_F(RadixPayloadRowTest, fusedFixed64GatherWithExplicitNullHints) {
   }
 }
 
-TEST_F(RadixPayloadRowTest, fixedPayloadBlockCapacityIsByteBounded) {
-  constexpr uint64_t kMaxPayloadFixedBlockBytes = 64 * 1024;
-  for (const auto columnCount : {1U, 256U, 8193U}) {
-    std::vector<TypePtr> types(columnCount, BIGINT());
-    auto layout = payloadLayout(ROW(std::move(types)));
-    RadixSortRunStorage arena(
-        pool_.get(),
-        keyLayout(),
-        RadixSortRunStorage::kTestingRowsPerBlock,
-        64 * 1024,
-        layout,
-        RadixSortRunStorage::kTestingRowsPerBlock,
-        64 * 1024);
-    PayloadRowBatch batch;
-    arena.allocateFixedPayloadRowBatch(1, batch);
-
-    ASSERT_EQ(arena.payloadFixedBlocks().size(), 1);
-    const auto& block = arena.payloadFixedBlocks().front();
-    const auto byteBoundedCapacity =
-        kMaxPayloadFixedBlockBytes / layout->rowWidth();
-    const auto expectedCapacity = static_cast<uint32_t>(std::min<uint64_t>(
-        RadixSortRunStorage::kTestingRowsPerBlock,
-        std::max<uint64_t>(1, byteBoundedCapacity)));
-    EXPECT_EQ(block.capacity, expectedCapacity) << "columns=" << columnCount;
-    EXPECT_EQ(block.count, 1);
-    if (layout->rowWidth() <= kMaxPayloadFixedBlockBytes) {
-      EXPECT_LE(
-          static_cast<uint64_t>(block.capacity) * layout->rowWidth(),
-          kMaxPayloadFixedBlockBytes);
-    } else {
-      EXPECT_EQ(block.capacity, 1);
-    }
-  }
-}
-
-TEST_F(RadixPayloadRowTest, defaultFixedPayloadBlockUsesByteCapacity) {
-  constexpr uint64_t kMaxPayloadFixedBlockBytes = 64 * 1024;
-  auto layout = payloadLayout(ROW({"value"}, {BIGINT()}));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout);
-  PayloadRowBatch batch;
-  arena.allocateFixedPayloadRowBatch(1, batch);
-
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 1);
-  const auto expectedCapacity = static_cast<uint32_t>(
-      std::max<uint64_t>(1, kMaxPayloadFixedBlockBytes / layout->rowWidth()));
-  EXPECT_EQ(arena.payloadFixedBlocks().front().capacity, expectedCapacity);
-  EXPECT_GT(expectedCapacity, RadixSortRunStorage::kTestingRowsPerBlock);
-}
-
-TEST_F(RadixPayloadRowTest, heapGroupsAndOversizedRows) {
+TEST_F(RadixPayloadRowTest, payloadAllocationHandlesOversizedRows) {
   auto layout = payloadLayout(ROW({"value"}, {VARCHAR()}));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 4, 64, layout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   const std::array<uint64_t, 7> heapSizes{17, 0, 20, 27, 100, 0, 17};
   PayloadRowBatch batch;
-  arena.allocatePayloadRowBatch(heapSizes, batch);
+  arena.allocatePayloadRowBatch(heapSizes, BufferPtr{}, batch);
 
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 2);
-  EXPECT_EQ(arena.payloadFixedBlocks()[0].count, 4);
-  EXPECT_EQ(arena.payloadFixedBlocks()[1].count, 3);
-  ASSERT_EQ(arena.payloadHeapGroups().size(), 3);
-  EXPECT_EQ(arena.payloadHeapGroups()[0].used, 64);
-  EXPECT_EQ(arena.payloadHeapGroups()[0].rowCount, 3);
-  EXPECT_EQ(arena.payloadHeapGroups()[1].used, 100);
-  EXPECT_EQ(arena.payloadHeapGroups()[1].rowCount, 1);
-  EXPECT_EQ(arena.payloadHeapGroups()[2].used, 17);
-  EXPECT_EQ(arena.payloadHeapGroups()[2].rowCount, 1);
-  EXPECT_EQ(batch.heapAt(0), arena.payloadHeapGroups()[0].base);
+  EXPECT_NE(batch.heapAt(0), nullptr);
   EXPECT_EQ(batch.heapAt(1), nullptr);
-  EXPECT_EQ(batch.heapAt(2), arena.payloadHeapGroups()[0].base + 17);
-  EXPECT_EQ(batch.heapAt(3), arena.payloadHeapGroups()[0].base + 37);
-  EXPECT_EQ(batch.heapAt(4), arena.payloadHeapGroups()[1].base);
+  EXPECT_EQ(batch.heapAt(2), batch.heapAt(0) + 17);
+  EXPECT_EQ(batch.heapAt(3), batch.heapAt(2) + 20);
+  EXPECT_NE(batch.heapAt(4), nullptr);
   EXPECT_EQ(batch.heapAt(5), nullptr);
-  EXPECT_EQ(batch.heapAt(6), arena.payloadHeapGroups()[2].base);
+  EXPECT_NE(batch.heapAt(6), nullptr);
+  for (vector_size_t row = 0; row < heapSizes.size(); ++row) {
+    if (heapSizes[row] > 0) {
+      std::memset(batch.heapAt(row), static_cast<int>(row), heapSizes[row]);
+    }
+  }
+  for (vector_size_t row = 0; row < heapSizes.size(); ++row) {
+    for (uint64_t byte = 0; byte < heapSizes[row]; ++byte) {
+      EXPECT_EQ(
+          static_cast<uint8_t>(batch.heapAt(row)[byte]),
+          static_cast<uint8_t>(row));
+    }
+  }
   const auto fixedBytes = heapSizes.size() * layout->rowWidth();
-  const auto heapBytes = totalHeapSize(batch);
+  const auto heapBytes =
+      std::accumulate(heapSizes.begin(), heapSizes.end(), uint64_t{0});
   EXPECT_EQ(heapBytes, 181);
   EXPECT_GE(
       static_cast<uint64_t>(arena.allocatedBytes()), fixedBytes + heapBytes);
@@ -1856,39 +1803,35 @@ TEST_F(RadixPayloadRowTest, heapGroupsAndOversizedRows) {
 TEST_F(RadixPayloadRowTest, payloadAllocationRangeBoundaryAndClear) {
   auto leaf = rootPool_->addLeafChild("payload-range-boundary");
   auto layout = payloadLayout(ROW({"value"}, {VARCHAR()}));
-  RadixSortRunStorage arena(
-      leaf.get(), keyLayout(), 2048, 64 * 1024, layout, 2048, 32 * 1024);
-  std::array<uint64_t, 2048> heapSizes{};
+  RadixSortRunStorage arena(leaf.get(), keyLayout(), layout);
+  std::array<uint64_t, kTestingRowsPerBlock> heapSizes{};
   heapSizes.fill(4096);
   PayloadRowBatch batch;
-  arena.allocatePayloadRowBatch(heapSizes, batch);
-  EXPECT_GT(arena.numRanges(), 1);
-  EXPECT_FALSE(arena.payloadFixedBlocks().empty());
-  EXPECT_GT(arena.payloadHeapGroups().size(), 1);
+  arena.allocatePayloadRowBatch(heapSizes, BufferPtr{}, batch);
+  EXPECT_GT(arena.allocatedBytes(), 64 * 1024);
   EXPECT_GT(leaf->currentBytes(), 0);
 
   batch = PayloadRowBatch{};
   arena.clear();
   expectArenaCleared(arena, *leaf);
-  EXPECT_EQ(arena.payloadSize(), 0);
-  EXPECT_TRUE(arena.payloadFixedBlocks().empty());
-  EXPECT_TRUE(arena.payloadHeapGroups().empty());
 }
 
 TEST_F(RadixPayloadRowTest, payloadFixedBlockRangeBoundary) {
   auto leaf = rootPool_->addLeafChild("payload-fixed-range-boundary");
   auto layout = payloadLayout(ROW({"value"}, {BIGINT()}));
-  RadixSortRunStorage arena(
-      leaf.get(), keyLayout(), 2048, 64 * 1024, layout, 2048, 64 * 1024);
-  const std::array<uint64_t, 2048> heapSizes{};
-  while (arena.numRanges() < 2) {
+  RadixSortRunStorage arena(leaf.get(), keyLayout(), layout);
+  const std::vector<uint64_t> heapSizes(arena.keysPerBlock(), 0);
+  PayloadRowBatch batch;
+  arena.allocatePayloadRowBatch(heapSizes, BufferPtr{}, batch);
+  const auto firstAllocationBytes = arena.allocatedBytes();
+  while (arena.allocatedBytes() == firstAllocationBytes) {
     PayloadRowBatch batch;
-    arena.allocatePayloadRowBatch(heapSizes, batch);
+    arena.allocatePayloadRowBatch(heapSizes, BufferPtr{}, batch);
   }
-  EXPECT_GT(arena.payloadFixedBlocks().size(), 1);
-  EXPECT_TRUE(arena.payloadHeapGroups().empty());
+  EXPECT_GT(arena.allocatedBytes(), firstAllocationBytes);
   EXPECT_GT(leaf->currentBytes(), 0);
 
+  batch = PayloadRowBatch{};
   arena.clear();
   expectArenaCleared(arena, *leaf);
 }
@@ -1898,35 +1841,31 @@ TEST_F(RadixPayloadRowTest, fixedKeyAndPayloadShareAllocationPoolRange) {
   auto layout = payloadLayout(ROW({"value"}, {BIGINT()}));
   auto physicalLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage arena(
-      leaf.get(),
-      physicalLayout,
-      RadixSortRunStorage::kTestingRowsPerBlock,
-      64 * 1024,
-      layout,
-      RadixSortRunStorage::kTestingRowsPerBlock,
-      64 * 1024);
-  const std::array<uint64_t, 2048> heapSizes{};
+  RadixSortRunStorage arena(leaf.get(), physicalLayout, layout);
+  const std::vector<uint64_t> heapSizes(arena.keysPerBlock(), 0);
   PayloadRowBatch batch;
-  arena.allocatePayloadRowBatch(heapSizes, batch);
+  arena.allocatePayloadRowBatch(heapSizes, BufferPtr{}, batch);
 
-  std::vector<std::string_view> keys(2048, std::string_view("12345678", 8));
-  std::vector<char*> payloads(2048);
-  for (vector_size_t row = 0; row < batch.size(); ++row) {
-    payloads[row] = batch.rowAt(row);
+  const auto rows = batchRows(batch, heapSizes.size());
+  arena.appendKeyBlocks(
+      heapSizes.size(),
+      [&](vector_size_t source, vector_size_t count, char* destination) {
+        for (vector_size_t row = 0; row < count; ++row) {
+          auto* record = destination + row * arena.layout().width();
+          std::memcpy(record, "12345678", 8);
+          storeCompactPointer(
+              record + *arena.layout().payloadOffset(), rows[source + row]);
+        }
+      });
+
+  EXPECT_GT(arena.allocatedBytes(), 0);
+  for (vector_size_t row = 0; row < heapSizes.size(); ++row) {
+    const auto keyRange = arena.keyRangeAt(row, 1);
+    ASSERT_EQ(keyRange.count, 1);
+    EXPECT_EQ(
+        loadCompactPointer(keyRange.data + *arena.layout().payloadOffset()),
+        rows[row]);
   }
-  arena.appendBatch(keys, payloads);
-
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 1);
-  ASSERT_EQ(arena.keyBlocks().size(), 1);
-  EXPECT_EQ(arena.numRanges(), 1);
-  EXPECT_EQ(arena.allocatedBytes(), 64 * 1024);
-  EXPECT_NE(arena.payloadFixedBlocks()[0].base, nullptr);
-  EXPECT_NE(arena.keyBlocks()[0].base, nullptr);
-  EXPECT_EQ(
-      arena.size() * arena.layout().width() +
-          arena.payloadSize() * layout->rowWidth(),
-      2048 * (arena.layout().width() + layout->rowWidth()));
 }
 
 TEST_F(RadixPayloadRowTest, segmentedGatherPreservesBitmapBoundaries) {
@@ -1954,17 +1893,15 @@ TEST_F(RadixPayloadRowTest, segmentedGatherPreservesBitmapBoundaries) {
       {makeVector<int64_t>(BIGINT(), validIntegers),
        makeVector<bool>(BOOLEAN(), validBooleans)});
   auto layout = payloadLayout(asRowType(nullableInput->type()));
-  RadixSortRunStorage nullableArena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 64);
-  RadixSortRunStorage nullFreeArena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 64);
+  RadixSortRunStorage nullableArena(pool_.get(), keyLayout(), layout);
+  RadixSortRunStorage nullFreeArena(pool_.get(), keyLayout(), layout);
   PayloadRowWriter writer;
   PayloadRowBatch nullableBatch;
   PayloadRowBatch nullFreeBatch;
   writer.append(*nullableInput, nullableArena, nullableBatch);
   writer.append(*nullFreeInput, nullFreeArena, nullFreeBatch);
-  const auto nullableRows = rowPointers(nullableBatch);
-  const auto nullFreeRows = rowPointers(nullFreeBatch);
+  const auto nullableRows = rowPointers(nullableBatch, nullableInput->size());
+  const auto nullFreeRows = rowPointers(nullFreeBatch, nullFreeInput->size());
 
   struct Segment {
     vector_size_t offset;
@@ -2050,10 +1987,10 @@ TEST_F(RadixPayloadRowTest, segmentedGatherInvalidatesFullRangeNullCount) {
       {makeVector<int64_t>(BIGINT(), {std::nullopt, 12}),
        makeVector<bool>(BOOLEAN(), {std::nullopt, true})});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 8, 64, layout, 8, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter{}.append(*input, arena, batch);
-  const auto rows = rowPointers(batch);
+  const auto rows = rowPointers(batch, input->size());
 
   auto output = makeRows(
       {makeVector<int64_t>(BIGINT(), {1, 2}),
@@ -2077,10 +2014,10 @@ TEST_F(RadixPayloadRowTest, gatherBatchFinalizesMetadataOnce) {
   auto input = makeRows({makeStringVector(
       VARCHAR(), {std::string{"left"}, std::string{"\xc3\xa9"}})});
   auto layout = payloadLayout(asRowType(input->type()));
-  RadixSortRunStorage arena(pool_.get(), keyLayout(), 8, 64, layout, 8, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout(), layout);
   PayloadRowBatch batch;
   PayloadRowWriter{}.append(*input, arena, batch);
-  const auto rows = rowPointers(batch);
+  const auto rows = rowPointers(batch, input->size());
 
   auto output = makeRows({makeStringVector(
       VARCHAR(),
@@ -2158,10 +2095,8 @@ TEST_F(RadixPayloadRowTest, segmentedGatherMapsStringsAndGrowingComplexValues) {
                })),
        growingMaps});
   auto layout = payloadLayout(asRowType(first->type()));
-  RadixSortRunStorage firstArena(
-      pool_.get(), keyLayout(), 8, 64, layout, 8, 1024);
-  RadixSortRunStorage secondArena(
-      pool_.get(), keyLayout(), 32, 64, layout, 32, 32 * 1024);
+  RadixSortRunStorage firstArena(pool_.get(), keyLayout(), layout);
+  RadixSortRunStorage secondArena(pool_.get(), keyLayout(), layout);
   PayloadRowWriter writer;
   PayloadRowBatch firstBatch;
   PayloadRowBatch secondBatch;
@@ -2185,8 +2120,8 @@ TEST_F(RadixPayloadRowTest, segmentedGatherMapsStringsAndGrowingComplexValues) {
   const auto untouchedMiddle = output->childAt(1);
   const std::array<column_index_t, 2> payloadChannels{2, 0};
   const std::array<uint8_t, 2> mayHaveNulls{1, 1};
-  auto firstRows = rowPointers(firstBatch);
-  auto secondRows = rowPointers(secondBatch);
+  auto firstRows = rowPointers(firstBatch, first->size());
+  auto secondRows = rowPointers(secondBatch, second->size());
   PayloadRowReaderTestHelper::GatherBatch gatherBatch(
       *layout, *output, payloadChannels, mayHaveNulls);
   gatherBatch.gather(firstRows, kFirstOffset);
@@ -2239,10 +2174,10 @@ TEST_F(RadixPayloadRowTest, invalidInputs) {
   auto layout = payloadLayout(ROW({"value"}, {VARCHAR()}));
   RowVectorPtr output;
   PayloadRowBatch emptyBatch;
-  RadixSortRunStorage emptyArena(
-      pool_.get(), keyLayout(), 4, 64, layout, 4, 64);
-  emptyArena.allocatePayloadRowBatch(std::span<const uint64_t>{}, emptyBatch);
-  gatherPayloadBatch(*layout, emptyBatch, pool_.get(), output);
+  RadixSortRunStorage emptyArena(pool_.get(), keyLayout(), layout);
+  emptyArena.allocatePayloadRowBatch(
+      std::span<const uint64_t>{}, BufferPtr{}, emptyBatch);
+  gatherPayloadBatch(*layout, emptyBatch, 0, pool_.get(), output);
   EXPECT_EQ(output->size(), 0);
 
   EXPECT_THROW(

--- a/bolt/exec/tests/RadixSortBufferTest.cpp
+++ b/bolt/exec/tests/RadixSortBufferTest.cpp
@@ -355,7 +355,6 @@ class RadixSortBufferTest : public testing::Test {
   struct SpillMemoryRunOptions {
     vector_size_t prefixRows;
     size_t expectedSpillRuns;
-    size_t expectedMergeStreams;
     uint64_t expectedSpilledRows;
   };
 
@@ -368,8 +367,6 @@ class RadixSortBufferTest : public testing::Test {
     ASSERT_EQ(prefix->size(), options.prefixRows);
 
     spillMemoryRunAndCheckStats(buffer, options.expectedSpilledRows);
-    EXPECT_EQ(buffer.testingSpilledRunCount(), 0);
-    EXPECT_EQ(buffer.testingMergeStreamCount(), options.expectedMergeStreams);
     ASSERT_TRUE(buffer.spilledStats());
     EXPECT_EQ(buffer.spilledStats()->spillRuns, options.expectedSpillRuns);
     EXPECT_GT(buffer.spilledStats()->spilledFiles, 1);
@@ -1544,7 +1541,6 @@ TEST_F(RadixSortBufferTest, equalAndNullVariableKeysAcrossDiskStreams) {
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 2);
   EXPECT_EQ(buffer.spilledStats()->spilledRows, 6);
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 3);
   collectAndVerify(buffer, input, 1, 1);
 }
 
@@ -1566,11 +1562,9 @@ TEST_F(RadixSortBufferTest, splitSpillFilesMergeAsSingleLogicalRun) {
 
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 1);
-  EXPECT_EQ(buffer.testingSpilledRunCount(), 1);
   ASSERT_GT(buffer.spilledStats()->spilledFiles, 1);
 
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 1);
   collectAndVerify(buffer, input, 257, 1);
 }
 
@@ -1601,11 +1595,9 @@ TEST_F(RadixSortBufferTest, splitSpillFilesPreserveRunMergeFanIn) {
 
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 2);
-  EXPECT_EQ(buffer.testingSpilledRunCount(), 2);
   ASSERT_GT(buffer.spilledStats()->spilledFiles, 2);
 
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   collectAndVerify(buffer, input, 1024, 1);
 }
 
@@ -1640,7 +1632,6 @@ TEST_F(RadixSortBufferTest, spillMergeReadersUseOperatorPool) {
     EXPECT_EQ(
         memory::spillMemoryPool()->stats().currentBytes, spillPoolBytesBefore);
     EXPECT_GT(pool()->currentBytes(), operatorPoolBytesBefore);
-    EXPECT_EQ(buffer.testingMergeStreamCount(), 1);
 
     collectAndVerify(
         buffer,
@@ -1707,7 +1698,6 @@ TEST_F(RadixSortBufferTest, spillMergeWidePayloadStaysWithinOperatorCap) {
   EXPECT_GE(buffer.spilledStats()->spillWrites, 12);
 
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   sortPool->release();
   auto output = buffer.getOutput(kRows);
 
@@ -2054,7 +2044,6 @@ DEBUG_ONLY_TEST_F(
 
   RadixSortBufferTestHelper::ensureOutputFits(buffer, kAdmissionRows);
   EXPECT_EQ(maybeReserveCalls, 2);
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 1);
   const auto mergeEstimate = RadixSortBufferTestHelper::outputAdmissionEstimate(
       buffer, kAdmissionRows);
   const auto mergeNeed = mergeEstimate.total;
@@ -2121,7 +2110,6 @@ DEBUG_ONLY_TEST_F(RadixSortBufferTest, ensureMergeFitsCanTriggerReclaimSpill) {
 
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 1);
-  EXPECT_EQ(buffer.testingSpilledRunCount(), 1);
   pool()->release();
 
   std::atomic<bool> injected{false};
@@ -2145,8 +2133,6 @@ DEBUG_ONLY_TEST_F(RadixSortBufferTest, ensureMergeFitsCanTriggerReclaimSpill) {
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 2);
   EXPECT_EQ(buffer.spilledStats()->spilledRows, input->size());
-  EXPECT_EQ(buffer.testingSpilledRunCount(), 0);
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   collectAndVerify(buffer, input, 2, 2);
 }
 
@@ -2156,7 +2142,6 @@ DEBUG_ONLY_TEST_F(RadixSortBufferTest, ensureOutputFitsCanTriggerReclaimSpill) {
   auto& buffer = spill.buffer;
   addInputRuns(buffer, input, {{3, true}, {3, false}});
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   pool()->release();
 
   std::atomic<bool> injected{false};
@@ -2179,9 +2164,6 @@ DEBUG_ONLY_TEST_F(RadixSortBufferTest, ensureOutputFitsCanTriggerReclaimSpill) {
   EXPECT_TRUE(injected);
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 2);
-  // The reclaimed memory suffix replaces its slot with one disk stream.
-  // Existing disk streams are preserved, so fan-in stays unchanged.
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   SortComparatorOracle::expectRowsMatchById(*input, *output, 1);
   SortComparatorOracle::expectSorted(
       *output, {0}, {SortComparatorOracle::makeSortFlags(true, true)});
@@ -2204,14 +2186,12 @@ TEST_F(RadixSortBufferTest, splitOutputStageSpillFilesMergeAsSingleRun) {
   buffer.addInput(input);
   buffer.noMoreInput();
   EXPECT_FALSE(buffer.spilledStats());
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 0);
 
   spillMemoryRunAndVerifyReplacement(
       buffer,
       input,
       {.prefixRows = 1,
        .expectedSpillRuns = 1,
-       .expectedMergeStreams = 1,
        .expectedSpilledRows = kRows - 1});
 }
 
@@ -2239,7 +2219,6 @@ TEST_F(RadixSortBufferTest, keyOnlyConcatOutputReplacement) {
   const auto filesBefore = buffer.spilledStats()->spilledFiles;
   spillMemoryRunAndCheckStats(buffer, 2);
   EXPECT_GT(buffer.spilledStats()->spilledFiles - filesBefore, 1);
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
 
   auto output = collect(buffer, 2, prefix);
   ASSERT_EQ(output->size(), kRows);
@@ -2279,19 +2258,15 @@ TEST_F(RadixSortBufferTest, outputStageSpillReplacesMultiStreamMerge) {
 
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, kInputSpillRuns);
-  EXPECT_EQ(buffer.testingSpilledRunCount(), kInputSpillRuns);
   ASSERT_GT(buffer.spilledStats()->spilledFiles, kInputSpillRuns);
 
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingSpilledRunCount(), 0);
-  EXPECT_EQ(buffer.testingMergeStreamCount(), kInputSpillRuns + 1);
 
   spillMemoryRunAndVerifyReplacement(
       buffer,
       input,
       {.prefixRows = 3,
        .expectedSpillRuns = kInputSpillRuns + 1,
-       .expectedMergeStreams = kInputSpillRuns + 1,
        .expectedSpilledRows = 1});
 }
 
@@ -2321,7 +2296,6 @@ TEST_F(RadixSortBufferTest, outputStageSpillUsesMemoryCursor) {
         slice(*input, test.diskKeys.size(), test.memoryKeys.size()));
     buffer.noMoreInput();
 
-    ASSERT_EQ(buffer.testingMergeStreamCount(), 2);
     auto prefix = buffer.getOutput(test.prefixRows);
     ASSERT_NE(prefix, nullptr);
     ASSERT_EQ(prefix->size(), test.prefixRows);
@@ -2334,13 +2308,11 @@ TEST_F(RadixSortBufferTest, outputStageSpillUsesMemoryCursor) {
       EXPECT_FALSE(buffer.canReclaim());
       buffer.spill();
       EXPECT_EQ(*buffer.spilledStats(), statsBefore);
-      EXPECT_EQ(buffer.testingMergeStreamCount(), 1);
       expectSpillReadStatsEqual(readStatsBefore, buffer.spillReadStats());
     } else {
       spillMemoryRunAndCheckStats(buffer, remainingMemoryRows);
       ASSERT_TRUE(buffer.spilledStats());
       EXPECT_EQ(buffer.spilledStats()->spillRuns, statsBefore.spillRuns + 1);
-      EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
       // Constructing the replacement stream eagerly loads its first block,
       // so aggregate read counters can legitimately increase here.
       expectSpillReadStatsNotDecreased(
@@ -2403,7 +2375,6 @@ TEST_F(RadixSortBufferTest, diskOnlyMergeIsNotReclaimable) {
   addInputRuns(buffer, input, {{3, true}, {3, true}});
   buffer.noMoreInput();
 
-  ASSERT_EQ(buffer.testingMergeStreamCount(), 2);
   ASSERT_TRUE(buffer.spilledStats());
   const auto statsBefore = *buffer.spilledStats();
   const auto readStatsBefore = buffer.spillReadStats();
@@ -2411,7 +2382,6 @@ TEST_F(RadixSortBufferTest, diskOnlyMergeIsNotReclaimable) {
   buffer.spill();
   EXPECT_EQ(*buffer.spilledStats(), statsBefore);
   expectSpillReadStatsEqual(readStatsBefore, buffer.spillReadStats());
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   collectAndVerify(buffer, input, 2, 2);
 }
 
@@ -2731,9 +2701,7 @@ TEST_F(RadixSortBufferTest, testSpillInjectionTriggersBeforeNextInput) {
   ASSERT_TRUE(buffer.spilledStats());
   EXPECT_EQ(buffer.spilledStats()->spillRuns, 1);
   EXPECT_EQ(buffer.spilledStats()->spilledRows, 3);
-  EXPECT_EQ(buffer.testingSpilledRunCount(), 1);
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   collectAndVerify(buffer, input, 1, 2);
 }
 
@@ -2925,7 +2893,6 @@ TEST_F(RadixSortBufferTest, spillBatchOutputSizesAcrossBlockBoundaries) {
     EXPECT_GT(
         buffer.spilledStats()->spillWrites, buffer.spilledStats()->spillRuns);
     buffer.noMoreInput();
-    EXPECT_EQ(buffer.testingMergeStreamCount(), 3);
 
     std::vector<vector_size_t> batchSizes;
     std::vector<RowVectorPtr> batches;
@@ -3005,7 +2972,6 @@ TEST_F(RadixSortBufferTest, fixedWidthSpillOutputCrossesBlockBoundaries) {
   EXPECT_GE(buffer.spilledStats()->spillWrites, 4);
 
   buffer.noMoreInput();
-  EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
   auto output = buffer.getOutput(kRows);
 
   ASSERT_NE(output, nullptr);
@@ -3244,7 +3210,6 @@ TEST_F(
     ASSERT_TRUE(buffer.spilledStats());
     EXPECT_EQ(buffer.spilledStats()->spillRuns, 2);
     EXPECT_GT(buffer.spilledStats()->spillWrites, 0);
-    EXPECT_EQ(buffer.testingSpilledRunCount(), 2);
     for (const auto& file :
          std::filesystem::directory_iterator(spillDirectory->path)) {
       sourceFiles.push_back(file.path());
@@ -3252,7 +3217,6 @@ TEST_F(
     ASSERT_EQ(sourceFiles.size(), 2);
 
     buffer.noMoreInput();
-    ASSERT_EQ(buffer.testingMergeStreamCount(), 3);
     auto prefix = buffer.getOutput(1);
     ASSERT_NE(prefix, nullptr);
     ASSERT_EQ(prefix->size(), 1);
@@ -3320,13 +3284,13 @@ TEST_F(
     }
     ASSERT_EQ(diskFiles.size(), 1);
     buffer.noMoreInput();
-    ASSERT_EQ(buffer.testingMergeStreamCount(), 2);
 
     corruptOutputFile = true;
     EXPECT_THROW(buffer.spill(), BoltException);
     EXPECT_FALSE(outputFile.empty());
     EXPECT_FALSE(std::filesystem::exists(outputFile));
-    EXPECT_TRUE(std::filesystem::exists(diskFiles.front()));
+    EXPECT_FALSE(std::filesystem::exists(diskFiles.front()));
+    EXPECT_FALSE(buffer.spillReadStats().has_value());
   }
   EXPECT_TRUE(std::filesystem::is_empty(spillDirectory->path));
 }
@@ -3345,7 +3309,6 @@ TEST_F(RadixSortBufferTest, destructionCleansOwnedAndMergeStreamFiles) {
         &config);
     buffer.addInput(input);
     buffer.spill();
-    EXPECT_EQ(buffer.testingSpilledRunCount(), 1);
     EXPECT_FALSE(std::filesystem::is_empty(spillDirectory->path));
   }
   EXPECT_TRUE(std::filesystem::is_empty(spillDirectory->path));
@@ -3360,8 +3323,6 @@ TEST_F(RadixSortBufferTest, destructionCleansOwnedAndMergeStreamFiles) {
     buffer.addInput(input);
     buffer.spill();
     buffer.noMoreInput();
-    EXPECT_EQ(buffer.testingSpilledRunCount(), 0);
-    EXPECT_EQ(buffer.testingMergeStreamCount(), 1);
     EXPECT_FALSE(std::filesystem::is_empty(spillDirectory->path));
   }
   EXPECT_TRUE(std::filesystem::is_empty(spillDirectory->path));
@@ -3606,7 +3567,6 @@ TEST_F(RadixSortBufferTest, pointerFreeSpillMergeLayoutAndTopologyMatrix) {
   struct TopologyCase {
     const char* name;
     Topology topology;
-    size_t expectedStreams;
   };
 
   constexpr vector_size_t kRows = 16;
@@ -3614,10 +3574,10 @@ TEST_F(RadixSortBufferTest, pointerFreeSpillMergeLayoutAndTopologyMatrix) {
       15, 3, 11, 7, 14, 2, 10, 6, 13, 1, 9, 5, 12, 0, 8, 4};
   const std::string commonPrefix(80, 'p');
   const std::array<TopologyCase, 4> topologies{{
-      {"single spill", Topology::kSingleSpill, 1},
-      {"memory-spill", Topology::kMemorySpill, 2},
-      {"spill-spill two-way", Topology::kTwoSpills, 2},
-      {"spill-spill loser tree", Topology::kLoserTree, 3},
+      {"single spill", Topology::kSingleSpill},
+      {"memory-spill", Topology::kMemorySpill},
+      {"spill-spill two-way", Topology::kTwoSpills},
+      {"spill-spill loser tree", Topology::kLoserTree},
   }};
 
   const auto makeInput = [&](bool variableKey, bool hasPayload) {
@@ -3701,7 +3661,6 @@ TEST_F(RadixSortBufferTest, pointerFreeSpillMergeLayoutAndTopologyMatrix) {
             &config);
         addRuns(buffer, input, topology.topology);
         buffer.noMoreInput();
-        EXPECT_EQ(buffer.testingMergeStreamCount(), topology.expectedStreams);
 
         auto output = collect(buffer, 3);
         ASSERT_NE(output, nullptr);
@@ -3775,13 +3734,12 @@ TEST_F(RadixSortBufferTest, variableMergeCommonPrefixEqualAndNullOrdering) {
   struct Plan {
     const char* name;
     std::vector<InputRun> runs;
-    size_t expectedStreams;
   };
   const std::array<Plan, 4> plans{{
-      {"memory-spill two-way", {{8, true}, {7, false}}, 2},
-      {"spill-spill two-way", {{8, true}, {7, true}}, 2},
-      {"memory-spill loser tree", {{5, true}, {5, true}, {5, false}}, 3},
-      {"spill-spill loser tree", {{5, true}, {5, true}, {5, true}}, 3},
+      {"memory-spill two-way", {{8, true}, {7, false}}},
+      {"spill-spill two-way", {{8, true}, {7, true}}},
+      {"memory-spill loser tree", {{5, true}, {5, true}, {5, false}}},
+      {"spill-spill loser tree", {{5, true}, {5, true}, {5, true}}},
   }};
 
   for (const auto ascending : {false, true}) {
@@ -3804,7 +3762,6 @@ TEST_F(RadixSortBufferTest, variableMergeCommonPrefixEqualAndNullOrdering) {
             &config);
         addInputRuns(buffer, input, plan.runs);
         buffer.noMoreInput();
-        EXPECT_EQ(buffer.testingMergeStreamCount(), plan.expectedStreams);
         auto output = collect(buffer, 1);
         SortComparatorOracle::expectRowsMatchById(*input, *output, 2);
         SortComparatorOracle::expectSorted(*output, {0}, {flags});
@@ -3848,7 +3805,6 @@ TEST_F(RadixSortBufferTest, variableMergeOutputProjectionModes) {
         &config);
     addInputRuns(buffer, input, {{6, true}, {6, true}, {6, false}});
     buffer.noMoreInput();
-    ASSERT_EQ(buffer.testingMergeStreamCount(), 3);
     scratchGrowth =
         RadixSortBufferTestHelper::outputAdmissionEstimate(buffer, 5)
             .scratchGrowth;
@@ -3935,7 +3891,6 @@ TEST_F(
         buffer.spilledStats()->spilledFiles);
 
     buffer.noMoreInput();
-    EXPECT_EQ(buffer.testingMergeStreamCount(), 2);
     while (auto batch = buffer.getOutput(257)) {
       batches.push_back(std::move(batch));
     }

--- a/bolt/exec/tests/RadixSortKeyCodecTest.cpp
+++ b/bolt/exec/tests/RadixSortKeyCodecTest.cpp
@@ -28,7 +28,7 @@
 
 #include "bolt/exec/radixsort/RadixSortKey.h"
 #include "bolt/exec/radixsort/RadixSortKeyCodec.h"
-#include "bolt/exec/radixsort/RadixSortUtils.h"
+#include "bolt/exec/radixsort/RadixSortRun.h"
 #include "bolt/exec/tests/utils/RadixSortComparatorOracle.h"
 #include "bolt/functions/prestosql/types/HyperLogLogType.h"
 #include "bolt/functions/prestosql/types/JsonType.h"
@@ -39,75 +39,34 @@
 
 namespace bytedance::bolt::exec::radixsort::test {
 
-class RadixSortKeyCodecTestHelper {
- public:
-  static void decodeWithMaskedPrefix(
-      const RadixSortKeyCodec& codec,
-      std::string_view key,
-      std::span<const uint8_t> decodedColumns,
-      memory::MemoryPool* pool,
-      RowVector& output) {
-    std::vector<uint8_t> mayHaveNulls(decodedColumns.size(), 0);
-    std::vector<column_index_t> directKeyChannels(decodedColumns.size());
-    std::iota(directKeyChannels.begin(), directKeyChannels.end(), 0);
-    const std::array<EncodedKeyView, 1> keys{{EncodedKeyView{key}}};
-    BufferPtr cursorScratch;
-    codec.decodeSuffixAt(
-        keys,
-        decodedColumns,
-        mayHaveNulls,
-        0,
-        pool,
-        cursorScratch,
-        output,
-        directKeyChannels,
-        codec.decodeScratchWordsPerRowWithMask(
-            decodedColumns,
-            mayHaveNulls,
-            0,
-            static_cast<uint32_t>(decodedColumns.size()),
-            /*skipMaskedVariableColumns=*/true),
-        0);
-  }
-
-  static void decodeWithColumnRange(
-      const RadixSortKeyCodec& codec,
-      std::string_view key,
-      std::span<const uint8_t> decodedColumns,
-      uint32_t firstColumn,
-      uint32_t endColumn,
-      memory::MemoryPool* pool,
-      RowVector& output) {
-    std::vector<uint8_t> mayHaveNulls(decodedColumns.size(), 0);
-    std::vector<column_index_t> directKeyChannels(decodedColumns.size());
-    std::iota(directKeyChannels.begin(), directKeyChannels.end(), 0);
-    const std::array<EncodedKeyView, 1> keys{{EncodedKeyView{key}}};
-    const auto scratchWords = codec.decodeScratchWordsPerRowWithMask(
-        decodedColumns,
-        mayHaveNulls,
-        firstColumn,
-        endColumn,
-        /*skipMaskedVariableColumns=*/true);
-    auto cursorScratch = AlignedBuffer::allocate<uint64_t>(scratchWords, pool);
-    codec.decodeSuffixAtWithPreparedScratch(
-        keys,
-        decodedColumns,
-        mayHaveNulls,
-        0,
-        pool,
-        cursorScratch,
-        output,
-        directKeyChannels,
-        scratchWords,
-        firstColumn,
-        endColumn);
-  }
-};
-
 namespace {
 
 constexpr vector_size_t kFuzzPairsPerSeed = 512;
 constexpr uint32_t kFuzzSeeds = 32;
+
+int32_t comparePhysicalKeys(
+    const RadixSortKeyLayout& layout,
+    const char* left,
+    const char* right) {
+#define COMPARE_KIND(kind)                                         \
+  case RadixSortKeyLayoutKind::kind:                               \
+    return RadixSortKeyOps<RadixSortKeyLayoutKind::kind>::compare( \
+        left, right, layout.heapKeyOffset())
+  switch (layout.kind()) {
+    COMPARE_KIND(kKeyOnlyFixed8);
+    COMPARE_KIND(kKeyOnlyFixed16);
+    COMPARE_KIND(kKeyOnlyFixed24);
+    COMPARE_KIND(kKeyOnlyFixed32);
+    COMPARE_KIND(kKeyOnlyVariable32);
+    COMPARE_KIND(kKeyWithPayloadFixed16);
+    COMPARE_KIND(kKeyWithPayloadFixed24);
+    COMPARE_KIND(kKeyWithPayloadFixed32);
+    COMPARE_KIND(kKeyWithPayloadVariable32);
+    default:
+      BOLT_UNREACHABLE();
+  }
+#undef COMPARE_KIND
+}
 
 class RadixSortKeyCodecTest : public testing::Test {
  public:
@@ -337,45 +296,86 @@ class RadixSortKeyCodecTest : public testing::Test {
     return codec;
   }
 
-  void verifyProperty(
+  std::unique_ptr<RadixSortRun> createEmptyRun(
+      const RowVectorPtr& rows,
+      const std::vector<CompareFlags>& compareFlags) {
+    auto rowType = std::static_pointer_cast<const RowType>(rows->type());
+    std::vector<column_index_t> channels(rows->childrenSize());
+    std::iota(channels.begin(), channels.end(), 0);
+    auto run = RadixSortRun::create(
+        pool_.get(),
+        rowType,
+        rowType,
+        compareFlags,
+        channels,
+        RadixSortRunOptions{});
+    BOLT_CHECK_NOT_NULL(run);
+    return run;
+  }
+
+  std::unique_ptr<RadixSortRun> createRun(
+      const RowVectorPtr& rows,
+      const std::vector<CompareFlags>& compareFlags) {
+    auto run = createEmptyRun(rows, compareFlags);
+    run->append(*rows);
+    return run;
+  }
+
+  static std::string logicalKeyAt(const RadixSortRun& run, uint64_t row) {
+    const auto* storage = run.storage();
+    BOLT_CHECK_NOT_NULL(storage);
+    const auto& layout = run.keyLayout();
+    const auto* record = storage->keyRangeAt(row, 1).data;
+    const auto key = RadixSortKey(layout, record);
+    if (layout.isVariable()) {
+      std::string bytes(record, record + layout.heapKeyOffset());
+      const auto encodedSize =
+          loadUnaligned<uint64_t>(record + *layout.sizeOffset());
+      const auto heapSize = encodedSize - layout.heapKeyOffset();
+      bytes.append(loadCompactPointer(record + *layout.dataOffset()), heapSize);
+      return bytes;
+    }
+
+    RadixSortInlineKeyBuffer buffer;
+    EncodedKeyView view;
+    key.deconstruct(buffer, view);
+    return std::string(view.bytes);
+  }
+
+  RowVectorPtr finalizeAndCollect(RadixSortRun& run) {
+    run.finalize();
+    RowVectorPtr output;
+    auto result = run.getOutput(
+        static_cast<vector_size_t>(run.metrics().inputRows),
+        pool_.get(),
+        output);
+    BOLT_CHECK_NOT_NULL(result);
+    EXPECT_EQ(run.getOutput(1, pool_.get(), output), nullptr);
+    return result;
+  }
+
+  void verifyRun(
+      RadixSortRun& run,
       const RowVectorPtr& rows,
       const std::vector<CompareFlags>& compareFlags,
       bool verifyAllPairs = true) {
-    std::vector<TypePtr> types;
     std::vector<column_index_t> channels;
     for (uint32_t column = 0; column < rows->childrenSize(); ++column) {
-      types.push_back(rows->childAt(column)->type());
       channels.push_back(column);
     }
-    auto codec = bind(types, compareFlags);
-    ASSERT_TRUE(codec->canEncodeDecode());
-
-    EncodedKeyBatch keys;
-    codec->encode(*rows, pool_.get(), keys);
-
-    RowVectorPtr decoded;
-    decodeBatch(*codec, keys, decoded);
-    ASSERT_EQ(decoded->size(), rows->size());
-
-    for (vector_size_t row = 0; row < rows->size(); ++row) {
-      EXPECT_EQ(
-          SortComparatorOracle::compareRows(
-              *rows, row, *decoded, row, channels, compareFlags),
-          0)
-          << "round-trip mismatch at row " << row << ", key "
-          << keyHex(keys, row);
-    }
-
     const auto comparePair = [&](vector_size_t left, vector_size_t right) {
       const auto expected = SortComparatorOracle::compareRows(
           *rows, left, *rows, right, channels, compareFlags);
-      const auto actual =
-          SortComparatorOracle::compareEncodedKeys(keys, left, right);
+      const auto& layout = run.keyLayout();
+      const auto actual = comparePhysicalKeys(
+          layout,
+          run.storage()->keyRangeAt(left, 1).data,
+          run.storage()->keyRangeAt(right, 1).data);
       EXPECT_EQ((actual > 0) - (actual < 0), (expected > 0) - (expected < 0))
           << "left " << left << ", right " << right << ", left-values "
           << rows->toString(left) << ", right-values " << rows->toString(right)
-          << ", left-key " << keyHex(keys, left) << ", right-key "
-          << keyHex(keys, right);
+          << ", left-key " << hex(logicalKeyAt(run, left)) << ", right-key "
+          << hex(logicalKeyAt(run, right));
       return (actual > 0) - (actual < 0);
     };
     if (verifyAllPairs) {
@@ -410,27 +410,34 @@ class RadixSortKeyCodecTest : public testing::Test {
         }
       }
     }
+
+    std::vector<vector_size_t> expectedRows(rows->size());
+    std::iota(expectedRows.begin(), expectedRows.end(), 0);
+    std::sort(
+        expectedRows.begin(),
+        expectedRows.end(),
+        [&](vector_size_t left, vector_size_t right) {
+          return SortComparatorOracle::compareRows(
+                     *rows, left, *rows, right, channels, compareFlags) < 0;
+        });
+    auto decoded = finalizeAndCollect(run);
+    ASSERT_EQ(decoded->size(), rows->size());
+    for (vector_size_t row = 0; row < rows->size(); ++row) {
+      EXPECT_EQ(
+          SortComparatorOracle::compareRows(
+              *rows, expectedRows[row], *decoded, row, channels, compareFlags),
+          0)
+          << "round-trip mismatch at sorted row " << row << ", input row "
+          << expectedRows[row];
+    }
   }
 
-  void decodeBatch(
-      const RadixSortKeyCodec& codec,
-      const EncodedKeyBatch& keys,
-      RowVectorPtr& decoded,
-      std::span<const uint8_t> decodedColumns = {},
-      std::span<const uint8_t> mayHaveNulls = {},
-      uint32_t encodedPrefixSize = 0,
-      uint32_t firstColumn = 0) {
-    std::vector<std::array<char, sizeof(uint64_t)>> fixedBytes;
-    auto views = makeViews(keys, fixedBytes, encodedPrefixSize);
-    BufferPtr cursorScratch;
-    codec.decode(
-        std::span<const EncodedKeyView>(views.data(), views.size()),
-        decodedColumns,
-        mayHaveNulls,
-        pool_.get(),
-        cursorScratch,
-        decoded,
-        firstColumn);
+  void verifyProperty(
+      const RowVectorPtr& rows,
+      const std::vector<CompareFlags>& compareFlags,
+      bool verifyAllPairs = true) {
+    auto run = createRun(rows, compareFlags);
+    verifyRun(*run, rows, compareFlags, verifyAllPairs);
   }
 
   static void expectColumnEqual(
@@ -452,30 +459,6 @@ class RadixSortKeyCodecTest : public testing::Test {
     }
   }
 
-  void verifySelectiveDecode(
-      const std::vector<TypeVector>& cases,
-      bool canSkip) {
-    constexpr std::array<uint8_t, 1> kSkipColumn{0};
-    constexpr std::array<uint8_t, 1> kMayHaveNulls{1};
-    const auto compareFlags = SortComparatorOracle::makeSortFlags(false, true);
-    for (const auto& vector : cases) {
-      const auto& type = vector->type();
-      SCOPED_TRACE(type->toString());
-      auto input = makeRows({vector});
-      auto codec = bind({type}, {compareFlags});
-      EncodedKeyBatch keys;
-      codec->encode(*input, pool_.get(), keys);
-      RowVectorPtr decoded;
-      decodeBatch(*codec, keys, decoded, kSkipColumn, kMayHaveNulls);
-      ASSERT_EQ(decoded->size(), input->size());
-      if (canSkip) {
-        EXPECT_EQ(decoded->childAt(0), nullptr);
-      } else {
-        expectColumnEqual(*input, *decoded, 0, compareFlags);
-      }
-    }
-  }
-
   void verifyAllFlags(
       const std::vector<TypeVector>& cases,
       bool verifyAllPairs = true) {
@@ -490,41 +473,6 @@ class RadixSortKeyCodecTest : public testing::Test {
     }
   }
 
-  static void expectBuffersEqual(
-      const BufferPtr& buffer,
-      const std::vector<uint64_t>& expected) {
-    EXPECT_EQ(
-        std::vector<uint64_t>(
-            buffer->as<uint64_t>(), buffer->as<uint64_t>() + expected.size()),
-        expected);
-  }
-
-  static std::vector<EncodedKeyView> makeViews(
-      const EncodedKeyBatch& keys,
-      std::vector<std::array<char, sizeof(uint64_t)>>& fixedBytes,
-      uint32_t prefixSize = 0) {
-    std::vector<EncodedKeyView> views(keys.size());
-    if (keys.format() == EncodedKeyFormat::kFixed64) {
-      fixedBytes.resize(keys.size());
-      for (vector_size_t row = 0; row < keys.size(); ++row) {
-        auto word = keys.fixedKeyAt(row);
-        if constexpr (std::endian::native == std::endian::little) {
-          word = byteSwap(word);
-        }
-        storeUnaligned(fixedBytes[row].data(), word);
-        views[row] = EncodedKeyView(
-            std::string_view(fixedBytes[row].data(), fixedBytes[row].size()));
-      }
-      return views;
-    }
-    for (vector_size_t row = 0; row < keys.size(); ++row) {
-      const auto key = keys.variableKeyAt(row);
-      BOLT_CHECK_LE(prefixSize, key.size());
-      views[row] = {key.substr(prefixSize)};
-    }
-    return views;
-  }
-
   static std::string hex(std::string_view bytes) {
     std::ostringstream out;
     out << std::hex << std::setfill('0');
@@ -532,19 +480,6 @@ class RadixSortKeyCodecTest : public testing::Test {
       out << std::setw(2) << static_cast<uint32_t>(static_cast<uint8_t>(byte));
     }
     return out.str();
-  }
-
-  static std::string keyHex(const EncodedKeyBatch& keys, vector_size_t row) {
-    if (keys.format() == EncodedKeyFormat::kVariableBinary) {
-      return hex(keys.variableKeyAt(row));
-    }
-    auto word = keys.fixedKeyAt(row);
-    if constexpr (std::endian::native == std::endian::little) {
-      word = byteSwap(word);
-    }
-    std::array<char, sizeof(word)> bytes{};
-    storeUnaligned(bytes.data(), word);
-    return hex(std::string_view(bytes.data(), bytes.size()));
   }
 };
 
@@ -554,8 +489,7 @@ TEST_F(RadixSortKeyCodecTest, bindMetadataAndCapability) {
       {SortComparatorOracle::makeSortFlags(true, true),
        SortComparatorOracle::makeSortFlags(false, false),
        SortComparatorOracle::makeSortFlags(true, false)});
-  EXPECT_TRUE(codec->canEncodeDecode());
-
+  ASSERT_NE(codec, nullptr);
   const std::vector<TypePtr> supportedTypes{
       BOOLEAN(),
       TINYINT(),
@@ -613,13 +547,6 @@ TEST_F(RadixSortKeyCodecTest, invalidBindAndInputContracts) {
       RadixSortKeyCodec::bind({BIGINT()}, {invalidFlags}, codec),
       BoltException);
   EXPECT_EQ(codec, nullptr);
-
-  codec = bind({BIGINT()}, {SortComparatorOracle::makeSortFlags(true, true)});
-  EncodedKeyBatch keys;
-  EXPECT_THROW(
-      codec->encode(
-          *makeRows({makeVector<int64_t>(BIGINT(), {1})}), nullptr, keys),
-      BoltException);
 }
 
 TEST_F(RadixSortKeyCodecTest, leadingSkippableValidityOffsets) {
@@ -684,442 +611,24 @@ TEST_F(RadixSortKeyCodecTest, leadingSkippableValidityOffsets) {
 TEST_F(RadixSortKeyCodecTest, knownEncodedKeyBytes) {
   auto integerRows =
       makeRows({makeVector<int32_t>(INTEGER(), {0, -1, std::nullopt})});
-  auto integerCodec =
-      bind({INTEGER()}, {SortComparatorOracle::makeSortFlags(true, true)});
-  EncodedKeyBatch integerKeys;
-  integerCodec->encode(*integerRows, pool_.get(), integerKeys);
-  EXPECT_EQ(keyHex(integerKeys, 0), "0280000000000000");
-  EXPECT_EQ(keyHex(integerKeys, 1), "027fffffff000000");
-  EXPECT_EQ(keyHex(integerKeys, 2), "0100000000000000");
+  auto integerRun =
+      createRun(integerRows, {SortComparatorOracle::makeSortFlags(true, true)});
+  EXPECT_EQ(hex(logicalKeyAt(*integerRun, 0)), "0280000000000000");
+  EXPECT_EQ(hex(logicalKeyAt(*integerRun, 1)), "027fffffff000000");
+  EXPECT_EQ(hex(logicalKeyAt(*integerRun, 2)), "0100000000000000");
 
   const std::string bytes{"\x00\x01\x02\xff", 4};
   auto stringRows =
       makeRows({makeStringVector(VARBINARY(), {bytes, std::nullopt})});
-  auto ascCodec =
-      bind({VARBINARY()}, {SortComparatorOracle::makeSortFlags(true, true)});
-  EncodedKeyBatch ascKeys;
-  ascCodec->encode(*stringRows, pool_.get(), ascKeys);
-  EXPECT_EQ(keyHex(ascKeys, 0), "020100010102ff00");
-  EXPECT_EQ(keyHex(ascKeys, 1), "01");
+  const auto ascFlags = SortComparatorOracle::makeSortFlags(true, true);
+  auto ascRun = createRun(stringRows, {ascFlags});
+  EXPECT_EQ(hex(logicalKeyAt(*ascRun, 0)), "020100010102ff00");
+  EXPECT_EQ(hex(logicalKeyAt(*ascRun, 1)), "01");
 
-  auto descCodec =
-      bind({VARBINARY()}, {SortComparatorOracle::makeSortFlags(false, true)});
-  EncodedKeyBatch descKeys;
-  descCodec->encode(*stringRows, pool_.get(), descKeys);
-  EXPECT_EQ(keyHex(descKeys, 0), "02fefffefefd00ff");
-  EXPECT_EQ(keyHex(descKeys, 1), "01");
-}
-
-TEST_F(RadixSortKeyCodecTest, fixed64BoundaryAndAllocation) {
-  auto fixedRows = makeRows(
-      {makeVector<int16_t>(SMALLINT(), {1, -1, std::nullopt}),
-       makeVector<int32_t>(INTEGER(), {2, -2, 0})});
-  auto fixedCodec = bind(
-      {SMALLINT(), INTEGER()},
-      {SortComparatorOracle::makeSortFlags(true, true),
-       SortComparatorOracle::makeSortFlags(true, true)});
-  EXPECT_EQ(fixedCodec->maximumEncodedSize(), 8);
-
-  auto before = pool_->stats();
-  EncodedKeyBatch fixedKeys;
-  fixedCodec->encode(*fixedRows, pool_.get(), fixedKeys);
-  auto after = pool_->stats();
-  EXPECT_EQ(fixedKeys.format(), EncodedKeyFormat::kFixed64);
-  EXPECT_EQ(after.numAllocs - before.numAllocs, 1);
-  EXPECT_NE(fixedKeys.fixedKeys(), nullptr);
-  EXPECT_EQ(fixedKeys.offsets(), nullptr);
-  EXPECT_EQ(fixedKeys.data(), nullptr);
-
-  auto variableRows =
-      makeRows({makeVector<int64_t>(BIGINT(), {1, -1, std::nullopt})});
-  auto variableCodec =
-      bind({BIGINT()}, {SortComparatorOracle::makeSortFlags(true, true)});
-  EXPECT_EQ(variableCodec->maximumEncodedSize(), 9);
-
-  before = pool_->stats();
-  EncodedKeyBatch variableKeys;
-  variableCodec->encode(*variableRows, pool_.get(), variableKeys);
-  after = pool_->stats();
-  EXPECT_EQ(variableKeys.format(), EncodedKeyFormat::kVariableBinary);
-  EXPECT_EQ(after.numAllocs - before.numAllocs, 2);
-  EXPECT_EQ(variableKeys.fixedKeys(), nullptr);
-  EXPECT_NE(variableKeys.offsets(), nullptr);
-  EXPECT_NE(variableKeys.data(), nullptr);
-}
-
-TEST_F(RadixSortKeyCodecTest, encodedBuffersReuseWithCopyOnWrite) {
-  auto fixedCodec = bind(
-      {SMALLINT(), INTEGER()},
-      {SortComparatorOracle::makeSortFlags(true, true),
-       SortComparatorOracle::makeSortFlags(true, true)});
-  auto firstFixed = makeRows(
-      {makeVector<int16_t>(SMALLINT(), {1, -1, std::nullopt}),
-       makeVector<int32_t>(INTEGER(), {2, -2, 0})});
-  auto secondFixed = makeRows(
-      {makeVector<int16_t>(SMALLINT(), {7, std::nullopt, -9}),
-       makeVector<int32_t>(INTEGER(), {-4, 5, 6})});
-
-  EncodedKeyBatch fixedKeys;
-  fixedCodec->encode(*firstFixed, pool_.get(), fixedKeys);
-  const auto* firstFixedBuffer = fixedKeys.fixedKeys().get();
-  auto before = pool_->stats();
-  fixedCodec->encode(*secondFixed, pool_.get(), fixedKeys);
-  auto after = pool_->stats();
-  EXPECT_EQ(after.numAllocs - before.numAllocs, 0);
-  EXPECT_EQ(fixedKeys.fixedKeys().get(), firstFixedBuffer);
-  RowVectorPtr decoded;
-  decodeBatch(*fixedCodec, fixedKeys, decoded);
-  expectColumnEqual(
-      *secondFixed,
-      *decoded,
-      0,
-      SortComparatorOracle::makeSortFlags(true, true));
-  expectColumnEqual(
-      *secondFixed,
-      *decoded,
-      1,
-      SortComparatorOracle::makeSortFlags(true, true));
-
-  BufferPtr retainedFixed = fixedKeys.fixedKeys();
-  const std::vector<uint64_t> retainedWords(
-      retainedFixed->as<uint64_t>(),
-      retainedFixed->as<uint64_t>() + secondFixed->size());
-  fixedCodec->encode(*firstFixed, pool_.get(), fixedKeys);
-  EXPECT_NE(fixedKeys.fixedKeys().get(), retainedFixed.get());
-  expectBuffersEqual(retainedFixed, retainedWords);
-
-  auto variableCodec =
-      bind({BIGINT()}, {SortComparatorOracle::makeSortFlags(true, true)});
-  auto firstVariable =
-      makeRows({makeVector<int64_t>(BIGINT(), {1, -1, std::nullopt})});
-  auto secondVariable =
-      makeRows({makeVector<int64_t>(BIGINT(), {7, std::nullopt, -9})});
-  EncodedKeyBatch variableKeys;
-  variableCodec->encode(*firstVariable, pool_.get(), variableKeys);
-  const auto* firstOffsets = variableKeys.offsets().get();
-  before = pool_->stats();
-  variableCodec->encode(*secondVariable, pool_.get(), variableKeys);
-  after = pool_->stats();
-  EXPECT_EQ(after.numAllocs - before.numAllocs, 1);
-  EXPECT_EQ(variableKeys.offsets().get(), firstOffsets);
-  decodeBatch(*variableCodec, variableKeys, decoded);
-  expectColumnEqual(
-      *secondVariable,
-      *decoded,
-      0,
-      SortComparatorOracle::makeSortFlags(true, true));
-
-  BufferPtr retainedOffsets = variableKeys.offsets();
-  const std::vector<uint64_t> retainedOffsetValues(
-      retainedOffsets->as<uint64_t>(),
-      retainedOffsets->as<uint64_t>() + secondVariable->size() + 1);
-  variableCodec->encode(*firstVariable, pool_.get(), variableKeys);
-  EXPECT_NE(variableKeys.offsets().get(), retainedOffsets.get());
-  expectBuffersEqual(retainedOffsets, retainedOffsetValues);
-
-  auto emptyVariable = makeRows(
-      {BaseVector::create<FlatVector<int64_t>>(BIGINT(), 0, pool_.get())});
-  const auto* reusableOffsets = variableKeys.offsets().get();
-  variableCodec->encode(*emptyVariable, pool_.get(), variableKeys);
-  EXPECT_EQ(variableKeys.offsets().get(), reusableOffsets);
-  ASSERT_EQ(variableKeys.offsets()->size(), sizeof(uint64_t));
-  EXPECT_EQ(variableKeys.offsets()->as<uint64_t>()[0], 0);
-  EXPECT_EQ(variableKeys.data(), nullptr);
-}
-
-TEST_F(RadixSortKeyCodecTest, selectiveDecodeSkipsFixedPrefix) {
-  auto rows = makeRows(
-      {makeVector<int64_t>(BIGINT(), {10, std::nullopt, -7, 42, std::nullopt}),
-       makeStringVector(
-           VARCHAR(),
-           {std::string("alpha"),
-            std::string("\x00", 1) + std::string("\x01", 1) + "beta",
-            std::nullopt,
-            std::string(128, 'z'),
-            std::string()}),
-       makeVector<double>(
-           DOUBLE(),
-           {1.5,
-            -0.0,
-            std::numeric_limits<double>::quiet_NaN(),
-            std::nullopt,
-            -7.25})});
-  const std::vector<CompareFlags> compareFlags{
-      SortComparatorOracle::makeSortFlags(true, true),
-      SortComparatorOracle::makeSortFlags(false, false),
-      SortComparatorOracle::makeSortFlags(false, true)};
-  auto codec = bind({BIGINT(), VARCHAR(), DOUBLE()}, compareFlags);
-
-  EncodedKeyBatch keys;
-  codec->encode(*rows, pool_.get(), keys);
-  RowVectorPtr decoded;
-  const std::vector<uint8_t> decodedColumns{0, 1, 1};
-  const std::vector<uint8_t> mayHaveNulls{1, 1, 1};
-  decodeBatch(*codec, keys, decoded, decodedColumns, mayHaveNulls);
-
-  ASSERT_EQ(decoded->childAt(0), nullptr);
-  expectColumnEqual(*rows, *decoded, 1, compareFlags[1]);
-  expectColumnEqual(*rows, *decoded, 2, compareFlags[2]);
-}
-
-TEST_F(RadixSortKeyCodecTest, selectiveDecodeSkipsFixedTypes) {
-  verifySelectiveDecode(
-      {makeVector<bool>(BOOLEAN(), {true, std::nullopt}),
-       makeVector<int8_t>(TINYINT(), {1, std::nullopt}),
-       makeVector<int16_t>(SMALLINT(), {1, std::nullopt}),
-       makeVector<int32_t>(INTEGER(), {1, std::nullopt}),
-       makeVector<int64_t>(BIGINT(), {1, std::nullopt}),
-       makeVector<int128_t>(HUGEINT(), {1, std::nullopt}),
-       makeVector<float>(REAL(), {1.5F, std::nullopt}),
-       makeVector<double>(DOUBLE(), {1.5, std::nullopt}),
-       makeVector<int64_t>(DECIMAL(18, 4), {1, std::nullopt}),
-       makeVector<int128_t>(DECIMAL(38, 18), {1, std::nullopt}),
-       makeVector<int32_t>(DATE(), {1, std::nullopt}),
-       makeVector<int64_t>(INTERVAL_DAY_TIME(), {1, std::nullopt}),
-       makeVector<int32_t>(INTERVAL_YEAR_MONTH(), {1, std::nullopt}),
-       makeVector<Timestamp>(TIMESTAMP(), {Timestamp(1, 2), std::nullopt}),
-       makeUnknownVector(2)},
-      true);
-}
-
-TEST_F(RadixSortKeyCodecTest, maskedDecodeRejectsTruncatedKeys) {
-  const auto validMarker = static_cast<char>(2);
-  const auto delimiter = static_cast<char>(0);
-  const auto escape = static_cast<char>(1);
-  const std::array<uint8_t, 2> decodedColumns{0, 1};
-
-  const auto expectRejected =
-      [&](const TypePtr& maskedType, std::string key, bool ascending = true) {
-        SCOPED_TRACE(maskedType->toString() + " key=" + hex(key));
-        const auto flags = SortComparatorOracle::makeSortFlags(ascending, true);
-        auto codec = bind({maskedType, UNKNOWN()}, {flags, flags});
-        auto output = BaseVector::create<RowVector>(
-            ROW({maskedType, UNKNOWN()}), 1, pool_.get());
-        EXPECT_THROW(
-            RadixSortKeyCodecTestHelper::decodeWithMaskedPrefix(
-                *codec, key, decodedColumns, pool_.get(), *output),
-            BoltException);
-      };
-
-  expectRejected(BIGINT(), {});
-  expectRejected(BIGINT(), std::string(1, static_cast<char>(3)));
-  expectRejected(BIGINT(), validMarker + std::string(7, '\0'));
-  expectRejected(VARCHAR(), std::string{validMarker, 'x'});
-  expectRejected(VARCHAR(), std::string{validMarker, escape});
-
-  const auto expectStringDecodeRejected = [&](bool ascending,
-                                              char encodedEscape) {
-    const auto stringFlags =
-        SortComparatorOracle::makeSortFlags(ascending, true);
-    auto codec = bind({VARCHAR()}, {stringFlags});
-    auto output =
-        BaseVector::create<RowVector>(ROW({VARCHAR()}), 1, pool_.get());
-    const std::array<uint8_t, 1> decodedStringColumn{1};
-    EXPECT_THROW(
-        RadixSortKeyCodecTestHelper::decodeWithColumnRange(
-            *codec,
-            std::string{validMarker, encodedEscape},
-            decodedStringColumn,
-            0,
-            1,
-            pool_.get(),
-            *output),
-        BoltException);
-  };
-  expectStringDecodeRejected(true, escape);
-  expectStringDecodeRejected(false, static_cast<char>(~escape));
-  expectRejected(
-      ARRAY(INTEGER()),
-      std::string{validMarker, validMarker} + std::string(4, '\0'));
-  expectRejected(
-      ARRAY(INTEGER()),
-      std::string{validMarker, validMarker} + std::string(3, '\0'));
-
-  const auto mapType = MAP(INTEGER(), BIGINT());
-  const auto encodedKey =
-      std::string{validMarker, validMarker} + std::string(4, '\0');
-  expectRejected(mapType, encodedKey);
-  expectRejected(
-      mapType, encodedKey + delimiter + validMarker + std::string(7, '\0'));
-  expectRejected(
-      mapType, encodedKey + delimiter + validMarker + std::string(8, '\0'));
-
-  const auto expectMapDecodeRejected = [&](std::string key) {
-    const auto mapFlags = SortComparatorOracle::makeSortFlags(true, true);
-    auto codec = bind({mapType}, {mapFlags});
-    auto output = BaseVector::create<RowVector>(ROW({mapType}), 1, pool_.get());
-    const std::array<uint8_t, 1> decodedMapColumn{1};
-    EXPECT_THROW(
-        RadixSortKeyCodecTestHelper::decodeWithColumnRange(
-            *codec, key, decodedMapColumn, 0, 1, pool_.get(), *output),
-        BoltException);
-  };
-  const auto oneKey =
-      std::string{validMarker, validMarker} + std::string(4, '\0') + delimiter;
-  expectMapDecodeRejected(oneKey + delimiter);
-  expectMapDecodeRejected(
-      oneKey + validMarker + std::string(8, '\0') + validMarker +
-      std::string(8, '\0') + delimiter);
-}
-
-TEST_F(RadixSortKeyCodecTest, maskedDecodeRejectsMissingFollowingMarker) {
-  const auto flags = SortComparatorOracle::makeSortFlags(true, true);
-  auto codec = bind({TINYINT(), BIGINT(), UNKNOWN()}, {flags, flags, flags});
-  auto output = BaseVector::create<RowVector>(
-      ROW({TINYINT(), BIGINT(), UNKNOWN()}), 1, pool_.get());
-  const std::array<uint8_t, 3> decodedColumns{0, 0, 1};
-  const std::string key{static_cast<char>(2), '\0'};
-  EXPECT_THROW(
-      RadixSortKeyCodecTestHelper::decodeWithMaskedPrefix(
-          *codec, key, decodedColumns, pool_.get(), *output),
-      BoltException);
-}
-
-TEST_F(RadixSortKeyCodecTest, offsetDecodeStopsAfterLastSelectedColumn) {
-  const auto flags = SortComparatorOracle::makeSortFlags(true, true);
-  const std::array<uint8_t, 3> decodedColumns{0, 1, 0};
-  const std::string key = std::string{static_cast<char>(2)} +
-      std::string(8, '\0') +
-      std::string{static_cast<char>(2), 'o', 'k', static_cast<char>(0)};
-
-  const std::array<TypePtr, 2> trailingTypes{
-      ARRAY(INTEGER()), MAP(INTEGER(), BIGINT())};
-  for (const auto& trailingType : trailingTypes) {
-    SCOPED_TRACE(trailingType->toString());
-    auto codec =
-        bind({BIGINT(), VARCHAR(), trailingType}, {flags, flags, flags});
-    auto output = BaseVector::create<RowVector>(
-        ROW({BIGINT(), VARCHAR(), trailingType}), 1, pool_.get());
-
-    // The encoded key ends after VARCHAR. A decoder that attempts to skip the
-    // trailing masked complex column will read past this view and fail.
-    RadixSortKeyCodecTestHelper::decodeWithColumnRange(
-        *codec, key, decodedColumns, 0, 2, pool_.get(), *output);
-
-    EXPECT_EQ(
-        output->childAt(1)
-            ->asUnchecked<SimpleVector<StringView>>()
-            ->valueAt(0)
-            .getString(),
-        "ok");
-  }
-}
-
-TEST_F(RadixSortKeyCodecTest, offsetDecodeRejectsInvalidUnknownMarker) {
-  const auto flags = SortComparatorOracle::makeSortFlags(true, true);
-  auto codec = bind({UNKNOWN()}, {flags});
-  auto output = BaseVector::create<RowVector>(ROW({UNKNOWN()}), 1, pool_.get());
-  const std::array<uint8_t, 1> decodedColumns{1};
-  EXPECT_THROW(
-      RadixSortKeyCodecTestHelper::decodeWithMaskedPrefix(
-          *codec,
-          std::string(1, static_cast<char>(2)),
-          decodedColumns,
-          pool_.get(),
-          *output),
-      BoltException);
-}
-
-TEST_F(
-    RadixSortKeyCodecTest,
-    selectiveDecodeCannotSkipVariableAndComplexTypes) {
-  auto timestampWithTimeZone = std::make_shared<RowVector>(
-      pool_.get(),
-      TIMESTAMP_WITH_TIME_ZONE(),
-      nullptr,
-      4,
-      std::vector<VectorPtr>{
-          makeVector<int64_t>(BIGINT(), {-1, 0, 1, std::nullopt}),
-          makeVector<int16_t>(SMALLINT(), {1, 2, 3, 4})});
-  auto arrays = makeIntegerArrays(
-      {std::vector<std::optional<int32_t>>{},
-       std::vector<std::optional<int32_t>>{1, std::nullopt},
-       std::vector<std::optional<int32_t>>{2, 3},
-       std::nullopt});
-  auto rows = makeNestedRows();
-  auto rowOfNested = std::make_shared<RowVector>(
-      pool_.get(),
-      ROW({"array", "row"}, {arrays->type(), rows->type()}),
-      nullptr,
-      4,
-      std::vector<VectorPtr>{arrays, rows});
-  rowOfNested->setNull(3, true);
-
-  verifySelectiveDecode(
-      {makeStringVector(
-           VARCHAR(), {"one", std::string(80, 'x'), std::nullopt, "four"}),
-       makeStringVector(
-           VARBINARY(),
-           {std::string("\x00", 1),
-            std::string("\xff", 1),
-            std::nullopt,
-            std::string("\x01\x02", 2)}),
-       makeStringVector(JSON(), {"1", "{\"a\":2}", std::nullopt, "[4]"}),
-       makeStringVector(
-           HYPERLOGLOG(), {"one", std::string(80, 'h'), std::nullopt, "four"}),
-       timestampWithTimeZone,
-       arrays,
-       makeIntegerStringMaps(),
-       makeStringStringMaps(),
-       rows,
-       rowOfNested},
-      false);
-}
-
-TEST_F(RadixSortKeyCodecTest, selectiveDecodeFixedPrefixAndComplexSuffix) {
-  auto arrays = makeIntegerArrays(
-      {std::vector<std::optional<int32_t>>{1, 2},
-       std::vector<std::optional<int32_t>>{1, std::nullopt},
-       std::vector<std::optional<int32_t>>{},
-       std::nullopt});
-  auto rows = makeRows(
-      {makeVector<int32_t>(INTEGER(), {10, 20, 30, 40}),
-       makeVector<int64_t>(BIGINT(), {100, std::nullopt, 300, 400}),
-       arrays});
-  const std::vector<CompareFlags> compareFlags{
-      SortComparatorOracle::makeSortFlags(true, true),
-      SortComparatorOracle::makeSortFlags(false, false),
-      SortComparatorOracle::makeSortFlags(true, true)};
-  auto codec = bind({INTEGER(), BIGINT(), arrays->type()}, compareFlags);
-  EncodedKeyBatch keys;
-  codec->encode(*rows, pool_.get(), keys);
-  RowVectorPtr decoded;
-  const std::array<uint8_t, 3> decodedColumns{0, 0, 1};
-  const std::array<uint8_t, 3> mayHaveNulls{0, 1, 1};
-  decodeBatch(*codec, keys, decoded, decodedColumns, mayHaveNulls);
-  ASSERT_EQ(decoded->size(), rows->size());
-  EXPECT_EQ(decoded->childAt(0), nullptr);
-  EXPECT_EQ(decoded->childAt(1), nullptr);
-  expectColumnEqual(*rows, *decoded, 2, compareFlags[2]);
-}
-
-TEST_F(RadixSortKeyCodecTest, emptyBatchAndVariableAllocation) {
-  auto codec =
-      bind({VARCHAR()}, {SortComparatorOracle::makeSortFlags(true, true)});
-  auto emptyRows = makeRows(
-      {BaseVector::create<FlatVector<StringView>>(VARCHAR(), 0, pool_.get())});
-  EncodedKeyBatch emptyKeys;
-  codec->encode(*emptyRows, pool_.get(), emptyKeys);
-  EXPECT_EQ(emptyKeys.size(), 0);
-  EXPECT_NE(emptyKeys.offsets(), nullptr);
-  EXPECT_EQ(emptyKeys.data(), nullptr);
-  RowVectorPtr decoded;
-  decodeBatch(*codec, emptyKeys, decoded);
-  EXPECT_EQ(decoded->size(), 0);
-
-  std::vector<std::optional<std::string>> values;
-  values.reserve(1024);
-  for (uint32_t row = 0; row < 1024; ++row) {
-    values.emplace_back(std::string(4096, static_cast<char>(2 + row % 200)));
-  }
-  auto rows = makeRows({makeStringVector(VARCHAR(), values)});
-  auto before = pool_->stats();
-  EncodedKeyBatch keys;
-  codec->encode(*rows, pool_.get(), keys);
-  auto after = pool_->stats();
-  EXPECT_EQ(after.numAllocs - before.numAllocs, 2);
-  EXPECT_EQ(keys.variableKeyAt(0).size(), 4098);
-  EXPECT_EQ(keys.variableKeyAt(1023).size(), 4098);
+  const auto descFlags = SortComparatorOracle::makeSortFlags(false, true);
+  auto descRun = createRun(stringRows, {descFlags});
+  EXPECT_EQ(hex(logicalKeyAt(*descRun, 0)), "02fefffefefd00ff");
+  EXPECT_EQ(hex(logicalKeyAt(*descRun, 1)), "01");
 }
 
 TEST_F(RadixSortKeyCodecTest, integralAndDecimalRoundTrip) {
@@ -1379,12 +888,14 @@ TEST_F(RadixSortKeyCodecTest, mapKeyEncodingDoesNotCanonicalizeInput) {
   ASSERT_EQ(rawKeys->valueAt(2), 2);
 
   const auto compareFlags = SortComparatorOracle::makeSortFlags(true, true);
-  auto codec = bind({maps->type()}, {compareFlags});
-  EncodedKeyBatch encoded;
-  codec->encode(*makeRows({maps}), pool_.get(), encoded);
-  RowVectorPtr decoded;
-  decodeBatch(*codec, encoded, decoded);
-  expectColumnEqual(*makeRows({maps}), *decoded, 0, compareFlags);
+  auto input = makeRows({maps});
+  auto run = createRun(input, {compareFlags});
+  std::vector<std::string> encoded;
+  encoded.reserve(run->size());
+  for (uint64_t row = 0; row < run->size(); ++row) {
+    encoded.push_back(logicalKeyAt(*run, row));
+  }
+  verifyProperty(input, {compareFlags});
 
   auto sortedMaps = std::make_shared<MapVector>(
       pool_.get(),
@@ -1400,12 +911,10 @@ TEST_F(RadixSortKeyCodecTest, mapKeyEncodingDoesNotCanonicalizeInput) {
       std::nullopt,
       true);
   ASSERT_TRUE(sortedMaps->hasSortedKeys());
-  EncodedKeyBatch sortedEncoded;
-  codec->encode(*makeRows({sortedMaps}), pool_.get(), sortedEncoded);
-  ASSERT_EQ(encoded.size(), sortedEncoded.size());
+  auto sortedRun = createRun(makeRows({sortedMaps}), {compareFlags});
+  ASSERT_EQ(encoded.size(), sortedRun->size());
   for (vector_size_t row = 0; row < encoded.size(); ++row) {
-    EXPECT_EQ(encoded.variableKeyAt(row), sortedEncoded.variableKeyAt(row))
-        << "row=" << row;
+    EXPECT_EQ(encoded[row], logicalKeyAt(*sortedRun, row)) << "row=" << row;
   }
 
   EXPECT_FALSE(maps->hasSortedKeys());
@@ -1498,13 +1007,11 @@ TEST_F(RadixSortKeyCodecTest, repeatedMapExceedingIndexCacheLimit) {
     auto repeated = BaseVector::wrapInDictionary(
         nullptr, makeBuffer(indices), indices.size(), map);
     auto input = makeRows({repeated});
-    auto codec =
-        bind({map->type()}, {SortComparatorOracle::makeSortFlags(true, true)});
-    EncodedKeyBatch encoded;
-    codec->encode(*input, pool_.get(), encoded);
-    ASSERT_EQ(encoded.size(), indices.size());
-    EXPECT_EQ(encoded.variableKeyAt(0), encoded.variableKeyAt(1));
-    EXPECT_EQ(encoded.variableKeyAt(0), encoded.variableKeyAt(2));
+    auto run =
+        createRun(input, {SortComparatorOracle::makeSortFlags(true, true)});
+    ASSERT_EQ(run->size(), indices.size());
+    EXPECT_EQ(logicalKeyAt(*run, 0), logicalKeyAt(*run, 1));
+    EXPECT_EQ(logicalKeyAt(*run, 0), logicalKeyAt(*run, 2));
   }
 }
 
@@ -1525,15 +1032,12 @@ TEST_F(RadixSortKeyCodecTest, nestedComplexVariableKeySizes) {
 
   verifyProperty(input, compareFlags);
 
-  auto codec = bind({rowKey->type()}, compareFlags);
-  EncodedKeyBatch keys;
-  codec->encode(*input, pool_.get(), keys);
-
-  ASSERT_EQ(keys.format(), EncodedKeyFormat::kVariableBinary);
-  ASSERT_EQ(keys.size(), 3);
-  EXPECT_EQ(keys.variableKeyAt(0).size(), 34);
-  EXPECT_EQ(keys.variableKeyAt(1).size(), 15);
-  EXPECT_EQ(keys.variableKeyAt(2).size(), 7);
+  auto run = createRun(input, compareFlags);
+  ASSERT_TRUE(run->keyLayout().isVariable());
+  ASSERT_EQ(run->size(), 3);
+  EXPECT_EQ(logicalKeyAt(*run, 0).size(), 34);
+  EXPECT_EQ(logicalKeyAt(*run, 1).size(), 15);
+  EXPECT_EQ(logicalKeyAt(*run, 2).size(), 7);
 }
 
 TEST_F(RadixSortKeyCodecTest, floatingPointRoundTrip) {
@@ -1801,20 +1305,24 @@ TEST_F(RadixSortKeyCodecTest, nestedDictionaryChildrenAndReuse) {
         std::vector<std::optional<vector_size_t>>(kRows, 1), wrapTwice(nested));
     verifyAllFlags({integerArrays, stringArrays, maps, arrayRows}, false);
 
-    // Reuse one codec after changing child values and nulls, so no decoded
-    // state can leak from the previous invocation.
+    // Append repeatedly through the same production codec after mutating the
+    // wrapped child vectors. This catches decoded-vector state leaking across
+    // append calls.
     const auto flags = SortComparatorOracle::makeSortFlags(false, false);
-    auto codec = bind({arrayRows->type()}, {flags});
-    EncodedKeyBatch encoded;
-    RowVectorPtr decoded;
-    for (uint32_t repeat = 0; repeat < 3; ++repeat) {
+    auto input = makeRows({arrayRows});
+    auto run = createEmptyRun(input, {flags});
+    constexpr uint32_t kRepeats = 3;
+    auto expectedArrays =
+        BaseVector::create(arrayRows->type(), kRows * kRepeats, pool_.get());
+    for (uint32_t repeat = 0; repeat < kRepeats; ++repeat) {
       integerChild->set(0, 100 + repeat);
       const auto text = std::string(64, static_cast<char>('m' + repeat));
       stringChild->set(0, StringView(text));
-      codec->encode(*makeRows({arrayRows}), pool_.get(), encoded);
-      decodeBatch(*codec, encoded, decoded);
-      expectColumnEqual(*makeRows({arrayRows}), *decoded, 0, flags);
+      run->append(*input);
+      expectedArrays->copy(
+          arrayRows.get(), repeat * kRows, 0, arrayRows->size());
     }
+    verifyRun(*run, makeRows({std::move(expectedArrays)}), {flags}, false);
   }
 }
 
@@ -1825,12 +1333,10 @@ TEST_F(RadixSortKeyCodecTest, nestedStringAllocationGrowth) {
         std::vector<std::optional<vector_size_t>>(rows, 1),
         makeStringVector(VARCHAR(), values));
     const auto flags = SortComparatorOracle::makeSortFlags(false, false);
-    auto codec = bind({arrays->type()}, {flags});
-    EncodedKeyBatch keys;
-    codec->encode(*makeRows({arrays}), pool_.get(), keys);
-    RowVectorPtr decoded;
+    auto input = makeRows({arrays});
+    auto run = createRun(input, {flags});
     const auto before = pool_->stats().numAllocs;
-    decodeBatch(*codec, keys, decoded);
+    auto decoded = finalizeAndCollect(*run);
     const auto allocations = pool_->stats().numAllocs - before;
     auto* strings = decoded->childAt(0)
                         ->as<ArrayVector>()
@@ -1849,13 +1355,12 @@ TEST_F(RadixSortKeyCodecTest, nestedStringAllocationGrowth) {
       EXPECT_LT(allocations, 100);
       EXPECT_LE(capacity - used, 32 * 1024);
     }
-    expectColumnEqual(*makeRows({arrays}), *decoded, 0, flags);
+    expectColumnEqual(*input, *decoded, 0, flags);
 
     auto rowValues = makeRows({makeStringVector(VARCHAR(), values)});
-    auto rowCodec = bind({rowValues->type()}, {flags});
-    rowCodec->encode(*makeRows({rowValues}), pool_.get(), keys);
-    decoded.reset();
-    decodeBatch(*rowCodec, keys, decoded);
+    auto rowInput = makeRows({rowValues});
+    auto rowRun = createRun(rowInput, {flags});
+    decoded = finalizeAndCollect(*rowRun);
     auto* rowStrings = decoded->childAt(0)
                            ->as<RowVector>()
                            ->childAt(0)
@@ -1864,7 +1369,7 @@ TEST_F(RadixSortKeyCodecTest, nestedStringAllocationGrowth) {
     for (const auto& buffer : rowStrings->stringBuffers())
       rowCapacity += buffer->capacity();
     EXPECT_LE(rowCapacity, rows == 1 ? 256 : used + used / 10);
-    expectColumnEqual(*makeRows({rowValues}), *decoded, 0, flags);
+    expectColumnEqual(*rowInput, *decoded, 0, flags);
   }
 }
 

--- a/bolt/exec/tests/RadixSortKeyTest.cpp
+++ b/bolt/exec/tests/RadixSortKeyTest.cpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include "bolt/exec/radixsort/RadixSortRunStorage.h"
+#include "bolt/exec/radixsort/RadixSortRun.h"
 #include "bolt/exec/radixsort/RadixSortUtils.h"
 #include "bolt/exec/tests/utils/RadixSortComparatorOracle.h"
 #include "bolt/type/HugeInt.h"
@@ -46,7 +46,7 @@ struct LayoutDescriptor {
   std::optional<uint32_t> sizeOffset;
   std::optional<uint32_t> dataOffset;
   std::optional<uint32_t> payloadOffset;
-  int32_t (*compare)(const char*, const char*);
+  int32_t (*compare)(const char*, const char*, uint32_t);
 };
 
 static_assert(sizeof(KeyOnlyVariable32Record) == 32);
@@ -91,15 +91,6 @@ constexpr std::array<LayoutDescriptor, 9> kLayouts{{
 #undef LAYOUT
 // clang-format on
 
-using StorageBoundaryScenario = std::pair<uint32_t, std::array<uint32_t, 3>>;
-
-constexpr std::array<StorageBoundaryScenario, 5> kStorageBoundaries{{
-    {1, {1, 1, 1}},
-    {2, {2, 2, 1}},
-    {31, {31, 31, 1}},
-    {32, {32, 32, 1}},
-    {33, {33, 33, 1}},
-}};
 struct PayloadPointers {
   explicit PayloadPointers(vector_size_t size) : storage(size), pointers(size) {
     for (vector_size_t row = 0; row < size; ++row) {
@@ -195,30 +186,198 @@ class RadixSortKeyTest : public testing::Test {
         children);
   }
 
-  std::pair<std::unique_ptr<RadixSortKeyCodec>, EncodedKeyBatch> bindAndEncode(
-      const RowVectorPtr& rows,
+  std::unique_ptr<RadixSortRun> makeRun(
+      const RowVectorPtr& input,
+      const std::vector<column_index_t>& keyChannels,
       const std::vector<CompareFlags>& compareFlags) {
-    std::unique_ptr<RadixSortKeyCodec> codec;
-    RadixSortKeyCodec::bind(
-        rows->type()->asRow().children(), compareFlags, codec);
-    EncodedKeyBatch keys;
-    codec->encode(*rows, pool_.get(), keys);
-    return {std::move(codec), std::move(keys)};
+    std::vector<std::string> keyNames;
+    std::vector<TypePtr> keyTypes;
+    keyNames.reserve(keyChannels.size());
+    keyTypes.reserve(keyChannels.size());
+    for (const auto channel : keyChannels) {
+      keyNames.push_back(input->type()->asRow().nameOf(channel));
+      keyTypes.push_back(input->type()->asRow().childAt(channel));
+    }
+    auto run = RadixSortRun::create(
+        pool_.get(),
+        std::static_pointer_cast<const RowType>(input->type()),
+        ROW(std::move(keyNames), std::move(keyTypes)),
+        compareFlags,
+        keyChannels,
+        {});
+    run->append(*input);
+    return run;
   }
 
-  static std::string encodedKeyAt(
-      const EncodedKeyBatch& keys,
-      vector_size_t row) {
-    if (keys.format() == EncodedKeyFormat::kVariableBinary) {
-      return std::string(keys.variableKeyAt(row));
+  std::unique_ptr<RadixSortRun> makeRun(
+      const RowVectorPtr& rows,
+      const std::vector<CompareFlags>& compareFlags,
+      bool hasPayload) {
+    std::vector<column_index_t> keyChannels(rows->childrenSize());
+    std::iota(keyChannels.begin(), keyChannels.end(), 0);
+    std::vector<std::string> outputNames(rows->childrenSize());
+    for (uint32_t column = 0; column < outputNames.size(); ++column) {
+      outputNames[column] = "key" + std::to_string(column);
     }
-    auto word = keys.fixedKeyAt(row);
-    if constexpr (std::endian::native == std::endian::little) {
-      word = byteSwap(word);
+    std::vector<std::string> keyNames = outputNames;
+    std::vector<TypePtr> keyTypes = rows->type()->asRow().children();
+    std::vector<TypePtr> outputTypes = rows->type()->asRow().children();
+    std::vector<VectorPtr> inputChildren = rows->children();
+    if (hasPayload) {
+      outputNames.push_back("payload");
+      outputTypes.push_back(BIGINT());
+      inputChildren.push_back(makeVector<int64_t>(
+          BIGINT(),
+          std::vector<std::optional<int64_t>>(rows->size(), int64_t{0})));
     }
-    std::string result(sizeof(word), '\0');
-    storeUnaligned(result.data(), word);
-    return result;
+    auto input = std::make_shared<RowVector>(
+        pool_.get(),
+        ROW(std::move(outputNames), std::move(outputTypes)),
+        nullptr,
+        rows->size(),
+        std::move(inputChildren));
+    return makeRun(input, keyChannels, compareFlags);
+  }
+
+  static const char* recordAt(
+      const RadixSortRunStorage& storage,
+      uint64_t row) {
+    const auto range = storage.keyRangeAt(row, 1);
+    BOLT_CHECK_EQ(range.count, 1);
+    return range.data;
+  }
+
+  static void constructPhysicalKey(
+      const RadixSortKeyLayout& layout,
+      std::string_view encodedKey,
+      char* heap,
+      char* payload,
+      char* record) {
+    if (layout.isVariable()) {
+      std::memset(record, 0, layout.inlineCapacity());
+      std::memcpy(
+          record,
+          encodedKey.data(),
+          std::min<size_t>(encodedKey.size(), layout.inlineCapacity()));
+      storeUnaligned<uint64_t>(
+          record + *layout.sizeOffset(), encodedKey.size());
+      const auto heapSize = encodedKey.size() - layout.heapKeyOffset();
+      if (heapSize > 0) {
+        std::memcpy(heap, encodedKey.data() + layout.heapKeyOffset(), heapSize);
+      }
+      storeCompactPointer(record + *layout.dataOffset(), heap);
+    } else {
+      RadixSortInlineKeyBuffer bytes{};
+      std::memcpy(
+          bytes.data(),
+          encodedKey.data(),
+          std::min<size_t>(encodedKey.size(), layout.inlineCapacity()));
+      for (uint32_t word = 0; word < layout.inlineWordCount(); ++word) {
+        auto value =
+            loadUnaligned<uint64_t>(bytes.data() + word * sizeof(uint64_t));
+        if constexpr (std::endian::native == std::endian::little) {
+          value = byteSwap(value);
+        }
+        storeUnaligned<uint64_t>(record + word * sizeof(uint64_t), value);
+      }
+      std::memcpy(
+          record + layout.inlineWordBytes(),
+          bytes.data() + layout.inlineWordBytes(),
+          layout.inlineTailBytes());
+    }
+    if (layout.hasPayload()) {
+      storeCompactPointer(record + *layout.payloadOffset(), payload);
+    }
+  }
+
+  static uint64_t storedSize(
+      const RadixSortKeyLayout& layout,
+      const char* record) {
+    return loadUnaligned<uint64_t>(record + *layout.sizeOffset());
+  }
+
+  static std::string_view heapKey(
+      const RadixSortKeyLayout& layout,
+      const char* record) {
+    return {
+        loadCompactPointer(record + *layout.dataOffset()),
+        storedSize(layout, record) - layout.heapKeyOffset()};
+  }
+
+  static char* payloadAt(const RadixSortKeyLayout& layout, const char* record) {
+    return layout.hasPayload()
+        ? loadCompactPointer(record + *layout.payloadOffset())
+        : nullptr;
+  }
+
+  static RowVectorPtr
+  output(RadixSortRun& run, vector_size_t maxRows, memory::MemoryPool* pool) {
+    RowVectorPtr result;
+    return run.getOutput(maxRows, pool, result);
+  }
+
+  static int32_t comparePhysical(
+      const RadixSortKeyLayout& layout,
+      const char* left,
+      const char* right) {
+#define COMPARE_KIND(kind)                             \
+  case LayoutKind::kind:                               \
+    return RadixSortKeyOps<LayoutKind::kind>::compare( \
+        left, right, layout.heapKeyOffset())
+    switch (layout.kind()) {
+      COMPARE_KIND(kKeyOnlyFixed8);
+      COMPARE_KIND(kKeyOnlyFixed16);
+      COMPARE_KIND(kKeyOnlyFixed24);
+      COMPARE_KIND(kKeyOnlyFixed32);
+      COMPARE_KIND(kKeyOnlyVariable32);
+      COMPARE_KIND(kKeyWithPayloadFixed16);
+      COMPARE_KIND(kKeyWithPayloadFixed24);
+      COMPARE_KIND(kKeyWithPayloadFixed32);
+      COMPARE_KIND(kKeyWithPayloadVariable32);
+      default:
+        BOLT_UNREACHABLE();
+    }
+#undef COMPARE_KIND
+  }
+
+  static std::vector<std::unique_ptr<std::string>> appendPhysicalKeys(
+      RadixSortRunStorage& storage,
+      std::span<const std::string_view> keys,
+      std::span<char* const> payloads = {}) {
+    BOLT_CHECK(payloads.empty() || payloads.size() == keys.size());
+    std::vector<std::unique_ptr<std::string>> heaps(keys.size());
+    storage.appendKeyBlocks(
+        keys.size(),
+        [&](vector_size_t source, vector_size_t count, char* records) {
+          for (vector_size_t row = 0; row < count; ++row) {
+            const auto inputRow = source + row;
+            auto* heap = static_cast<char*>(nullptr);
+            const auto heapSize = storage.layout().isVariable()
+                ? keys[inputRow].size() - storage.layout().heapKeyOffset()
+                : 0;
+            if (heapSize > 0) {
+              heaps[inputRow] = std::make_unique<std::string>(
+                  keys[inputRow].substr(storage.layout().heapKeyOffset()));
+              heap = heaps[inputRow]->data();
+            }
+            constructPhysicalKey(
+                storage.layout(),
+                keys[inputRow],
+                heap,
+                payloads.empty() ? nullptr : payloads[inputRow],
+                records +
+                    static_cast<uint64_t>(row) * storage.layout().width());
+          }
+        });
+    return heaps;
+  }
+
+  static std::vector<std::unique_ptr<std::string>> appendPhysicalKeys(
+      RadixSortRunStorage& storage,
+      const std::vector<std::string>& keys,
+      std::span<char* const> payloads = {}) {
+    const std::vector<std::string_view> views(keys.begin(), keys.end());
+    return appendPhysicalKeys(storage, views, payloads);
   }
 
   template <typename Expected>
@@ -228,7 +387,8 @@ class RadixSortKeyTest : public testing::Test {
       Expected expected) {
     for (vector_size_t left = 0; left < size; ++left) {
       for (vector_size_t right = 0; right < size; ++right) {
-        const auto actual = arena.keyAt(left).compare(arena.keyAt(right));
+        const auto actual = comparePhysical(
+            arena.layout(), recordAt(arena, left), recordAt(arena, right));
         const auto reference = expected(left, right);
         EXPECT_EQ(
             (actual > 0) - (actual < 0), (reference > 0) - (reference < 0));
@@ -248,21 +408,33 @@ class RadixSortKeyTest : public testing::Test {
   static void verifyPhysicalStorage(
       const RadixSortKeyLayout& layout,
       const char* record,
-      const RadixSortKey& physical,
       std::string_view original) {
     if (layout.isVariable()) {
       EXPECT_EQ(
           std::string_view(record, layout.heapKeyOffset()),
           original.substr(0, layout.heapKeyOffset()));
-      EXPECT_EQ(physical.heapKey(), original.substr(layout.heapKeyOffset()));
+      EXPECT_EQ(
+          heapKey(layout, record), original.substr(layout.heapKeyOffset()));
       return;
     }
-    RadixSortInlineKeyBuffer buffer;
-    EncodedKeyView view;
-    physical.deconstruct(buffer, view);
-    EXPECT_EQ(view.bytes.substr(0, original.size()), original);
+    RadixSortInlineKeyBuffer bytes{};
+    for (uint32_t word = 0; word < layout.inlineWordCount(); ++word) {
+      auto value = loadUnaligned<uint64_t>(
+          record + static_cast<uint64_t>(word) * sizeof(uint64_t));
+      if constexpr (std::endian::native == std::endian::little) {
+        value = byteSwap(value);
+      }
+      storeUnaligned<uint64_t>(
+          bytes.data() + static_cast<uint64_t>(word) * sizeof(uint64_t), value);
+    }
+    std::memcpy(
+        bytes.data() + layout.inlineWordBytes(),
+        record + layout.inlineWordBytes(),
+        layout.inlineTailBytes());
+    const std::string_view encoded(bytes.data(), layout.inlineCapacity());
+    EXPECT_EQ(encoded.substr(0, original.size()), original);
     EXPECT_EQ(
-        view.bytes.substr(original.size()),
+        encoded.substr(original.size()),
         std::string(layout.inlineCapacity() - original.size(), '\0'));
   }
 
@@ -271,91 +443,58 @@ class RadixSortKeyTest : public testing::Test {
       uint64_t row,
       std::string_view original,
       char* payload = nullptr) {
-    const auto key = arena.keyAt(row);
+    const auto* record = recordAt(arena, row);
     const auto& layout = arena.layout();
-    verifyPhysicalStorage(layout, arena.keyDataAt(row), key, original);
-    EXPECT_EQ(key.payload(), payload);
+    verifyPhysicalStorage(layout, record, original);
+    EXPECT_EQ(payloadAt(layout, record), payload);
   }
 
-  RowVectorPtr decodeArena(
-      const RadixSortKeyCodec& codec,
-      const RadixSortRunStorage& arena) {
-    std::vector<std::string> logicalKeys(arena.size());
-    std::vector<RadixSortInlineKeyBuffer> inlineBuffers(arena.size());
-    std::vector<EncodedKeyView> views(arena.size());
-    for (uint64_t row = 0; row < arena.size(); ++row) {
-      if (arena.layout().isVariable()) {
-        logicalKeys[row].assign(
-            arena.keyDataAt(row), arena.layout().heapKeyOffset());
-        logicalKeys[row].append(arena.keyAt(row).heapKey());
-        views[row] = {logicalKeys[row]};
-      } else {
-        arena.keyAt(row).deconstruct(inlineBuffers[row], views[row]);
-      }
-    }
-    RowVectorPtr decoded;
-    BufferPtr cursorScratch;
-    codec.decode(views, {}, {}, pool_.get(), cursorScratch, decoded);
-    return decoded;
-  }
-
-  template <typename ExpectedCompare, typename VerifyDecoded>
   void verifyCodecStorage(
       const RowVectorPtr& rows,
       const std::vector<CompareFlags>& compareFlags,
-      uint32_t keysPerBlock,
       bool withPayloadCase,
-      bool expectVariable,
-      ExpectedCompare expectedCompare,
-      VerifyDecoded verifyDecoded) {
-    auto [codec, encoded] = bindAndEncode(rows, compareFlags);
+      bool expectVariable) {
+    std::vector<column_index_t> channels(rows->childrenSize());
+    std::iota(channels.begin(), channels.end(), 0);
     const auto verify = [&](bool hasPayload) {
-      auto layout =
-          RadixSortKeyLayout::select(codec->maximumEncodedSize(), hasPayload);
+      auto run = makeRun(rows, compareFlags, hasPayload);
+      const auto& arena = *run->storage();
+      const auto& layout = arena.layout();
       if (expectVariable) {
         ASSERT_TRUE(layout.isVariable());
       }
-      PayloadPointers payloads(rows->size());
-      RadixSortRunStorage arena(pool_.get(), layout, keysPerBlock, 64);
-      arena.appendBatch(encoded, payloads.span(hasPayload));
       ASSERT_EQ(arena.size(), rows->size());
-      for (vector_size_t row = 0; row < rows->size(); ++row) {
-        verifyStoredKey(
-            arena,
-            row,
-            encodedKeyAt(encoded, row),
-            hasPayload ? payloads.pointers[row] : nullptr);
-      }
       expectPairwiseCompare(arena, rows->size(), [&](auto left, auto right) {
-        return expectedCompare(encoded, left, right);
+        return SortComparatorOracle::compareRows(
+            *rows, left, *rows, right, channels, compareFlags);
       });
-      auto decoded = decodeArena(*codec, arena);
+      std::vector<vector_size_t> expectedRows(rows->size());
+      std::iota(expectedRows.begin(), expectedRows.end(), 0);
+      std::stable_sort(
+          expectedRows.begin(), expectedRows.end(), [&](auto left, auto right) {
+            return SortComparatorOracle::compareRows(
+                       *rows, left, *rows, right, channels, compareFlags) < 0;
+          });
+      run->finalize();
+      auto decoded = output(*run, rows->size(), pool_.get());
+      ASSERT_NE(decoded, nullptr);
       for (vector_size_t row = 0; row < rows->size(); ++row) {
-        EXPECT_EQ(verifyDecoded(*decoded, row), 0);
+        EXPECT_EQ(
+            SortComparatorOracle::compareRows(
+                *rows,
+                expectedRows[row],
+                *decoded,
+                row,
+                channels,
+                compareFlags),
+            0)
+            << "row=" << row;
       }
     };
     verify(false);
     if (withPayloadCase) {
       verify(true);
     }
-  }
-
-  template <typename Groups>
-  static uint64_t groupBytes(const Groups& groups, bool capacity = false) {
-    uint64_t bytes = 0;
-    for (const auto& group : groups) {
-      bytes += capacity ? group.capacity : group.used;
-    }
-    return bytes;
-  }
-
-  template <typename Blocks>
-  static uint64_t blockBytes(const Blocks& blocks, uint64_t width) {
-    uint64_t bytes = 0;
-    for (const auto& block : blocks) {
-      bytes += static_cast<uint64_t>(block.count) * width;
-    }
-    return bytes;
   }
 };
 
@@ -456,10 +595,11 @@ TEST_F(RadixSortKeyTest, allLayoutsRoundTripAndCompare) {
     }
     PayloadPointers payloads(keys.size());
 
-    RadixSortRunStorage arena(pool_.get(), layout, 2, 64);
+    RadixSortRunStorage arena(pool_.get(), layout);
+    const auto heaps =
+        appendPhysicalKeys(arena, keys, payloads.span(layout.hasPayload()));
     for (uint64_t index = 0; index < keys.size(); ++index) {
       auto* payload = layout.hasPayload() ? payloads.pointers[index] : nullptr;
-      arena.append(keys[index], payload);
       verifyStoredKey(arena, index, keys[index], payload);
     }
     expectPhysicalCompare(arena, keys);
@@ -475,23 +615,21 @@ TEST_F(RadixSortKeyTest, variableLayoutStoresHeapFromColumnBoundary) {
       std::string("abcde") + std::string(32, 'x'),
       std::string("abcdf") + std::string(32, 'x'),
   };
-  RadixSortRunStorage arena(pool_.get(), layout, 2, 64);
-  for (const auto& key : keys) {
-    arena.append(key);
-  }
+  RadixSortRunStorage arena(pool_.get(), layout);
+  const auto heaps = appendPhysicalKeys(arena, keys);
   ASSERT_EQ(arena.size(), keys.size());
-  EXPECT_EQ(arena.keyAt(0).heapSize(), keys[0].size() - layout.heapKeyOffset());
-  EXPECT_EQ(arena.keyAt(0).heapKey(), "f");
-  ASSERT_NE(arena.keyAt(1).heapKeyData(), nullptr);
-  EXPECT_EQ(arena.keyAt(1).heapSize(), keys[1].size() - layout.heapKeyOffset());
+  const auto first = heapKey(layout, recordAt(arena, 0));
+  const auto second = heapKey(layout, recordAt(arena, 1));
+  EXPECT_EQ(first.size(), keys[0].size() - layout.heapKeyOffset());
+  EXPECT_EQ(first, "f");
+  ASSERT_NE(second.data(), nullptr);
+  EXPECT_EQ(second.size(), keys[1].size() - layout.heapKeyOffset());
+  EXPECT_EQ(second, std::string_view(keys[1]).substr(layout.heapKeyOffset()));
   EXPECT_EQ(
-      std::string_view(arena.keyAt(1).heapKeyData(), arena.keyAt(1).heapSize()),
-      std::string_view(keys[1]).substr(layout.heapKeyOffset()));
-  EXPECT_EQ(
-      arena.keyAt(0).compare(arena.keyAt(1)),
+      comparePhysical(layout, recordAt(arena, 0), recordAt(arena, 1)),
       SortComparatorOracle::compareUnsignedBytes(keys[0], keys[1]));
   EXPECT_EQ(
-      arena.keyAt(1).compare(arena.keyAt(2)),
+      comparePhysical(layout, recordAt(arena, 1), recordAt(arena, 2)),
       SortComparatorOracle::compareUnsignedBytes(keys[1], keys[2]));
   for (uint64_t row = 0; row < arena.size(); ++row) {
     verifyStoredKey(arena, row, keys[row]);
@@ -505,15 +643,15 @@ TEST_F(RadixSortKeyTest, suffixCompareDoesNotReadRadixPrefix) {
   left[12] = 'a';
   right[12] = 'z';
 
-  RadixSortRunStorage arena(pool_.get(), layout, 2, 64);
-  arena.append(left);
-  arena.append(right);
+  RadixSortRunStorage arena(pool_.get(), layout);
+  const std::vector<std::string_view> keys{left, right};
+  const auto heaps = appendPhysicalKeys(arena, keys);
 
-  ASSERT_LT(arena.keyAt(0).compare(arena.keyAt(1)), 0);
+  ASSERT_LT(comparePhysical(layout, recordAt(arena, 0), recordAt(arena, 1)), 0);
   EXPECT_EQ(
       RadixSortKeyOps<LayoutKind::kKeyOnlyVariable32>::compareSuffix(
-          arena.keyDataAt(0),
-          arena.keyDataAt(1),
+          recordAt(arena, 0),
+          recordAt(arena, 1),
           layout.heapKeyOffset(),
           layout.radixWidth()),
       0);
@@ -549,14 +687,15 @@ TEST_F(RadixSortKeyTest, suffixCompareCoversLengthDataAndEquality) {
     keys[2][radixWidth + 1] = 'a';
     keys[3][radixWidth + 1] = 'z';
     PayloadPointers payloads(keys.size());
-    RadixSortRunStorage arena(pool_.get(), layout, 3, 64);
+    RadixSortRunStorage arena(pool_.get(), layout);
     std::vector<std::string_view> views(keys.begin(), keys.end());
-    arena.appendBatch(views, payloads.span(layout.hasPayload()));
+    const auto heaps =
+        appendPhysicalKeys(arena, views, payloads.span(layout.hasPayload()));
 
     const auto compare = [&](uint64_t left, uint64_t right) {
       return compareSuffix(
-          arena.keyDataAt(left),
-          arena.keyDataAt(right),
+          recordAt(arena, left),
+          recordAt(arena, right),
           layout.heapKeyOffset(),
           radixWidth);
     };
@@ -565,25 +704,6 @@ TEST_F(RadixSortKeyTest, suffixCompareCoversLengthDataAndEquality) {
     EXPECT_LT(compare(4, 5), 0);
     EXPECT_EQ(compare(6, 7), 0);
   }
-}
-
-TEST_F(RadixSortKeyTest, radixSortUtilsBoundaryChecks) {
-  EXPECT_EQ(checkedAlignUp<uint64_t>(0, 8), 0);
-  EXPECT_EQ(checkedAlignUp<uint64_t>(9, 8), 16);
-  EXPECT_EQ(checkedAlignUp<uint64_t>(9, 0), std::nullopt);
-  EXPECT_EQ(checkedAlignUp<uint64_t>(9, 3), std::nullopt);
-  EXPECT_EQ(
-      checkedAlignUp<uint64_t>(std::numeric_limits<uint64_t>::max(), 8),
-      std::nullopt);
-
-  EXPECT_TRUE(isValidRecordRelativeRange(16, 1, 15));
-  EXPECT_FALSE(isValidRecordRelativeRange(16, 0, 0));
-  EXPECT_TRUE(isValidRecordRelativeRange(16, 0, 0, 1, true));
-  EXPECT_FALSE(isValidRecordRelativeRange(16, 0, 1, 1, true));
-  EXPECT_FALSE(isValidRecordRelativeRange(16, 15, 2));
-  EXPECT_FALSE(isValidRecordRelativeRange(16, 16, 0));
-  EXPECT_FALSE(
-      isValidRecordRelativeRange(16, std::numeric_limits<uint64_t>::max(), 2));
 }
 
 TEST_F(RadixSortKeyTest, compactPointerAccessIsExactAndRangeChecked) {
@@ -663,11 +783,16 @@ TEST_F(RadixSortKeyTest, nonWordAlignedPrefixTailParticipatesInComparison) {
       left[offset] = '\x10';
       right[offset] = '\x20';
       PayloadPointers payloads(2);
-      RadixSortRunStorage arena(pool_.get(), layout, 2, 64);
-      arena.append(left, layout.hasPayload() ? payloads.pointers[0] : nullptr);
-      arena.append(right, layout.hasPayload() ? payloads.pointers[1] : nullptr);
-      EXPECT_LT(arena.keyAt(0).compare(arena.keyAt(1)), 0);
-      EXPECT_LT(descriptor->compare(arena.keyDataAt(0), arena.keyDataAt(1)), 0);
+      RadixSortRunStorage arena(pool_.get(), layout);
+      const std::vector<std::string_view> keys{left, right};
+      const auto heaps =
+          appendPhysicalKeys(arena, keys, payloads.span(layout.hasPayload()));
+      EXPECT_LT(
+          comparePhysical(layout, recordAt(arena, 0), recordAt(arena, 1)), 0);
+      EXPECT_LT(
+          descriptor->compare(
+              recordAt(arena, 0), recordAt(arena, 1), layout.heapKeyOffset()),
+          0);
     }
   }
 }
@@ -692,15 +817,16 @@ TEST_F(RadixSortKeyTest, knownPerWordByteSwap) {
       0x16,
       0x17,
       0x18};
-  RadixSortKey key(layout, storage.data());
-  key.construct(std::string_view(encoded.data(), encoded.size()), nullptr);
+  constructPhysicalKey(
+      layout,
+      std::string_view(encoded.data(), encoded.size()),
+      nullptr,
+      nullptr,
+      storage.data());
   EXPECT_EQ(loadUnaligned<uint64_t>(storage.data()), 0x0102030405060708ULL);
   EXPECT_EQ(loadUnaligned<uint64_t>(storage.data() + 8), 0x1112131415161718ULL);
   verifyPhysicalStorage(
-      layout,
-      storage.data(),
-      key,
-      std::string_view(encoded.data(), encoded.size()));
+      layout, storage.data(), std::string_view(encoded.data(), encoded.size()));
 }
 
 TEST_F(RadixSortKeyTest, templatedCompareMatchesGenericCompare) {
@@ -715,11 +841,15 @@ TEST_F(RadixSortKeyTest, templatedCompareMatchesGenericCompare) {
       storage.push_back(std::string(layout.inlineCapacity() + 64, 'p') + "b");
     }
     PayloadPointers payloads(storage.size());
-    RadixSortRunStorage arena(pool_.get(), layout, 3, 64);
+    RadixSortRunStorage arena(pool_.get(), layout);
     std::vector<std::string_view> keys(storage.begin(), storage.end());
-    arena.appendBatch(keys, payloads.span(layout.hasPayload()));
+    const auto heaps =
+        appendPhysicalKeys(arena, keys, payloads.span(layout.hasPayload()));
     expectPairwiseCompare(arena, arena.size(), [&](auto left, auto right) {
-      return descriptor.compare(arena.keyDataAt(left), arena.keyDataAt(right));
+      return descriptor.compare(
+          recordAt(arena, left),
+          recordAt(arena, right),
+          layout.heapKeyOffset());
     });
   }
 }
@@ -777,20 +907,7 @@ TEST_F(RadixSortKeyTest, codecPhysicalCompareProperty) {
           (compareFlags.ascending ? " ASC" : " DESC") +
           (compareFlags.nullsFirst ? " NULLS FIRST" : " NULLS LAST"));
       auto rows = makeRows(input);
-      verifyCodecStorage(
-          rows,
-          {compareFlags},
-          3,
-          true,
-          false,
-          [](const auto& encoded, auto left, auto right) {
-            return SortComparatorOracle::compareEncodedKeys(
-                encoded, left, right);
-          },
-          [&](const RowVector& decoded, auto row) {
-            return SortComparatorOracle::compare(
-                *input, row, *decoded.childAt(0), row, compareFlags);
-          });
+      verifyCodecStorage(rows, {compareFlags}, true, false);
     }
   }
 }
@@ -811,20 +928,7 @@ TEST_F(RadixSortKeyTest, multipleColumnCodecPhysicalCompare) {
       SortComparatorOracle::makeSortFlags(true, false),
       SortComparatorOracle::makeSortFlags(false, true),
       SortComparatorOracle::makeSortFlags(true, true)};
-  const std::vector<column_index_t> channels{0, 1, 2};
-  verifyCodecStorage(
-      rows,
-      compareFlags,
-      2,
-      true,
-      false,
-      [](const auto& encoded, auto left, auto right) {
-        return SortComparatorOracle::compareEncodedKeys(encoded, left, right);
-      },
-      [&](const RowVector& decoded, auto row) {
-        return SortComparatorOracle::compareRows(
-            *rows, row, decoded, row, channels, compareFlags);
-      });
+  verifyCodecStorage(rows, compareFlags, true, false);
 }
 
 TEST_F(RadixSortKeyTest, nestedCodecPhysicalCompare) {
@@ -853,204 +957,131 @@ TEST_F(RadixSortKeyTest, nestedCodecPhysicalCompare) {
   const std::vector<CompareFlags> compareFlags{
       SortComparatorOracle::makeSortFlags(true, true),
       SortComparatorOracle::makeSortFlags(false, false)};
-  const std::vector<column_index_t> channels{0, 1};
-  verifyCodecStorage(
-      rows,
-      compareFlags,
-      3,
-      false,
-      true,
-      [&](const auto&, auto left, auto right) {
-        return SortComparatorOracle::compareRows(
-            *rows, left, *rows, right, channels, compareFlags);
-      },
-      [&](const RowVector& decoded, auto row) {
-        return SortComparatorOracle::compareRows(
-            *rows, row, decoded, row, channels, compareFlags);
-      });
-}
-
-TEST_F(RadixSortKeyTest, blockAndHeapGroups) {
-  auto layout = RadixSortKeyLayout::fromKind(LayoutKind::kKeyOnlyVariable32);
-  RadixSortRunStorage arena(pool_.get(), layout, 3, 64);
-  const std::vector<std::string> keys{
-      std::string(16, 'i'),
-      std::string(17, 'a'),
-      std::string(20, 'b'),
-      std::string(27, 'c'),
-      std::string(100, 'd'),
-      std::string(17, 'e')};
-  for (const auto& key : keys) {
-    arena.append(key);
-  }
-
-  ASSERT_EQ(arena.keyBlocks().size(), 2);
-  EXPECT_EQ(arena.keyBlocks()[0].capacity, 3);
-  EXPECT_EQ(arena.keyBlocks()[0].count, 3);
-  EXPECT_EQ(arena.keyBlocks()[1].capacity, 3);
-  EXPECT_EQ(arena.keyBlocks()[1].count, 3);
-  ASSERT_EQ(arena.keyHeapGroups().size(), 4);
-  EXPECT_EQ(arena.keyHeapGroups()[0].capacity, 64);
-  EXPECT_EQ(arena.keyHeapGroups()[0].used, 53);
-  EXPECT_EQ(arena.keyHeapGroups()[0].keyCount, 3);
-  EXPECT_EQ(arena.keyHeapGroups()[1].capacity, 64);
-  EXPECT_EQ(arena.keyHeapGroups()[1].used, 27);
-  EXPECT_EQ(arena.keyHeapGroups()[1].keyCount, 1);
-  EXPECT_EQ(arena.keyHeapGroups()[2].capacity, 100);
-  EXPECT_EQ(arena.keyHeapGroups()[2].used, 100);
-  EXPECT_EQ(arena.keyHeapGroups()[2].keyCount, 1);
-  EXPECT_EQ(arena.keyHeapGroups()[3].capacity, 64);
-  EXPECT_EQ(arena.keyHeapGroups()[3].used, 17);
-  EXPECT_EQ(arena.keyHeapGroups()[3].keyCount, 1);
-
-  const auto heapBytes = groupBytes(arena.keyHeapGroups());
-  const auto keyBytes = keys.size() * layout.width();
-  EXPECT_EQ(heapBytes, 197);
-  EXPECT_GE(
-      static_cast<uint64_t>(arena.allocatedBytes()), keyBytes + heapBytes);
+  verifyCodecStorage(rows, compareFlags, false, true);
 }
 
 TEST_F(RadixSortKeyTest, defaultKeyBlocksUseDefaultByteStorageTarget) {
-  for (const auto kind :
-       {LayoutKind::kKeyOnlyFixed8,
-        LayoutKind::kKeyOnlyFixed16,
-        LayoutKind::kKeyWithPayloadVariable32}) {
+  constexpr uint64_t kDefaultBlockBytes = 64 * 1024;
+  for (const auto& descriptor : kLayouts) {
+    const auto kind = descriptor.kind;
     SCOPED_TRACE(static_cast<uint8_t>(kind));
     auto layout = RadixSortKeyLayout::fromKind(kind);
     RadixSortRunStorage arena(pool_.get(), layout);
-    const auto expectedRows = static_cast<uint32_t>(
-        (RadixSortRunStorage::kDefaultKeyBlockBytes + layout.width() - 1) /
-        layout.width());
+    const auto expectedRows =
+        static_cast<uint32_t>(kDefaultBlockBytes / layout.width());
     EXPECT_EQ(arena.keysPerBlock(), expectedRows);
+    EXPECT_LE(
+        static_cast<uint64_t>(expectedRows) * layout.width(),
+        kDefaultBlockBytes);
 
     const auto rows = expectedRows + 1;
-    for (uint32_t row = 0; row < rows; ++row) {
-      arena.append(std::string(layout.inlineCapacity(), 'a'));
-    }
-    ASSERT_EQ(arena.keyBlocks().size(), 2);
-    EXPECT_EQ(arena.keyBlocks()[0].capacity, expectedRows);
-    EXPECT_EQ(arena.keyBlocks()[0].count, expectedRows);
-    EXPECT_EQ(arena.keyBlocks()[1].capacity, expectedRows);
-    EXPECT_EQ(arena.keyBlocks()[1].count, 1);
+    const std::vector<std::string> keys(
+        rows, std::string(layout.inlineCapacity(), 'a'));
+    PayloadPointers payloads(rows);
+    const auto heaps =
+        appendPhysicalKeys(arena, keys, payloads.span(layout.hasPayload()));
+    EXPECT_EQ(arena.keyRangeAt(0, rows).count, expectedRows);
+    EXPECT_EQ(arena.keyRangeAt(expectedRows, rows).count, 1);
   }
 }
 
 TEST_F(RadixSortKeyTest, storageBlockAllocationAndAddressingBoundaries) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(LayoutKind::kKeyWithPayloadFixed16);
-  auto payloadLayout = PayloadRowLayout::create(ROW({"value"}, {BIGINT()}));
+  RadixSortRunStorage arena(pool_.get(), keyLayout);
+  const auto rowsPerBlock = arena.keysPerBlock();
+  const auto rowCount = static_cast<vector_size_t>(rowsPerBlock * 2 + 1);
+  const std::array<uint32_t, 3> blockCounts{rowsPerBlock, rowsPerBlock, 1};
+  PayloadPointers payloadPointers(rowCount);
 
-  for (const auto& [rowsPerBlock, blockCounts] : kStorageBoundaries) {
-    SCOPED_TRACE("rowsPerBlock=" + std::to_string(rowsPerBlock));
-    RadixSortRunStorage arena(
-        pool_.get(),
-        keyLayout,
-        rowsPerBlock,
-        64,
-        payloadLayout,
-        rowsPerBlock,
-        64);
-    const auto rowCount = static_cast<vector_size_t>(rowsPerBlock * 2 + 1);
-    PayloadRowBatch payloadBatch;
-    arena.allocateFixedPayloadRowBatch(rowCount, payloadBatch);
+  std::vector<std::string> keyStorage(rowCount);
+  std::vector<std::string_view> keys(rowCount);
+  std::vector<char*> payloads(rowCount);
+  for (vector_size_t row = 0; row < rowCount; ++row) {
+    keyStorage[row] = std::string(8, static_cast<char>('a' + row % 26));
+    keyStorage[row][7] = static_cast<char>(row);
+    keys[row] = keyStorage[row];
+    payloads[row] = payloadPointers.pointers[row];
+  }
+  const auto heaps = appendPhysicalKeys(arena, keys, payloads);
 
-    std::vector<std::string> keyStorage(rowCount);
-    std::vector<std::string_view> keys(rowCount);
-    std::vector<char*> payloads(rowCount);
-    for (vector_size_t row = 0; row < rowCount; ++row) {
-      keyStorage[row] = std::string(8, static_cast<char>('a' + row % 26));
-      keyStorage[row][7] = static_cast<char>(row);
-      keys[row] = keyStorage[row];
-      payloads[row] = payloadBatch.rowAt(row);
-    }
-    arena.appendBatch(keys, payloads);
+  ASSERT_EQ(arena.size(), rowCount);
+  for (uint32_t block = 0; block < 3; ++block) {
+    const auto expectedCount = blockCounts[block];
+    EXPECT_EQ(
+        arena.keyRangeAt(static_cast<uint64_t>(block) * rowsPerBlock, rowCount)
+            .count,
+        expectedCount);
+  }
 
-    ASSERT_EQ(arena.size(), rowCount);
-    ASSERT_EQ(arena.payloadSize(), rowCount);
-    ASSERT_EQ(arena.keyBlocks().size(), 3);
-    ASSERT_EQ(arena.payloadFixedBlocks().size(), 3);
-    for (uint32_t block = 0; block < 3; ++block) {
-      const auto expectedCount = blockCounts[block];
-      EXPECT_EQ(arena.keyBlocks()[block].capacity, rowsPerBlock);
-      EXPECT_EQ(arena.keyBlocks()[block].count, expectedCount);
-      EXPECT_EQ(arena.payloadFixedBlocks()[block].capacity, rowsPerBlock);
-      EXPECT_EQ(arena.payloadFixedBlocks()[block].count, expectedCount);
-    }
+  for (vector_size_t row = 0; row < rowCount; ++row) {
+    const auto block = static_cast<uint32_t>(row) / rowsPerBlock;
+    const auto indexInBlock = static_cast<uint32_t>(row) % rowsPerBlock;
+    const auto blockRange =
+        arena.keyRangeAt(static_cast<uint64_t>(block) * rowsPerBlock, rowCount);
+    EXPECT_EQ(
+        recordAt(arena, row),
+        blockRange.data +
+            static_cast<uint64_t>(indexInBlock) * keyLayout.width());
+    EXPECT_EQ(
+        payloadAt(keyLayout, recordAt(arena, row)),
+        payloadPointers.pointers[row]);
+    verifyPhysicalStorage(keyLayout, recordAt(arena, row), keys[row]);
+  }
 
-    for (vector_size_t row = 0; row < rowCount; ++row) {
-      const auto block = static_cast<uint32_t>(row) / rowsPerBlock;
-      const auto indexInBlock = static_cast<uint32_t>(row) % rowsPerBlock;
+  for (uint64_t begin = 0; begin < arena.size();) {
+    const auto range = arena.keyRangeAt(begin, rowCount);
+    const auto expectedCount = std::min<vector_size_t>(
+        rowsPerBlock - begin % rowsPerBlock, rowCount - begin);
+    ASSERT_EQ(range.count, expectedCount);
+    EXPECT_EQ(range.data, recordAt(arena, begin));
+    begin += range.count;
+  }
+  EXPECT_EQ(arena.keyRangeAt(arena.size(), rowCount).count, 0);
+
+  const std::array<uint64_t, 6> starts{
+      0,
+      rowsPerBlock - 1,
+      rowsPerBlock,
+      rowsPerBlock * 2 - 1,
+      rowsPerBlock * 2,
+      static_cast<uint64_t>(rowCount)};
+  const std::array<vector_size_t, 4> requested{
+      1,
+      static_cast<vector_size_t>(rowsPerBlock - 1),
+      static_cast<vector_size_t>(rowsPerBlock),
+      static_cast<vector_size_t>(rowsPerBlock + 1)};
+  for (const auto start : starts) {
+    for (const auto maxCount : requested) {
+      const auto range = arena.keyRangeAt(start, maxCount);
+      const auto expectedCount = start == arena.size() || maxCount == 0
+          ? 0
+          : std::min<vector_size_t>(
+                maxCount,
+                blockCounts[start / rowsPerBlock] - start % rowsPerBlock);
+      EXPECT_EQ(range.count, expectedCount);
       EXPECT_EQ(
-          arena.keyDataAt(row),
-          arena.keyBlocks()[block].base +
-              static_cast<uint64_t>(indexInBlock) * keyLayout.width());
-      EXPECT_EQ(
-          payloadBatch.rowAt(row),
-          arena.payloadFixedBlocks()[block].base +
-              static_cast<uint64_t>(indexInBlock) * payloadLayout->rowWidth());
-      EXPECT_EQ(arena.keyAt(row).payload(), payloadBatch.rowAt(row));
-      verifyPhysicalStorage(
-          keyLayout, arena.keyDataAt(row), arena.keyAt(row), keys[row]);
-    }
-
-    for (uint64_t begin = 0; begin < arena.size();) {
-      const auto range = arena.keyRangeAt(begin, rowCount);
-      const auto expectedCount = std::min<vector_size_t>(
-          rowsPerBlock - begin % rowsPerBlock, rowCount - begin);
-      ASSERT_EQ(range.count, expectedCount);
-      EXPECT_EQ(range.data, arena.keyDataAt(begin));
-      begin += range.count;
-    }
-    EXPECT_EQ(arena.keyRangeAt(arena.size(), rowCount).count, 0);
-
-    const std::array<uint64_t, 6> starts{
-        0,
-        rowsPerBlock - 1,
-        rowsPerBlock,
-        rowsPerBlock * 2 - 1,
-        rowsPerBlock * 2,
-        static_cast<uint64_t>(rowCount)};
-    const std::array<vector_size_t, 4> requested{
-        1,
-        static_cast<vector_size_t>(rowsPerBlock - 1),
-        static_cast<vector_size_t>(rowsPerBlock),
-        static_cast<vector_size_t>(rowsPerBlock + 1)};
-    for (const auto start : starts) {
-      for (const auto maxCount : requested) {
-        const auto range = arena.keyRangeAt(start, maxCount);
-        const auto expectedCount = start == arena.size() || maxCount == 0
-            ? 0
-            : std::min<vector_size_t>(
-                  maxCount,
-                  blockCounts[start / rowsPerBlock] - start % rowsPerBlock);
-        EXPECT_EQ(range.count, expectedCount);
-        EXPECT_EQ(
-            range.data, expectedCount == 0 ? nullptr : arena.keyDataAt(start));
-      }
+          range.data, expectedCount == 0 ? nullptr : recordAt(arena, start));
     }
   }
 }
 
 TEST_F(RadixSortKeyTest, storageKeyRangeConstAccessAndEncodedAppend) {
   auto rows = makeRows(makeVector<int32_t>(INTEGER(), {5, 1, 7, 3, 9}));
-  auto [codec, encoded] =
-      bindAndEncode(rows, {SortComparatorOracle::makeSortFlags(true, true)});
-
-  auto layout = RadixSortKeyLayout::select(codec->maximumEncodedSize(), true);
-  PayloadPointers payloads(rows->size());
-  RadixSortRunStorage arena(pool_.get(), layout, 2, 64);
-  arena.appendBatch(encoded, payloads.pointers);
+  auto run =
+      makeRun(rows, {SortComparatorOracle::makeSortFlags(true, true)}, true);
+  const auto& arena = *run->storage();
   ASSERT_EQ(arena.size(), rows->size());
 
   const auto& constArena = arena;
   auto firstRange = constArena.keyRangeAt(0, 5);
   ASSERT_NE(firstRange.data, nullptr);
-  EXPECT_EQ(firstRange.count, 2);
-  EXPECT_EQ(firstRange.data, constArena.keyDataAt(0));
+  EXPECT_EQ(firstRange.count, 5);
+  EXPECT_EQ(firstRange.data, recordAt(constArena, 0));
   auto secondRange = constArena.keyRangeAt(2, 2);
   ASSERT_NE(secondRange.data, nullptr);
   EXPECT_EQ(secondRange.count, 2);
-  EXPECT_EQ(secondRange.data, constArena.keyDataAt(2));
+  EXPECT_EQ(secondRange.data, recordAt(constArena, 2));
   auto tailRange = constArena.keyRangeAt(4, 5);
   ASSERT_NE(tailRange.data, nullptr);
   EXPECT_EQ(tailRange.count, 1);
@@ -1058,8 +1089,7 @@ TEST_F(RadixSortKeyTest, storageKeyRangeConstAccessAndEncodedAppend) {
   EXPECT_EQ(constArena.keyRangeAt(0, 0).count, 0);
 
   for (uint64_t row = 0; row < arena.size(); ++row) {
-    EXPECT_EQ(arena.keyAt(row).payload(), payloads.pointers[row]);
-    EXPECT_EQ(constArena.keyAt(row).payload(), payloads.pointers[row]);
+    EXPECT_NE(payloadAt(arena.layout(), recordAt(arena, row)), nullptr);
   }
 }
 
@@ -1068,46 +1098,34 @@ TEST_F(RadixSortKeyTest, storageAppendsInlineVariableKeysToFixedLayouts) {
     std::vector<VectorPtr> columns;
     RadixSortKeyLayoutKind kind;
   };
-  auto strings = makeStringVector(VARCHAR(), {"a", "bb", "ccc"});
-  auto integers = makeVector<int32_t>(INTEGER(), {3, 2, 1});
+  auto bigints = makeVector<int64_t>(BIGINT(), {3, -2, 1});
+  auto integers = makeVector<int32_t>(INTEGER(), {6, -5, 4});
   const std::vector<Case> cases{
-      {{strings}, RadixSortKeyLayoutKind::kKeyWithPayloadFixed16},
-      {{strings}, RadixSortKeyLayoutKind::kKeyOnlyFixed16},
-      {{strings}, RadixSortKeyLayoutKind::kKeyWithPayloadFixed24},
-      {{strings, integers}, RadixSortKeyLayoutKind::kKeyWithPayloadFixed32},
-      {{strings, integers}, RadixSortKeyLayoutKind::kKeyOnlyFixed24},
-      {{strings, integers, makeVector<int32_t>(INTEGER(), {6, 5, 4})},
-       RadixSortKeyLayoutKind::kKeyOnlyFixed32},
+      {{bigints}, RadixSortKeyLayoutKind::kKeyWithPayloadFixed16},
+      {{bigints}, RadixSortKeyLayoutKind::kKeyOnlyFixed16},
+      {{bigints, bigints}, RadixSortKeyLayoutKind::kKeyWithPayloadFixed24},
+      {{bigints, bigints, integers},
+       RadixSortKeyLayoutKind::kKeyWithPayloadFixed32},
+      {{bigints, bigints}, RadixSortKeyLayoutKind::kKeyOnlyFixed24},
+      {{bigints, bigints, bigints}, RadixSortKeyLayoutKind::kKeyOnlyFixed32},
   };
 
   for (const auto& testCase : cases) {
     SCOPED_TRACE(static_cast<uint8_t>(testCase.kind));
     auto rows = makeRows(testCase.columns);
-    auto [codec, encoded] = bindAndEncode(
-        rows,
-        std::vector<CompareFlags>(
-            rows->childrenSize(),
-            SortComparatorOracle::makeSortFlags(true, true)));
-    ASSERT_EQ(encoded.format(), EncodedKeyFormat::kVariableBinary);
-    std::vector<std::string> expectedKeys;
-    expectedKeys.reserve(rows->size());
-    for (vector_size_t row = 0; row < rows->size(); ++row) {
-      expectedKeys.push_back(std::string(encoded.variableKeyAt(row)));
-    }
-
-    auto layout = RadixSortKeyLayout::fromKind(testCase.kind);
-    PayloadPointers payloads(rows->size());
-    RadixSortRunStorage arena(pool_.get(), layout, 2, 64);
-    arena.appendBatch(encoded, payloads.span(layout.hasPayload()));
+    const auto flags = std::vector<CompareFlags>(
+        rows->childrenSize(), SortComparatorOracle::makeSortFlags(true, true));
+    const auto requested = RadixSortKeyLayout::fromKind(testCase.kind);
+    auto run = makeRun(rows, flags, requested.hasPayload());
+    const auto& arena = *run->storage();
+    ASSERT_EQ(arena.layout().kind(), testCase.kind);
     ASSERT_EQ(arena.size(), rows->size());
-    for (uint64_t row = 0; row < arena.size(); ++row) {
-      verifyStoredKey(
-          arena,
-          row,
-          expectedKeys[row],
-          layout.hasPayload() ? payloads.pointers[row] : nullptr);
-    }
-    expectPhysicalCompare(arena, expectedKeys);
+    expectPairwiseCompare(arena, rows->size(), [&](auto left, auto right) {
+      std::vector<column_index_t> keyChannels(rows->childrenSize());
+      std::iota(keyChannels.begin(), keyChannels.end(), 0);
+      return SortComparatorOracle::compareRows(
+          *rows, left, *rows, right, keyChannels, flags);
+    });
   }
 }
 
@@ -1138,13 +1156,15 @@ TEST_F(RadixSortKeyTest, fixedSeedPhysicalCompareProperty) {
     }
 
     PayloadPointers payloads(keys.size());
-    RadixSortRunStorage arena(pool_.get(), layout, 127, 4096);
-    arena.appendBatch(keys, payloads.span(layout.hasPayload()));
+    RadixSortRunStorage arena(pool_.get(), layout);
+    const auto heaps =
+        appendPhysicalKeys(arena, keys, payloads.span(layout.hasPayload()));
 
     for (uint32_t index = 0; index < kPairsPerSeed; ++index) {
       const auto expected = SortComparatorOracle::compareUnsignedBytes(
           keys[index], keys[index + 1]);
-      const auto actual = arena.keyAt(index).compare(arena.keyAt(index + 1));
+      const auto actual = comparePhysical(
+          layout, recordAt(arena, index), recordAt(arena, index + 1));
       EXPECT_EQ((actual > 0) - (actual < 0), expected)
           << "left=" << index << ", right=" << index + 1;
     }
@@ -1155,94 +1175,71 @@ TEST_F(RadixSortKeyTest, allocationRangeBoundaryAndClear) {
   auto leaf = rootPool_->addLeafChild("radix-sort-arena-clear-test");
   EXPECT_EQ(leaf->currentBytes(), 0);
   auto layout = RadixSortKeyLayout::fromKind(LayoutKind::kKeyOnlyFixed32);
-  RadixSortRunStorage arena(leaf.get(), layout, 2048, 64 * 1024);
+  RadixSortRunStorage arena(leaf.get(), layout);
   EXPECT_EQ(arena.size(), 0);
   EXPECT_EQ(arena.allocatedBytes(), 0);
-  EXPECT_EQ(arena.numRanges(), 0);
-  EXPECT_TRUE(arena.keyBlocks().empty());
-  EXPECT_TRUE(arena.keyHeapGroups().empty());
-  arena.appendBatch(std::span<const std::string_view>{});
+  EXPECT_EQ(arena.keyRangeAt(0, 1).count, 0);
+  arena.appendKeyBlocks(0, [](auto, auto, auto*) {});
   EXPECT_EQ(leaf->currentBytes(), 0);
-  const std::string key(32, 'k');
-  while (arena.numRanges() < 2) {
-    arena.append(key);
-  }
+  arena.appendKeyBlocks(
+      arena.keysPerBlock() + 1,
+      [&](vector_size_t, vector_size_t count, char* records) {
+        std::memset(
+            records, 'k', static_cast<uint64_t>(count) * layout.width());
+      });
 
-  ASSERT_GE(arena.keyBlocks().size(), 2);
-  EXPECT_EQ(arena.keyBlocks()[0].count, 2048);
-  EXPECT_GE(arena.numRanges(), 2);
+  EXPECT_EQ(arena.keyRangeAt(0, arena.size()).count, 2048);
   EXPECT_GE(arena.allocatedBytes(), arena.size() * arena.layout().width());
   EXPECT_GT(leaf->currentBytes(), 0);
 
   arena.clear();
   EXPECT_EQ(arena.size(), 0);
-  EXPECT_TRUE(arena.keyBlocks().empty());
-  EXPECT_TRUE(arena.keyHeapGroups().empty());
-  EXPECT_EQ(arena.allocatedBytes(), 0);
-  EXPECT_EQ(arena.numRanges(), 0);
-  EXPECT_EQ(leaf->currentBytes(), 0);
-
-  uint64_t index = std::numeric_limits<uint64_t>::max();
-  arena.append(key, nullptr, &index);
-  EXPECT_EQ(index, 0);
-  arena.append(key, nullptr, &index);
-  EXPECT_EQ(index, 1);
-  EXPECT_EQ(arena.size(), 2);
-  verifyStoredKey(arena, 0, key);
-  verifyStoredKey(arena, 1, key);
-  EXPECT_GT(arena.allocatedBytes(), 0);
-  arena.clear();
-  EXPECT_EQ(arena.size(), 0);
+  EXPECT_EQ(arena.keyRangeAt(0, 1).count, 0);
   EXPECT_EQ(arena.allocatedBytes(), 0);
   EXPECT_EQ(leaf->currentBytes(), 0);
 }
 
 TEST_F(RadixSortKeyTest, heapAllocationRangeBoundary) {
-  auto leaf = rootPool_->addLeafChild("radix-sort-heap-range-test");
-  auto layout = RadixSortKeyLayout::fromKind(LayoutKind::kKeyOnlyVariable32);
-  RadixSortRunStorage arena(leaf.get(), layout, 4096, 32 * 1024);
-  const std::string key(4096, 'h');
-  arena.append(key);
-  const auto initialRanges = arena.numRanges();
-  ASSERT_GT(initialRanges, 0);
+  constexpr vector_size_t kRows = 33;
+  const std::vector<std::optional<std::string>> values(
+      kRows, std::string(4096, 'h'));
+  auto rows = makeRows(makeStringVector(VARCHAR(), values));
+  auto run =
+      makeRun(rows, {SortComparatorOracle::makeSortFlags(true, true)}, false);
+  ASSERT_TRUE(run->keyLayout().isVariable());
+  EXPECT_GT(run->retainedBytes(), run->estimatedOutputBytes());
 
-  while (arena.numRanges() == initialRanges && arena.size() < 10'000) {
-    arena.append(key);
+  run->finalize();
+  auto output = RadixSortKeyTest::output(*run, kRows, pool_.get());
+  ASSERT_NE(output, nullptr);
+  ASSERT_EQ(output->size(), kRows);
+  for (vector_size_t row = 0; row < kRows; ++row) {
+    EXPECT_EQ(
+        output->childAt(0)
+            ->asUnchecked<SimpleVector<StringView>>()
+            ->valueAt(row)
+            .str(),
+        *values[row]);
   }
-  ASSERT_GT(arena.numRanges(), initialRanges);
-  ASSERT_GT(arena.keyHeapGroups().size(), 1);
-  for (uint64_t index = 0; index < arena.size(); ++index) {
-    verifyStoredKey(arena, index, key);
-  }
-
-  arena.clear();
-  EXPECT_EQ(arena.allocatedBytes(), 0);
-  EXPECT_EQ(arena.numRanges(), 0);
-  EXPECT_EQ(leaf->currentBytes(), 0);
+  EXPECT_EQ(run->retainedBytes(), 0);
 }
 
 TEST_F(
     RadixSortKeyTest,
     storageEstimatedOutputBytesIncludesVariableKeyAndPayload) {
   constexpr vector_size_t kRows = 33;
-  constexpr uint32_t kRowsPerBlock = 32;
-  auto layout =
-      RadixSortKeyLayout::fromKind(LayoutKind::kKeyWithPayloadVariable32);
-  auto payloadLayout = PayloadRowLayout::create(
-      ROW({"payload_string", "payload_map", "payload_bigint"},
-          {VARCHAR(), MAP(INTEGER(), VARCHAR()), BIGINT()}));
-  RadixSortRunStorage arena(
-      pool_.get(), layout, kRowsPerBlock, 64, payloadLayout, kRowsPerBlock, 64);
-
+  std::vector<std::optional<std::string>> keyStrings;
   std::vector<std::optional<std::string>> payloadStrings;
   std::vector<std::optional<int64_t>> payloadBigints;
   std::vector<vector_size_t> rawOffsets(kRows);
   std::vector<vector_size_t> rawSizes(kRows);
   std::vector<std::optional<int32_t>> mapKeys;
   std::vector<std::optional<std::string>> mapValues;
+  keyStrings.reserve(kRows);
   payloadStrings.reserve(kRows);
   payloadBigints.reserve(kRows);
   for (vector_size_t row = 0; row < kRows; ++row) {
+    keyStrings.emplace_back(std::string(48 + row * 5, 'k'));
     payloadStrings.emplace_back(
         row % 3 == 1 ? std::optional<std::string>{}
                      : std::optional<std::string>(
@@ -1274,76 +1271,38 @@ TEST_F(
       std::move(mapSizes),
       makeVector<int32_t>(INTEGER(), mapKeys),
       makeStringVector(VARCHAR(), mapValues));
-  auto payload = makeRows(
-      {makeStringVector(VARCHAR(), payloadStrings),
-       maps,
-       makeVector<int64_t>(BIGINT(), payloadBigints)});
-  PayloadRowBatch payloadBatch;
-  PayloadRowWriter payloadWriter;
-  payloadWriter.append(*payload, arena, payloadBatch);
-
-  std::vector<std::string> keyStorage(kRows);
-  std::vector<std::string_view> keys(kRows);
-  std::vector<char*> payloadPointers(kRows);
-  for (vector_size_t row = 0; row < kRows; ++row) {
-    keyStorage[row] = std::string(
-        row % 5 == 1 ? layout.inlineCapacity()
-                     : layout.inlineCapacity() + 17 + row * 5,
-        'k' + row % 11);
-    keys[row] = keyStorage[row];
-    payloadPointers[row] = payloadBatch.rowAt(row);
+  std::vector<VectorPtr> children{
+      makeStringVector(VARCHAR(), keyStrings),
+      makeStringVector(VARCHAR(), payloadStrings),
+      maps,
+      makeVector<int64_t>(BIGINT(), payloadBigints)};
+  std::vector<std::string> names{
+      "key", "payload_string", "payload_map", "payload_bigint"};
+  std::vector<TypePtr> types;
+  types.reserve(children.size());
+  for (const auto& child : children) {
+    types.push_back(child->type());
   }
-  arena.appendBatch(keys, payloadPointers);
+  auto input = std::make_shared<RowVector>(
+      pool_.get(),
+      ROW(std::move(names), std::move(types)),
+      nullptr,
+      kRows,
+      std::move(children));
+  auto run =
+      makeRun(input, {0}, {SortComparatorOracle::makeSortFlags(true, true)});
 
-  ASSERT_EQ(arena.size(), kRows);
-  ASSERT_EQ(arena.payloadSize(), kRows);
-  ASSERT_EQ(arena.keyBlocks().size(), 2);
-  ASSERT_EQ(arena.payloadFixedBlocks().size(), 2);
-  EXPECT_EQ(arena.keyBlocks()[0].count, kRowsPerBlock);
-  EXPECT_EQ(arena.keyBlocks()[1].count, 1);
-  EXPECT_EQ(arena.payloadFixedBlocks()[0].count, kRowsPerBlock);
-  EXPECT_EQ(arena.payloadFixedBlocks()[1].count, 1);
+  ASSERT_EQ(run->size(), kRows);
+  EXPECT_GT(run->retainedBytes(), run->estimatedOutputBytes());
+
+  run->finalize();
+  auto output = RadixSortKeyTest::output(*run, kRows, pool_.get());
+  ASSERT_NE(output, nullptr);
+  ASSERT_EQ(output->size(), kRows);
   for (vector_size_t row = 0; row < kRows; ++row) {
-    EXPECT_EQ(arena.keyAt(row).payload(), payloadBatch.rowAt(row));
+    EXPECT_TRUE(input->equalValueAt(output.get(), row, row));
   }
-
-  const auto keyFixedBytes =
-      blockBytes(arena.keyBlocks(), *layout.payloadOffset());
-  const auto payloadFixedBytes =
-      blockBytes(arena.payloadFixedBlocks(), payloadLayout->rowWidth());
-  const auto keyHeapUsed = groupBytes(arena.keyHeapGroups());
-  const auto keyHeapCapacity = groupBytes(arena.keyHeapGroups(), true);
-  const auto expectedKeyHeapUsed = std::accumulate(
-      keys.begin(), keys.end(), uint64_t{0}, [&](uint64_t sum, auto key) {
-        return sum + layout.heapSize(key.size());
-      });
-  const auto payloadHeapUsed = groupBytes(arena.payloadHeapGroups());
-  const auto payloadHeapCapacity = groupBytes(arena.payloadHeapGroups(), true);
-  const auto expectedPayloadHeapUsed = std::accumulate(
-      payloadBatch.heapSizes()->as<uint64_t>(),
-      payloadBatch.heapSizes()->as<uint64_t>() + kRows,
-      uint64_t{0});
-
-  EXPECT_EQ(keyHeapUsed, expectedKeyHeapUsed);
-  EXPECT_EQ(payloadHeapUsed, expectedPayloadHeapUsed);
-  EXPECT_EQ(
-      arena.estimatedOutputBytes(),
-      keyFixedBytes + keyHeapUsed + payloadFixedBytes + payloadHeapUsed);
-  EXPECT_GT(arena.keyHeapGroups().size(), 1);
-  EXPECT_GT(arena.payloadHeapGroups().size(), 1);
-  EXPECT_GE(keyHeapCapacity, keyHeapUsed);
-  EXPECT_GE(payloadHeapCapacity, payloadHeapUsed);
-  const auto reservedBytes = static_cast<uint64_t>(arena.keyBlocks().size()) *
-          kRowsPerBlock * layout.width() +
-      keyHeapCapacity +
-      static_cast<uint64_t>(arena.payloadFixedBlocks().size()) * kRowsPerBlock *
-          payloadLayout->rowWidth() +
-      payloadHeapCapacity;
-  EXPECT_GT(reservedBytes, arena.estimatedOutputBytes());
-  EXPECT_GE(static_cast<uint64_t>(arena.allocatedBytes()), reservedBytes);
-  EXPECT_GT(
-      static_cast<uint64_t>(arena.allocatedBytes()),
-      arena.estimatedOutputBytes());
+  EXPECT_EQ(run->retainedBytes(), 0);
 }
 
 } // namespace

--- a/bolt/exec/tests/RadixSortRunSorterTest.cpp
+++ b/bolt/exec/tests/RadixSortRunSorterTest.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+#include "bolt/exec/radixsort/RadixSortRun.h"
 #include "bolt/exec/radixsort/RadixSortRunSorter.h"
 #include "bolt/vector/FlatVector.h"
 
@@ -54,6 +55,49 @@ class RadixSortRunSorterTest : public testing::Test {
     return RadixSortKeyLayout::fromKind(kind);
   }
 
+  static void constructPhysicalKey(
+      const RadixSortKeyLayout& layout,
+      std::string_view encodedKey,
+      char* heap,
+      char* payload,
+      char* record) {
+    if (layout.isVariable()) {
+      std::memset(record, 0, layout.inlineCapacity());
+      std::memcpy(
+          record,
+          encodedKey.data(),
+          std::min<size_t>(encodedKey.size(), layout.inlineCapacity()));
+      storeUnaligned<uint64_t>(
+          record + *layout.sizeOffset(), encodedKey.size());
+      std::memcpy(
+          heap,
+          encodedKey.data() + layout.heapKeyOffset(),
+          encodedKey.size() - layout.heapKeyOffset());
+      storeCompactPointer(record + *layout.dataOffset(), heap);
+    } else {
+      RadixSortInlineKeyBuffer bytes{};
+      std::memcpy(
+          bytes.data(),
+          encodedKey.data(),
+          std::min<size_t>(encodedKey.size(), layout.inlineCapacity()));
+      for (uint32_t word = 0; word < layout.inlineWordCount(); ++word) {
+        auto value =
+            loadUnaligned<uint64_t>(bytes.data() + word * sizeof(uint64_t));
+        if constexpr (std::endian::native == std::endian::little) {
+          value = byteSwap(value);
+        }
+        storeUnaligned<uint64_t>(record + word * sizeof(uint64_t), value);
+      }
+      std::memcpy(
+          record + layout.inlineWordBytes(),
+          bytes.data() + layout.inlineWordBytes(),
+          layout.inlineTailBytes());
+    }
+    if (layout.hasPayload()) {
+      storeCompactPointer(record + *layout.payloadOffset(), payload);
+    }
+  }
+
   static std::string fixedKey(uint64_t value, uint8_t prefix = 0) {
     std::string key(8, '\0');
     key[0] = static_cast<char>(prefix);
@@ -61,21 +105,6 @@ class RadixSortRunSorterTest : public testing::Test {
       key[byte] = static_cast<char>(value >> ((key.size() - byte - 1) * 8));
     }
     return key;
-  }
-
-  static std::string encodedKeyAt(
-      const EncodedKeyBatch& keys,
-      vector_size_t row) {
-    if (keys.format() == EncodedKeyFormat::kVariableBinary) {
-      return std::string(keys.variableKeyAt(row));
-    }
-    auto word = keys.fixedKeyAt(row);
-    if constexpr (std::endian::native == std::endian::little) {
-      word = byteSwap(word);
-    }
-    std::string result(sizeof(word), '\0');
-    storeUnaligned(result.data(), word);
-    return result;
   }
 
   static std::string
@@ -106,19 +135,32 @@ class RadixSortRunSorterTest : public testing::Test {
       RadixSortRunStorage& arena,
       const std::vector<std::string>& keys,
       std::vector<PayloadIdentity>* payloads = nullptr) {
-    auto keyViews = views(keys);
-    if (payloads == nullptr) {
-      arena.appendBatch(keyViews);
-      return;
+    if (payloads != nullptr) {
+      payloads->resize(keys.size());
+      for (uint64_t index = 0; index < keys.size(); ++index) {
+        (*payloads)[index].index = index;
+      }
     }
-
-    payloads->resize(keys.size());
-    std::vector<char*> pointers(keys.size());
-    for (uint64_t index = 0; index < keys.size(); ++index) {
-      (*payloads)[index].index = index;
-      pointers[index] = reinterpret_cast<char*>(&(*payloads)[index]);
-    }
-    arena.appendBatch(keyViews, pointers);
+    arena.appendKeyBlocks(
+        keys.size(),
+        [&](vector_size_t source, vector_size_t count, char* records) {
+          for (vector_size_t row = 0; row < count; ++row) {
+            const auto inputRow = source + row;
+            auto* heap = keys[inputRow].size() == arena.layout().heapKeyOffset()
+                ? nullptr
+                : const_cast<char*>(
+                      keys[inputRow].data() + arena.layout().heapKeyOffset());
+            auto* payload = payloads == nullptr
+                ? nullptr
+                : reinterpret_cast<char*>(&(*payloads)[inputRow]);
+            constructPhysicalKey(
+                arena.layout(),
+                keys[inputRow],
+                heap,
+                payload,
+                records + static_cast<uint64_t>(row) * arena.layout().width());
+          }
+        });
   }
 
   static int32_t unsignedByteCompare(
@@ -150,17 +192,27 @@ class RadixSortRunSorterTest : public testing::Test {
   }
 
   static std::string logicalKey(
-      const RadixSortKey& key,
       const RadixSortKeyLayout& layout,
       const char* record) {
     if (layout.isVariable()) {
+      const auto size = loadUnaligned<uint64_t>(record + *layout.sizeOffset());
       return std::string(record, layout.heapKeyOffset()) +
-          std::string(key.heapKey());
+          std::string(
+                 loadCompactPointer(record + *layout.dataOffset()),
+                 size - layout.heapKeyOffset());
     }
     RadixSortInlineKeyBuffer buffer;
     EncodedKeyView view;
-    key.deconstruct(buffer, view);
+    RadixSortKey(layout, record).deconstruct(buffer, view);
     return std::string(view.bytes);
+  }
+
+  static const char* recordAt(
+      const RadixSortRunStorage& storage,
+      uint64_t row) {
+    const auto range = storage.keyRangeAt(row, 1);
+    BOLT_CHECK_EQ(range.count, 1);
+    return range.data;
   }
 
   static void expectMatchesIndependentOracle(
@@ -181,8 +233,8 @@ class RadixSortRunSorterTest : public testing::Test {
     std::vector<std::string> actualKeys;
     actualKeys.reserve(actual.size());
     for (uint64_t index = 0; index < actual.size(); ++index) {
-      actualKeys.emplace_back(logicalKey(
-          actual.keyAt(index), actual.layout(), actual.keyDataAt(index)));
+      const auto* record = recordAt(actual, index);
+      actualKeys.emplace_back(logicalKey(actual.layout(), record));
     }
     EXPECT_EQ(actualKeys, expected);
   }
@@ -193,15 +245,15 @@ class RadixSortRunSorterTest : public testing::Test {
     ASSERT_TRUE(arena.layout().hasPayload());
     std::vector<bool> seen(originalKeys.size(), false);
     for (uint64_t index = 0; index < arena.size(); ++index) {
+      const auto* record = recordAt(arena, index);
       const auto* identity = reinterpret_cast<const PayloadIdentity*>(
-          arena.keyAt(index).payload());
+          loadCompactPointer(record + *arena.layout().payloadOffset()));
       ASSERT_NE(identity, nullptr);
       ASSERT_LT(identity->index, originalKeys.size());
       EXPECT_FALSE(seen[identity->index])
           << "duplicate payload identity=" << identity->index;
       seen[identity->index] = true;
-      const auto key = logicalKey(
-          arena.keyAt(index), arena.layout(), arena.keyDataAt(index));
+      const auto key = logicalKey(arena.layout(), record);
       const auto expected =
           normalizedKeyForLayout(arena.layout(), originalKeys[identity->index]);
       EXPECT_EQ(unsignedByteCompare(key, expected), 0)
@@ -215,13 +267,10 @@ class RadixSortRunSorterTest : public testing::Test {
       const std::vector<std::string>& keys,
       RadixSortKeyLayoutKind kind,
       std::span<const uint32_t> skippableByteOffsets = {},
-      uint32_t keysPerBlock = 31,
-      uint64_t keyHeapGroupBytes = 4096,
       std::optional<RadixSortKeyLayout> layoutOverride = std::nullopt) {
     auto selectedLayout = layoutOverride.value_or(layout(kind));
     std::vector<PayloadIdentity> payloads;
-    RadixSortRunStorage actual(
-        pool_.get(), selectedLayout, keysPerBlock, keyHeapGroupBytes);
+    RadixSortRunStorage actual(pool_.get(), selectedLayout);
     append(actual, keys, selectedLayout.hasPayload() ? &payloads : nullptr);
     RadixSortRunSorter sorter(actual);
     sorter.sort(skippableByteOffsets);
@@ -394,59 +443,62 @@ TEST_F(RadixSortRunSorterTest, codecKeysWithManyNullsMatchBoltComparator) {
       values->set(row, static_cast<int32_t>(random() % 257));
     }
   }
+  auto rowIds =
+      BaseVector::create<FlatVector<int64_t>>(BIGINT(), kRows, pool_.get());
+  for (vector_size_t row = 0; row < kRows; ++row) {
+    rowIds->set(row, row);
+  }
   auto rows = std::make_shared<RowVector>(
       pool_.get(),
-      ROW({INTEGER()}),
+      ROW({"key", "id"}, {INTEGER(), BIGINT()}),
       nullptr,
       kRows,
-      std::vector<VectorPtr>{values});
+      std::vector<VectorPtr>{values, rowIds});
   const CompareFlags compareFlags{
       .nullsFirst = false,
       .ascending = true,
       .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue};
-  std::unique_ptr<RadixSortKeyCodec> codec;
-  RadixSortKeyCodec::bind({INTEGER()}, {compareFlags}, codec);
-  EncodedKeyBatch encodedKeys;
-  codec->encode(*rows, pool_.get(), encodedKeys);
-
-  auto selectedLayout =
-      RadixSortKeyLayout::select(codec->maximumEncodedSize(), true);
-  RadixSortRunStorage arena(pool_.get(), selectedLayout, 31, 4096);
-  std::vector<uint64_t> rowIds(kRows);
-  std::vector<char*> payloads(kRows);
-  for (uint64_t row = 0; row < kRows; ++row) {
-    rowIds[row] = row;
-    payloads[row] = reinterpret_cast<char*>(&rowIds[row]);
+  auto run = RadixSortRun::create(
+      pool_.get(),
+      std::static_pointer_cast<const RowType>(rows->type()),
+      ROW({"key"}, {INTEGER()}),
+      {compareFlags},
+      {0},
+      {});
+  run->append(*rows);
+  run->finalize();
+  const auto* storage = run->storage();
+  ASSERT_NE(storage, nullptr);
+  for (uint64_t index = 1; index < storage->size(); ++index) {
+    const auto left = storage->keyRangeAt(index - 1, 1);
+    const auto right = storage->keyRangeAt(index, 1);
+    ASSERT_EQ(left.count, 1);
+    ASSERT_EQ(right.count, 1);
+    EXPECT_LE(
+        RadixSortKeyOps<RadixSortKeyLayoutKind::kKeyWithPayloadFixed16>::
+            compare(left.data, right.data, 0),
+        0);
   }
-  arena.appendBatch(encodedKeys, payloads);
-
-  RadixSortRunSorter sorter(arena);
-  const std::vector<uint8_t> keyMayHaveNulls{1};
-  sorter.sort(codec->leadingSkippableValidityOffsets(
-      keyMayHaveNulls, selectedLayout.radixWidth()));
-
+  RowVectorPtr output;
+  output = run->getOutput(kRows, pool_.get(), output);
+  ASSERT_NE(output, nullptr);
+  auto* outputValues = output->childAt(0)->asUnchecked<SimpleVector<int32_t>>();
+  auto* outputIds = output->childAt(1)->asUnchecked<SimpleVector<int64_t>>();
   std::vector<bool> seen(kRows, false);
-  for (uint64_t index = 1; index < arena.size(); ++index) {
-    const auto left =
-        *reinterpret_cast<const uint64_t*>(arena.keyAt(index - 1).payload());
-    const auto right =
-        *reinterpret_cast<const uint64_t*>(arena.keyAt(index).payload());
+  for (vector_size_t index = 1; index < output->size(); ++index) {
     const auto result =
-        values->compare(values.get(), left, right, compareFlags);
+        outputValues->compare(outputValues, index - 1, index, compareFlags);
     ASSERT_TRUE(result.has_value());
     EXPECT_LE(*result, 0);
   }
-  for (uint64_t index = 0; index < arena.size(); ++index) {
-    const auto row =
-        *reinterpret_cast<const uint64_t*>(arena.keyAt(index).payload());
+  for (vector_size_t index = 0; index < output->size(); ++index) {
+    const auto row = outputIds->valueAt(index);
     ASSERT_LT(row, kRows);
     EXPECT_FALSE(seen[row]) << "duplicate row=" << row;
     seen[row] = true;
-    const auto encoded =
-        normalizedKeyForLayout(arena.layout(), encodedKeyAt(encodedKeys, row));
-    const auto stored =
-        logicalKey(arena.keyAt(index), arena.layout(), arena.keyDataAt(index));
-    EXPECT_EQ(unsignedByteCompare(stored, encoded), 0) << "row=" << row;
+    EXPECT_EQ(
+        values->compare(outputValues, row, index, compareFlags).value_or(1), 0)
+        << "row=" << row;
   }
   EXPECT_TRUE(
       std::all_of(seen.begin(), seen.end(), [](bool value) { return value; }));
@@ -568,36 +620,30 @@ TEST_F(RadixSortRunSorterTest, variableComparisonFallbackBoundaries) {
 TEST_F(
     RadixSortRunSorterTest,
     blockSizeKMinusOneKAndKPlusOnePreservePayloadCoupling) {
-  for (const uint32_t keysPerBlock : {1, 31, 32, 33}) {
-    for (const uint64_t size :
-         {static_cast<uint64_t>(keysPerBlock) - 1,
-          static_cast<uint64_t>(keysPerBlock),
-          static_cast<uint64_t>(keysPerBlock) + 1}) {
-      SCOPED_TRACE(
-          "keysPerBlock=" + std::to_string(keysPerBlock) +
-          ", size=" + std::to_string(size));
-      auto keys = makeKeys(size, [size](auto row) {
-        return fixedKey((row * 37 + 11) % std::max<uint64_t>(size, 1), row % 5);
-      });
-      avoidNaturalRuns(keys);
-      verifyAgainstOracle(
-          keys,
-          RadixSortKeyLayoutKind::kKeyWithPayloadFixed16,
-          {},
-          keysPerBlock);
-    }
+  const auto kind = RadixSortKeyLayoutKind::kKeyWithPayloadFixed16;
+  RadixSortRunStorage probe(pool_.get(), layout(kind));
+  const auto keysPerBlock = static_cast<uint64_t>(probe.keysPerBlock());
+  for (const uint64_t size :
+       {keysPerBlock - 1, keysPerBlock, keysPerBlock + 1}) {
+    SCOPED_TRACE(
+        "keysPerBlock=" + std::to_string(keysPerBlock) +
+        ", size=" + std::to_string(size));
+    auto keys = makeKeys(size, [size](auto row) {
+      return fixedKey((row * 37 + 11) % size, row % 5);
+    });
+    avoidNaturalRuns(keys);
+    verifyAgainstOracle(keys, kind);
   }
 }
 
 TEST_F(RadixSortRunSorterTest, sortsAcrossManyStorageBlocks) {
+  const auto kind = RadixSortKeyLayoutKind::kKeyWithPayloadFixed16;
+  RadixSortRunStorage probe(pool_.get(), layout(kind));
+  const auto size = static_cast<uint64_t>(probe.keysPerBlock()) * 2 + 17;
   auto keys = makeKeys(
-      257, [](auto row) { return fixedKey((row * 37) % 257, row % 5); });
+      size, [size](auto row) { return fixedKey((row * 37) % size, row % 5); });
   avoidNaturalRuns(keys);
-  for (const uint32_t keysPerBlock : {1, 31, 32, 33}) {
-    SCOPED_TRACE("keysPerBlock=" + std::to_string(keysPerBlock));
-    verifyAgainstOracle(
-        keys, RadixSortKeyLayoutKind::kKeyWithPayloadFixed16, {}, keysPerBlock);
-  }
+  verifyAgainstOracle(keys, kind);
 }
 
 TEST_F(RadixSortRunSorterTest, exactLargeBucketBoundaryInputsMatchOracle) {
@@ -770,7 +816,7 @@ TEST_F(RadixSortRunSorterTest, variableHeapOffsetSortsBySuffix) {
   }
   std::reverse(keys.begin(), keys.end());
   verifyAgainstOracle(
-      keys, RadixSortKeyLayoutKind::kKeyOnlyVariable32, {}, 31, 4096, layout);
+      keys, RadixSortKeyLayoutKind::kKeyOnlyVariable32, {}, layout);
 }
 
 TEST_F(RadixSortRunSorterTest, variableRadixCoversEntireRecordPrefix) {
@@ -787,7 +833,7 @@ TEST_F(RadixSortRunSorterTest, variableRadixCoversEntireRecordPrefix) {
       key[layout.inlineCapacity() - 1] = static_cast<char>(value);
       keys.push_back(std::move(key));
     }
-    verifyAgainstOracle(keys, kind, {}, 31, 4096, layout);
+    verifyAgainstOracle(keys, kind, {}, layout);
   }
 }
 

--- a/bolt/exec/tests/RadixSortRunTest.cpp
+++ b/bolt/exec/tests/RadixSortRunTest.cpp
@@ -33,6 +33,92 @@
 #include "bolt/vector/SimpleVector.h"
 
 namespace bytedance::bolt::exec::radixsort::test {
+namespace {
+
+uint64_t storedKeySize(const RadixSortKeyLayout& layout, const char* record) {
+  return loadUnaligned<uint64_t>(record + *layout.sizeOffset());
+}
+
+std::string_view overflowKeyBytes(
+    const RadixSortKeyLayout& layout,
+    const char* record) {
+  return {
+      loadCompactPointer(record + *layout.dataOffset()),
+      storedKeySize(layout, record) - layout.heapKeyOffset()};
+}
+
+char* payloadAt(const RadixSortKeyLayout& layout, const char* record) {
+  return layout.hasPayload()
+      ? loadCompactPointer(record + *layout.payloadOffset())
+      : nullptr;
+}
+
+RowTypePtr outputTypeOf(const RadixSortRun& run) {
+  std::vector<TypePtr> types;
+  types.reserve(run.projection().columns().size());
+  for (const auto& column : run.projection().columns()) {
+    types.push_back(
+        column.source == RadixSortOutputSource::kDecodedKey
+            ? run.projection().keyType()->childAt(column.sourceIndex)
+            : run.projection().payloadType()->childAt(column.sourceIndex));
+  }
+  return ROW(std::move(types));
+}
+
+RowVectorPtr nextOutput(
+    RadixSortRun& run,
+    vector_size_t maxRows,
+    memory::MemoryPool* pool,
+    RowVectorPtr& output) {
+  auto outputSize = maxRows;
+  if (run.state() != RadixSortRunState::kBuilding) {
+    outputSize = static_cast<vector_size_t>(std::min<uint64_t>(
+        maxRows, run.metrics().inputRows - run.metrics().outputRows));
+  }
+  if (output != nullptr && output.use_count() == 1 && output->pool() == pool) {
+    for (auto& child : output->children()) {
+      child.reset();
+    }
+    VectorPtr reusable = std::move(output);
+    BaseVector::prepareForReuse(reusable, outputSize);
+    output = std::static_pointer_cast<RowVector>(reusable);
+  } else {
+    const auto outputType = outputTypeOf(run);
+    output = std::make_shared<RowVector>(
+        pool,
+        outputType,
+        nullptr,
+        outputSize,
+        std::vector<VectorPtr>(outputType->size()));
+  }
+  return run.getOutput(maxRows, pool, output);
+}
+
+int32_t comparePhysicalKeys(
+    const RadixSortKeyLayout& layout,
+    const char* left,
+    const char* right) {
+#define COMPARE_KIND(kind)                                         \
+  case RadixSortKeyLayoutKind::kind:                               \
+    return RadixSortKeyOps<RadixSortKeyLayoutKind::kind>::compare( \
+        left, right, layout.heapKeyOffset())
+  switch (layout.kind()) {
+    COMPARE_KIND(kKeyOnlyFixed8);
+    COMPARE_KIND(kKeyOnlyFixed16);
+    COMPARE_KIND(kKeyOnlyFixed24);
+    COMPARE_KIND(kKeyOnlyFixed32);
+    COMPARE_KIND(kKeyOnlyVariable32);
+    COMPARE_KIND(kKeyWithPayloadFixed16);
+    COMPARE_KIND(kKeyWithPayloadFixed24);
+    COMPARE_KIND(kKeyWithPayloadFixed32);
+    COMPARE_KIND(kKeyWithPayloadVariable32);
+    default:
+      BOLT_UNREACHABLE();
+  }
+#undef COMPARE_KIND
+}
+
+} // namespace
 
 class RadixSortRunOffsetOutputTest {
  public:
@@ -49,8 +135,7 @@ class RadixSortRunOffsetOutputTest {
         vector_size_t outputOffset) {
       auto externalViews = selectedViewsFor(keys.size());
       for (size_t row = 0; row < externalViews.size(); ++row) {
-        externalViews[row] = {
-            RadixSortKey(run_.keyLayout(), keys[row]).heapKey()};
+        externalViews[row] = {overflowKeyBytes(run_.keyLayout(), keys[row])};
       }
       writeSelected(keys, payloads, outputOffset);
     }
@@ -195,12 +280,11 @@ class BoundaryVariableMemoryMergeStream final
       encodedSuffix_ = {};
       return;
     }
-    key_ = storage_.keyDataAt(index_);
-    payload_ = storage_.layout().hasPayload()
-        ? RadixSortKey(storage_.layout(), key_).payload()
-        : nullptr;
-    encodedSuffix_ =
-        EncodedKeyView{RadixSortKey(storage_.layout(), key_).heapKey()};
+    const auto range = storage_.keyRangeAt(index_, 1);
+    BOLT_CHECK_EQ(range.count, 1);
+    key_ = range.data;
+    payload_ = payloadAt(storage_.layout(), key_);
+    encodedSuffix_ = EncodedKeyView{overflowKeyBytes(storage_.layout(), key_)};
   }
 
   const RadixSortRunStorage& storage_;
@@ -536,13 +620,16 @@ class RadixSortRunTest : public testing::Test {
     BOLT_CHECK_GT(batchSize, 0);
     const auto total = static_cast<vector_size_t>(run.metrics().inputRows);
     std::vector<VectorPtr> children;
-    children.reserve(run.projection().outputType()->size());
-    for (const auto& type : run.projection().outputType()->children()) {
+    const auto outputType = outputTypeOf(run);
+    children.reserve(outputType->size());
+    for (const auto& type : outputType->children()) {
       children.push_back(BaseVector::create(type, total, outputPool_.get()));
     }
 
     vector_size_t offset = 0;
-    while (auto batch = run.getOutput(batchSize, outputPool_.get())) {
+    RowVectorPtr reusableOutput;
+    while (auto batch =
+               nextOutput(run, batchSize, outputPool_.get(), reusableOutput)) {
       if (offset + batch->size() > total) {
         ADD_FAILURE() << "RadixSortRun returned more rows than it accepted";
         return nullptr;
@@ -552,11 +639,7 @@ class RadixSortRunTest : public testing::Test {
     }
     EXPECT_EQ(offset, total);
     return std::make_shared<RowVector>(
-        outputPool_.get(),
-        run.projection().outputType(),
-        nullptr,
-        total,
-        std::move(children));
+        outputPool_.get(), outputType, nullptr, total, std::move(children));
   }
 
   RowVectorPtr collectAndVerify(
@@ -591,6 +674,14 @@ class RadixSortRunTest : public testing::Test {
         ->valueAt(row);
   }
 
+  static const char* recordAt(
+      const RadixSortRunStorage& storage,
+      uint64_t row) {
+    const auto range = storage.keyRangeAt(row, 1);
+    BOLT_CHECK_EQ(range.count, 1);
+    return range.data;
+  }
+
   static std::pair<std::vector<const char*>, std::vector<char*>> rowPointers(
       const RadixSortRun& run) {
     std::vector<const char*> keys;
@@ -600,10 +691,10 @@ class RadixSortRunTest : public testing::Test {
       payloads.reserve(run.storage()->size());
     }
     for (uint64_t row = 0; row < run.storage()->size(); ++row) {
-      const auto* key = run.storage()->keyDataAt(row);
+      const auto* key = recordAt(*run.storage(), row);
       keys.push_back(key);
       if (run.projection().hasPayload()) {
-        payloads.push_back(RadixSortKey(run.keyLayout(), key).payload());
+        payloads.push_back(payloadAt(run.keyLayout(), key));
       }
     }
     return {std::move(keys), std::move(payloads)};
@@ -611,7 +702,7 @@ class RadixSortRunTest : public testing::Test {
 
   RowVectorPtr makePreparedOutput(const RadixSortRun& run, vector_size_t size) {
     auto output = BaseVector::create<RowVector>(
-        run.projection().outputType(), size, outputPool_.get());
+        outputTypeOf(run), size, outputPool_.get());
     for (auto& child : output->children()) {
       child->resize(size);
     }
@@ -703,7 +794,8 @@ class RadixSortRunTest : public testing::Test {
     EXPECT_EQ(run.state(), RadixSortRunState::kConsumed);
     EXPECT_EQ(run.storage(), nullptr);
     EXPECT_EQ(run.retainedBytes(), 0);
-    EXPECT_EQ(run.getOutput(1, outputPool_.get()), nullptr);
+    RowVectorPtr reusableOutput;
+    EXPECT_EQ(nextOutput(run, 1, outputPool_.get(), reusableOutput), nullptr);
   }
 };
 
@@ -777,8 +869,12 @@ TEST_F(RadixSortRunTest, variableKeyHeapOffsetSortsAndDecodes) {
   EXPECT_EQ(run->keyLayout().heapKeyOffset(), 5);
   ASSERT_NE(run->storage(), nullptr);
   for (uint64_t row = 0; row < run->storage()->size(); ++row) {
-    const auto key = run->storage()->keyAt(row);
-    EXPECT_EQ(key.heapKey().size(), key.heapSize());
+    const auto record = recordAt(*run->storage(), row);
+    const auto key = overflowKeyBytes(run->keyLayout(), record);
+    EXPECT_EQ(
+        key.size(),
+        storedKeySize(run->keyLayout(), record) -
+            run->keyLayout().heapKeyOffset());
   }
   collectAndVerify(*run, *input, 2, 2, {0, 1}, keyFlags);
 }
@@ -827,22 +923,32 @@ TEST_F(RadixSortRunTest, variableKeyEncodesDirectlyIntoRecordAndHeap) {
       SortComparatorOracle::makeSortFlags(true, true),
       SortComparatorOracle::makeSortFlags(true, true)};
 
-  std::array<EncodedKeyBatch, 3> encodedColumns;
-  for (uint32_t column = 0; column < encodedColumns.size(); ++column) {
-    std::unique_ptr<RadixSortKeyCodec> codec;
-    RadixSortKeyCodec::bind(
-        {input->childAt(column)->type()}, {keyFlags[column]}, codec);
-    auto columnInput = makeRows({"key"}, {input->childAt(column)});
-    codec->encode(*columnInput, runPool_.get(), encodedColumns[column]);
-  }
-  const auto encodedFixedColumnAt = [&](uint32_t column, vector_size_t row) {
-    auto word = encodedColumns[column].fixedKeyAt(row);
-    if constexpr (std::endian::native == std::endian::little) {
-      word = byteSwap(word);
+  const auto encodedIntegerAt = [&](uint32_t column, vector_size_t row) {
+    std::string encoded(5, '\0');
+    const auto& vector = *input->childAt(column);
+    if (vector.isNullAt(row)) {
+      encoded[0] = 1;
+      return encoded;
     }
-    std::string encoded(sizeof(word), '\0');
-    storeUnaligned(encoded.data(), word);
-    encoded.resize(5);
+    encoded[0] = 2;
+    const auto value =
+        vector.asUnchecked<SimpleVector<int32_t>>()->valueAt(row);
+    const auto sortable = static_cast<uint32_t>(value) ^ (uint32_t{1} << 31);
+    storeUnaligned<uint32_t>(encoded.data() + 1, folly::Endian::big(sortable));
+    return encoded;
+  };
+  const auto encodedStringAt = [&](vector_size_t row) {
+    const auto* vector =
+        input->childAt(2)->asUnchecked<SimpleVector<StringView>>();
+    if (vector->isNullAt(row)) {
+      return std::string(1, 1);
+    }
+    const auto value = vector->valueAt(row);
+    std::string encoded;
+    encoded.reserve(value.size() + 2);
+    encoded.push_back(2);
+    encoded.append(value.data(), value.size());
+    encoded.push_back(0);
     return encoded;
   };
 
@@ -859,15 +965,17 @@ TEST_F(RadixSortRunTest, variableKeyEncodesDirectlyIntoRecordAndHeap) {
   ASSERT_NE(storage, nullptr);
   uint64_t expectedHeapBytes = 0;
   for (vector_size_t row = 0; row < input->size(); ++row) {
-    const auto first = encodedFixedColumnAt(0, row);
-    const auto second = encodedFixedColumnAt(1, row);
-    const auto suffix = encodedColumns[2].variableKeyAt(row);
-    const auto* record = storage->keyDataAt(row);
-    const auto key = storage->keyAt(row);
+    const auto first = encodedIntegerAt(0, row);
+    const auto second = encodedIntegerAt(1, row);
+    const auto suffix = encodedStringAt(row);
+    const auto recordRange = storage->keyRangeAt(row, 1);
+    ASSERT_EQ(recordRange.count, 1);
+    const auto* record = recordRange.data;
+    const auto key = overflowKeyBytes(storage->layout(), record);
 
     EXPECT_EQ(std::string_view(record, 5), first);
     EXPECT_EQ(std::string_view(record + 5, 5), second);
-    EXPECT_EQ(key.heapKey(), suffix);
+    EXPECT_EQ(key, suffix);
     EXPECT_EQ(
         std::string_view(record + 10, std::min<size_t>(suffix.size(), 8)),
         suffix.substr(0, 8));
@@ -878,11 +986,9 @@ TEST_F(RadixSortRunTest, variableKeyEncodesDirectlyIntoRecordAndHeap) {
     }
     expectedHeapBytes += suffix.size();
   }
-  uint64_t actualHeapBytes = 0;
-  for (const auto& group : storage->keyHeapGroups()) {
-    actualHeapBytes += group.used;
-  }
-  EXPECT_EQ(actualHeapBytes, expectedHeapBytes);
+  EXPECT_EQ(
+      storage->estimatedOutputBytes(),
+      input->size() * run->keyLayout().width() + expectedHeapBytes);
 
   run->finalize();
   auto output = collect(*run, 2);
@@ -916,13 +1022,11 @@ TEST_F(RadixSortRunTest, variableKeyOutputSourceIsSelectedAtFinalize) {
   shortRun->append(*slice(*shortInput, 0, 2));
   shortRun->append(*slice(*shortInput, 2, 4));
   EXPECT_EQ(shortRun->keyLayout().inlineCapacity(), 12);
-  EXPECT_EQ(shortRun->maximumEncodedKeySize(), 4);
-  EXPECT_FALSE(shortRun->decodesVariableKeysFromInline());
   shortRun->finalize();
-  ASSERT_TRUE(shortRun->decodesVariableKeysFromInline());
   for (uint64_t row = 0; row < shortRun->storage()->size(); ++row) {
-    auto key = shortRun->storage()->keyAt(row);
-    std::memset(key.heapKeyData(), 'x', key.heapSize());
+    const auto key = overflowKeyBytes(
+        shortRun->keyLayout(), recordAt(*shortRun->storage(), row));
+    std::memset(const_cast<char*>(key.data()), 'x', key.size());
   }
   collectAndVerify(*shortRun, *shortInput, 2, 1);
 
@@ -934,12 +1038,10 @@ TEST_F(RadixSortRunTest, variableKeyOutputSourceIsSelectedAtFinalize) {
       {*mixedInput, {0}, {SortComparatorOracle::makeSortFlags(true, true)}});
   mixedRun->append(*slice(*mixedInput, 0, 1));
   mixedRun->append(*slice(*mixedInput, 1, 4));
-  EXPECT_EQ(mixedRun->maximumEncodedKeySize(), 34);
   mixedRun->finalize();
-  ASSERT_FALSE(mixedRun->decodesVariableKeysFromInline());
   for (uint64_t row = 0; row < mixedRun->storage()->size(); ++row) {
     std::memset(
-        const_cast<char*>(mixedRun->storage()->keyDataAt(row)),
+        const_cast<char*>(recordAt(*mixedRun->storage(), row)),
         'x',
         mixedRun->keyLayout().inlineCapacity());
   }
@@ -957,10 +1059,9 @@ TEST_F(RadixSortRunTest, inheritedVariableKeySizeSelectsHeapOutput) {
   run->append(*input);
   EXPECT_FALSE(run->variableKeysFitRadixPrefix());
   run->finalize();
-  ASSERT_FALSE(run->decodesVariableKeysFromInline());
   for (uint64_t row = 0; row < run->storage()->size(); ++row) {
     std::memset(
-        const_cast<char*>(run->storage()->keyDataAt(row)),
+        const_cast<char*>(recordAt(*run->storage(), row)),
         'x',
         run->keyLayout().inlineCapacity());
   }
@@ -979,10 +1080,10 @@ TEST_F(RadixSortRunTest, fixedPrefixAndVariableSuffixDecodeFromRecord) {
   run->append(*input);
   run->finalize();
   ASSERT_EQ(run->keyLayout().heapKeyOffset(), 10);
-  ASSERT_TRUE(run->decodesVariableKeysFromInline());
   for (uint64_t row = 0; row < run->storage()->size(); ++row) {
-    auto key = run->storage()->keyAt(row);
-    std::memset(key.heapKeyData(), 'x', key.heapSize());
+    const auto key =
+        overflowKeyBytes(run->keyLayout(), recordAt(*run->storage(), row));
+    std::memset(const_cast<char*>(key.data()), 'x', key.size());
   }
   auto output = collect(*run, 2);
   expectSortedValues(*input, *output, {0, 1, 2}, keyFlags);
@@ -1093,14 +1194,16 @@ TEST_F(RadixSortRunTest, keyOnlyEmptyAndOneRow) {
   EXPECT_FALSE(emptyRun->projection().hasPayload());
   EXPECT_EQ(emptyRun->storage()->payloadLayout(), nullptr);
   emptyRun->finalize();
-  EXPECT_EQ(emptyRun->getOutput(10, outputPool_.get()), nullptr);
+  RowVectorPtr reusableOutput;
+  EXPECT_EQ(
+      nextOutput(*emptyRun, 10, outputPool_.get(), reusableOutput), nullptr);
   EXPECT_EQ(emptyRun->state(), RadixSortRunState::kConsumed);
 
   auto input = makeRows({"key"}, {makeVector<int64_t>(BIGINT(), {42})});
   auto run = createRun(
       {*input, {0}, {SortComparatorOracle::makeSortFlags(true, true)}});
   run->append(*input);
-  EXPECT_EQ(run->storage()->payloadSize(), 0);
+  EXPECT_FALSE(run->projection().hasPayload());
   run->finalize();
   auto output = collect(*run, 1);
   ASSERT_EQ(output->size(), 1);
@@ -1113,7 +1216,9 @@ TEST_F(RadixSortRunTest, lifecycleAndOutputValidation) {
       makeKeyStringRows({2, 1}, {std::string(32, 'b'), std::string(32, 'a')});
   auto run = createRun(
       {*input, {0}, {SortComparatorOracle::makeSortFlags(true, true)}});
-  EXPECT_THROW(run->getOutput(1, outputPool_.get()), BoltException);
+  RowVectorPtr reusableOutput;
+  EXPECT_THROW(
+      nextOutput(*run, 1, outputPool_.get(), reusableOutput), BoltException);
 
   run->append(*input);
   run->finalize();
@@ -1158,15 +1263,16 @@ TEST_F(RadixSortRunTest, outputScratchGrowsAndShrinksAcrossCalls) {
         BaseVector::create(type, kRows, outputPool_.get()));
   }
   vector_size_t offset = 0;
+  RowVectorPtr reusableOutput;
   for (const auto batchSize : {1, 129, 2, 301}) {
-    auto batch = run->getOutput(batchSize, outputPool_.get());
+    auto batch = nextOutput(*run, batchSize, outputPool_.get(), reusableOutput);
     ASSERT_NE(batch, nullptr);
     EXPECT_EQ(batch->size(), batchSize);
     copyBatch(*batch, outputChildren, offset);
     offset += batch->size();
   }
   ASSERT_EQ(offset, kRows);
-  EXPECT_EQ(run->getOutput(1, outputPool_.get()), nullptr);
+  EXPECT_EQ(nextOutput(*run, 1, outputPool_.get(), reusableOutput), nullptr);
   auto output = std::make_shared<RowVector>(
       outputPool_.get(),
       input->type(),
@@ -1212,6 +1318,31 @@ TEST_F(RadixSortRunTest, duplicateDirectKeyStaysInPayload) {
   EXPECT_EQ(
       run->projection().columns()[0].source, RadixSortOutputSource::kPayload);
   collectAndVerify(*run, *input, 9, 1);
+}
+
+TEST_F(RadixSortRunTest, maskedComplexKeysRemainPayloadBacked) {
+  const std::vector<VectorPtr> variables{
+      makeStringVector(
+          {"a", "b", std::nullopt, "", std::string(80, 'x'), "d", "e"}),
+      makeIntegerArrays(),
+      makeIntegerStringMaps(),
+      makeNestedRows()};
+  for (const auto& variable : variables) {
+    for (const auto flags : SortComparatorOracle::allSortFlags()) {
+      auto input = makeRows(
+          {"key", "value", "id"},
+          {makeVector<int64_t>(BIGINT(), {3, 1, 2, 1, 3, 2, 1}),
+           variable,
+           makeIds(7)});
+      const std::vector<column_index_t> channels{0, 1, 1};
+      const std::vector<CompareFlags> keyFlags(3, flags);
+      auto run = finalizedRun({*input, channels, keyFlags});
+      EXPECT_EQ(
+          run->projection().columns()[1].source,
+          RadixSortOutputSource::kPayload);
+      collectAndVerify(*run, *input, 2, 2, channels, keyFlags);
+    }
+  }
 }
 
 TEST_F(RadixSortRunTest, floatingPointKeyOutputUsesDecodedKey) {
@@ -1531,7 +1662,8 @@ TEST_F(RadixSortRunTest, nullFreeDecodedKeysAndPayloadResetNullBuffers) {
       run->payloadMayHaveNulls(), (std::vector<uint8_t>{0, 0, 0, 0, 0, 1, 0}));
   run->finalize();
 
-  auto first = run->getOutput(4, outputPool_.get());
+  RowVectorPtr reusableOutput;
+  auto first = nextOutput(*run, 4, outputPool_.get(), reusableOutput);
   ASSERT_NE(first, nullptr);
   std::vector<VectorPtr> children;
   children.reserve(input->childrenSize());
@@ -1547,7 +1679,7 @@ TEST_F(RadixSortRunTest, nullFreeDecodedKeysAndPayloadResetNullBuffers) {
   }
   first.reset();
 
-  auto second = run->getOutput(4, outputPool_.get());
+  auto second = nextOutput(*run, 4, outputPool_.get(), reusableOutput);
   ASSERT_NE(second, nullptr);
   for (const auto column : {0, 2, 3, 4, 5, 6, 7, 8, 10}) {
     EXPECT_EQ(second->childAt(column)->rawNulls(), nullptr) << column;
@@ -1556,7 +1688,7 @@ TEST_F(RadixSortRunTest, nullFreeDecodedKeysAndPayloadResetNullBuffers) {
 
   copyBatch(*second, children, offset);
   offset += second->size();
-  while (auto batch = run->getOutput(4, outputPool_.get())) {
+  while (auto batch = nextOutput(*run, 4, outputPool_.get(), reusableOutput)) {
     copyBatch(*batch, children, offset);
     offset += batch->size();
   }
@@ -1580,14 +1712,15 @@ TEST_F(RadixSortRunTest, singleStringPayloadNullFreeReuseResetsNullBuffer) {
   EXPECT_EQ(run->payloadMayHaveNulls(), (std::vector<uint8_t>{0, 0}));
   run->finalize();
 
-  auto first = run->getOutput(3, outputPool_.get());
+  RowVectorPtr reusableOutput;
+  auto first = nextOutput(*run, 3, outputPool_.get(), reusableOutput);
   ASSERT_NE(first, nullptr);
   ASSERT_EQ(first->childAt(1)->rawNulls(), nullptr);
   first->childAt(1)->mutableRawNulls();
   ASSERT_NE(first->childAt(1)->rawNulls(), nullptr);
   first.reset();
 
-  auto second = run->getOutput(3, outputPool_.get());
+  auto second = nextOutput(*run, 3, outputPool_.get(), reusableOutput);
   ASSERT_NE(second, nullptr);
   EXPECT_EQ(second->childAt(1)->rawNulls(), nullptr);
   EXPECT_FALSE(second->childAt(1)->mayHaveNulls());
@@ -1614,25 +1747,16 @@ TEST_F(RadixSortRunTest, runOwnedAllocationPoolCoversPersistentData) {
 
   const auto* arena = run->storage();
   ASSERT_NE(arena, nullptr);
-  EXPECT_FALSE(arena->keyBlocks().empty());
-  EXPECT_FALSE(arena->keyHeapGroups().empty());
-  EXPECT_FALSE(arena->payloadFixedBlocks().empty());
-  EXPECT_FALSE(arena->payloadHeapGroups().empty());
+  EXPECT_GT(arena->allocatedBytes(), 0);
   ASSERT_NE(run->payloadLayout(), nullptr);
   ASSERT_EQ(run->payloadLayout()->columns().size(), 3);
 
-  const auto* keyBlockBegin = arena->keyBlocks()[0].base;
-  const auto* keyBlockEnd =
-      keyBlockBegin + arena->keyBlocks()[0].count * arena->layout().width();
   for (vector_size_t row = 0; row < kRows; ++row) {
-    EXPECT_GE(arena->keyDataAt(row), keyBlockBegin);
-    EXPECT_LT(arena->keyDataAt(row), keyBlockEnd);
-    const auto key = arena->keyAt(row);
-    ASSERT_NE(key.heapKeyData(), nullptr);
-    EXPECT_EQ(key.heapSize(), key.heapKey().size());
-    EXPECT_EQ(key.heapKeyData(), key.heapKey().data());
+    const auto record = recordAt(*arena, row);
+    const auto key = overflowKeyBytes(arena->layout(), record);
+    ASSERT_NE(key.data(), nullptr);
 
-    const auto* payload = key.payload();
+    const auto* payload = payloadAt(arena->layout(), record);
     ASSERT_NE(payload, nullptr);
 
     const auto longString = loadUnaligned<StringView>(
@@ -1660,22 +1784,26 @@ TEST_F(RadixSortRunTest, outputDoesNotMutateOrReferenceRun) {
   std::vector<std::array<char, 32>> records(run->size());
   std::vector<char*> payloadPointers(run->size());
   for (uint64_t row = 0; row < run->size(); ++row) {
-    std::memcpy(records[row].data(), run->storage()->keyDataAt(row), width);
-    payloadPointers[row] = run->storage()->keyAt(row).payload();
+    const auto* key = recordAt(*run->storage(), row);
+    std::memcpy(records[row].data(), key, width);
+    payloadPointers[row] = payloadAt(run->keyLayout(), key);
   }
 
-  auto firstBatch = run->getOutput(7, outputPool_.get());
+  RowVectorPtr reusableOutput;
+  auto firstBatch = nextOutput(*run, 7, outputPool_.get(), reusableOutput);
   ASSERT_NE(firstBatch, nullptr);
   EXPECT_EQ(run->state(), RadixSortRunState::kSortedInMemory);
   for (uint64_t row = 0; row < run->size(); ++row) {
     EXPECT_EQ(
-        std::memcmp(records[row].data(), run->storage()->keyDataAt(row), width),
+        std::memcmp(records[row].data(), recordAt(*run->storage(), row), width),
         0);
-    EXPECT_EQ(run->storage()->keyAt(row).payload(), payloadPointers[row]);
+    EXPECT_EQ(
+        payloadAt(run->keyLayout(), recordAt(*run->storage(), row)),
+        payloadPointers[row]);
   }
 
   uint64_t drainedRows = firstBatch->size();
-  while (auto batch = run->getOutput(9, outputPool_.get())) {
+  while (auto batch = nextOutput(*run, 9, outputPool_.get(), reusableOutput)) {
     drainedRows += batch->size();
   }
   EXPECT_EQ(run->state(), RadixSortRunState::kConsumed);
@@ -1702,7 +1830,7 @@ TEST_F(RadixSortRunTest, outputDoesNotMutateOrReferenceRun) {
 TEST_F(
     RadixSortRunTest,
     wideVariableKeyRoundTripAcrossBlocksBatchesAndPointerMerge) {
-  constexpr vector_size_t kRows = 41;
+  constexpr vector_size_t kRows = 4'097;
   constexpr uint32_t kKeys = 8;
   std::vector<VectorPtr> children;
   std::vector<std::string> names;
@@ -1733,10 +1861,10 @@ TEST_F(
   names.insert(names.end(), {"key7", "payload", "id"});
   children.push_back(makeStringVector(makeValues<std::string>(
       kRows, [](vector_size_t row) -> std::optional<std::string> {
-        return row % 18 == 0 ? std::nullopt
-                             : std::optional{std::string(
-                                   row % 5 == 0 ? 64 : 3 + row % 7,
-                                   static_cast<char>('a' + row % 17))};
+        return row % 18 == 0
+            ? std::nullopt
+            : std::optional{std::string(
+                  64 + row % 17, static_cast<char>('a' + row % 17))};
       })));
   children.push_back(makeStringVector(makeValues<std::string>(
       kRows, [](vector_size_t row) -> std::optional<std::string> {
@@ -1752,11 +1880,7 @@ TEST_F(
   auto input = makeRows(std::move(names), children);
 
   const auto makeRun = [&](const RowVector& rows) {
-    RadixSortRunOptions options;
-    options.keysPerBlock = 3;
-    options.preferredKeyHeapGroupBytes = 29;
-    options.payloadRowsPerBlock = 2;
-    auto run = createRun({*input, keyChannels, keyFlags}, options);
+    auto run = createRun({*input, keyChannels, keyFlags});
     const auto middle = (rows.size() - 6) / 2;
     run->append(*slice(rows, 0, 5));
     run->append(*slice(rows, 5, 1));
@@ -1765,20 +1889,33 @@ TEST_F(
     EXPECT_EQ(
         run->keyLayout().kind(),
         RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-    EXPECT_GT(run->storage()->keyBlocks().size(), 1);
-    EXPECT_GT(run->storage()->keyHeapGroups().size(), 1);
-    EXPECT_GT(run->storage()->payloadFixedBlocks().size(), 1);
+    EXPECT_GT(run->retainedBytes(), run->estimatedOutputBytes());
     run->finalize();
     return run;
   };
 
   auto inMemoryRun = makeRun(*input);
-  auto first = inMemoryRun->getOutput(6, outputPool_.get());
+  const auto firstKeyRange = inMemoryRun->storage()->keyRangeAt(0, kRows);
+  ASSERT_GT(firstKeyRange.count, 0);
+  EXPECT_LT(firstKeyRange.count, kRows);
+  EXPECT_GT(
+      inMemoryRun->storage()->keyRangeAt(firstKeyRange.count, kRows).count, 0);
+  for (uint64_t row = 1; row < inMemoryRun->storage()->size(); ++row) {
+    const auto left = inMemoryRun->storage()->keyRangeAt(row - 1, 1);
+    const auto right = inMemoryRun->storage()->keyRangeAt(row, 1);
+    ASSERT_EQ(left.count, 1);
+    ASSERT_EQ(right.count, 1);
+    EXPECT_LE(
+        comparePhysicalKeys(inMemoryRun->keyLayout(), left.data, right.data),
+        0);
+  }
+  RowVectorPtr reusableOutput;
+  auto first = nextOutput(*inMemoryRun, 6, outputPool_.get(), reusableOutput);
   ASSERT_NE(first, nullptr);
   auto firstCopy = slice(*first, 0, first->size());
   const auto reusableBuffers = outputBuffers(*first);
   first.reset();
-  auto second = inMemoryRun->getOutput(6, outputPool_.get());
+  auto second = nextOutput(*inMemoryRun, 6, outputPool_.get(), reusableOutput);
   ASSERT_NE(second, nullptr);
   const auto retainedBuffers = outputBuffers(*second);
   EXPECT_EQ(retainedBuffers[0], reusableBuffers[0]);
@@ -1787,7 +1924,7 @@ TEST_F(
                                    ->asUnchecked<SimpleVector<StringView>>()
                                    ->valueAt(0)
                                    .str();
-  auto third = inMemoryRun->getOutput(6, outputPool_.get());
+  auto third = nextOutput(*inMemoryRun, 6, outputPool_.get(), reusableOutput);
   ASSERT_NE(third, nullptr);
   EXPECT_NE(outputBuffers(*third)[0], retainedBuffers[0]);
   EXPECT_EQ(idAt(*second, 0, kKeys + 1), retainedId);
@@ -1799,7 +1936,8 @@ TEST_F(
       retainedPayload);
   auto alternateOutputPool =
       rootPool_->addLeafChild("radix-sort-run-alternate-output-test");
-  auto alternate = inMemoryRun->getOutput(6, alternateOutputPool.get());
+  auto alternate =
+      nextOutput(*inMemoryRun, 6, alternateOutputPool.get(), reusableOutput);
   ASSERT_NE(alternate, nullptr);
   EXPECT_EQ(alternate->pool(), alternateOutputPool.get());
   for (uint32_t column = 0; column < alternate->childrenSize(); ++column) {
@@ -1807,7 +1945,8 @@ TEST_F(
   }
   std::vector<RowVectorPtr> inMemoryBatches{
       firstCopy, second, third, alternate};
-  while (auto batch = inMemoryRun->getOutput(7, outputPool_.get())) {
+  while (auto batch =
+             nextOutput(*inMemoryRun, 7, outputPool_.get(), reusableOutput)) {
     inMemoryBatches.push_back(std::move(batch));
   }
   auto inMemoryOutput = concatenate(inMemoryBatches);
@@ -1864,13 +2003,14 @@ TEST_F(RadixSortRunTest, outputReusesBuffersWithCopyOnWrite) {
   auto run = finalizedRun(
       {*input, {0}, {SortComparatorOracle::makeSortFlags(true, true)}});
 
-  auto first = run->getOutput(4, outputPool_.get());
+  RowVectorPtr reusableOutput;
+  auto first = nextOutput(*run, 4, outputPool_.get(), reusableOutput);
   ASSERT_NE(first, nullptr);
   const auto reusableBuffers = outputBuffers(*first, true);
   ASSERT_NE(reusableBuffers[2], nullptr);
   first.reset();
 
-  auto second = run->getOutput(4, outputPool_.get());
+  auto second = nextOutput(*run, 4, outputPool_.get(), reusableOutput);
   ASSERT_NE(second, nullptr);
   auto* secondKey = second->childAt(0)->asUnchecked<FlatVector<int64_t>>();
   auto* secondString =
@@ -1884,7 +2024,7 @@ TEST_F(RadixSortRunTest, outputReusesBuffersWithCopyOnWrite) {
   const auto retainedKey = secondKey->valueAt(0);
   const auto retainedString = secondString->valueAt(0).getString();
 
-  auto third = run->getOutput(4, outputPool_.get());
+  auto third = nextOutput(*run, 4, outputPool_.get(), reusableOutput);
   ASSERT_NE(third, nullptr);
   const auto thirdBuffers = outputBuffers(*third, true);
   ASSERT_NE(thirdBuffers[2], nullptr);
@@ -1907,7 +2047,8 @@ TEST_F(RadixSortRunTest, outputSurvivesExplicitRunClear) {
       {*input, {0}, {SortComparatorOracle::makeSortFlags(true, true)}});
   run->append(*input);
   run->finalize();
-  auto output = run->getOutput(1, outputPool_.get());
+  RowVectorPtr reusableOutput;
+  auto output = nextOutput(*run, 1, outputPool_.get(), reusableOutput);
   ASSERT_NE(output, nullptr);
   ASSERT_EQ(output->size(), 1);
   run->clear();
@@ -2027,7 +2168,6 @@ TEST_F(RadixSortRunTest, spillOffsetLayeredVariableSegmentsAndChildIdentity) {
   auto run = finalizedRun({*input, keyChannels, flags});
   ASSERT_TRUE(run->keyLayout().isVariable());
   ASSERT_GT(run->keyLayout().heapKeyOffset(), 0);
-  ASSERT_FALSE(run->decodesVariableKeysFromInline());
   auto expectedRun = finalizedRun({*input, keyChannels, flags});
   auto expected = collect(*expectedRun, input->size());
   auto [keys, payloads] = rowPointers(*run);
@@ -2082,7 +2222,6 @@ TEST_F(
       keyChannels.size(), SortComparatorOracle::makeSortFlags(true, true));
   auto run = finalizedRun({*input, keyChannels, flags});
   ASSERT_TRUE(run->keyLayout().isVariable());
-  ASSERT_FALSE(run->decodesVariableKeysFromInline());
   auto expectedRun = finalizedRun({*input, keyChannels, flags});
   auto expected = collect(*expectedRun, kRows);
 
@@ -2114,7 +2253,7 @@ TEST_F(
         segmentSizes.push_back(segmentSize);
         for (vector_size_t row = 0; row < segmentSize; ++row) {
           const auto expectedView =
-              RadixSortKey(run->keyLayout(), keys[row]).heapKey();
+              overflowKeyBytes(run->keyLayout(), keys[row]);
           EXPECT_EQ(batch.selectedViews()[row].bytes, expectedView);
           EXPECT_NE(batch.selectedViews()[row].bytes, kUnselected);
         }
@@ -2141,7 +2280,6 @@ TEST_F(RadixSortRunTest, spillOffsetInlineVariableNeedsNoExternalViews) {
       SortComparatorOracle::makeSortFlags(true, true)};
   auto run = finalizedRun({*input, keyChannels, flags});
   ASSERT_TRUE(run->keyLayout().isVariable());
-  ASSERT_TRUE(run->decodesVariableKeysFromInline());
   auto expectedRun = finalizedRun({*input, keyChannels, flags});
   auto expected = collect(*expectedRun, input->size());
   auto [keys, payloads] = rowPointers(*run);
@@ -2192,7 +2330,6 @@ TEST_F(RadixSortRunTest, spillOffsetVariablePrefixOnlyNeedsNoExternalViews) {
       keyChannels.size(), SortComparatorOracle::makeSortFlags(true, true));
   auto run = finalizedRun({*input, keyChannels, flags});
   ASSERT_TRUE(run->keyLayout().isVariable());
-  ASSERT_FALSE(run->decodesVariableKeysFromInline());
   EXPECT_EQ(
       run->projection().decodedKeyMask(), (std::vector<uint8_t>{1, 0, 0}));
   EXPECT_EQ(
@@ -2247,7 +2384,6 @@ TEST_F(RadixSortRunTest, prepareMergeOutputPreSizesDecodeScratch) {
       keyChannels.size(), SortComparatorOracle::makeSortFlags(true, true));
   auto run = finalizedRun({*input, keyChannels, flags});
   ASSERT_TRUE(run->keyLayout().isVariable());
-  ASSERT_FALSE(run->decodesVariableKeysFromInline());
   auto expectedRun = finalizedRun({*input, keyChannels, flags});
   auto expected = collect(*expectedRun, kRows);
   auto [keys, payloads] = rowPointers(*run);

--- a/bolt/exec/tests/RadixSortSpillSectionsTest.cpp
+++ b/bolt/exec/tests/RadixSortSpillSectionsTest.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <numeric>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -34,9 +35,12 @@
 
 #include "bolt/common/base/tests/GTestUtils.h"
 #include "bolt/common/file/FileSystems.h"
+#include "bolt/common/testutil/TestValue.h"
 #include "bolt/exec/SpillFile.h"
-#include "bolt/exec/radixsort/PayloadRow.h"
-#include "bolt/exec/radixsort/RadixSortKeyCodec.h"
+// clang-format off
+#include "bolt/exec/radixsort/RadixSortRunStorage.h"
+#include "bolt/exec/radixsort/RadixSortRun.h"
+// clang-format on
 #include "bolt/exec/radixsort/RadixSortSpill.h"
 #include "bolt/exec/radixsort/RadixSortSpillSections.h"
 #include "bolt/exec/tests/utils/TempDirectoryPath.h"
@@ -44,6 +48,28 @@
 
 namespace bytedance::bolt::exec::radixsort::test {
 namespace {
+
+class PrefetchReadFile final : public InMemoryReadFile {
+ public:
+  explicit PrefetchReadFile(std::string_view data) : InMemoryReadFile(data) {}
+
+  bool uringEnabled() override {
+    return true;
+  }
+
+  void submitRead(char* buffer, uint64_t offset, size_t size) override {
+    EXPECT_FALSE(pending_);
+    pread(offset, size, buffer);
+    pending_ = true;
+  }
+
+  bool waitForComplete() override {
+    return std::exchange(pending_, false);
+  }
+
+ private:
+  bool pending_{false};
+};
 
 struct TestRadixSortSpillBlockHeader {
   int32_t uncompressedSize;
@@ -85,6 +111,56 @@ constexpr std::array kSupportedSpillCompressionKinds{
     common::CompressionKind_LZ4,
     common::CompressionKind_ZSTD,
     common::CompressionKind_GZIP};
+
+const char* recordAt(const RadixSortRunStorage& storage, uint64_t row) {
+  const auto range = storage.keyRangeAt(row, 1);
+  BOLT_CHECK_EQ(range.count, 1);
+  return range.data;
+}
+
+uint64_t storedKeySize(const RadixSortKeyLayout& layout, const char* record) {
+  return loadUnaligned<uint64_t>(record + *layout.sizeOffset());
+}
+
+std::string_view heapKey(const RadixSortKeyLayout& layout, const char* record) {
+  return {
+      loadCompactPointer(record + *layout.dataOffset()),
+      storedKeySize(layout, record) - layout.heapKeyOffset()};
+}
+
+char* payloadAt(const RadixSortKeyLayout& layout, const char* record) {
+  return layout.hasPayload()
+      ? loadCompactPointer(record + *layout.payloadOffset())
+      : nullptr;
+}
+
+int32_t comparePhysical(
+    const RadixSortKeyLayout& layout,
+    const char* left,
+    const char* right) {
+#define COMPARE_KIND(kind)                                         \
+  case RadixSortKeyLayoutKind::kind:                               \
+    return RadixSortKeyOps<RadixSortKeyLayoutKind::kind>::compare( \
+        left, right, layout.heapKeyOffset())
+  switch (layout.kind()) {
+    COMPARE_KIND(kKeyOnlyFixed8);
+    COMPARE_KIND(kKeyOnlyFixed16);
+    COMPARE_KIND(kKeyOnlyFixed24);
+    COMPARE_KIND(kKeyOnlyFixed32);
+    COMPARE_KIND(kKeyOnlyVariable32);
+    COMPARE_KIND(kKeyWithPayloadFixed16);
+    COMPARE_KIND(kKeyWithPayloadFixed24);
+    COMPARE_KIND(kKeyWithPayloadFixed32);
+    COMPARE_KIND(kKeyWithPayloadVariable32);
+    default:
+      BOLT_UNREACHABLE();
+  }
+#undef COMPARE_KIND
+}
+
+char* mutableRecordAt(RadixSortRunStorage& storage, uint64_t row) {
+  return const_cast<char*>(recordAt(storage, row));
+}
 
 class BoundaryTestMergeStream final : public RadixSortMergeStream {
  public:
@@ -201,9 +277,8 @@ class TrackingStorageMergeStream final : public RadixSortMergeStream {
       payload_ = nullptr;
       return;
     }
-    key_ = storage_.keyDataAt(position_);
-    payload_ =
-        hasPayload_ ? RadixSortKey(storage_.layout(), key_).payload() : nullptr;
+    key_ = recordAt(storage_, position_);
+    payload_ = hasPayload_ ? payloadAt(storage_.layout(), key_) : nullptr;
   }
 
   const RadixSortRunStorage& storage_;
@@ -245,7 +320,7 @@ class InspectableVariableMemoryMergeStream final
       encodedSuffix_ = {};
       return;
     }
-    key_ = storage_.keyDataAt(position_);
+    key_ = recordAt(storage_, position_);
     payload_ = nullptr;
     encodedSuffix_ = {};
   }
@@ -259,6 +334,7 @@ class RadixSortSpillSectionsTest : public testing::Test {
   static void SetUpTestSuite() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     filesystems::registerLocalFileSystem();
+    BOLT_TEST_VALUE_ENABLE();
   }
 
  protected:
@@ -271,6 +347,57 @@ class RadixSortSpillSectionsTest : public testing::Test {
   std::shared_ptr<memory::MemoryPool> pool_{
       rootPool_->addLeafChild("radix-sort-spill-sections-test")};
   std::vector<std::shared_ptr<exec::test::TempDirectoryPath>> spillDirectories_;
+  std::vector<std::unique_ptr<std::string>> keyHeaps_;
+
+  void appendPhysicalKey(
+      RadixSortRunStorage& storage,
+      std::string_view encodedKey,
+      char* payload = nullptr) {
+    char* heap = nullptr;
+    if (encodedKey.size() > storage.layout().heapKeyOffset()) {
+      keyHeaps_.push_back(std::make_unique<std::string>(
+          encodedKey.substr(storage.layout().heapKeyOffset())));
+      heap = keyHeaps_.back()->data();
+    }
+    storage.appendKeyBlocks(1, [&](vector_size_t, vector_size_t, char* record) {
+      const auto& layout = storage.layout();
+      if (layout.isVariable()) {
+        std::memset(record, 0, layout.inlineCapacity());
+        std::memcpy(
+            record,
+            encodedKey.data(),
+            std::min<size_t>(encodedKey.size(), layout.inlineCapacity()));
+        storeUnaligned<uint64_t>(
+            record + *layout.sizeOffset(), encodedKey.size());
+        std::memcpy(
+            heap,
+            encodedKey.data() + layout.heapKeyOffset(),
+            encodedKey.size() - layout.heapKeyOffset());
+        storeCompactPointer(record + *layout.dataOffset(), heap);
+      } else {
+        RadixSortInlineKeyBuffer bytes{};
+        std::memcpy(
+            bytes.data(),
+            encodedKey.data(),
+            std::min<size_t>(encodedKey.size(), layout.inlineCapacity()));
+        for (uint32_t word = 0; word < layout.inlineWordCount(); ++word) {
+          auto value =
+              loadUnaligned<uint64_t>(bytes.data() + word * sizeof(uint64_t));
+          if constexpr (std::endian::native == std::endian::little) {
+            value = byteSwap(value);
+          }
+          storeUnaligned<uint64_t>(record + word * sizeof(uint64_t), value);
+        }
+        std::memcpy(
+            record + layout.inlineWordBytes(),
+            bytes.data() + layout.inlineWordBytes(),
+            layout.inlineTailBytes());
+      }
+      if (layout.hasPayload()) {
+        storeCompactPointer(record + *layout.payloadOffset(), payload);
+      }
+    });
+  }
 
   template <typename T, typename U = T>
   FlatVectorPtr<T> makeVector(
@@ -709,7 +836,8 @@ class RadixSortSpillSectionsTest : public testing::Test {
     EXPECT_TRUE(file.good());
     std::vector<UncompressedSpillBlock> blocks;
     uint64_t offset = 0;
-    while (offset < fileInfo.size) {
+    const auto fileSize = std::filesystem::file_size(fileInfo.path);
+    while (offset < fileSize) {
       UncompressedSpillBlock block;
       file.read(reinterpret_cast<char*>(&block.header), sizeof(block.header));
       EXPECT_TRUE(file.good()) << "offset=" << offset;
@@ -720,8 +848,16 @@ class RadixSortSpillSectionsTest : public testing::Test {
       offset += kBlockHeaderSize + block.header.storedSize;
       blocks.push_back(std::move(block));
     }
-    EXPECT_EQ(offset, fileInfo.size);
+    EXPECT_EQ(offset, fileSize);
     return blocks;
+  }
+
+  uint64_t rowsInUncompressedSpillFile(const RadixSortSpillFile& file) {
+    uint64_t rows = 0;
+    for (const auto& block : readUncompressedBlocks(file)) {
+      rows += block.header.rowCount;
+    }
+    return rows;
   }
 
   static std::vector<char*> payloadsFromKeys(
@@ -730,9 +866,7 @@ class RadixSortSpillSectionsTest : public testing::Test {
     std::vector<char*> payloads;
     payloads.reserve(keys.size());
     for (const auto* key : keys) {
-      payloads.push_back(
-          keyLayout.hasPayload() ? RadixSortKey(keyLayout, key).payload()
-                                 : nullptr);
+      payloads.push_back(payloadAt(keyLayout, key));
     }
     return payloads;
   }
@@ -742,10 +876,7 @@ class RadixSortSpillSectionsTest : public testing::Test {
       const RadixSortMergeStream& stream,
       const char* expectedKey) {
     if (!keyLayout.isVariable()) {
-      EXPECT_EQ(
-          RadixSortKey(keyLayout, stream.key())
-              .compare(RadixSortKey(keyLayout, expectedKey)),
-          0);
+      EXPECT_EQ(comparePhysical(keyLayout, stream.key(), expectedKey), 0);
       return;
     }
     ASSERT_NE(stream.key(), nullptr);
@@ -755,9 +886,7 @@ class RadixSortSpillSectionsTest : public testing::Test {
     const auto* variable =
         dynamic_cast<const RadixSortVariableMergeStream*>(&stream);
     ASSERT_NE(variable, nullptr);
-    EXPECT_EQ(
-        variable->encodedSuffix().bytes,
-        RadixSortKey(keyLayout, expectedKey).heapKey());
+    EXPECT_EQ(variable->encodedSuffix().bytes, heapKey(keyLayout, expectedKey));
   }
 
   static std::string fixed8Key(uint8_t value) {
@@ -791,17 +920,18 @@ class RadixSortSpillSectionsTest : public testing::Test {
       uint64_t maxFileSize = 1) {
     const auto keyLayout =
         RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-    RadixSortRunStorage storage(pool_.get(), keyLayout, 1'024, 64);
+    RadixSortRunStorage storage(pool_.get(), keyLayout);
     for (uint64_t row = 0; row < rowCount; ++row) {
-      storage.append(orderedFixed8EncodedKey(row + 1));
+      appendPhysicalKey(storage, orderedFixed8EncodedKey(row + 1));
     }
     auto files = spillRunFiles(storage, nullptr, maxFileSize);
     EXPECT_GT(files.size(), 1);
     uint64_t totalRows = 0;
     bool sawBoundary = false;
     for (const auto& file : files) {
-      totalRows += file.rowCount;
-      sawBoundary |= file.rowCount < rowCount;
+      const auto fileRows = rowsInUncompressedSpillFile(file);
+      totalRows += fileRows;
+      sawBoundary |= fileRows < rowCount;
     }
     EXPECT_EQ(totalRows, rowCount);
     EXPECT_TRUE(sawBoundary);
@@ -824,11 +954,11 @@ class RadixSortSpillSectionsTest : public testing::Test {
     auto files = writer.writeRun(storage, payloadLayout);
     BOLT_CHECK_EQ(files.size(), 1);
     auto file = std::move(files.front());
-    EXPECT_EQ(file.rowCount, storage.size());
     EXPECT_EQ(file.compressionKind, compression);
-    EXPECT_GT(file.size, 0);
+    const auto fileSize = std::filesystem::file_size(file.path);
+    EXPECT_GT(fileSize, 0);
     const auto written = stats.copy();
-    EXPECT_EQ(written.spilledBytes, file.size);
+    EXPECT_EQ(written.spilledBytes, fileSize);
     EXPECT_EQ(written.spilledRows, 0);
     EXPECT_EQ(written.spilledFiles, 1);
     EXPECT_EQ(written.spillSerializationTimeUs, 0);
@@ -871,11 +1001,11 @@ class RadixSortSpillSectionsTest : public testing::Test {
     uint64_t totalRows = 0;
     for (const auto& file : files) {
       EXPECT_TRUE(std::filesystem::exists(file.path));
-      EXPECT_GT(file.size, 0);
-      EXPECT_GT(file.rowCount, 0);
+      const auto fileSize = std::filesystem::file_size(file.path);
+      EXPECT_GT(fileSize, 0);
       EXPECT_EQ(file.compressionKind, common::CompressionKind_NONE);
-      totalSize += file.size;
-      totalRows += file.rowCount;
+      totalSize += fileSize;
+      totalRows += rowsInUncompressedSpillFile(file);
     }
     const auto written = stats.copy();
     EXPECT_EQ(written.spilledBytes, totalSize);
@@ -904,12 +1034,12 @@ class RadixSortSpillSectionsTest : public testing::Test {
     uint64_t row = 0;
     while (stream->hasData()) {
       ASSERT_LT(row, storage.size());
-      expectSpillStreamKey(storage.layout(), *stream, storage.keyDataAt(row));
+      expectSpillStreamKey(storage.layout(), *stream, recordAt(storage, row));
       ASSERT_NE(stream->payload(), nullptr);
       EXPECT_EQ(
           std::memcmp(
               stream->payload(),
-              RadixSortKey(storage.layout(), storage.keyDataAt(row)).payload(),
+              payloadAt(storage.layout(), recordAt(storage, row)),
               payloadLayout.rowWidth()),
           0)
           << "row=" << row;
@@ -930,14 +1060,15 @@ class RadixSortSpillSectionsTest : public testing::Test {
       uint64_t writeBufferSize = 1 << 20) {
     auto keyLayout = RadixSortKeyLayout::fromKind(kind);
     const auto layout = keyLayout.hasPayload() ? payloadLayout : nullptr;
-    RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64, layout, 4, 1024);
+    RadixSortRunStorage storage(pool_.get(), keyLayout, layout);
     PayloadRowBatch rows;
     if (layout) {
       PayloadRowWriter payloadWriter;
       payloadWriter.append(*payload, storage, rows);
     }
     for (uint32_t row = 0; row < keys.size(); ++row) {
-      storage.append(keys[row], layout ? rows.rowAt(row) : nullptr);
+      appendPhysicalKey(
+          storage, keys[row], layout ? rows.rows()->as<char*>()[row] : nullptr);
     }
     auto spill =
         spillSingleRun(storage, layout.get(), compression, writeBufferSize);
@@ -959,7 +1090,7 @@ class RadixSortSpillSectionsTest : public testing::Test {
     vector_size_t outputOffset = 0;
     while (stream->hasData()) {
       ASSERT_LT(outputOffset, storage.size());
-      expectSpillStreamKey(keyLayout, *stream, storage.keyDataAt(outputOffset));
+      expectSpillStreamKey(keyLayout, *stream, recordAt(storage, outputOffset));
       if (layout) {
         RowVectorPtr output;
         std::array<char*, 1> restoredPayloads{stream->payload()};
@@ -980,9 +1111,9 @@ class RadixSortSpillSectionsTest : public testing::Test {
       const std::shared_ptr<const PayloadRowLayout>& payloadLayout,
       char* payload) {
     auto keyLayout = RadixSortKeyLayout::fromKind(kind);
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
-    storage.append(
+    RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
+    appendPhysicalKey(
+        storage,
         std::string(
             keyLayout.isVariable() ? keyLayout.inlineCapacity() : 8, 'a'),
         payload);
@@ -990,7 +1121,7 @@ class RadixSortSpillSectionsTest : public testing::Test {
     auto stream = makeRadixSortSpillMergeStream(
         RadixSortSpillRun{{spill.file}}, spill.meta, pool_.get(), false);
     ASSERT_TRUE(stream->hasData());
-    expectSpillStreamKey(keyLayout, *stream, storage.keyDataAt(0));
+    expectSpillStreamKey(keyLayout, *stream, recordAt(storage, 0));
     EXPECT_EQ(
         std::memcmp(stream->payload(), payload, payloadLayout->rowWidth()), 0);
     EXPECT_FALSE(stream->tryAdvance());
@@ -1006,14 +1137,14 @@ class RadixSortSpillSectionsTest : public testing::Test {
     std::vector<std::pair<uint8_t, int64_t>> expected;
     payloadValues.resize(streamKeys.size());
     for (size_t stream = 0; stream < streamKeys.size(); ++stream) {
-      auto storage =
-          std::make_unique<RadixSortRunStorage>(pool_.get(), layout, 2, 64);
+      auto storage = std::make_unique<RadixSortRunStorage>(pool_.get(), layout);
       for (size_t row = 0; row < streamKeys[stream].size(); ++row) {
         const auto key = streamKeys[stream][row];
         const auto payloadId =
             static_cast<int64_t>(stream * 1'000 + row * 10 + key);
         payloadValues[stream].push_back(std::make_unique<int64_t>(payloadId));
-        storage->append(
+        appendPhysicalKey(
+            *storage,
             fixed8Key(key),
             reinterpret_cast<char*>(payloadValues[stream].back().get()));
         expected.emplace_back(key, payloadId);
@@ -1021,10 +1152,9 @@ class RadixSortSpillSectionsTest : public testing::Test {
       runs.push_back(std::move(storage));
     }
     std::sort(expected.begin(), expected.end());
-    RadixSortRunStorage expectedStorage(
-        pool_.get(), layout, std::max<size_t>(expected.size(), 1), 64);
+    RadixSortRunStorage expectedStorage(pool_.get(), layout);
     for (const auto& [key, payloadId] : expected) {
-      expectedStorage.append(fixed8Key(key), nullptr);
+      appendPhysicalKey(expectedStorage, fixed8Key(key), nullptr);
     }
     std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
     for (const auto& run : runs) {
@@ -1042,9 +1172,8 @@ class RadixSortSpillSectionsTest : public testing::Test {
         [&](vector_size_t size) {
           for (vector_size_t row = 0; row < size; ++row) {
             EXPECT_EQ(
-                RadixSortKey(layout, keys[row])
-                    .compare(RadixSortKey(
-                        layout, expectedStorage.keyDataAt(outputOffset))),
+                comparePhysical(
+                    layout, keys[row], recordAt(expectedStorage, outputOffset)),
                 0)
                 << "row=" << outputOffset;
             EXPECT_EQ(
@@ -1062,11 +1191,12 @@ class RadixSortSpillSectionsTest : public testing::Test {
       RadixSortKeyLayoutKind kind,
       uint32_t rowCount) {
     auto keyLayout = RadixSortKeyLayout::fromKind(kind);
-    RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64);
+    RadixSortRunStorage storage(pool_.get(), keyLayout);
     const auto keySize =
         keyLayout.isVariable() ? keyLayout.inlineCapacity() : 8;
     for (uint32_t row = 0; row < rowCount; ++row) {
-      storage.append(std::string(keySize, static_cast<char>(row + 1)));
+      appendPhysicalKey(
+          storage, std::string(keySize, static_cast<char>(row + 1)));
     }
     return spillSingleRun(storage, nullptr);
   }
@@ -1086,16 +1216,13 @@ class RadixSortSpillSectionsTest : public testing::Test {
         pool_.get(),
         RadixSortKeyLayout::fromKind(
             RadixSortKeyLayoutKind::kKeyWithPayloadVariable32),
-        4,
-        64,
-        payloadLayout,
-        4,
-        2 << 20);
+        payloadLayout);
     PayloadRowBatch rows;
     PayloadRowWriter payloadWriter;
     payloadWriter.append(*payload, storage, rows);
     for (vector_size_t row = 0; row < payload->size(); ++row) {
-      storage.append("key_" + std::to_string(row), rows.rowAt(row));
+      appendPhysicalKey(
+          storage, "key_" + std::to_string(row), rows.rows()->as<char*>()[row]);
     }
     return spillSingleRun(storage, payloadLayout.get());
   }
@@ -1122,14 +1249,15 @@ class RadixSortSpillSectionsTest : public testing::Test {
       payload = makeRows({"payload"}, {makeVector<int64_t>(BIGINT(), values)});
       payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
     }
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 8, 1 << 20, payloadLayout, 8, 1024);
+    RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
     if (payloadLayout) {
       PayloadRowWriter{}.append(*payload, storage, payloadBatch);
     }
     for (size_t row = 0; row < keys.size(); ++row) {
-      storage.append(
-          keys[row], payloadLayout ? payloadBatch.rowAt(row) : nullptr);
+      appendPhysicalKey(
+          storage,
+          keys[row],
+          payloadLayout ? payloadBatch.rows()->as<char*>()[row] : nullptr);
     }
     return {spillSingleRun(storage, payloadLayout.get()), payloadLayout};
   }
@@ -1210,8 +1338,7 @@ TEST_F(
     const auto keyLayout = RadixSortKeyLayout::fromKind(kind);
     std::shared_ptr<const PayloadRowLayout> layout =
         keyLayout.hasPayload() ? payloadLayout : nullptr;
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 4, 1024, layout, 4, 1024);
+    RadixSortRunStorage storage(pool_.get(), keyLayout, layout);
     PayloadRowBatch payloadRows;
     if (layout) {
       PayloadRowWriter{}.append(*payload, storage, payloadRows);
@@ -1222,14 +1349,17 @@ TEST_F(
           : keyLayout.inlineCapacity();
       std::string key(keySize, static_cast<char>('a' + row));
       key.back() = static_cast<char>('x' + row);
-      storage.append(key, layout ? payloadRows.rowAt(row) : nullptr);
+      appendPhysicalKey(
+          storage,
+          key,
+          layout ? payloadRows.rows()->as<char*>()[row] : nullptr);
     }
 
     const auto meta =
         RadixSortSpillSectionMeta::create(keyLayout, layout.get());
     const auto batchSize = RadixSortSpillSections::sizeForSerializeRows(
         meta,
-        storage.keyDataAt(0),
+        recordAt(storage, 0),
         storage.size(),
         std::numeric_limits<uint64_t>::max());
     ASSERT_EQ(batchSize.rowCount, storage.size());
@@ -1246,7 +1376,7 @@ TEST_F(
     auto* payloadHeapCursor = payloadHeap;
     RadixSortSpillSections::copyRowsToSections(
         meta,
-        storage.keyDataAt(0),
+        recordAt(storage, 0),
         storage.size(),
         batchSize.keyHeapBytes,
         batchSize.payloadHeapBytes,
@@ -1259,24 +1389,23 @@ TEST_F(
     EXPECT_EQ(guarded.back(), kSentinel);
     const char* expectedKeyHeap = keyHeap;
     for (vector_size_t row = 0; row < storage.size(); ++row) {
-      const auto* source = storage.keyDataAt(row);
+      const auto* source = recordAt(storage, row);
       const auto* wire =
           keyRecords + static_cast<uint64_t>(row) * meta.wireKeyRecordSize;
       EXPECT_EQ(std::memcmp(wire, source, meta.wireKeyRecordSize), 0)
           << "row=" << row;
       if (keyLayout.isVariable()) {
-        const auto sourceKey = RadixSortKey(keyLayout, source);
+        const auto sourceHeap = heapKey(keyLayout, source);
         EXPECT_EQ(
-            std::string_view(expectedKeyHeap, sourceKey.heapSize()),
-            sourceKey.heapKey());
-        expectedKeyHeap += sourceKey.heapSize();
+            std::string_view(expectedKeyHeap, sourceHeap.size()), sourceHeap);
+        expectedKeyHeap += sourceHeap.size();
       }
       if (layout) {
         EXPECT_EQ(
             std::memcmp(
                 payloadFixed +
                     static_cast<uint64_t>(row) * meta.payloadFixedSize,
-                RadixSortKey(keyLayout, source).payload(),
+                payloadAt(keyLayout, source),
                 meta.payloadFixedSize),
             0);
       }
@@ -1307,8 +1436,7 @@ TEST_F(
     SCOPED_TRACE(static_cast<uint8_t>(kind));
     const auto keyLayout = RadixSortKeyLayout::fromKind(kind);
     const auto layout = keyLayout.hasPayload() ? payloadLayout : nullptr;
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 1, 1024, layout, 1, 1024);
+    RadixSortRunStorage storage(pool_.get(), keyLayout, layout);
     PayloadRowBatch payloadBatch;
     if (layout) {
       PayloadRowWriter{}.append(*payload, storage, payloadBatch);
@@ -1317,10 +1445,12 @@ TEST_F(
     const auto keySize = keyLayout.isVariable()
         ? keyLayout.inlineCapacity() + 32
         : keyLayout.inlineCapacity();
-    storage.append(
-        std::string(keySize, 'k'), layout ? payloadBatch.rowAt(0) : nullptr);
+    appendPhysicalKey(
+        storage,
+        std::string(keySize, 'k'),
+        layout ? payloadBatch.rows()->as<char*>()[0] : nullptr);
 
-    auto* const runtimeKey = storage.keyDataAt(0);
+    auto* const runtimeKey = mutableRecordAt(storage, 0);
     const auto meta =
         RadixSortSpillSectionMeta::create(keyLayout, layout.get());
     ASSERT_LT(meta.wireKeyRecordSize, meta.runtimeKeyRecordSize);
@@ -1447,11 +1577,11 @@ TEST_F(
 TEST_F(RadixSortSpillSectionsTest, batchSizeFixedKeyOnlyUsesFixedWidth) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed16);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 8, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   for (uint32_t row = 0; row < 5; ++row) {
     std::array<char, sizeof(uint64_t)> key{};
     key.back() = static_cast<char>(row + 1);
-    storage.append(std::string(key.data(), key.size()));
+    appendPhysicalKey(storage, std::string(key.data(), key.size()));
   }
 
   const auto meta = RadixSortSpillSectionMeta::create(keyLayout, nullptr);
@@ -1459,7 +1589,7 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeFixedKeyOnlyUsesFixedWidth) {
   auto expectSize =
       [&](uint64_t maxRowCount, uint64_t maxBytes, uint64_t expectedRows) {
         const auto batchSize = RadixSortSpillSections::sizeForSerializeRows(
-            meta, storage.keyDataAt(0), maxRowCount, maxBytes);
+            meta, recordAt(storage, 0), maxRowCount, maxBytes);
         EXPECT_EQ(batchSize.rowCount, expectedRows);
         EXPECT_EQ(batchSize.keyHeapBytes, 0);
         EXPECT_EQ(batchSize.payloadHeapBytes, 0);
@@ -1485,16 +1615,17 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeFixedPayloadUsesFixedWidth) {
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 8, 64, payloadLayout, 8, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < payload->size(); ++row) {
     std::array<char, sizeof(uint64_t)> key{};
     key.back() = static_cast<char>(row + 1);
-    storage.append(
-        std::string(key.data(), key.size()), payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage,
+        std::string(key.data(), key.size()),
+        payloadBatch.rows()->as<char*>()[row]);
   }
 
   const auto meta =
@@ -1502,7 +1633,7 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeFixedPayloadUsesFixedWidth) {
   const auto fixedRowBytes = meta.fixedWireBytesPerRow();
   auto expectSize = [&](uint64_t maxBytes, uint64_t expectedRows) {
     const auto batchSize = RadixSortSpillSections::sizeForSerializeRows(
-        meta, storage.keyDataAt(0), storage.size(), maxBytes);
+        meta, recordAt(storage, 0), storage.size(), maxBytes);
     EXPECT_EQ(batchSize.rowCount, expectedRows);
     EXPECT_EQ(batchSize.keyHeapBytes, 0);
     EXPECT_EQ(batchSize.payloadHeapBytes, 0);
@@ -1521,13 +1652,13 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeFixedPayloadUsesFixedWidth) {
 
 TEST_F(RadixSortSpillSectionsTest, batchSizeVariableKeyStopsAtByteBoundary) {
   auto keyLayout = RadixSortKeyLayout::select(std::nullopt, false, 7);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 8, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   const std::vector<std::string> keys{
       std::string("prefix_") + std::string(13, 'a'),
       std::string("prefix_") + std::string(18, 'b'),
       std::string("prefix_") + std::string(23, 'c')};
   for (const auto& key : keys) {
-    storage.append(key);
+    appendPhysicalKey(storage, key);
   }
 
   const auto meta = RadixSortSpillSectionMeta::create(keyLayout, nullptr);
@@ -1537,11 +1668,11 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeVariableKeyStopsAtByteBoundary) {
   }
   auto expectSize = [&](uint64_t maxBytes, uint64_t expectedRows) {
     const auto batchSize = RadixSortSpillSections::sizeForSerializeRows(
-        meta, storage.keyDataAt(0), storage.size(), maxBytes);
+        meta, recordAt(storage, 0), storage.size(), maxBytes);
     EXPECT_EQ(batchSize.rowCount, expectedRows);
     uint64_t expectedKeyHeapBytes = 0;
     for (uint64_t row = 0; row < expectedRows; ++row) {
-      expectedKeyHeapBytes += keyHeapBytesForRow(meta, storage.keyDataAt(row));
+      expectedKeyHeapBytes += keyHeapBytesForRow(meta, recordAt(storage, row));
     }
     const auto expectedTotalBytes =
         expectedRows * meta.fixedWireBytesPerRow() + expectedKeyHeapBytes;
@@ -1552,11 +1683,11 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeVariableKeyStopsAtByteBoundary) {
   };
 
   EXPECT_EQ(
-      keyHeapBytesForRow(meta, storage.keyDataAt(0)), perRowKeyHeapBytes[0]);
+      keyHeapBytesForRow(meta, recordAt(storage, 0)), perRowKeyHeapBytes[0]);
   EXPECT_EQ(
-      keyHeapBytesForRow(meta, storage.keyDataAt(1)), perRowKeyHeapBytes[1]);
+      keyHeapBytesForRow(meta, recordAt(storage, 1)), perRowKeyHeapBytes[1]);
   EXPECT_EQ(
-      keyHeapBytesForRow(meta, storage.keyDataAt(2)), perRowKeyHeapBytes[2]);
+      keyHeapBytesForRow(meta, recordAt(storage, 2)), perRowKeyHeapBytes[2]);
   const auto firstRowBytes = totalSizeForRow(meta, perRowKeyHeapBytes[0]);
   const auto secondRowBytes = totalSizeForRow(meta, perRowKeyHeapBytes[1]);
   const auto thirdRowBytes = totalSizeForRow(meta, perRowKeyHeapBytes[2]);
@@ -1575,17 +1706,17 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeVariablePayloadWithNoHeapBytes) {
   ASSERT_TRUE(payloadLayout->hasVariableFields());
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 8, 64, payloadLayout, 8, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < payload->size(); ++row) {
     std::array<char, sizeof(uint64_t)> key{};
     key.back() = static_cast<char>(row + 1);
-    storage.append(
-        std::string(key.data(), key.size()), payloadBatch.rowAt(row));
-    ASSERT_EQ(payloadBatch.heapSizeAt(row), 0);
+    appendPhysicalKey(
+        storage,
+        std::string(key.data(), key.size()),
+        payloadBatch.rows()->as<char*>()[row]);
   }
 
   const auto meta =
@@ -1593,7 +1724,7 @@ TEST_F(RadixSortSpillSectionsTest, batchSizeVariablePayloadWithNoHeapBytes) {
   const auto fixedRowBytes = meta.fixedWireBytesPerRow();
   const auto batchSize = RadixSortSpillSections::sizeForSerializeRows(
       meta,
-      storage.keyDataAt(0),
+      recordAt(storage, 0),
       storage.size(),
       fixedRowBytes * storage.size());
   EXPECT_EQ(batchSize.rowCount, storage.size());
@@ -1616,23 +1747,23 @@ TEST_F(
       makeRows({"payload_string"}, {makeStringVector({values[0], values[1]})});
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::select(std::nullopt, true, 3);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 8, 64, payloadLayout, 8, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < keys.size(); ++row) {
-    storage.append(keys[row], payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, keys[row], payloadBatch.rows()->as<char*>()[row]);
   }
 
   const auto meta =
       RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   const std::array expected{
-      batchSizeForSingleRow(meta, storage.keyDataAt(0)),
-      batchSizeForSingleRow(meta, storage.keyDataAt(1))};
+      batchSizeForSingleRow(meta, recordAt(storage, 0)),
+      batchSizeForSingleRow(meta, recordAt(storage, 1))};
   auto expectSize = [&](uint64_t maxBytes, uint64_t expectedRows) {
     const auto batchSize = RadixSortSpillSections::sizeForSerializeRows(
-        meta, storage.keyDataAt(0), storage.size(), maxBytes);
+        meta, recordAt(storage, 0), storage.size(), maxBytes);
     EXPECT_EQ(batchSize.rowCount, expectedRows);
     uint64_t expectedKeyHeapBytes = 0;
     uint64_t expectedPayloadHeapTotal = 0;
@@ -1650,9 +1781,9 @@ TEST_F(
   };
 
   EXPECT_EQ(
-      expected[0].keyHeapBytes, keyHeapBytesForRow(meta, storage.keyDataAt(0)));
+      expected[0].keyHeapBytes, keyHeapBytesForRow(meta, recordAt(storage, 0)));
   EXPECT_EQ(
-      expected[1].keyHeapBytes, keyHeapBytesForRow(meta, storage.keyDataAt(1)));
+      expected[1].keyHeapBytes, keyHeapBytesForRow(meta, recordAt(storage, 1)));
   const auto firstRowBytes =
       expected[0].totalBytes(meta.fixedWireBytesPerRow());
   const auto secondRowBytes =
@@ -1704,14 +1835,17 @@ TEST_F(
 TEST_F(RadixSortSpillSectionsTest, fixedKeyOnlyRowsHaveNoHeaderOrPointers) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed16);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64);
-  storage.append(std::string_view("\x01\x02\x03\x04\x05\x06\x07\x08", 8));
-  storage.append(std::string_view("\x10\x20\x30\x40\x50\x60\x70\x80", 8));
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
+  appendPhysicalKey(
+      storage, std::string_view("\x01\x02\x03\x04\x05\x06\x07\x08", 8));
+  appendPhysicalKey(
+      storage, std::string_view("\x10\x20\x30\x40\x50\x60\x70\x80", 8));
 
   auto spill = spillSingleRun(storage, nullptr);
   const auto expectedBodySize = storage.size() * keyLayout.width();
-  ASSERT_EQ(spill.file.size, kBlockHeaderSize + expectedBodySize);
-  EXPECT_EQ(spill.file.rowCount, storage.size());
+  ASSERT_EQ(
+      std::filesystem::file_size(spill.file.path),
+      kBlockHeaderSize + expectedBodySize);
 
   const auto block = readUncompressedBlock(spill.file);
   const auto& header = block.header;
@@ -1729,12 +1863,12 @@ TEST_F(RadixSortSpillSectionsTest, fixedKeyOnlyRowsHaveNoHeaderOrPointers) {
           header.payloadHeapBytes);
   ASSERT_EQ(block.body.size(), expectedBodySize);
   EXPECT_EQ(
-      std::memcmp(block.body.data(), storage.keyDataAt(0), keyLayout.width()),
+      std::memcmp(block.body.data(), recordAt(storage, 0), keyLayout.width()),
       0);
   EXPECT_EQ(
       std::memcmp(
           block.body.data() + keyLayout.width(),
-          storage.keyDataAt(1),
+          recordAt(storage, 1),
           keyLayout.width()),
       0);
 
@@ -1746,13 +1880,13 @@ TEST_F(RadixSortSpillSectionsTest, fixedKeyOnlyRowsHaveNoHeaderOrPointers) {
       view->keyRecordsBegin + storage.size() * spill.meta.wireKeyRecordSize);
   EXPECT_EQ(view->payloadFixedBegin, view->keyHeapBegin);
   EXPECT_EQ(
-      RadixSortKey(keyLayout, view->keyRecordsBegin)
-          .compare(RadixSortKey(keyLayout, storage.keyDataAt(0))),
+      comparePhysical(keyLayout, view->keyRecordsBegin, recordAt(storage, 0)),
       0);
   EXPECT_EQ(
-      RadixSortKey(
-          keyLayout, view->keyRecordsBegin + spill.meta.wireKeyRecordSize)
-          .compare(RadixSortKey(keyLayout, storage.keyDataAt(1))),
+      comparePhysical(
+          keyLayout,
+          view->keyRecordsBegin + spill.meta.wireKeyRecordSize,
+          recordAt(storage, 1)),
       0);
   EXPECT_FALSE(reader.nextBatch().has_value());
 }
@@ -1765,16 +1899,16 @@ TEST_F(RadixSortSpillSectionsTest, fixedPayloadRoundTrip) {
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, arena, payloadBatch);
-  arena.append(
+  appendPhysicalKey(
+      arena,
       std::string_view("\x10\x00\x00\x00\x00\x00\x00\x01", 8),
-      payloadBatch.rowAt(0));
+      payloadBatch.rows()->as<char*>()[0]);
 
-  const auto* key = arena.keyDataAt(0);
+  const auto* key = recordAt(arena, 0);
   auto meta = RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   const auto serializedSize = batchSizeForSingleRow(meta, key);
   EXPECT_EQ(serializedSize.keyHeapBytes, 0);
@@ -1791,7 +1925,9 @@ TEST_F(RadixSortSpillSectionsTest, fixedPayloadRoundTrip) {
   expectDiskKeyRecord(meta, keyRecords, key);
   EXPECT_EQ(
       std::memcmp(
-          payloadFixed, payloadBatch.rowAt(0), payloadLayout->rowWidth()),
+          payloadFixed,
+          payloadBatch.rows()->as<char*>()[0],
+          payloadLayout->rowWidth()),
       0);
   EXPECT_EQ(payloadHeap, block.data() + block.size());
 
@@ -1817,11 +1953,11 @@ TEST_F(
     RadixSortSpillSectionsTest,
     variableKeyOnlyUsesExistingSizeWithoutHeader) {
   auto keyLayout = RadixSortKeyLayout::select(std::nullopt, false, 7);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   const std::string key = std::string("prefix_") + std::string(64, 'k');
-  storage.append(key);
+  appendPhysicalKey(storage, key);
 
-  const auto* storedKey = storage.keyDataAt(0);
+  const auto* storedKey = recordAt(storage, 0);
   const auto meta = RadixSortSpillSectionMeta::create(keyLayout, nullptr);
   const auto size = batchSizeForSingleRow(meta, storedKey);
   EXPECT_EQ(size.keyHeapBytes, key.size() - keyLayout.heapKeyOffset());
@@ -1859,19 +1995,17 @@ TEST_F(RadixSortSpillSectionsTest, variableKeyAndPayloadRoundTrip) {
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+  RadixSortRunStorage arena(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, arena, payloadBatch);
-  arena.append(longKey, payloadBatch.rowAt(0));
+  appendPhysicalKey(arena, longKey, payloadBatch.rows()->as<char*>()[0]);
 
-  const auto* key = arena.keyDataAt(0);
+  const auto* key = recordAt(arena, 0);
   auto meta = RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   const auto serializedSize = batchSizeForSingleRow(meta, key);
   auto block = materializeSectionBlock(meta, key, 1);
   EXPECT_EQ(serializedSize.keyHeapBytes, longKey.size());
-  EXPECT_EQ(serializedSize.payloadHeapBytes, payloadBatch.heapSizeAt(0));
   EXPECT_EQ(
       serializedSize.totalBytes(meta.fixedWireBytesPerRow()),
       meta.wireKeyRecordSize + serializedSize.keyHeapBytes +
@@ -1890,7 +2024,11 @@ TEST_F(RadixSortSpillSectionsTest, variableKeyAndPayloadRoundTrip) {
       std::string_view(longKey));
 
   EXPECT_EQ(
-      std::memcmp(fixed, payloadBatch.rowAt(0), payloadLayout->nullBytes()), 0);
+      std::memcmp(
+          fixed,
+          payloadBatch.rows()->as<char*>()[0],
+          payloadLayout->nullBytes()),
+      0);
   const auto stringValue =
       loadUnaligned<StringView>(fixed + payloadLayout->columns()[0].offset);
   ASSERT_FALSE(stringValue.isInline());
@@ -1906,13 +2044,14 @@ TEST_F(RadixSortSpillSectionsTest, variableKeyAndPayloadRoundTrip) {
   EXPECT_EQ(
       nestedValue.size,
       loadUnaligned<PayloadVarlenRef>(
-          payloadBatch.rowAt(0) + payloadLayout->columns()[1].offset)
+          payloadBatch.rows()->as<char*>()[0] +
+          payloadLayout->columns()[1].offset)
           .size);
   EXPECT_EQ(nestedValue.data, nullptr);
 
   EXPECT_EQ(
       std::memcmp(
-          payloadHeap, payloadBatch.heapAt(0), payloadBatch.heapSizeAt(0)),
+          payloadHeap, payloadBatch.heapAt(0), serializedSize.payloadHeapBytes),
       0);
 
   char* payloadHeapCursor = payloadHeap;
@@ -1940,7 +2079,8 @@ TEST_F(RadixSortSpillSectionsTest, variableKeyAndPayloadRoundTrip) {
   EXPECT_EQ(
       restoredNested.size,
       loadUnaligned<PayloadVarlenRef>(
-          payloadBatch.rowAt(0) + payloadLayout->columns()[1].offset)
+          payloadBatch.rows()->as<char*>()[0] +
+          payloadLayout->columns()[1].offset)
           .size);
 
   std::array<char*, 1> rows{fixed};
@@ -1968,13 +2108,13 @@ TEST_F(RadixSortSpillSectionsTest, writerUsesBatchSectionBlockLayout) {
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < keys.size(); ++row) {
-    storage.append(keys[row], payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, keys[row], payloadBatch.rows()->as<char*>()[row]);
   }
 
   auto spill = spillSingleRun(storage, payloadLayout.get());
@@ -1988,8 +2128,8 @@ TEST_F(RadixSortSpillSectionsTest, writerUsesBatchSectionBlockLayout) {
   uint64_t payloadHeapBytes = 0;
   for (vector_size_t row = 0; row < keys.size(); ++row) {
     keyHeapBytes +=
-        batchSizeForSingleRow(meta, storage.keyDataAt(row)).keyHeapBytes;
-    payloadHeapBytes += payloadBatch.heapSizeAt(row);
+        batchSizeForSingleRow(meta, recordAt(storage, row)).keyHeapBytes;
+    payloadHeapBytes += payloadHeapBytesForRow(meta, recordAt(storage, row));
   }
   const auto expectedBodySize =
       keyRecordBytes + keyHeapBytes + payloadFixedBytes + payloadHeapBytes;
@@ -2021,18 +2161,19 @@ TEST_F(RadixSortSpillSectionsTest, writerUsesBatchSectionBlockLayout) {
     expectDiskKeyRecord(
         meta,
         keyRecords + static_cast<uint64_t>(row) * meta.wireKeyRecordSize,
-        storage.keyDataAt(row));
+        recordAt(storage, row));
 
-    const auto keyView = RadixSortKey(keyLayout, storage.keyDataAt(row));
-    EXPECT_EQ(
-        std::string_view(keyHeapCursor, keyView.heapSize()), keyView.heapKey());
-    keyHeapCursor += keyView.heapSize();
+    const auto keyView = heapKey(keyLayout, recordAt(storage, row));
+    EXPECT_EQ(std::string_view(keyHeapCursor, keyView.size()), keyView);
+    keyHeapCursor += keyView.size();
 
     const auto* fixedRow =
         payloadFixed + static_cast<uint64_t>(row) * meta.payloadFixedSize;
     EXPECT_EQ(
         std::memcmp(
-            fixedRow, payloadBatch.rowAt(row), payloadLayout->nullBytes()),
+            fixedRow,
+            payloadBatch.rows()->as<char*>()[row],
+            payloadLayout->nullBytes()),
         0);
     const auto value = loadUnaligned<StringView>(
         fixedRow + payloadLayout->columns()[0].offset);
@@ -2050,9 +2191,9 @@ TEST_F(RadixSortSpillSectionsTest, writerUsesBatchSectionBlockLayout) {
         std::memcmp(
             payloadHeapCursor,
             payloadBatch.heapAt(row),
-            payloadBatch.heapSizeAt(row)),
+            payloadHeapBytesForRow(meta, recordAt(storage, row))),
         0);
-    payloadHeapCursor += payloadBatch.heapSizeAt(row);
+    payloadHeapCursor += payloadHeapBytesForRow(meta, recordAt(storage, row));
   }
   EXPECT_EQ(keyHeapCursor, keyHeap + keyHeapBytes);
   EXPECT_EQ(payloadHeapCursor, payloadHeap + payloadHeapBytes);
@@ -2061,12 +2202,13 @@ TEST_F(RadixSortSpillSectionsTest, writerUsesBatchSectionBlockLayout) {
 TEST_F(RadixSortSpillSectionsTest, writerDoesNotFlushAtStorageBlockBoundary) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  constexpr uint32_t kRowsPerBlock = RadixSortRunStorage::kTestingRowsPerBlock;
-  RadixSortRunStorage storage(pool_.get(), keyLayout, kRowsPerBlock, 64);
-  for (uint32_t row = 0; row <= kRowsPerBlock; ++row) {
-    storage.append(fixed8Key(static_cast<uint8_t>(row + 1)));
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
+  const auto rowsPerBlock = storage.keysPerBlock();
+  for (uint32_t row = 0; row <= rowsPerBlock; ++row) {
+    appendPhysicalKey(storage, fixed8Key(static_cast<uint8_t>(row + 1)));
   }
-  ASSERT_EQ(storage.keyBlocks().size(), 2);
+  ASSERT_EQ(storage.keyRangeAt(0, storage.size()).count, rowsPerBlock);
+  ASSERT_EQ(storage.keyRangeAt(rowsPerBlock, storage.size()).count, 1);
 
   auto spill = spillSingleRun(
       storage,
@@ -2102,29 +2244,13 @@ TEST_F(
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   const auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-  RadixSortRunStorage storage(
-      pool_.get(),
-      keyLayout,
-      /*keysPerBlock=*/2,
-      /*preferredHeapGroupBytes=*/64,
-      payloadLayout,
-      /*payloadRowsPerBlock=*/3,
-      /*preferredPayloadHeapGroupBytes=*/64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < keys.size(); ++row) {
-    storage.append(keys[row], payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, keys[row], payloadBatch.rows()->as<char*>()[row]);
   }
-
-  ASSERT_EQ(storage.keyBlocks().size(), 3);
-  ASSERT_EQ(storage.keyBlocks()[0].count, 2);
-  ASSERT_EQ(storage.keyBlocks()[1].count, 2);
-  ASSERT_EQ(storage.keyBlocks()[2].count, 1);
-  ASSERT_GT(storage.keyHeapGroups().size(), 1);
-  ASSERT_EQ(storage.payloadFixedBlocks().size(), 2);
-  ASSERT_EQ(storage.payloadFixedBlocks()[0].count, 3);
-  ASSERT_EQ(storage.payloadFixedBlocks()[1].count, 2);
-  ASSERT_GT(storage.payloadHeapGroups().size(), 1);
 
   auto spill = spillSingleRun(storage, payloadLayout.get());
   const auto blocks = readUncompressedBlocks(spill.file);
@@ -2157,7 +2283,7 @@ TEST_F(
     SCOPED_TRACE(row);
     const auto* const wireKey =
         keyRecords + static_cast<uint64_t>(row) * meta.wireKeyRecordSize;
-    expectDiskKeyRecord(meta, wireKey, storage.keyDataAt(row));
+    expectDiskKeyRecord(meta, wireKey, recordAt(storage, row));
     const auto keyHeapBytes = keys[row].size() - keyLayout.heapKeyOffset();
     EXPECT_EQ(
         std::string_view(keyHeapCursor, keyHeapBytes),
@@ -2233,9 +2359,9 @@ TEST_F(
 TEST_F(RadixSortSpillSectionsTest, writerIgnoresSmallWriteBufferSize) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 1024, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   for (uint8_t row = 1; row <= 5; ++row) {
-    storage.append(fixed8Key(row));
+    appendPhysicalKey(storage, fixed8Key(row));
   }
 
   auto spill = spillSingleRun(
@@ -2254,9 +2380,9 @@ TEST_F(RadixSortSpillSectionsTest, writerRollsOverOneRowPastExactBodyCapacity) {
   const auto bodyCapacity = kFixedWriteBufferSize - kBlockHeaderSize;
   ASSERT_EQ(bodyCapacity % keyLayout.width(), 0);
   const auto rowsAtCapacity = bodyCapacity / keyLayout.width();
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4'096, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   for (uint64_t row = 0; row < rowsAtCapacity; ++row) {
-    storage.append(fixed8Key(static_cast<uint8_t>(row)));
+    appendPhysicalKey(storage, fixed8Key(static_cast<uint8_t>(row)));
   }
 
   auto exact = spillSingleRun(storage, nullptr);
@@ -2265,7 +2391,7 @@ TEST_F(RadixSortSpillSectionsTest, writerRollsOverOneRowPastExactBodyCapacity) {
   EXPECT_EQ(exactBlocks[0].header.rowCount, rowsAtCapacity);
   EXPECT_EQ(exactBlocks[0].header.uncompressedSize, bodyCapacity);
 
-  storage.append(fixed8Key(0));
+  appendPhysicalKey(storage, fixed8Key(0));
   auto overflow = spillSingleRun(storage, nullptr);
   const auto overflowBlocks = readUncompressedBlocks(overflow.file);
   ASSERT_EQ(overflowBlocks.size(), 2);
@@ -2297,9 +2423,9 @@ TEST_F(
       keyForSerializedBytes(kSmallRowBytes, 'b'),
       keyForSerializedBytes(largeRowBytes, 'c'),
       keyForSerializedBytes(kSmallRowBytes, 'd')};
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 2 << 20);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   for (const auto& key : keys) {
-    storage.append(key);
+    appendPhysicalKey(storage, key);
   }
 
   auto spill = spillSingleRun(storage, nullptr);
@@ -2317,7 +2443,7 @@ TEST_F(
       RadixSortSpillRun{{spill.file}}, spill.meta, pool_.get(), false);
   for (vector_size_t row = 0; row < storage.size(); ++row) {
     ASSERT_TRUE(stream->hasData());
-    expectSpillStreamKey(keyLayout, *stream, storage.keyDataAt(row));
+    expectSpillStreamKey(keyLayout, *stream, recordAt(storage, row));
     if (!stream->tryAdvance()) {
       stream->advanceAfterFlush();
     }
@@ -2347,13 +2473,13 @@ TEST_F(
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < keys.size(); ++row) {
-    storage.append(keys[row], payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, keys[row], payloadBatch.rows()->as<char*>()[row]);
   }
 
   auto spill = spillSingleRun(storage, payloadLayout.get());
@@ -2382,7 +2508,7 @@ TEST_F(
     const auto* const key =
         keyRecords + static_cast<uint64_t>(row) * meta.wireKeyRecordSize;
 
-    const auto size = batchSizeForSingleRow(meta, storage.keyDataAt(row));
+    const auto size = batchSizeForSingleRow(meta, recordAt(storage, row));
     EXPECT_EQ(
         std::string(key, keyLayout.heapKeyOffset()) +
             std::string(keyHeapCursor, size.keyHeapBytes),
@@ -2437,16 +2563,16 @@ TEST_F(
 
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
-  storage.append(
+  appendPhysicalKey(
+      storage,
       std::string_view("\x10\x00\x00\x00\x00\x00\x00\x01", 8),
-      payloadBatch.rowAt(0));
+      payloadBatch.rows()->as<char*>()[0]);
 
-  const auto* key = storage.keyDataAt(0);
+  const auto* key = recordAt(storage, 0);
   const auto meta =
       RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   const auto size = batchSizeForSingleRow(meta, key);
@@ -2455,7 +2581,7 @@ TEST_F(
 
   auto* keyRecord = block.data();
   auto* keyHeap = keyRecord + meta.wireKeyRecordSize;
-  const auto* sourceFixed = payloadBatch.rowAt(0);
+  const auto* sourceFixed = payloadBatch.rows()->as<char*>()[0];
   auto* diskFixed = keyHeap;
   auto* diskHeap = diskFixed + meta.payloadFixedSize;
   expectDiskKeyRecord(meta, keyRecord, key);
@@ -2533,18 +2659,18 @@ TEST_F(
 TEST_F(RadixSortSpillSectionsTest, variableKeyHeapOffsetRoundTrip) {
   auto keyLayout = RadixSortKeyLayout::select(std::nullopt, true, 5);
   auto payloadLayout = PayloadRowLayout::create(ROW({"payload"}, {BIGINT()}));
-  RadixSortRunStorage arena(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage arena(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   auto payload = makeRows({"payload"}, {makeVector<int64_t>(BIGINT(), {7})});
   payloadWriter.append(*payload, arena, payloadBatch);
 
   const std::string key = std::string("abcde") + std::string(48, 'x');
-  arena.append(key, payloadBatch.rowAt(0));
-  const auto* storedKey = arena.keyDataAt(0);
-  ASSERT_NE(arena.keyAt(0).heapKeyData(), nullptr);
-  EXPECT_EQ(arena.keyAt(0).heapSize(), key.size() - keyLayout.heapKeyOffset());
+  appendPhysicalKey(arena, key, payloadBatch.rows()->as<char*>()[0]);
+  const auto* storedKey = recordAt(arena, 0);
+  const auto physical = heapKey(keyLayout, storedKey);
+  ASSERT_NE(physical.data(), nullptr);
+  EXPECT_EQ(physical.size(), key.size() - keyLayout.heapKeyOffset());
 
   auto meta = RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   const auto serializedSize = batchSizeForSingleRow(meta, storedKey);
@@ -2568,7 +2694,10 @@ TEST_F(RadixSortSpillSectionsTest, variableKeyHeapOffsetRoundTrip) {
       std::string_view(diskKeyHeap, key.size() - keyLayout.heapKeyOffset()),
       std::string_view(key).substr(keyLayout.heapKeyOffset()));
   EXPECT_EQ(
-      std::memcmp(payloadFixed, payloadBatch.rowAt(0), meta.payloadFixedSize),
+      std::memcmp(
+          payloadFixed,
+          payloadBatch.rows()->as<char*>()[0],
+          meta.payloadFixedSize),
       0);
 
   char* payloadHeapCursor = payloadHeap;
@@ -2600,8 +2729,7 @@ TEST_F(
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
@@ -2614,8 +2742,8 @@ TEST_F(
 
   std::array<char, 1> pointerPoison{};
   auto* const poisonData = pointerPoison.data();
-  auto* const row0 = payloadBatch.rowAt(0);
-  auto* const row1 = payloadBatch.rowAt(1);
+  auto* const row0 = payloadBatch.rows()->as<char*>()[0];
+  auto* const row1 = payloadBatch.rows()->as<char*>()[1];
   storeUnaligned<const char*>(
       row0 + stringColumn.offset + sizeof(uint64_t), poisonData);
   storeUnaligned<PayloadVarlenRef>(
@@ -2633,14 +2761,14 @@ TEST_F(
       poisonData);
 
   for (vector_size_t row = 0; row < payload->size(); ++row) {
-    ASSERT_EQ(payloadBatch.heapSizeAt(row), 0);
-    storage.append(fixed8Key(row + 1), payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, fixed8Key(row + 1), payloadBatch.rows()->as<char*>()[row]);
   }
 
   const auto meta =
       RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   auto block =
-      materializeSectionBlock(meta, storage.keyDataAt(0), storage.size());
+      materializeSectionBlock(meta, recordAt(storage, 0), storage.size());
   auto* keyRecords = block.data();
   auto* payloadFixed = keyRecords + storage.size() * meta.wireKeyRecordSize;
   auto* payloadHeap = payloadFixed + storage.size() * meta.payloadFixedSize;
@@ -2648,7 +2776,7 @@ TEST_F(
 
   uint64_t nullVariableSlots = 0;
   for (vector_size_t row = 0; row < storage.size(); ++row) {
-    const auto* const sourceFixed = payloadBatch.rowAt(row);
+    const auto* const sourceFixed = payloadBatch.rows()->as<char*>()[row];
     const auto* const serializedFixed =
         payloadFixed + static_cast<uint64_t>(row) * meta.payloadFixedSize;
     for (const auto& op : meta.payloadVariableOps) {
@@ -2708,12 +2836,10 @@ TEST_F(
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   const auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
-  ASSERT_EQ(payloadBatch.heapSizeAt(0), 0);
-  storage.append(fixed8Key(1), payloadBatch.rowAt(0));
+  appendPhysicalKey(storage, fixed8Key(1), payloadBatch.rows()->as<char*>()[0]);
 
   const auto readPayloadFixedOffset = [&](const SpilledRun& spill) {
     const auto header =
@@ -2772,14 +2898,13 @@ TEST_F(
       makeRows({"payload_string"}, {makeStringVector({payloadText})});
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::select(std::nullopt, true, 3);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
-  storage.append(key, payloadBatch.rowAt(0));
+  appendPhysicalKey(storage, key, payloadBatch.rows()->as<char*>()[0]);
 
-  const auto* storedKey = storage.keyDataAt(0);
+  const auto* storedKey = recordAt(storage, 0);
   const auto meta =
       RadixSortSpillSectionMeta::create(keyLayout, payloadLayout.get());
   const auto size = batchSizeForSingleRow(meta, storedKey);
@@ -2827,11 +2952,10 @@ TEST_F(RadixSortSpillSectionsTest, readerRejectsTrailingPayloadHeapByte) {
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   const auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
-  storage.append(fixed8Key(1), payloadBatch.rowAt(0));
+  appendPhysicalKey(storage, fixed8Key(1), payloadBatch.rows()->as<char*>()[0]);
 
   auto spill = spillSingleRun(storage, payloadLayout.get());
   auto header =
@@ -2841,8 +2965,8 @@ TEST_F(RadixSortSpillSectionsTest, readerRejectsTrailingPayloadHeapByte) {
   ++header.storedSize;
   ++header.payloadHeapBytes;
   overwriteSpillValue(spill.file.path, 0, header);
-  ++spill.file.size;
-  std::filesystem::resize_file(spill.file.path, spill.file.size);
+  std::filesystem::resize_file(
+      spill.file.path, std::filesystem::file_size(spill.file.path) + 1);
 
   RadixSortSpillReader reader(spill.file, spill.meta, pool_.get(), false);
   BOLT_ASSERT_THROW(
@@ -2993,9 +3117,8 @@ TEST_F(RadixSortSpillSectionsTest, encodedBlockWriterPreservesHeaderAndStats) {
 
     auto files = writer.finish();
     ASSERT_EQ(files.size(), 1);
-    EXPECT_EQ(files[0].rowCount, kRows);
     EXPECT_EQ(files[0].compressionKind, compression);
-    EXPECT_EQ(files[0].size, writtenBytes);
+    EXPECT_EQ(std::filesystem::file_size(files[0].path), writtenBytes);
     EXPECT_TRUE(std::filesystem::exists(files[0].path));
 
     const auto finalStats = stats.copy();
@@ -3101,9 +3224,9 @@ TEST_F(
 
   {
     auto keyLayout = RadixSortKeyLayout::select(std::nullopt, false, 7);
-    RadixSortRunStorage storage(pool_.get(), keyLayout, 1, 64);
-    storage.append(std::string(keyLayout.heapKeyOffset() + 1, 'k'));
-    auto* key = storage.keyDataAt(0);
+    RadixSortRunStorage storage(pool_.get(), keyLayout);
+    appendPhysicalKey(storage, std::string(keyLayout.heapKeyOffset() + 1, 'k'));
+    auto* key = mutableRecordAt(storage, 0);
     storeUnaligned<uint64_t>(key + *keyLayout.sizeOffset(), 6);
 
     RadixSortSpillWriter writer(
@@ -3151,12 +3274,9 @@ TEST_F(RadixSortSpillSectionsTest, encodedBlockWriterTracksRolledFileRows) {
   auto files = writer.finish();
 
   ASSERT_EQ(files.size(), 2);
-  EXPECT_EQ(files[0].id, 0);
-  EXPECT_EQ(files[1].id, 1);
-  EXPECT_EQ(files[0].rowCount, 8);
-  EXPECT_EQ(files[1].rowCount, 7);
-  EXPECT_EQ(files[0].size, firstBytes + secondBytes);
-  EXPECT_EQ(files[1].size, thirdBytes);
+  EXPECT_EQ(
+      std::filesystem::file_size(files[0].path), firstBytes + secondBytes);
+  EXPECT_EQ(std::filesystem::file_size(files[1].path), thirdBytes);
   EXPECT_EQ(limitBytes, firstBytes + secondBytes + thirdBytes);
   for (const auto& file : files) {
     EXPECT_TRUE(std::filesystem::exists(file.path));
@@ -3179,8 +3299,9 @@ TEST_F(RadixSortSpillSectionsTest, encodedBlockWriterTracksRolledFileRows) {
 TEST_F(RadixSortSpillSectionsTest, writerReturnedFilesOutliveWriter) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64);
-  storage.append(std::string_view("\x00\x00\x00\x00\x00\x00\x00\x01", 8));
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
+  appendPhysicalKey(
+      storage, std::string_view("\x00\x00\x00\x00\x00\x00\x00\x01", 8));
 
   {
     auto directory = exec::test::TempDirectoryPath::create();
@@ -3213,8 +3334,7 @@ TEST_F(RadixSortSpillSectionsTest, writerRollsFilesAtConfiguredMaxSize) {
 
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   std::vector<BufferPtr> payloadBuffers;
   payloadBuffers.reserve(kRows);
   for (vector_size_t row = 0; row < kRows; ++row) {
@@ -3230,7 +3350,8 @@ TEST_F(RadixSortSpillSectionsTest, writerRollsFilesAtConfiguredMaxSize) {
 
     std::array<char, sizeof(uint64_t)> key{};
     key.back() = static_cast<char>(row + 1);
-    storage.append(
+    appendPhysicalKey(
+        storage,
         std::string(key.data(), key.size()),
         payloadBuffers.back()->asMutable<char>());
   }
@@ -3238,7 +3359,7 @@ TEST_F(RadixSortSpillSectionsTest, writerRollsFilesAtConfiguredMaxSize) {
   auto files = spillRunFiles(storage, payloadLayout.get(), kMaxFileSize);
   ASSERT_GT(files.size(), 1);
   for (size_t i = 0; i + 1 < files.size(); ++i) {
-    EXPECT_GT(files[i].size, kMaxFileSize);
+    EXPECT_GT(std::filesystem::file_size(files[i].path), kMaxFileSize);
   }
   verifySpillFilesRoundTrip(files, storage, *payloadLayout);
 }
@@ -3277,12 +3398,13 @@ TEST_F(
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   const auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
-  storage.append(
-      std::string(keyLayout.inlineCapacity() + 1, 'k'), payloadBatch.rowAt(0));
+  appendPhysicalKey(
+      storage,
+      std::string(keyLayout.inlineCapacity() + 1, 'k'),
+      payloadBatch.rows()->as<char*>()[0]);
 
   for (const auto sectionOffset :
        {offsetof(TestRadixSortSpillBlockHeader, keyHeapBytes),
@@ -3348,14 +3470,14 @@ TEST_F(
   auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   PayloadRowBatch payloadBatch;
   PayloadRowWriter payloadWriter;
   payloadWriter.append(*payload, storage, payloadBatch);
-  storage.append(
+  appendPhysicalKey(
+      storage,
       std::string_view("\x10\x00\x00\x00\x00\x00\x00\x01", 8),
-      payloadBatch.rowAt(0));
+      payloadBatch.rows()->as<char*>()[0]);
 
   struct Mutation {
     const char* name;
@@ -3392,15 +3514,15 @@ TEST_F(
     rejectsCompressedSizeAboveCodecBoundBeforeAllocation) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64);
-  storage.append(std::string(8, 'k'));
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
+  appendPhysicalKey(storage, std::string(8, 'k'));
   auto spill = spillSingleRun(storage, nullptr, common::CompressionKind_ZSTD);
   const auto uncompressedSize = readSpillValue<int32_t>(spill.file.path, 0);
   const auto invalidStoredSize =
       static_cast<int32_t>(ZSTD_compressBound(uncompressedSize) + 1);
   overwriteSpillValue(spill.file.path, sizeof(int32_t), invalidStoredSize);
-  spill.file.size = kBlockHeaderSize + invalidStoredSize;
-  std::filesystem::resize_file(spill.file.path, spill.file.size);
+  std::filesystem::resize_file(
+      spill.file.path, kBlockHeaderSize + invalidStoredSize);
 
   RadixSortSpillReader reader(spill.file, spill.meta, pool_.get(), false);
   const auto allocations = pool_->stats().numAllocs;
@@ -3455,22 +3577,89 @@ TEST_F(RadixSortSpillSectionsTest, rejectsTruncatedHeaderAndBody) {
     auto spill = writeInlineKeySpill(RadixSortKeyLayoutKind::kKeyOnlyFixed8, 1);
     std::filesystem::resize_file(spill.file.path, kBlockHeaderSize - 1);
     RadixSortSpillReader reader(spill.file, spill.meta, pool_.get(), false);
+    const auto allocations = pool_->stats().numAllocs;
     EXPECT_THROW(reader.nextBatch(), BoltException);
+    EXPECT_EQ(pool_->stats().numAllocs, allocations);
   }
   {
     auto spill = writeInlineKeySpill(RadixSortKeyLayoutKind::kKeyOnlyFixed8, 1);
-    std::filesystem::resize_file(spill.file.path, spill.file.size - 1);
+    std::filesystem::resize_file(
+        spill.file.path, std::filesystem::file_size(spill.file.path) - 1);
     RadixSortSpillReader reader(spill.file, spill.meta, pool_.get(), false);
+    const auto allocations = pool_->stats().numAllocs;
     EXPECT_THROW(reader.nextBatch(), BoltException);
+    EXPECT_EQ(pool_->stats().numAllocs, allocations);
+  }
+}
+
+TEST_F(
+    RadixSortSpillSectionsTest,
+    rejectsConsistentOversizedHeaderBeforeAllocation) {
+  for (const auto compression : kSupportedSpillCompressionKinds) {
+    SCOPED_TRACE(static_cast<int>(compression));
+    auto spill = writeInlineKeySpill(RadixSortKeyLayoutKind::kKeyOnlyFixed8, 1);
+    constexpr int32_t kBodyBytes = 64 << 20;
+    const TestRadixSortSpillBlockHeader header{
+        kBodyBytes,
+        kBodyBytes,
+        kBodyBytes / 8,
+        kCurrentRadixSortSpillFormat,
+        kBodyBytes,
+        0,
+        0,
+        0};
+    overwriteSpillValue(spill.file.path, 0, header);
+    spill.file.compressionKind = compression;
+    RadixSortSpillReader reader(spill.file, spill.meta, pool_.get(), false);
+    const auto allocations = pool_->stats().numAllocs;
+    BOLT_ASSERT_THROW(reader.nextBatch(), "Radix sort spill body is truncated");
+    EXPECT_EQ(pool_->stats().numAllocs, allocations);
+  }
+}
+
+TEST_F(
+    RadixSortSpillSectionsTest,
+    remainingFileBytesTracksConsumptionAndPrefetch) {
+  const std::string data(1031, 'x');
+  for (const auto prefetch : {false, true}) {
+    SCOPED_TRACE(prefetch);
+    std::unique_ptr<ReadFile> file;
+    if (prefetch) {
+      file = std::make_unique<PrefetchReadFile>(data);
+    } else {
+      file = std::make_unique<InMemoryReadFile>(data);
+    }
+    std::vector<BufferPtr> buffers;
+    for (int i = 0; i < (prefetch ? 2 : 1); ++i) {
+      buffers.push_back(AlignedBuffer::allocate<char>(64, pool_.get()));
+    }
+    SpillInputStream input(std::move(file), std::move(buffers), prefetch);
+    EXPECT_EQ(input.remainingFileBytes(), data.size());
+    size_t consumed = 0;
+    std::array<char, 173> bytes;
+    while (consumed < data.size()) {
+      const auto size = std::min(bytes.size(), data.size() - consumed);
+      input.readBytes(bytes.data(), size);
+      EXPECT_EQ(std::string_view(bytes.data(), size), std::string(size, 'x'));
+      consumed += size;
+      EXPECT_EQ(input.remainingFileBytes(), data.size() - consumed);
+    }
+    EXPECT_TRUE(input.atEnd());
+    if (!prefetch) {
+      input.reuse();
+      EXPECT_EQ(input.remainingFileBytes(), data.size());
+      input.readBytes(bytes.data(), bytes.size());
+      EXPECT_EQ(input.remainingFileBytes(), data.size() - bytes.size());
+    }
   }
 }
 
 TEST_F(RadixSortSpillSectionsTest, propagatesCorruptCompressedBody) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage storage(pool_.get(), keyLayout, 4, 64);
+  RadixSortRunStorage storage(pool_.get(), keyLayout);
   for (uint8_t value = 1; value <= 32; ++value) {
-    storage.append(fixed8Key(value));
+    appendPhysicalKey(storage, fixed8Key(value));
   }
   auto spill = spillSingleRun(storage, nullptr, common::CompressionKind_ZSTD);
   overwriteSpillBytes(
@@ -3511,11 +3700,11 @@ TEST_F(RadixSortSpillSectionsTest, rejectsCorruptSectionMetadata) {
     auto payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
     auto keyLayout = RadixSortKeyLayout::fromKind(
         RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 1024);
+    RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
     PayloadRowBatch payloadBatch;
     PayloadRowWriter{}.append(*payload, storage, payloadBatch);
-    storage.append(fixed8Key(1), payloadBatch.rowAt(0));
+    appendPhysicalKey(
+        storage, fixed8Key(1), payloadBatch.rows()->as<char*>()[0]);
     auto spill = spillSingleRun(storage, payloadLayout.get());
     const auto header =
         readSpillValue<TestRadixSortSpillBlockHeader>(spill.file.path, 0);
@@ -3544,8 +3733,8 @@ TEST_F(RadixSortSpillSectionsTest, rejectsCorruptSectionMetadata) {
   ++header.storedSize;
   ++header.keyHeapBytes;
   overwriteSpillValue(spill.file.path, 0, header);
-  ++spill.file.size;
-  std::filesystem::resize_file(spill.file.path, spill.file.size);
+  std::filesystem::resize_file(
+      spill.file.path, std::filesystem::file_size(spill.file.path) + 1);
   auto stream = makeRadixSortSpillMergeStream(
       RadixSortSpillRun{{spill.file}}, spill.meta, pool_.get(), false);
   ASSERT_TRUE(stream->hasData());
@@ -3605,8 +3794,7 @@ TEST_F(RadixSortSpillSectionsTest, oversizedRowGetsDedicatedBlock) {
       PayloadRowLayout::create(ROW({"payload_string"}, {VARCHAR()}));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 1024, 64, payloadLayout, 1024, 2 << 20);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   auto payload = makeRows(
       {"payload_string"},
       {makeStringVector(
@@ -3616,7 +3804,8 @@ TEST_F(RadixSortSpillSectionsTest, oversizedRowGetsDedicatedBlock) {
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < payload->size(); ++row) {
-    storage.append(fixed8Key(row + 1), payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, fixed8Key(row + 1), payloadBatch.rows()->as<char*>()[row]);
   }
 
   auto spill = spillSingleRun(
@@ -3677,27 +3866,6 @@ TEST_F(
         std::string(capacity - 2, 'b'),
         std::string(capacity - 1, 'c'),
         std::string(capacity + 32, 'd')};
-    auto logicalKeys = makeRows({"key"}, {makeStringVector(keyValues)});
-    std::unique_ptr<RadixSortKeyCodec> codec;
-    RadixSortKeyCodec::bind({VARCHAR()}, {flags}, codec);
-    EncodedKeyBatch encodedKeys;
-    codec->encode(*logicalKeys, pool_.get(), encodedKeys);
-    ASSERT_EQ(encodedKeys.format(), EncodedKeyFormat::kVariableBinary);
-    ASSERT_EQ(encodedKeys.size(), keyValues.size());
-    EXPECT_EQ(encodedKeys.variableKeyAt(0).size(), 1);
-    EXPECT_EQ(encodedKeys.variableKeyAt(1).size(), 2);
-    EXPECT_EQ(encodedKeys.variableKeyAt(2).size(), capacity - 1);
-    EXPECT_EQ(encodedKeys.variableKeyAt(3).size(), capacity);
-    EXPECT_EQ(encodedKeys.variableKeyAt(4).size(), capacity + 1);
-    EXPECT_GT(encodedKeys.variableKeyAt(5).size(), capacity + 1);
-
-    auto keyLayout = RadixSortKeyLayout::select(
-        codec->maximumEncodedSize(),
-        requestedLayout.hasPayload(),
-        codec->heapKeyOffsetForVariableLayout(capacity));
-    ASSERT_EQ(keyLayout.kind(), kind);
-    ASSERT_EQ(keyLayout.heapKeyOffset(), 0);
-
     const std::vector<std::optional<std::string>> payloadValues{
         std::nullopt,
         std::string{},
@@ -3705,31 +3873,47 @@ TEST_F(
         std::string(StringView::kInlineSize, 'v'),
         std::string(StringView::kInlineSize + 1, 'w'),
         std::string(StringView::kInlineSize + 32, 'x')};
+    auto logicalKeys = makeRows({"key"}, {makeStringVector(keyValues)});
     RowVectorPtr payload;
-    std::shared_ptr<const PayloadRowLayout> payloadLayout;
-    PayloadRowBatch payloadBatch;
-    std::vector<char*> payloadPointers;
-    if (keyLayout.hasPayload()) {
+    RowVectorPtr input = logicalKeys;
+    if (requestedLayout.hasPayload()) {
       payload = makeRows({"payload"}, {makeStringVector(payloadValues)});
-      payloadLayout = PayloadRowLayout::create(asRowType(payload->type()));
+      input = makeRows(
+          {"key", "payload"}, {logicalKeys->childAt(0), payload->childAt(0)});
     }
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 8, 1024, payloadLayout, 8, 1024);
-    if (payloadLayout) {
-      PayloadRowWriter{}.append(*payload, storage, payloadBatch);
-      payloadPointers.reserve(payloadBatch.size());
-      for (vector_size_t row = 0; row < payloadBatch.size(); ++row) {
-        payloadPointers.push_back(payloadBatch.rowAt(row));
+    auto run = RadixSortRun::create(
+        pool_.get(),
+        asRowType(input->type()),
+        ROW({"key"}, {VARCHAR()}),
+        {flags},
+        {0},
+        {});
+    run->append(*input);
+    const auto& keyLayout = run->keyLayout();
+    ASSERT_EQ(keyLayout.kind(), kind);
+    ASSERT_EQ(keyLayout.heapKeyOffset(), 0);
+    const auto& storage = *run->storage();
+    const auto& payloadLayout = run->payloadLayout();
+    std::vector<std::string> encodedKeys;
+    encodedKeys.reserve(keyValues.size());
+    for (const auto& value : keyValues) {
+      if (!value.has_value()) {
+        encodedKeys.emplace_back(1, 1);
+      } else {
+        encodedKeys.push_back(std::string(1, 2) + *value + std::string(1, 0));
       }
-      storage.appendBatch(encodedKeys, payloadPointers);
-    } else {
-      storage.appendBatch(encodedKeys);
     }
+    EXPECT_EQ(encodedKeys[0].size(), 1);
+    EXPECT_EQ(encodedKeys[1].size(), 2);
+    EXPECT_EQ(encodedKeys[2].size(), capacity - 1);
+    EXPECT_EQ(encodedKeys[3].size(), capacity);
+    EXPECT_EQ(encodedKeys[4].size(), capacity + 1);
+    EXPECT_GT(encodedKeys[5].size(), capacity + 1);
 
     uint64_t expectedKeyHeapBytes = 0;
     for (vector_size_t row = 0; row < encodedKeys.size(); ++row) {
       expectedKeyHeapBytes +=
-          encodedKeys.variableKeyAt(row).size() - keyLayout.heapKeyOffset();
+          encodedKeys[row].size() - keyLayout.heapKeyOffset();
     }
     uint64_t expectedPayloadHeapBytes = 0;
     if (payloadLayout) {
@@ -3764,7 +3948,7 @@ TEST_F(
       ASSERT_NE(variable, nullptr);
       EXPECT_EQ(
           variable->encodedSuffix().bytes,
-          encodedKeys.variableKeyAt(row).substr(keyLayout.heapKeyOffset()));
+          std::string_view(encodedKeys[row]).substr(keyLayout.heapKeyOffset()));
       if (payloadLayout) {
         RowVectorPtr output;
         std::array<char*, 1> rows{directStream->payload()};
@@ -3777,15 +3961,16 @@ TEST_F(
     }
     EXPECT_FALSE(directStream->hasData());
 
-    RadixSortRunStorage left(
-        pool_.get(), keyLayout, 8, 1024, payloadLayout, 8, 1024);
-    RadixSortRunStorage right(
-        pool_.get(), keyLayout, 8, 1024, payloadLayout, 8, 1024);
+    RadixSortRunStorage left(pool_.get(), keyLayout, payloadLayout);
+    RadixSortRunStorage right(pool_.get(), keyLayout, payloadLayout);
     for (vector_size_t row = 0; row < encodedKeys.size(); ++row) {
       auto& run = row % 2 == 0 ? left : right;
-      run.append(
-          encodedKeys.variableKeyAt(row),
-          payloadLayout ? payloadBatch.rowAt(row) : nullptr);
+      appendPhysicalKey(
+          run,
+          encodedKeys[row],
+          payloadLayout
+              ? payloadAt(storage.layout(), storage.keyRangeAt(row, 1).data)
+              : nullptr);
     }
     auto leftSpill = spillSingleRun(left, payloadLayout.get());
     auto rightSpill = spillSingleRun(right, payloadLayout.get());
@@ -3806,7 +3991,6 @@ TEST_F(
     std::vector<const char*> records(encodedKeys.size());
     std::vector<char*> payloadRows(encodedKeys.size());
     std::vector<EncodedKeyView> views(encodedKeys.size());
-    BufferPtr decodeScratch;
     vector_size_t outputOffset = 0;
     EXPECT_EQ(
         merger.collectRows(
@@ -3815,15 +3999,9 @@ TEST_F(
             keyLayout.hasPayload() ? payloadRows.data() : nullptr,
             views,
             [&](vector_size_t size) {
-              RowVectorPtr decoded;
-              codec->decode(
-                  std::span<const EncodedKeyView>(views.data(), size),
-                  {},
-                  {},
-                  pool_.get(),
-                  decodeScratch,
-                  decoded);
-              expectEquivalent(*logicalKeys, outputOffset, *decoded);
+              for (vector_size_t row = 0; row < size; ++row) {
+                EXPECT_EQ(views[row].bytes, encodedKeys[outputOffset + row]);
+              }
               if (payloadLayout) {
                 RowVectorPtr output;
                 PayloadRowReader::gather(
@@ -3847,8 +4025,7 @@ TEST_F(RadixSortSpillSectionsTest, readerReusesBuffersAcrossBlocks) {
   auto payloadLayout = PayloadRowLayout::create(ROW({"payload"}, {VARCHAR()}));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadFixed16);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 4, 64, payloadLayout, 4, 2 << 20);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   const std::vector<std::optional<std::string>> values{
       std::string(700 << 10, 'a'),
       std::string(400 << 10, 'b'),
@@ -3858,7 +4035,8 @@ TEST_F(RadixSortSpillSectionsTest, readerReusesBuffersAcrossBlocks) {
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < payload->size(); ++row) {
-    storage.append(fixed8Key(row + 1), payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, fixed8Key(row + 1), payloadBatch.rows()->as<char*>()[row]);
   }
   auto files = spillRunFiles(
       storage,
@@ -3924,12 +4102,12 @@ TEST_F(RadixSortSpillSectionsTest, readerCacheReusesAcrossFiles) {
   const auto runReader = [&](const std::string& value,
                              uint8_t key,
                              Buffer* expectedReusableBuffer = nullptr) {
-    RadixSortRunStorage storage(
-        pool_.get(), keyLayout, 1, 64, payloadLayout, 1, value.size());
+    RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
     auto payload = makeRows({"payload"}, {makeStringVector({value})});
     PayloadRowBatch payloadBatch;
     PayloadRowWriter{}.append(*payload, storage, payloadBatch);
-    storage.append(fixed8Key(key), payloadBatch.rowAt(0));
+    appendPhysicalKey(
+        storage, fixed8Key(key), payloadBatch.rows()->as<char*>()[0]);
     auto files = spillRunFiles(
         storage,
         payloadLayout.get(),
@@ -3980,8 +4158,7 @@ TEST_F(RadixSortSpillSectionsTest, writerWritesOnlyRequestedStorageSuffix) {
   auto payloadLayout = PayloadRowLayout::create(ROW({"payload"}, {VARCHAR()}));
   auto keyLayout = RadixSortKeyLayout::fromKind(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
-  RadixSortRunStorage storage(
-      pool_.get(), keyLayout, 2, 64, payloadLayout, 3, 1024);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
   auto payload = makeRows(
       {"payload"},
       {makeStringVector(
@@ -3993,9 +4170,10 @@ TEST_F(RadixSortSpillSectionsTest, writerWritesOnlyRequestedStorageSuffix) {
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
   for (uint8_t row = 0; row < 5; ++row) {
-    storage.append(
+    appendPhysicalKey(
+        storage,
         std::string(48 + row, static_cast<char>('k' + row)),
-        payloadBatch.rowAt(row));
+        payloadBatch.rows()->as<char*>()[row]);
   }
 
   auto directory = exec::test::TempDirectoryPath::create();
@@ -4008,7 +4186,7 @@ TEST_F(RadixSortSpillSectionsTest, writerWritesOnlyRequestedStorageSuffix) {
       &stats);
   auto files = writer.writeRun(storage, payloadLayout.get(), 1);
   ASSERT_EQ(files.size(), 1);
-  EXPECT_EQ(files.front().rowCount, 4);
+  EXPECT_EQ(rowsInUncompressedSpillFile(files.front()), 4);
 
   auto stream = makeRadixSortSpillMergeStream(
       RadixSortSpillRun{files},
@@ -4018,7 +4196,7 @@ TEST_F(RadixSortSpillSectionsTest, writerWritesOnlyRequestedStorageSuffix) {
   std::vector<std::string> restoredPayloads;
   for (vector_size_t row = 0; row < 4; ++row) {
     ASSERT_TRUE(stream->hasData());
-    expectSpillStreamKey(keyLayout, *stream, storage.keyDataAt(row + 1));
+    expectSpillStreamKey(keyLayout, *stream, recordAt(storage, row + 1));
     auto restored = readStringPayloads(*payloadLayout, {stream->payload()});
     ASSERT_EQ(restored.size(), 1);
     restoredPayloads.push_back(std::move(restored.front()));
@@ -4201,20 +4379,49 @@ TEST_F(RadixSortSpillSectionsTest, mergerRejectsInvalidMemoryOperations) {
             {},
             RadixSortSpillSectionMeta::create(layout, nullptr),
             pool_.get(),
-            false),
+            false,
+            []() noexcept {}),
         BoltException);
   }
   {
-    RadixSortRunStorage storage(pool_.get(), layout, 1, 64);
-    storage.append(fixed8Key(1));
+    auto merger = makeMergerWithoutMemory();
+    RadixSortRunStorage storage(pool_.get(), layout);
+    appendPhysicalKey(storage, fixed8Key(1));
+    auto files = spillRunFiles(storage, nullptr, 1 << 20);
+    const auto path = files.front().path;
+    bool released = false;
+    EXPECT_THROW(
+        merger->replaceMemory(
+            RadixSortSpillRun{std::move(files)},
+            RadixSortSpillSectionMeta::create(layout, nullptr),
+            pool_.get(),
+            false,
+            [&]() noexcept { released = true; }),
+        BoltException);
+    EXPECT_FALSE(released);
+    std::array<const char*, 1> keys{};
+    EXPECT_EQ(
+        merger->collectRows(
+            1,
+            keys.data(),
+            nullptr,
+            std::span<EncodedKeyView>{},
+            [](vector_size_t) {}),
+        1);
+    EXPECT_EQ(loadUnaligned<uint64_t>(keys[0]), uint64_t{1} << 56);
+    EXPECT_FALSE(std::filesystem::exists(path));
+  }
+  {
+    RadixSortRunStorage storage(pool_.get(), layout);
+    appendPhysicalKey(storage, fixed8Key(1));
     std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
     streams.push_back(std::make_unique<RadixSortMemoryRunMergeStream>(storage));
     RadixSortMerger merger(layout, std::move(streams), 0);
     EXPECT_THROW(merger.removeMemory(), BoltException);
   }
   {
-    RadixSortRunStorage storage(pool_.get(), layout, 1, 64);
-    storage.append(fixed8Key(1));
+    RadixSortRunStorage storage(pool_.get(), layout);
+    appendPhysicalKey(storage, fixed8Key(1));
     std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
     streams.push_back(std::make_unique<RadixSortMemoryRunMergeStream>(storage));
     RadixSortMerger merger(layout, std::move(streams), 0);
@@ -4223,7 +4430,8 @@ TEST_F(RadixSortSpillSectionsTest, mergerRejectsInvalidMemoryOperations) {
             {},
             RadixSortSpillSectionMeta::create(layout, nullptr),
             pool_.get(),
-            false),
+            false,
+            []() noexcept {}),
         BoltException);
   }
 }
@@ -4231,18 +4439,18 @@ TEST_F(RadixSortSpillSectionsTest, mergerRejectsInvalidMemoryOperations) {
 TEST_F(RadixSortSpillSectionsTest, mergerReplacesMemoryAndResetsSelection) {
   const auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage memoryStorage(pool_.get(), keyLayout, 1, 64);
+  RadixSortRunStorage memoryStorage(pool_.get(), keyLayout);
   for (const auto key : {uint64_t{2}, uint64_t{5}, uint64_t{8}}) {
-    memoryStorage.append(fixed8Key(key));
+    appendPhysicalKey(memoryStorage, fixed8Key(key));
   }
 
-  RadixSortRunStorage leftStorage(pool_.get(), keyLayout, 1, 64);
-  RadixSortRunStorage rightStorage(pool_.get(), keyLayout, 1, 64);
+  RadixSortRunStorage leftStorage(pool_.get(), keyLayout);
+  RadixSortRunStorage rightStorage(pool_.get(), keyLayout);
   for (const auto key : {uint64_t{1}, uint64_t{4}, uint64_t{7}}) {
-    leftStorage.append(fixed8Key(key));
+    appendPhysicalKey(leftStorage, fixed8Key(key));
   }
   for (const auto key : {uint64_t{3}, uint64_t{6}, uint64_t{9}}) {
-    rightStorage.append(fixed8Key(key));
+    appendPhysicalKey(rightStorage, fixed8Key(key));
   }
 
   std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
@@ -4281,9 +4489,9 @@ TEST_F(RadixSortSpillSectionsTest, mergerReplacesMemoryAndResetsSelection) {
   const auto leftPosition = leftPtr->position();
   const auto rightPosition = rightPtr->position();
 
-  RadixSortRunStorage suffixStorage(pool_.get(), keyLayout, 1, 64);
+  RadixSortRunStorage suffixStorage(pool_.get(), keyLayout);
   for (const auto key : {uint64_t{5}, uint64_t{8}}) {
-    suffixStorage.append(fixed8Key(key));
+    appendPhysicalKey(suffixStorage, fixed8Key(key));
   }
   auto suffixFiles = spillRunFiles(suffixStorage, nullptr, /*maxFileSize=*/1);
   ASSERT_EQ(suffixFiles.size(), 1);
@@ -4291,30 +4499,80 @@ TEST_F(RadixSortSpillSectionsTest, mergerReplacesMemoryAndResetsSelection) {
       RadixSortSpillRun{std::move(suffixFiles)},
       RadixSortSpillSectionMeta::create(keyLayout, nullptr),
       pool_.get(),
-      false);
+      false,
+      [&memoryStorage]() noexcept { memoryStorage.clear(); });
 
+  EXPECT_EQ(memoryStorage.allocatedBytes(), 0);
   EXPECT_FALSE(merger.memoryPosition());
-  EXPECT_EQ(merger.testingNumStreams(), 3);
   EXPECT_EQ(leftPtr->position(), leftPosition);
   EXPECT_EQ(rightPtr->position(), rightPosition);
   EXPECT_EQ(collect(5), 5);
   EXPECT_EQ(outputRows, 9);
 }
 
+TEST_F(
+    RadixSortSpillSectionsTest,
+    failedMemoryReplacementClearsStreamsAndFiles) {
+  const auto layout =
+      RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
+  for (const auto corruptHeader : {false, true}) {
+    SCOPED_TRACE(corruptHeader);
+    RadixSortRunStorage storage(pool_.get(), layout);
+    appendPhysicalKey(storage, fixed8Key(1));
+    auto files = spillRunFiles(storage, nullptr, 1 << 20);
+    const auto path = files.front().path;
+    const auto replacementPath = corruptHeader ? path : path + ".missing";
+    if (corruptHeader) {
+      std::filesystem::resize_file(path, kBlockHeaderSize - 1);
+    } else {
+      files.front().path = replacementPath;
+    }
+    std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
+    streams.push_back(makeRadixSortMemoryRunMergeStream(storage));
+    RadixSortMerger merger(layout, std::move(streams), 0);
+    bool released = false;
+    EXPECT_THROW(
+        merger.replaceMemory(
+            RadixSortSpillRun{std::move(files)},
+            RadixSortSpillSectionMeta::create(layout, nullptr),
+            pool_.get(),
+            false,
+            [&]() noexcept {
+              storage.clear();
+              released = true;
+            }),
+        BoltException);
+    EXPECT_TRUE(released);
+    EXPECT_EQ(storage.allocatedBytes(), 0);
+    EXPECT_FALSE(merger.memoryPosition());
+    EXPECT_EQ(merger.getSpillReadTime(), 0);
+    EXPECT_FALSE(std::filesystem::exists(replacementPath));
+    std::array<const char*, 1> keys{};
+    EXPECT_THROW(
+        merger.collectRows(
+            1,
+            keys.data(),
+            nullptr,
+            std::span<EncodedKeyView>{},
+            [](vector_size_t) {}),
+        BoltException);
+  }
+}
+
 TEST_F(RadixSortSpillSectionsTest, mergerRemovesExhaustedMemoryStream) {
   const auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage leftStorage(pool_.get(), keyLayout, 1, 64);
-  RadixSortRunStorage rightStorage(pool_.get(), keyLayout, 1, 64);
-  RadixSortRunStorage memoryStorage(pool_.get(), keyLayout, 1, 64);
+  RadixSortRunStorage leftStorage(pool_.get(), keyLayout);
+  RadixSortRunStorage rightStorage(pool_.get(), keyLayout);
+  RadixSortRunStorage memoryStorage(pool_.get(), keyLayout);
   for (const auto key : {uint8_t{3}, uint8_t{5}}) {
-    leftStorage.append(fixed8Key(key));
+    appendPhysicalKey(leftStorage, fixed8Key(key));
   }
   for (const auto key : {uint8_t{4}, uint8_t{6}}) {
-    rightStorage.append(fixed8Key(key));
+    appendPhysicalKey(rightStorage, fixed8Key(key));
   }
   for (const auto key : {uint8_t{1}, uint8_t{2}}) {
-    memoryStorage.append(fixed8Key(key));
+    appendPhysicalKey(memoryStorage, fixed8Key(key));
   }
   auto leftFiles = spillRunFiles(leftStorage, nullptr, 1 << 20);
   auto rightFiles = spillRunFiles(rightStorage, nullptr, 1 << 20);
@@ -4358,7 +4616,6 @@ TEST_F(RadixSortSpillSectionsTest, mergerRemovesExhaustedMemoryStream) {
 
   merger.removeMemory();
   EXPECT_FALSE(merger.memoryPosition());
-  EXPECT_EQ(merger.testingNumStreams(), 2);
   EXPECT_EQ(collect(4), 4);
   EXPECT_EQ(outputRows, 6);
 }
@@ -4532,9 +4789,9 @@ TEST_F(
 TEST_F(RadixSortSpillSectionsTest, mergerRejectsTooSmallSelectedViews) {
   const auto layout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyVariable32);
-  RadixSortRunStorage storage(pool_.get(), layout, 2, 64);
-  storage.append(std::string(32, 'a'));
-  storage.append(std::string(32, 'b'));
+  RadixSortRunStorage storage(pool_.get(), layout);
+  appendPhysicalKey(storage, std::string(32, 'a'));
+  appendPhysicalKey(storage, std::string(32, 'b'));
   std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
   streams.push_back(makeRadixSortMemoryRunMergeStream(storage));
   RadixSortMerger merger(layout, std::move(streams));
@@ -4556,8 +4813,8 @@ TEST_F(RadixSortSpillSectionsTest, mergerRejectsTooSmallSelectedViews) {
 TEST_F(RadixSortSpillSectionsTest, fixedMergerRejectsExternalSelectedViews) {
   const auto layout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
-  RadixSortRunStorage storage(pool_.get(), layout, 1, 64);
-  storage.append(fixed8Key(1));
+  RadixSortRunStorage storage(pool_.get(), layout);
+  appendPhysicalKey(storage, fixed8Key(1));
   std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
   streams.push_back(makeRadixSortMemoryRunMergeStream(storage));
   RadixSortMerger merger(layout, std::move(streams));
@@ -4620,25 +4877,29 @@ TEST_F(
         RadixSortKeyLayoutKind::kKeyWithPayloadVariable32}) {
     SCOPED_TRACE(static_cast<uint8_t>(kind));
     const auto layout = RadixSortKeyLayout::fromKind(kind);
-    RadixSortRunStorage left(pool_.get(), layout, 4, 1024);
-    RadixSortRunStorage right(pool_.get(), layout, 4, 1024);
+    RadixSortRunStorage left(pool_.get(), layout);
+    RadixSortRunStorage right(pool_.get(), layout);
     std::array<int64_t, 4> payloadValues{1, 2, 3, 4};
     const std::string prefix(layout.inlineCapacity() + 16, 'p');
     const std::array<std::string, 4> expected{
         prefix + "1", prefix + "2", prefix + "3", prefix + "4"};
-    left.append(
+    appendPhysicalKey(
+        left,
         expected[0],
         layout.hasPayload() ? reinterpret_cast<char*>(&payloadValues[0])
                             : nullptr);
-    left.append(
+    appendPhysicalKey(
+        left,
         expected[2],
         layout.hasPayload() ? reinterpret_cast<char*>(&payloadValues[2])
                             : nullptr);
-    right.append(
+    appendPhysicalKey(
+        right,
         expected[1],
         layout.hasPayload() ? reinterpret_cast<char*>(&payloadValues[1])
                             : nullptr);
-    right.append(
+    appendPhysicalKey(
+        right,
         expected[3],
         layout.hasPayload() ? reinterpret_cast<char*>(&payloadValues[3])
                             : nullptr);
@@ -4688,10 +4949,10 @@ TEST_F(
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyVariable32);
   const auto runCase =
       [&](std::string leftKey, std::string rightKey, bool expectRightSuffix) {
-        RadixSortRunStorage left(pool_.get(), layout, 1, 1024);
-        RadixSortRunStorage right(pool_.get(), layout, 1, 1024);
-        left.append(leftKey);
-        right.append(rightKey);
+        RadixSortRunStorage left(pool_.get(), layout);
+        RadixSortRunStorage right(pool_.get(), layout);
+        appendPhysicalKey(left, leftKey);
+        appendPhysicalKey(right, rightKey);
 
         std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
         auto leftStream =
@@ -4729,8 +4990,8 @@ TEST_F(
     variableMergerRequiresVariableStreamDynamicType) {
   const auto layout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyVariable32);
-  RadixSortRunStorage storage(pool_.get(), layout, 4, 1024);
-  storage.append(std::string(32, 'a'));
+  RadixSortRunStorage storage(pool_.get(), layout);
+  appendPhysicalKey(storage, std::string(32, 'a'));
 
   {
     std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
@@ -4768,7 +5029,7 @@ TEST_F(
       auto header = readSpillValue<TestRadixSortSpillBlockHeader>(spillPath, 0);
       ASSERT_GT(header.keyHeapBytes, 1);
       auto bytes = readSpillBytes(spillPath);
-      ASSERT_EQ(bytes.size(), fixture.spill.file.size);
+      ASSERT_EQ(bytes.size(), std::filesystem::file_size(spillPath));
       const auto keyHeapEnd =
           kBlockHeaderSize + header.keyRecordBytes + header.keyHeapBytes;
       ASSERT_LE(keyHeapEnd, bytes.size());
@@ -4777,16 +5038,14 @@ TEST_F(
         --header.uncompressedSize;
         --header.storedSize;
         --header.keyHeapBytes;
-        --fixture.spill.file.size;
       } else {
         bytes.insert(bytes.begin() + keyHeapEnd, 'x');
         ++header.uncompressedSize;
         ++header.storedSize;
         ++header.keyHeapBytes;
-        ++fixture.spill.file.size;
       }
       std::memcpy(bytes.data(), &header, sizeof(header));
-      std::filesystem::resize_file(spillPath, fixture.spill.file.size);
+      std::filesystem::resize_file(spillPath, bytes.size());
       overwriteSpillBytes(spillPath, 0, bytes);
 
       {
@@ -4839,6 +5098,112 @@ TEST_F(
       EXPECT_FALSE(std::filesystem::exists(spillPath));
     }
   }
+}
+
+TEST_F(
+    RadixSortSpillSectionsTest,
+    corruptedProductionEncodedKeysFailThroughSpillDecode) {
+  const auto flags = CompareFlags{
+      .nullsFirst = true,
+      .ascending = true,
+      .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue};
+  const auto expectRejected = [&](const RowVectorPtr& input,
+                                  std::vector<uint8_t> decodedColumns,
+                                  uint64_t corruptOffset,
+                                  char corruptValue,
+                                  std::string_view expectedMessage) {
+    std::vector<column_index_t> keyChannels(input->childrenSize());
+    std::iota(keyChannels.begin(), keyChannels.end(), 0);
+    std::vector<CompareFlags> keyFlags(input->childrenSize(), flags);
+    auto keyType = asRowType(input->type());
+    auto run = RadixSortRun::create(
+        pool_.get(), keyType, keyType, keyFlags, keyChannels, {});
+    run->append(*input);
+    ASSERT_TRUE(run->keyLayout().isVariable());
+    ASSERT_EQ(run->keyLayout().heapKeyOffset(), 0);
+
+    auto spill = spillSingleRun(*run->storage(), nullptr);
+    const auto header =
+        readSpillValue<TestRadixSortSpillBlockHeader>(spill.file.path, 0);
+    ASSERT_EQ(header.rowCount, 1);
+    ASSERT_LT(corruptOffset, header.keyHeapBytes);
+    overwriteSpillValue(
+        spill.file.path,
+        kBlockHeaderSize + header.keyRecordBytes + corruptOffset,
+        corruptValue);
+
+    auto stream = makeRadixSortSpillMergeStream(
+        RadixSortSpillRun{{spill.file}}, spill.meta, pool_.get(), false);
+    ASSERT_TRUE(stream->hasData());
+    auto* variable = dynamic_cast<RadixSortVariableMergeStream*>(stream.get());
+    ASSERT_NE(variable, nullptr);
+    const std::array<EncodedKeyView, 1> encoded{variable->encodedSuffix()};
+    std::unique_ptr<RadixSortKeyCodec> codec;
+    RadixSortKeyCodec::bind(keyType->children(), keyFlags, codec);
+    ASSERT_EQ(decodedColumns.size(), keyType->size());
+    ASSERT_EQ(run->keyMayHaveNulls().size(), keyType->size());
+    BufferPtr scratch;
+    RowVectorPtr decoded;
+    BOLT_ASSERT_THROW(
+        codec->decode(
+            encoded,
+            decodedColumns,
+            run->keyMayHaveNulls(),
+            pool_.get(),
+            scratch,
+            decoded),
+        expectedMessage);
+  };
+
+  const auto unknown =
+      BaseVector::createNullConstant(UNKNOWN(), 1, pool_.get());
+  const auto stringAndUnknown =
+      makeRows({"masked", "decoded"}, {makeStringVector({"x"}), unknown});
+  expectRejected(
+      stringAndUnknown,
+      {0, 1},
+      0,
+      static_cast<char>(3),
+      "Invalid radix sort key marker");
+  expectRejected(
+      stringAndUnknown, {0, 1}, 2, 'x', "Radix sort key input is truncated");
+  expectRejected(
+      stringAndUnknown,
+      {0, 1},
+      2,
+      static_cast<char>(1),
+      "Radix sort key input is truncated");
+
+  auto array = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      nullptr,
+      1,
+      makeBuffer<vector_size_t>({0}),
+      makeBuffer<vector_size_t>({1}),
+      makeVector<int32_t>(INTEGER(), {7}));
+  expectRejected(
+      makeRows({"masked", "decoded"}, {array, unknown}),
+      {0, 1},
+      6,
+      static_cast<char>(2),
+      "Radix sort key input is truncated");
+
+  auto map = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), BIGINT()),
+      nullptr,
+      1,
+      makeBuffer<vector_size_t>({0}),
+      makeBuffer<vector_size_t>({1}),
+      makeVector<int32_t>(INTEGER(), {7}),
+      makeVector<int64_t>(BIGINT(), {9}));
+  expectRejected(
+      makeRows({"map"}, {map}),
+      {1},
+      7,
+      static_cast<char>(0),
+      "Radix sort encoded map key and value counts differ");
 }
 
 TEST_F(
@@ -5095,7 +5460,7 @@ TEST_F(
   const auto rowCount = fixed8RowsPerBlock() + 17;
   auto files = spillLargeFixedKeyRunFiles(rowCount);
   ASSERT_GE(files.size(), 2);
-  const auto firstFileRows = files.front().rowCount;
+  const auto firstFileRows = rowsInUncompressedSpillFile(files.front());
   std::vector<std::string> paths;
   for (const auto& file : files) {
     paths.push_back(file.path);
@@ -5136,14 +5501,7 @@ TEST_F(
       RadixSortKeyLayoutKind::kKeyWithPayloadVariable32);
   const auto payloadType = ROW({"payload"}, {VARCHAR()});
   auto payloadLayout = PayloadRowLayout::create(payloadType);
-  RadixSortRunStorage storage(
-      pool_.get(),
-      keyLayout,
-      1'024,
-      kVariableBytesPerRow,
-      payloadLayout,
-      1'024,
-      kVariableBytesPerRow);
+  RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
 
   std::vector<std::string> keys;
   std::vector<std::optional<std::string>> payloadValues;
@@ -5163,7 +5521,8 @@ TEST_F(
   PayloadRowBatch payloadBatch;
   PayloadRowWriter{}.append(*payload, storage, payloadBatch);
   for (vector_size_t row = 0; row < kRows; ++row) {
-    storage.append(keys[row], payloadBatch.rowAt(row));
+    appendPhysicalKey(
+        storage, keys[row], payloadBatch.rows()->as<char*>()[row]);
   }
 
   auto files =
@@ -5197,7 +5556,7 @@ TEST_F(
   size_t nextFile = 0;
   for (vector_size_t row = 0; row < kRows; ++row) {
     ASSERT_TRUE(stream->hasData()) << "row=" << row;
-    expectSpillStreamKey(keyLayout, *stream, storage.keyDataAt(row));
+    expectSpillStreamKey(keyLayout, *stream, recordAt(storage, row));
     EXPECT_EQ(
         readStringPayloads(*payloadLayout, {stream->payload()}),
         std::vector<std::string>{*payloadValues[row]});
@@ -5245,14 +5604,7 @@ TEST_F(
     auto payloadLayout = PayloadRowLayout::create(payloadType);
     originalLayout = payloadLayout;
     constexpr uint64_t kPayloadBytesPerRow = 16 << 10;
-    RadixSortRunStorage storage(
-        pool_.get(),
-        keyLayout,
-        1'024,
-        64,
-        payloadLayout,
-        1'024,
-        kPayloadBytesPerRow);
+    RadixSortRunStorage storage(pool_.get(), keyLayout, payloadLayout);
     std::vector<std::optional<std::string>> values;
     values.reserve(kRows);
     for (vector_size_t row = 0; row < kRows; ++row) {
@@ -5264,7 +5616,8 @@ TEST_F(
     PayloadRowBatch payloadBatch;
     PayloadRowWriter{}.append(*payload, storage, payloadBatch);
     for (vector_size_t row = 0; row < kRows; ++row) {
-      storage.append(fixed8Key(row), payloadBatch.rowAt(row));
+      appendPhysicalKey(
+          storage, fixed8Key(row), payloadBatch.rows()->as<char*>()[row]);
     }
     auto files = spillRunFiles(
         storage, payloadLayout.get(), std::numeric_limits<uint64_t>::max());
@@ -5304,7 +5657,7 @@ TEST_F(
   std::vector<uint64_t> fileRowCounts;
   for (const auto& file : files) {
     paths.push_back(file.path);
-    fileRowCounts.push_back(file.rowCount);
+    fileRowCounts.push_back(rowsInUncompressedSpillFile(file));
   }
   RadixSortSpillReadBufferCache bufferCache;
   auto stream = makeRadixSortSpillMergeStream(
@@ -5341,11 +5694,11 @@ TEST_F(RadixSortSpillSectionsTest, concatFileMergeStreamsMergeByLogicalRun) {
   auto keyLayout =
       RadixSortKeyLayout::fromKind(RadixSortKeyLayoutKind::kKeyOnlyFixed8);
   const auto kRowsPerRun = fixed8RowsPerBlock() + 17;
-  RadixSortRunStorage oddStorage(pool_.get(), keyLayout, 1'024, 64);
-  RadixSortRunStorage evenStorage(pool_.get(), keyLayout, 1'024, 64);
+  RadixSortRunStorage oddStorage(pool_.get(), keyLayout);
+  RadixSortRunStorage evenStorage(pool_.get(), keyLayout);
   for (uint64_t row = 0; row < kRowsPerRun; ++row) {
-    oddStorage.append(orderedFixed8EncodedKey(2 * row + 1));
-    evenStorage.append(orderedFixed8EncodedKey(2 * row + 2));
+    appendPhysicalKey(oddStorage, orderedFixed8EncodedKey(2 * row + 1));
+    appendPhysicalKey(evenStorage, orderedFixed8EncodedKey(2 * row + 2));
   }
 
   auto oddFiles = spillRunFiles(oddStorage, nullptr, /*maxFileSize=*/1);
@@ -5360,9 +5713,9 @@ TEST_F(RadixSortSpillSectionsTest, concatFileMergeStreamsMergeByLogicalRun) {
   for (const auto& file : evenFiles) {
     filePaths.push_back(file.path);
   }
-  RadixSortRunStorage expectedStorage(pool_.get(), keyLayout, 1, 64);
+  RadixSortRunStorage expectedStorage(pool_.get(), keyLayout);
   for (uint64_t value = 1; value <= 2 * kRowsPerRun; ++value) {
-    expectedStorage.append(orderedFixed8EncodedKey(value));
+    appendPhysicalKey(expectedStorage, orderedFixed8EncodedKey(value));
   }
 
   std::vector<std::unique_ptr<RadixSortMergeStream>> streams;
@@ -5390,9 +5743,10 @@ TEST_F(RadixSortSpillSectionsTest, concatFileMergeStreamsMergeByLogicalRun) {
         [&](vector_size_t size) {
           for (vector_size_t row = 0; row < size; ++row) {
             EXPECT_EQ(
-                RadixSortKey(keyLayout, keys[row])
-                    .compare(RadixSortKey(
-                        keyLayout, expectedStorage.keyDataAt(outputOffset))),
+                comparePhysical(
+                    keyLayout,
+                    keys[row],
+                    recordAt(expectedStorage, outputOffset)),
                 0)
                 << "row=" << outputOffset;
             ++outputOffset;

--- a/bolt/exec/tests/utils/RadixSortComparatorOracle.cpp
+++ b/bolt/exec/tests/utils/RadixSortComparatorOracle.cpp
@@ -22,7 +22,6 @@
 #include <gtest/gtest.h>
 
 #include "bolt/common/base/Exceptions.h"
-#include "bolt/exec/radixsort/RadixSortKeyCodec.h"
 #include "bolt/vector/SimpleVector.h"
 
 namespace bytedance::bolt::exec::radixsort::test {
@@ -53,23 +52,6 @@ int32_t SortComparatorOracle::compareUnsignedBytes(
     return (result > 0) - (result < 0);
   }
   return (left.size() > right.size()) - (left.size() < right.size());
-}
-
-int32_t SortComparatorOracle::compareEncodedKeys(
-    const EncodedKeyBatch& keys,
-    vector_size_t left,
-    vector_size_t right) {
-  BOLT_CHECK_GE(left, 0);
-  BOLT_CHECK_GE(right, 0);
-  BOLT_CHECK_LT(left, keys.size());
-  BOLT_CHECK_LT(right, keys.size());
-  if (keys.format() == EncodedKeyFormat::kFixed64) {
-    const auto leftKey = keys.fixedKeyAt(left);
-    const auto rightKey = keys.fixedKeyAt(right);
-    return (leftKey > rightKey) - (leftKey < rightKey);
-  }
-  return compareUnsignedBytes(
-      keys.variableKeyAt(left), keys.variableKeyAt(right));
 }
 
 int32_t SortComparatorOracle::compare(

--- a/bolt/exec/tests/utils/RadixSortComparatorOracle.h
+++ b/bolt/exec/tests/utils/RadixSortComparatorOracle.h
@@ -23,11 +23,7 @@
 #include "bolt/vector/BaseVector.h"
 #include "bolt/vector/ComplexVector.h"
 
-namespace bytedance::bolt::exec::radixsort {
-
-class EncodedKeyBatch;
-
-namespace test {
+namespace bytedance::bolt::exec::radixsort::test {
 
 struct RowIdMatchOptions {
   int64_t idBase{0};
@@ -44,11 +40,6 @@ class SortComparatorOracle {
   static int32_t compareUnsignedBytes(
       std::string_view left,
       std::string_view right);
-
-  static int32_t compareEncodedKeys(
-      const EncodedKeyBatch& keys,
-      vector_size_t left,
-      vector_size_t right);
 
   static int32_t compare(
       const BaseVector& left,
@@ -77,5 +68,4 @@ class SortComparatorOracle {
       RowIdMatchOptions options = {});
 };
 
-} // namespace test
-} // namespace bytedance::bolt::exec::radixsort
+} // namespace bytedance::bolt::exec::radixsort::test


### PR DESCRIPTION

### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->
Issue Number: close #xxx

### Type of Change
<!-- Please check the one that applies to this PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Remove production APIs and storage tuning maintained only for tests and benchmarks, and migrate those callers to the real RadixSortRun production path. Consolidate scalar type dispatch into templated implementations while keeping dispatch outside row loops and preserving specialized encoders.

Simplify key, run storage, spill, and output surfaces; remove dead metrics, getters, convenience methods, and duplicate codec paths. Keep the independent SortComparatorOracle for correctness validation. Harden spill truncation and memory-replacement lifecycle handling discovered during the review.
The standard suite below contains all seven suites, 107 cases, and three independent runs per case. The algorithm benchmark now measures production RadixSortRun append/finalize behavior, so its delta against the previous sorter-only table is not a same-harness performance comparison.

Validation:
- Release radix suite: 313 tests passed; 5 existing tests disabled.
- Debug ASAN/UBSAN radix suite: 318 tests passed before the final inline-only code-generation annotation.
- Pre-commit format, secret, whitespace, license, and spell checks passed; standalone clang-tidy was interrupted at user request before commit.

# Standard benchmark comparison

Exactly 107 cases; current values are medians of three JSON runs.

## Summary

```
| suite | cases | median raw radix delta | median legacy-normalized delta | median speedup | aggregate speedup | |---|---:|---:|---:|---:|---:|
| buffer | 21 | +4.62% | -1.85% | 1.809x | 1.653x | 
| algorithm | 14 | +12.59% | +7.14% | 2.342x | 2.014x | 
| spill_none | 21 | +1.40% | +0.38% | 1.774x | 1.579x | 
| spill_lz4 | 21 | +0.31% | +0.92% | 1.820x | 1.688x | 
| spill_zstd | 21 | +0.57% | +0.14% | 1.980x | 1.697x | 
| buffer_large | 5 | -1.07% | -0.83% | 2.651x | 2.836x | 
| spill_large_none | 4 | +0.74% | +2.08% | 2.427x | 2.134x | 
| global | 107 | +1.25% | +0.38% | 1.896x | 1.885x |

```
## buffer

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_i64_narrow_256k | 43.651 | 20.074 | 2.175x | +4.41% | +0.33% | 
| duplicate_i64_narrow_256k | 20.083 | 12.109 | 1.659x | +8.05% | -3.95% | 
| low_cardinality_i64_256k | 9.478 | 8.681 | 1.092x | +10.28% | +29.24% | 
| null_heavy_i64_128k | 15.143 | 8.369 | 1.809x | +1.25% | -7.58% | 
| eight_key_i64_128k | 28.415 | 21.457 | 1.324x | +4.33% | +1.00% | 
| inline_varchar_128k | 26.665 | 20.192 | 1.321x | +0.49% | -7.62% | 
| long_varchar_64k | 41.941 | 19.857 | 2.112x | +0.01% | -1.50% | 
| varchar_common_prefix_128k | 97.221 | 60.138 | 1.617x | +1.81% | -3.45% | 
| nullable_fixed_payload_128k | 21.470 | 10.753 | 1.997x | +4.37% | -5.21% | 
| wide_fixed_payload_128k | 37.330 | 19.153 | 1.949x | +4.09% | -6.27% | 
| very_wide_fixed_payload_64k | 58.293 | 32.199 | 1.810x | +3.86% | -1.85% | 
| wide_string_payload_64k | 97.023 | 36.497 | 2.658x | +5.71% | -1.11% | 
| random_i64_narrow_1m | 219.847 | 85.822 | 2.562x | +4.89% | -5.03% | 
| low_cardinality_i64_1m | 51.157 | 37.695 | 1.357x | +9.19% | +7.96% | 
| eight_key_i64_1m | 374.291 | 249.122 | 1.502x | +7.57% | +0.62% | 
| sixteen_key_i64_1m | 511.697 | 376.279 | 1.360x | +9.64% | +0.36% | 
| wide_fixed_payload_1m | 525.422 | 218.114 | 2.409x | +5.14% | -2.79% | 
| very_wide_fixed_payload_1m | 1279.721 | 604.426 | 2.117x | +2.83% | -6.20% | 
| wide_string_payload_1m | 2224.978 | 757.664 | 2.937x | +6.62% | -9.44% | 
| low_card_i32_log_pattern_payload_1m | 4879.072 | 3237.784 | 1.507x | +4.62% | +0.66% | 
| low_card_i32_30_array15_5_payload_1m | 22215.459 | 13993.398 | 1.588x | +5.15% | +3.13% |
```

## algorithm

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_w1_10k | 0.797 | 0.591 | 1.348x | +33.99% | +29.34% | 
| random_w1_100k | 10.391 | 5.500 | 1.889x | +28.61% | +25.93% | 
| random_w1_1m | 135.982 | 53.841 | 2.526x | +12.54% | +8.45% | 
| random_w1_10m | 2195.385 | 765.823 | 2.867x | +34.34% | +26.33% | 
| low_cardinality_w1_1m | 44.965 | 18.061 | 2.490x | +119.50% | +118.35% | 
| random_w2_1m | 154.787 | 61.904 | 2.500x | +8.22% | +0.62% | 
| random_w4_1m | 163.756 | 83.602 | 1.959x | -13.63% | -15.82% | 
| random_w8_1m | 186.247 | 84.892 | 2.194x | -0.50% | -5.29% | 
| low_cardinality_w4_1m | 211.288 | 157.999 | 1.337x | +9.33% | +2.68% | 
| random_w2_10m | 2433.272 | 898.855 | 2.707x | +14.86% | +9.27% | 
| random_w4_10m | 2578.383 | 809.949 | 3.183x | -46.04% | -48.73% | 
| low_cardinality_w4_10m | 3350.210 | 2563.305 | 1.307x | +38.65% | +31.09% | 
| random_w8_10m | 2793.464 | 800.405 | 3.490x | +0.26% | -6.88% | 
| low_cardinality_w8_10m | 3590.458 | 2557.521 | 1.404x | +12.64% | +5.83% |
```

## spill_none

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_i64_256k_spill | 70.875 | 26.435 | 2.681x | +1.42% | +1.07% | 
| duplicate_i64_256k_spill | 49.005 | 17.208 | 2.848x | +1.40% | -0.69% | 
| null_heavy_i64_128k_spill | 27.702 | 11.405 | 2.429x | +0.24% | -0.65% | 
| eight_key_i64_128k_spill | 50.840 | 31.380 | 1.620x | +6.67% | +5.89% | 
| inline_varchar_128k_spill | 41.639 | 31.275 | 1.331x | -1.32% | -2.55% | 
| long_varchar_64k_spill | 62.312 | 29.166 | 2.136x | +4.99% | +4.18% | 
| varchar_common_prefix_128k_spill | 116.768 | 71.378 | 1.636x | +2.57% | -2.51% | 
| wide_fixed_payload_128k_spill | 40.947 | 16.935 | 2.418x | +1.07% | -1.28% | 
| very_wide_fixed_payload_64k_spill | 95.772 | 53.993 | 1.774x | +4.84% | +2.32% | 
| wide_string_payload_64k_spill | 66.084 | 33.099 | 1.997x | +0.66% | -2.02% | 
| random_i64_1m_spill | 322.593 | 106.264 | 3.036x | +1.30% | -0.71% | 
| eight_key_i64_1m_spill | 568.598 | 315.667 | 1.801x | +3.36% | +1.38% | 
| sixteen_key_i64_1m_spill | 780.970 | 479.886 | 1.627x | +3.83% | +3.99% | 
| wide_fixed_payload_1m_spill | 432.559 | 160.519 | 2.695x | +3.23% | +4.00% | 
| wide_string_payload_1m_spill | 1331.145 | 702.536 | 1.895x | +5.26% | +6.53% | 
| bucket_write_key_only_1m_spill | 358.033 | 260.767 | 1.373x | +0.60% | +0.43% | 
| bucket_write_fixed_payload_1m_spill | 2516.250 | 1606.629 | 1.566x | -1.21% | +0.38% | 
| bucket_write_key_string_fixed_payload_1m_spill | 2603.001 | 1704.651 | 1.527x | +1.17% | +0.82% | 
| bucket_write_string_payload_1m_spill | 2886.169 | 1959.593 | 1.473x | +1.91% | -1.33% | 
| bucket_write_complex_payload_1m_spill | 5363.655 | 3293.834 | 1.628x | -0.19% | -0.99% | 
| single_key_very_wide_mixed_payload_256k_spill | 2526.025 | 1953.741 | 1.293x | +0.32% | -2.46% |
```

## spill_lz4

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_i64_256k_spill | 81.549 | 28.091 | 2.903x | +0.69% | +1.31% | 
| duplicate_i64_256k_spill | 50.843 | 18.455 | 2.755x | +2.16% | +2.97% | 
| null_heavy_i64_128k_spill | 31.663 | 12.457 | 2.542x | +1.80% | +1.17% | 
| eight_key_i64_128k_spill | 73.798 | 42.090 | 1.753x | +2.54% | -0.04% | 
| inline_varchar_128k_spill | 44.634 | 32.132 | 1.389x | +0.53% | +2.30% | 
| long_varchar_64k_spill | 59.187 | 28.020 | 2.112x | -1.80% | -1.47% | 
| varchar_common_prefix_128k_spill | 118.287 | 69.875 | 1.693x | -0.99% | -1.01% | 
| wide_fixed_payload_128k_spill | 57.834 | 24.364 | 2.374x | +0.62% | +0.68% | 
| very_wide_fixed_payload_64k_spill | 136.226 | 71.866 | 1.896x | -0.45% | +0.92% | 
| wide_string_payload_64k_spill | 50.686 | 21.724 | 2.333x | -4.31% | -3.72% | 
| random_i64_1m_spill | 359.169 | 114.968 | 3.124x | -0.18% | +0.43% | 
| eight_key_i64_1m_spill | 728.779 | 410.008 | 1.777x | +2.88% | +3.36% | 
| sixteen_key_i64_1m_spill | 1061.575 | 645.081 | 1.646x | +3.34% | +2.88% | 
| wide_fixed_payload_1m_spill | 578.150 | 212.260 | 2.724x | +0.31% | -1.13% | 
| wide_string_payload_1m_spill | 1135.655 | 526.309 | 2.158x | +5.16% | +4.48% | 
| bucket_write_key_only_1m_spill | 377.221 | 293.618 | 1.285x | -1.02% | -1.65% | 
| bucket_write_fixed_payload_1m_spill | 4980.360 | 2846.457 | 1.750x | -0.54% | +0.95% | 
| bucket_write_key_string_fixed_payload_1m_spill | 5101.560 | 2904.926 | 1.756x | -0.57% | -0.40% | 
| bucket_write_string_payload_1m_spill | 5448.953 | 3249.264 | 1.677x | +2.10% | +0.96% | 
| bucket_write_complex_payload_1m_spill | 8973.349 | 4931.059 | 1.820x | -1.34% | +3.43% | 
| single_key_very_wide_mixed_payload_256k_spill | 3757.500 | 3195.074 | 1.176x | -0.42% | -0.27% |
```

## spill_zstd

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_i64_256k_spill | 111.925 | 38.406 | 2.914x | +0.83% | +0.46% | 
| duplicate_i64_256k_spill | 60.371 | 24.445 | 2.470x | +0.63% | +1.06% | 
| null_heavy_i64_128k_spill | 42.322 | 16.190 | 2.614x | +1.02% | +2.47% | | eight_key_i64_128k_spill | 122.838 | 75.267 | 1.632x | +1.77% | +3.05% | | inline_varchar_128k_spill | 49.420 | 35.650 | 1.386x | +0.57% | -0.21% | 
| long_varchar_64k_spill | 78.869 | 39.103 | 2.017x | +0.97% | +0.61% | 
| varchar_common_prefix_128k_spill | 152.307 | 89.568 | 1.700x | +3.12% | -0.19% | 
| wide_fixed_payload_128k_spill | 103.142 | 41.080 | 2.511x | -0.35% | -1.50% | 
| very_wide_fixed_payload_64k_spill | 203.548 | 100.627 | 2.023x | +0.58% | -1.16% | 
| wide_string_payload_64k_spill | 70.726 | 29.811 | 2.373x | +0.94% | +0.62% | 
| random_i64_1m_spill | 496.485 | 153.719 | 3.230x | +0.94% | -0.27% | 
| eight_key_i64_1m_spill | 1208.815 | 679.048 | 1.780x | +0.53% | +1.00% | 
| sixteen_key_i64_1m_spill | 1908.401 | 1089.684 | 1.751x | +0.33% | +0.65% | 
| wide_fixed_payload_1m_spill | 973.114 | 359.125 | 2.710x | -3.19% | -3.56% | 
| wide_string_payload_1m_spill | 1466.820 | 646.015 | 2.271x | +1.75% | +2.11% | 
| bucket_write_key_only_1m_spill | 576.233 | 428.029 | 1.346x | +0.25% | -1.83% | 
| bucket_write_fixed_payload_1m_spill | 7410.590 | 3962.504 | 1.870x | -3.08% | -0.44% | 
| bucket_write_key_string_fixed_payload_1m_spill | 7780.307 | 4178.706 | 1.862x | -1.39% | -0.03% | 
| bucket_write_string_payload_1m_spill | 7928.411 | 4455.599 | 1.779x | -2.46% | +0.14% | 
| bucket_write_complex_payload_1m_spill | 13986.422 | 7063.451 | 1.980x | -0.07% | +0.13% | 
| single_key_very_wide_mixed_payload_256k_spill | 8277.763 | 7732.146 | 1.071x | -1.18% | +1.10% |

```
## buffer_large

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_i64_narrow_10m | 3274.449 | 1107.171 | 2.957x | +1.22% | +1.89% | 
| eight_key_i64_10m | 4828.178 | 2413.502 | 2.000x | -1.40% | -0.83% | 
| sixteen_key_i64_10m | 6066.091 | 3532.059 | 1.717x | -1.07% | -1.05% | 
| wide_fixed_payload_10m | 6004.555 | 2265.406 | 2.651x | +1.74% | +0.27% | 
| long_varchar_10m | 22071.720 | 5579.918 | 3.956x | -1.62% | -3.30% |
```

## spill_large_none

```
| case | current Legacy ms | current Radix ms | speedup | raw Radix delta | legacy-normalized delta | 
|---|---:|---:|---:|---:|---:|
| random_i64_10m_spill | 4661.047 | 1464.416 | 3.183x | -0.68% | -1.18% | 
| eight_key_i64_10m_spill | 6810.251 | 3570.908 | 1.907x | +1.37% | +3.18% | 
| sixteen_key_i64_10m_spill | 8587.795 | 5088.405 | 1.688x | +3.51% | +4.14% | 
| wide_fixed_payload_10m_spill | 5593.336 | 1898.039 | 2.947x | +0.10% | +0.97% |
```

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    Paste your google-benchmark or TPC-H results here.
    Before: 10.5s
    After:   8.2s  (+20%)
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Fixed a crash in `substr` when input is null.
- optimized `group by` performance by 20%.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    Breaking Changes:
    - Description of the breaking change.
    - Possible solutions or workarounds.
    - Any other relevant information.
    ```
    </details>
