### PR TITLE
fix: clarify presto round control flow

### DIFF
--- a/bolt/functions/prestosql/ArithmeticImpl.h
+++ b/bolt/functions/prestosql/ArithmeticImpl.h
@@ -78,20 +78,23 @@ round(const TNum& number, const TDecimals& decimals = 0) {
     } else {
       return number;
     }
-  }
-  if (!std::isfinite(number)) {
-    return number;
-  }
+  } else {
+    if (!std::isfinite(number)) {
+      return number;
+    }
 
-  double dNumber = static_cast<double>(number);
-  BigDecimal decimal(dNumber);
-  decimal.setScale(decimals);
-  if constexpr (std::is_same_v<TNum, double>) {
-    auto res = decimal.doubleValue();
-    return res;
-  } else if constexpr (std::is_same_v<TNum, float>) {
-    auto res = decimal.floatValue();
-    return res;
+    double dNumber = static_cast<double>(number);
+    BigDecimal decimal(dNumber);
+    decimal.setScale(decimals);
+    if constexpr (std::is_same_v<TNum, double>) {
+      auto res = decimal.doubleValue();
+      return res;
+    } else if constexpr (std::is_same_v<TNum, float>) {
+      auto res = decimal.floatValue();
+      return res;
+    }
+
+    BOLT_UNREACHABLE("Unsupported input type for round");
   }
 }
 


### PR DESCRIPTION
Separate the non-integral round path from the integral if constexpr branch so supported instantiations always have an explicit return path.

Unsupported non-integral instantiations now terminate through BOLT_UNREACHABLE instead of leaving a dangling non-void fallthrough path.

### What problem does this PR solve?

The Presto `round` helper leaves the non-integral handling after the integral
`if constexpr` branch instead of making it an explicit `else` branch.

For some compiler/configuration combinations, this can make an instantiated
non-void function appear to have a fallthrough path after the floating-point-only
return statements are discarded, producing:

```text
warning: control reaches end of non-void function [-Wreturn-type]
```

Godbolt reproduction: https://godbolt.org/z/q3xzh6eTE

Issue Number: N/A

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement (optimization)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no logic changes)
- [ ] Build/CI or Infrastructure changes
- [ ] Documentation only

### Description

This PR makes the `round` helper's template control flow explicit by moving the
non-integral logic into the `else` branch of the integral `if constexpr`.

The existing behavior for supported integral and floating-point `round`
instantiations is unchanged. Unsupported non-integral instantiations now end in
`BOLT_UNREACHABLE`, so the function no longer exposes a dangling non-void
control-flow path.

### Performance Impact

- [x] **No Impact**: This change only clarifies compile-time dispatch and unreachable control flow.
- [ ] **Positive Impact**: I have run benchmarks.
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note

Release Note:

```text
Release Note:
- Fixed Presto `round` template control flow to avoid non-void fallthrough warnings.
```

### Checklist (For Author)

- [ ] I have added/updated unit tests (ctest).
- [ ] I have verified the code with local build (Release/Debug).
- [ ] I have run clang-format / linters.
- [x] No need to test or manual test.

### Breaking Changes

- [x] No
- [ ] Yes (Description: ...)

