### PR TITLE
fix(flinksql): align substr null semantics

### DIFF
--- a/bolt/functions/flinksql/String.h
+++ b/bolt/functions/flinksql/String.h
@@ -19,6 +19,7 @@
 #include "bolt/functions/Macros.h"
 #include "bolt/functions/lib/string/StringCore.h"
 #include "bolt/functions/lib/string/StringImpl.h"
+#include "bolt/functions/prestosql/StringFunctions.h"
 #include "bolt/functions/sparksql/String.h"
 namespace bytedance::bolt::functions::flinksql {
 
@@ -33,6 +34,15 @@ struct FlinkRPadFunction : public sparksql::PadFunctionBase<
                                T,
                                false,
                                sparksql::PadInvalidInputPolicy::kReturnNull> {};
+
+/// substr(string, start[, length]) -> varchar
+/// Flink-compatible substring: zero start uses the first character and a
+/// negative length returns null.
+template <typename T>
+struct FlinkSubstrFunction : public SubstrFunctionBase<
+                                 T,
+                                 true,
+                                 SubstrInvalidInputPolicy::kReturnNull> {};
 
 /// isDigit function
 /// isDigit(str) -> boolean

--- a/bolt/functions/flinksql/registration/Register.cpp
+++ b/bolt/functions/flinksql/registration/Register.cpp
@@ -47,6 +47,10 @@ static void registerStringFunctions(const std::string& prefix) {
       {prefix + "lpad"});
   registerFunction<FlinkRPadFunction, Varchar, Varchar, int32_t, Varchar>(
       {prefix + "rpad"});
+  registerFunction<FlinkSubstrFunction, Varchar, Varchar, int32_t>(
+      {prefix + "substr", prefix + "substring"});
+  registerFunction<FlinkSubstrFunction, Varchar, Varchar, int32_t, int32_t>(
+      {prefix + "substr", prefix + "substring"});
   registerFunction<IsAlphaFunction, bool, Varchar>({prefix + "is_alpha"});
   registerFunction<IsDecimalFunction, bool, Varchar>({prefix + "is_decimal"});
   registerFunction<IsDigitFunction, bool, Varchar>({prefix + "is_digit"});

--- a/bolt/functions/flinksql/tests/StringFunctionsTest.cpp
+++ b/bolt/functions/flinksql/tests/StringFunctionsTest.cpp
@@ -37,6 +37,17 @@ class StringFunctionsTest : public FlinkFunctionBaseTest {
         "rpad(c0, c1, c2)", string, size, padString);
   }
 
+  std::optional<std::string> substr(
+      std::optional<std::string> str,
+      std::optional<int32_t> start,
+      std::optional<int32_t> length = std::nullopt) {
+    if (length.has_value()) {
+      return evaluateOnce<std::string>(
+          "substr(c0, c1, c2)", str, start, length);
+    }
+    return evaluateOnce<std::string>("substr(c0, c1)", str, start);
+  }
+
   std::optional<bool> isDigit(std::optional<std::string> str) {
     return evaluateOnce<bool>("is_digit(c0)", str);
   }
@@ -76,6 +87,48 @@ TEST_F(StringFunctionsTest, rpad) {
   EXPECT_EQ(std::nullopt, rpad(std::nullopt, 5, "??"));
   EXPECT_EQ(std::nullopt, rpad("hi", std::nullopt, "??"));
   EXPECT_EQ(std::nullopt, rpad("hi", 5, std::nullopt));
+}
+
+TEST_F(StringFunctionsTest, substr) {
+  // Positive start, 1-indexed.
+  EXPECT_EQ("hello", substr("hello", 1));
+  EXPECT_EQ("ello", substr("hello", 2));
+  EXPECT_EQ("o", substr("hello", 5));
+  EXPECT_EQ("", substr("hello", 6));
+  EXPECT_EQ("", substr("hello", 100));
+
+  // Start == 0 treated as 1 (Flink semantics).
+  EXPECT_EQ("hello", substr("hello", 0));
+  EXPECT_EQ("hello", substr("hello", 0, 5));
+
+  // Negative start: count from end.
+  EXPECT_EQ("o", substr("hello", -1));
+  EXPECT_EQ("lo", substr("hello", -2));
+  EXPECT_EQ("hello", substr("hello", -5));
+  EXPECT_EQ("", substr("hello", -100));
+
+  // With length.
+  EXPECT_EQ("el", substr("hello", 2, 2));
+  EXPECT_EQ("ello", substr("hello", 2, 10));
+
+  // length == 0 returns empty string.
+  EXPECT_EQ("", substr("hello", 1, 0));
+
+  // Negative length returns NULL (Flink semantics).
+  EXPECT_EQ(std::nullopt, substr("hello", 1, -1));
+  EXPECT_EQ(std::nullopt, substr("hello", 5, -1));
+
+  // NULL input.
+  EXPECT_EQ(std::nullopt, substr(std::nullopt, 1));
+  EXPECT_EQ(std::nullopt, substr(std::nullopt, 1, 2));
+  EXPECT_EQ(std::nullopt, substr("hello", std::nullopt));
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<std::string>(
+          "substr(c0, c1, c2)",
+          std::optional<std::string>{"hello"},
+          std::optional<int32_t>{1},
+          std::optional<int32_t>{}));
 }
 
 TEST_F(StringFunctionsTest, splitIndex) {

--- a/bolt/functions/prestosql/StringFunctions.h
+++ b/bolt/functions/prestosql/StringFunctions.h
@@ -72,6 +72,12 @@ struct CodePointFunction {
 ///     absolute value of start is greater then length of the string.
 
 ///
+/// Controls how negative length is handled across dialects.
+enum class SubstrInvalidInputPolicy {
+  kReturnEmpty, // length <= 0 returns empty string (Presto, Spark)
+  kReturnNull, // length < 0 returns NULL (Flink)
+};
+
 /// substr(string, start, length) -> varchar
 ///
 ///     Returns a substring from string of length length from the
@@ -79,7 +85,11 @@ struct CodePointFunction {
 ///     position is interpreted as being relative to the end of the string.
 ///     Returns empty string if absolute value of start is greater then length
 ///     of the string.
-template <typename T, bool supportZeroIndex = false>
+template <
+    typename T,
+    bool supportZeroIndex = false,
+    SubstrInvalidInputPolicy invalidInputPolicy =
+        SubstrInvalidInputPolicy::kReturnEmpty>
 struct SubstrFunctionBase {
   BOLT_DEFINE_FUNCTION_TYPES(T);
 
@@ -90,33 +100,38 @@ struct SubstrFunctionBase {
   static constexpr bool is_default_ascii_behavior = true;
 
   template <typename I>
-  FOLLY_ALWAYS_INLINE void call(
+  FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       I start,
       I length = std::numeric_limits<I>::max()) {
-    doCall<false>(result, input, start, length);
+    return doCall<false>(result, input, start, length);
   }
 
   template <typename I>
-  FOLLY_ALWAYS_INLINE void callAscii(
+  FOLLY_ALWAYS_INLINE bool callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       I start,
       I length = std::numeric_limits<I>::max()) {
-    doCall<true>(result, input, start, length);
+    return doCall<true>(result, input, start, length);
   }
 
   template <bool isAscii, typename I>
-  FOLLY_ALWAYS_INLINE void doCall(
+  FOLLY_ALWAYS_INLINE bool doCall(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       I start,
       I length = std::numeric_limits<I>::max()) {
-    // Following Presto semantics
+    // Handle length-based early returns per dialect policy.
+    if constexpr (invalidInputPolicy == SubstrInvalidInputPolicy::kReturnNull) {
+      if (length < 0) {
+        return false;
+      }
+    }
     if (length <= 0) {
       result.setEmpty();
-      return;
+      return true;
     }
 
     if (start == 0) {
@@ -124,7 +139,7 @@ struct SubstrFunctionBase {
         start = 1;
       } else {
         result.setEmpty();
-        return;
+        return true;
       }
     }
 
@@ -138,7 +153,7 @@ struct SubstrFunctionBase {
     // Following Presto semantics
     if (start <= 0 || start > numCharacters) {
       result.setEmpty();
-      return;
+      return true;
     }
 
     // Adjusting length
@@ -153,6 +168,7 @@ struct SubstrFunctionBase {
     // Generating output string
     result.setNoCopy(StringView(
         input.data() + byteRange.first, byteRange.second - byteRange.first));
+    return true;
   }
 };
 


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please explain the context and the problem.
If this fixes a specific issue, please link it below.
-->

Flink SUBSTR/SUBSTRING return null when the requested length is negative. Bolt's existing implementations 
return empty string, so the Flink planner cannot map these functions to Bolt without changing 
query behavior.

Issue Number: N/A

### Type of Change
<!-- Please check the one that applies to this PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Performance improvement (optimization)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔨 Refactoring (no logic changes)
- [ ] 🔧 Build/CI or Infrastructure changes
- [ ] 📝 Documentation only

### Description

Add a compile-time invalid-input policy to the shared SUBSTR/SUBSTRING implementation.
Presto/Spark keeps the existing exception behavior by default. Flink registers its own
SUBSTR/SUBSTRING specializations, which return null for negative lengths.

### Performance Impact
<!--
REQUIRED for Performance PRs and Core Engine changes.
Please verify that your change does not introduce performance regressions.
-->
- [x] **No Impact**: This change does not affect the critical path (e.g., build system, doc, error handling).
- [ ] **Positive Impact**: I have run benchmarks.
    <details>
    <summary>Click to view Benchmark Results</summary>

    ```text
    N/A
    ```
    </details>
- [ ] **Negative Impact**: Explained below (e.g., trade-off for correctness).

### Release Note
<!-- Please write a short summary for the release notes. -->

Please describe the changes in this PR

Release Note:

```text
Release Note:
- Added Flink-compatible null semantics for SUBSTR/SUBSTRING.
```

### Checklist (For Author)
<!--
Please double-check the following before submitting.
-->

- [x] I have added/updated unit tests (ctest).
- [x] I have verified the code with local build (Release/Debug).
- [x] I have run clang-format / linters.
- [ ] (Optional) I have run Sanitizers (ASAN/TSAN) locally for complex C++ changes.
- [ ] No need to test or manual test.

### Breaking Changes
<!--
Does this PR introduce API or ABI incompatibilities?
If yes, please describe how users should migrate.
-->

- [x] No
- [ ] Yes (Description: ...)
    <details>
    <summary>Click to view Breaking Changes</summary>

    ```text
    N/A
    ```
    </details>
